### PR TITLE
Update cmake.sh

### DIFF
--- a/images/linux/scripts/installers/cmake.sh
+++ b/images/linux/scripts/installers/cmake.sh
@@ -12,7 +12,7 @@ echo "Checking to see if the installer script has already been run"
 if command -v cmake; then
     echo "Example variable already set to $EXAMPLE_VAR"
 else
-	curl -sL https://cmake.org/files/v3.12/cmake-3.12.4-Linux-x86_64.sh -o cmakeinstall.sh \
+	curl -sL https://cmake.org/files/v3.15/cmake-3.15.5-Linux-x86_64.sh -o cmakeinstall.sh \
 	&& chmod +x cmakeinstall.sh \
 	&& ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir \
 	&& rm cmakeinstall.sh

--- a/images/win/Windows2016-Readme.md
+++ b/images/win/Windows2016-Readme.md
@@ -476,7 +476,7 @@ _Environment:_
 ## Google Chrome
 
 _version:_
-77.0.3865.90
+78.0.3904.108
 
 ## Mozilla Firefox
 

--- a/images/win/Windows2019-Readme.md
+++ b/images/win/Windows2019-Readme.md
@@ -443,7 +443,7 @@ _Environment:_
 ## Google Chrome
 
 _version:_
-77.0.3865.90
+79.0.3945.88
 
 ## Mozilla Firefox
 


### PR DESCRIPTION
cmake 3.15.5 has been released in 2019.10.30. Update CMake to 3.15 stable could let us to make it possible to apply the latest CMake in our build. Link to the previous PR in original repos: #https://github.com/microsoft/azure-pipelines-image-generation/pull/1424