### PR TITLE
Upgrade maven to 3.6.3

### DIFF
--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -37,8 +37,8 @@ echo "ANT_HOME=/usr/share/ant" | tee -a /etc/environment
 curl -sL https://www.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip
 unzip -d /usr/share maven.zip
 rm maven.zip
-ln -s /usr/share/apache-maven-3.6.2/bin/mvn /usr/bin/mvn
-echo "M2_HOME=/usr/share/apache-maven-3.6.2" | tee -a /etc/environment
+ln -s /usr/share/apache-maven-3.6.3/bin/mvn /usr/bin/mvn
+echo "M2_HOME=/usr/share/apache-maven-3.6.3" | tee -a /etc/environment
 
 # Install Gradle
 # This script downloads the latest HTML list of releases at https://gradle.org/releases/.

--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -34,7 +34,7 @@ apt-fast install -y --no-install-recommends ant ant-optional
 echo "ANT_HOME=/usr/share/ant" | tee -a /etc/environment
 
 # Install Maven
-curl -sL https://www-eu.apache.org/dist/maven/maven-3/3.6.2/binaries/apache-maven-3.6.2-bin.zip -o maven.zip
+curl -sL https://www.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip
 unzip -d /usr/share maven.zip
 rm maven.zip
 ln -s /usr/share/apache-maven-3.6.2/bin/mvn /usr/bin/mvn


### PR DESCRIPTION
For some reason, 3.6.2. is deleted in the repository bumping to 3.6.3 instead..

Fix for: https://github.com/actions/virtual-environments/issues/166