### PR TITLE
Install Google Chrome, Chromedriver and Selenium

### DIFF
--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -58,6 +58,14 @@ SELENIUM_VERSION_MAJOR_MINOR=$(echo $SELENIUM_VERSION | cut -d '.' -f 1,2)
 
 # Download selenium standalone server (hardcoded version 3.141.59)
 echo "Downloading selenium-server-standalone v$SELENIUM_VERSION..."
-wget https://selenium-release.storage.googleapis.com/$SELENIUM_VERSION_MAJOR_MINOR/selenium-server-standalone-$SELENIUM_VERSION.jar
+SELENIUM_JAR_NAME=selenium-server-standalone-$SELENIUM_VERSION.jar
+wget https://selenium-release.storage.googleapis.com/$SELENIUM_VERSION_MAJOR_MINOR/$SELENIUM_JAR_NAME
+
+echo "Testing to make sure that script performed as expected, and basic scenarios work"
+if [ ! -f "$SELENIUM_JAR_NAME" ]; then
+    echo "Selenium server was not installed"
+    exit 1
+fi
+
 mv selenium-server-standalone-$SELENIUM_VERSION.jar /usr/share/java/selenium-server-standalone.jar
 echo "CLASSPATH=/usr/share/java/selenium-server-standalone.jar:." | tee -a /etc/environment

--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -51,9 +51,13 @@ fi
 echo "Lastly, documenting what we added to the metadata file"
 DocumentInstalledItem "Chromedriver ($(chromedriver --version))"
 
+# Determine latest selenium standalone server version
+SELENIUM_LATEST_VERSION_URL=https://api.github.com/repos/SeleniumHQ/selenium/releases/latest
+SELENIUM_VERSION=$(curl $SELENIUM_LATEST_VERSION_URL | jq '.name' | tr -d '"' | cut -d ' ' -f 2)
+SELENIUM_VERSION_MAJOR_MINOR=$(echo $SELENIUM_VERSION | cut -d '.' -f 1,2)
+
 # Download selenium standalone server (hardcoded version 3.141.59)
-SELENIUM_VERSION=3.141.59
 echo "Downloading selenium-server-standalone v$SELENIUM_VERSION..."
-wget https://selenium-release.storage.googleapis.com/3.141/selenium-server-standalone-$SELENIUM_VERSION.jar
+wget https://selenium-release.storage.googleapis.com/$SELENIUM_VERSION_MAJOR_MINOR/selenium-server-standalone-$SELENIUM_VERSION.jar
 mv selenium-server-standalone-$SELENIUM_VERSION.jar /usr/share/java/selenium-server-standalone.jar
 echo "CLASSPATH=/usr/share/java/selenium-server-standalone.jar:." | tee -a /etc/environment

