### PR TITLE
Add Validate-SQLPowerShellTools to VS2019 on WS2019 template

### DIFF
--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -655,6 +655,12 @@
         {
             "type": "powershell",
             "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-SQLPowerShellTools.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-MinGW.ps1"
             ]
         },


### PR DESCRIPTION
Validate-SQLPowerShellTools was missing from VS2019 on WS2019 template, original from @ryanspletzer