### PR TITLE
New badges that point to current readme for

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![](https://mmshostedimagedeploymentstatus.azurewebsites.net/api/status?imageName=Ubuntu18&badge=1)](https://mmshostedimagedeploymentstatus.azurewebsites.net/api/status?imageName=Ubuntu18&redirect=1)
+[![](https://mmshostedimagedeploymentstatus.azurewebsites.net/api/status?imageName=Ubuntu16&badge=1)](https://mmshostedimagedeploymentstatus.azurewebsites.net/api/status?imageName=Ubuntu16&redirect=1)
+[![](https://mmshostedimagedeploymentstatus.azurewebsites.net/api/status?imageName=windows-2019-vs2019&badge=1)](https://mmshostedimagedeploymentstatus.azurewebsites.net/api/status?imageName=windows-2019-vs2019&redirect=1)
+
 # GitHub Actions Virtual Environments
 This repository will contain the code that we use to create the GitHub Actions [virtual environments](https://help.github.com/en/articles/software-in-virtual-environments-for-github-actions).
 We're not quite ready to share the code and accept contributions yet. However, we want to gather your software requests and bug reports.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![](https://mmshostedimagedeploymentstatus.azurewebsites.net/api/status?imageName=Ubuntu18&badge=1)](https://mmshostedimagedeploymentstatus.azurewebsites.net/api/status?imageName=Ubuntu18&redirect=1)
-[![](https://mmshostedimagedeploymentstatus.azurewebsites.net/api/status?imageName=Ubuntu16&badge=1)](https://mmshostedimagedeploymentstatus.azurewebsites.net/api/status?imageName=Ubuntu16&redirect=1)
-[![](https://mmshostedimagedeploymentstatus.azurewebsites.net/api/status?imageName=windows-2019-vs2019&badge=1)](https://mmshostedimagedeploymentstatus.azurewebsites.net/api/status?imageName=windows-2019-vs2019&redirect=1)
+[![](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=Ubuntu18&badge=1)](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=Ubuntu18&redirect=1)
+[![](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=Ubuntu16&badge=1)](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=Ubuntu16&redirect=1)
+[![](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=windows-2019-vs2019&badge=1)](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=windows-2019-vs2019&redirect=1)
 
 # GitHub Actions Virtual Environments
 This repository will contain the code that we use to create the GitHub Actions [virtual environments](https://help.github.com/en/articles/software-in-virtual-environments-for-github-actions).


### PR DESCRIPTION
These new badges render green when a VE version is fully deployed and yellow when there is a partial deployment (along with percent deployed).  Clicking on the badge navigates to the current Readme.md file for that image version.