### PR TITLE
Update docker-compose to 1.25.0

### DIFF
--- a/images/linux/Ubuntu1604-README.md
+++ b/images/linux/Ubuntu1604-README.md
@@ -33,7 +33,7 @@ The following software is installed on machines in the Hosted Ubuntu 1604 (20191
 - build-essential
 - Clang 6.0 (clang version 6.0.1-svn334776-1~exp1~20190309042730.123 (branches/release_60))
 - CMake (cmake version 3.12.4)
-- Docker Compose (docker-compose version 1.22.0, build f46880fe)
+- Docker Compose (docker-compose version 1.25.0, build 4038169)
 - Docker (Docker version 3.0.8, build 2355349d)
 - Docker (Docker version 3.0.8, build 2355349d)
 - .NET Core SDK:

--- a/images/linux/Ubuntu1804-README.md
+++ b/images/linux/Ubuntu1804-README.md
@@ -33,7 +33,7 @@ The following software is installed on machines in the Hosted Ubuntu 1804 (v2019
 - build-essential
 - Clang 6.0 (clang version 6.0.1-svn334776-1~exp1~20190309042703.125 (branches/release_60))
 - CMake (cmake version 3.12.4)
-- Docker Compose (docker-compose version 1.22.0, build f46880fe)
+- Docker Compose (docker-compose version 1.25.0, build 4038169)
 - Docker (Docker version 3.0.8, build 2355349d)
 - Docker (Docker version 3.0.8, build 2355349d)
 - .NET Core SDK:

--- a/images/linux/scripts/installers/docker-compose.sh
+++ b/images/linux/scripts/installers/docker-compose.sh
@@ -7,7 +7,7 @@
 source $HELPER_SCRIPTS/apt.sh
 source $HELPER_SCRIPTS/document.sh
 
-version="1.22.0"
+version="1.25.0"
 
 # Install latest docker-compose from releases
 curl -L "https://github.com/docker/compose/releases/download/$version/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose


### PR DESCRIPTION
This updates the installed version of `docker-compose` on Linux images
to 1.25.0, which includes several helpful features such as the
`--parallel` flag.