### PR TITLE
Bump kind version

### DIFF
--- a/images/linux/scripts/installers/kind.sh
+++ b/images/linux/scripts/installers/kind.sh
@@ -9,7 +9,7 @@ source $HELPER_SCRIPTS/document.sh
 source $HELPER_SCRIPTS/apt.sh
 
 # Install KIND
-KIND_VERSION="v0.5.1"
+KIND_VERSION="v0.6.1"
 
 curl -L -o /usr/local/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64"
 chmod +x /usr/local/bin/kind


### PR DESCRIPTION
There have been a lot of changes in 0.6 release. One point to note is that even though this is a minor release, there is a breaking change as described in the release notes - https://github.com/kubernetes-sigs/kind/releases/tag/v0.6.0. The breaking change is easy to fix in pipeline though - users will just have to change handling the KUBECONFIG as described in the release notes.