--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -30,7 +30,7 @@ CHROME_VERSION=$(google-chrome --version | grep -Eo "([0-9]+\.?){4}" | cut -d ".
 echo "Current Google Chrome version: $CHROME_VERSION"
 
 # Determine latest release of chromedriver
-LATEST_CHROMEDRIVER_VERSION=$(curl "https://chromedriver.storage.googleapis.com/LATEST_RELEASE")
+LATEST_CHROMEDRIVER_VERSION=$(curl "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_VERSION")
 
 # Download and unpack latest release of chromedriver
 echo "Downloading chromedriver v$LATEST_CHROMEDRIVER_VERSION..."

--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -45,10 +45,14 @@ chown root:root /usr/bin/chromedriver
 chmod +x /usr/bin/chromedriver
 
 # Run tests to determine that the chromedriver installed as expected
+echo "Testing to make sure that script performed as expected, and basic scenarios work"
 if ! command -v chromedriver; then
     echo "chromedriver was not installed"
     exit 1
 fi
+
+echo "Lastly, documenting what we added to the metadata file"
+DocumentInstalledItem "Chromedriver ($(chromedriver --version))"
 
 # Download selenium standalone server (hardcoded version 3.141.59)
 echo "Downloading selenium-server-standalone v3.141.59..."

--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -69,3 +69,6 @@ fi
 
 mv "selenium-server-standalone-$SELENIUM_VERSION.jar" "/usr/share/java/selenium-server-standalone.jar"
 echo "CLASSPATH=/usr/share/java/selenium-server-standalone.jar:.:$CLASSPATH" | tee -a /etc/environment
+
+echo "Lastly, documenting what we added to the metadata file"
+DocumentInstalledItem "Selenium server standalone"

--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -58,7 +58,7 @@ SELENIUM_LATEST_VERSION_URL=https://api.github.com/repos/SeleniumHQ/selenium/rel
 SELENIUM_VERSION=$(curl $SELENIUM_LATEST_VERSION_URL | jq '.name' | tr -d '"' | cut -d ' ' -f 2)
 SELENIUM_VERSION_MAJOR_MINOR=$(echo $SELENIUM_VERSION | cut -d '.' -f 1,2)
 
-# Download selenium standalone server (hardcoded version 3.141.59)
+# Download selenium standalone server
 echo "Downloading selenium-server-standalone v$SELENIUM_VERSION..."
 SELENIUM_JAR_NAME=selenium-server-standalone-$SELENIUM_VERSION.jar
 wget https://selenium-release.storage.googleapis.com/$SELENIUM_VERSION_MAJOR_MINOR/$SELENIUM_JAR_NAME

--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -37,7 +37,7 @@ echo "Downloading chromedriver v$LATEST_CHROMEDRIVER_VERSION..."
 wget "https://chromedriver.storage.googleapis.com/$LATEST_CHROMEDRIVER_VERSION/chromedriver_linux64.zip"
 unzip chromedriver_linux64.zip
 rm chromedriver_linux64.zip
-mv chromedriver /usr/bin/chromedriver
+mv "chromedriver" "/usr/bin/chromedriver"
 chown root:root /usr/bin/chromedriver
 chmod +x /usr/bin/chromedriver
 
@@ -67,5 +67,5 @@ if [ ! -f "$SELENIUM_JAR_NAME" ]; then
     exit 1
 fi
 
-mv selenium-server-standalone-$SELENIUM_VERSION.jar /usr/share/java/selenium-server-standalone.jar
-echo "CLASSPATH=/usr/share/java/selenium-server-standalone.jar:." | tee -a /etc/environment
+mv "selenium-server-standalone-$SELENIUM_VERSION.jar" "/usr/share/java/selenium-server-standalone.jar"
+echo "CLASSPATH=/usr/share/java/selenium-server-standalone.jar:.:$CLASSPATH" | tee -a /etc/environment

--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -37,9 +37,11 @@ echo "Downloading chromedriver v$LATEST_CHROMEDRIVER_VERSION..."
 wget "https://chromedriver.storage.googleapis.com/$LATEST_CHROMEDRIVER_VERSION/chromedriver_linux64.zip"
 unzip chromedriver_linux64.zip
 rm chromedriver_linux64.zip
-mv "chromedriver" "/usr/bin/chromedriver"
-chown root:root /usr/bin/chromedriver
-chmod +x /usr/bin/chromedriver
+
+CHROMEDRIVER_BIN="/usr/bin/chromedriver"
+mv "chromedriver" $CHROMEDRIVER_BIN
+chown root:root $CHROMEDRIVER_BIN
+chmod +x $CHROMEDRIVER_BIN
 
 # Run tests to determine that the chromedriver installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"

--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -30,6 +30,7 @@ CHROME_VERSION=$(google-chrome --version | grep -Eo "([0-9]+\.?){4}" | cut -d ".
 echo "Current Google Chrome version: $CHROME_VERSION"
 
 # Determine latest release of chromedriver
+# Compatibility of Google Chrome and Chromedriver: https://sites.google.com/a/chromium.org/chromedriver/downloads/version-selection
 LATEST_CHROMEDRIVER_VERSION=$(curl "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_VERSION")
 
 # Download and unpack latest release of chromedriver

--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -30,10 +30,7 @@ CHROME_VERSION=$(google-chrome --version | grep -Eo "([0-9]+\.?){4}" | cut -d ".
 echo "Current Google Chrome version: $CHROME_VERSION"
 
 # Determine latest release of chromedriver
-LATEST_RELEASE_FILENAME="LATEST_RELEASE_$CHROME_VERSION"
-wget "https://chromedriver.storage.googleapis.com/$LATEST_RELEASE_FILENAME"
-LATEST_CHROMEDRIVER_VERSION=$(cat $LATEST_RELEASE_FILENAME)
-rm $LATEST_RELEASE_FILENAME
+LATEST_CHROMEDRIVER_VERSION=$(curl "https://chromedriver.storage.googleapis.com/LATEST_RELEASE")
 
 # Download and unpack latest release of chromedriver
 echo "Downloading chromedriver v$LATEST_CHROMEDRIVER_VERSION..."
@@ -55,5 +52,8 @@ echo "Lastly, documenting what we added to the metadata file"
 DocumentInstalledItem "Chromedriver ($(chromedriver --version))"
 
 # Download selenium standalone server (hardcoded version 3.141.59)
-echo "Downloading selenium-server-standalone v3.141.59..."
-wget https://selenium-release.storage.googleapis.com/3.141/selenium-server-standalone-3.141.59.jar
+SELENIUM_VERSION=3.141.59
+echo "Downloading selenium-server-standalone v$SELENIUM_VERSION..."
+wget https://selenium-release.storage.googleapis.com/3.141/selenium-server-standalone-$SELENIUM_VERSION.jar
+mv selenium-server-standalone-$SELENIUM_VERSION.jar /usr/share/java/selenium-server-standalone.jar
+echo "CLASSPATH=/usr/share/java/selenium-server-standalone.jar:." | tee -a /etc/environment

--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ################################################################################
 ##  File:  google-chrome.sh
-##  Desc:  Installs google-chrome
+##  Desc:  Installs google-chrome, chromedriver and selenium server
 ################################################################################
 
 # Source the helpers for use with the script
@@ -25,3 +25,31 @@ fi
 # Document what was added to the image
 echo "Lastly, documenting what we added to the metadata file"
 DocumentInstalledItem "Google Chrome ($(google-chrome --version))"
+
+CHROME_VERSION=$(google-chrome --version | grep -Eo "([0-9]+\.?){4}" | cut -d "." -f 1,2,3)
+echo "Current Google Chrome version: $CHROME_VERSION"
+
+# Determine latest release of chromedriver
+LATEST_RELEASE_FILENAME="LATEST_RELEASE_$CHROME_VERSION"
+wget "https://chromedriver.storage.googleapis.com/$LATEST_RELEASE_FILENAME"
+LATEST_CHROMEDRIVER_VERSION=$(cat $LATEST_RELEASE_FILENAME)
+rm $LATEST_RELEASE_FILENAME
+
+# Download and unpack latest release of chromedriver
+echo "Downloading chromedriver v$LATEST_CHROMEDRIVER_VERSION..."
+wget "https://chromedriver.storage.googleapis.com/$LATEST_CHROMEDRIVER_VERSION/chromedriver_linux64.zip"
+unzip chromedriver_linux64.zip
+rm chromedriver_linux64.zip
+mv chromedriver /usr/bin/chromedriver
+chown root:root /usr/bin/chromedriver
+chmod +x /usr/bin/chromedriver
+
+# Run tests to determine that the chromedriver installed as expected
+if ! command -v chromedriver; then
+    echo "chromedriver was not installed"
+    exit 1
+fi
+
+# Download selenium standalone server (hardcoded version 3.141.59)
+echo "Downloading selenium-server-standalone v3.141.59..."
+wget https://selenium-release.storage.googleapis.com/3.141/selenium-server-standalone-3.141.59.jar

--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -27,7 +27,6 @@ echo "Lastly, documenting what we added to the metadata file"
 DocumentInstalledItem "Google Chrome ($(google-chrome --version))"
 
 CHROME_VERSION=$(google-chrome --version | grep -Eo "([0-9]+\.?){4}" | cut -d "." -f 1,2,3)
-echo "Current Google Chrome version: $CHROME_VERSION"
 
 # Determine latest release of chromedriver
 # Compatibility of Google Chrome and Chromedriver: https://sites.google.com/a/chromium.org/chromedriver/downloads/version-selection

--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -33,11 +33,11 @@ apt-fast install -y --no-install-recommends ant ant-optional
 echo "ANT_HOME=/usr/share/ant" | tee -a /etc/environment
 
 # Install Maven
-curl -sL https://www-eu.apache.org/dist/maven/maven-3/3.6.2/binaries/apache-maven-3.6.2-bin.zip -o maven.zip
+curl -sL https://www-eu.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip
 unzip -d /usr/share maven.zip
 rm maven.zip
-ln -s /usr/share/apache-maven-3.6.2/bin/mvn /usr/bin/mvn
-echo "M2_HOME=/usr/share/apache-maven-3.6.2" | tee -a /etc/environment
+ln -s /usr/share/apache-maven-3.6.3/bin/mvn /usr/bin/mvn
+echo "M2_HOME=/usr/share/apache-maven-3.6.3" | tee -a /etc/environment
 
 # Install Gradle
 # This script downloads the latest HTML list of releases at https://gradle.org/releases/.


### PR DESCRIPTION
In this PR we've extended `images/linux/scripts/installers/google-chrome.sh` script in order to install Chromedriver compatible with installed Google Chrome version and latest stable selenium-server-standalone version