### PR TITLE
Add a triager and update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -10,7 +10,7 @@ assignees: ''
 **Describe the bug**
 A clear and concise description of what the bug is, and why you consider it to be a bug.
 
-**Area for Triage**: See https://github.com/actions/virtual-environments/tree/master/.github/workflows/triage-rules.yaml for areas
+**Area for Triage**: See https://github.com/actions/virtual-environments/tree/master/triage-rules.yml for areas
 **Question, Bug, or Feature?**:
 
 **Virtual environments affected**

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -10,6 +10,9 @@ assignees: ''
 **Describe the bug**
 A clear and concise description of what the bug is, and why you consider it to be a bug.
 
+**Area for Triage**: See https://github.com/actions/virtual-environments/tree/master/.github/workflows/triage-rules.yaml for areas
+**Question, Bug, or Feature?**:
+
 **Virtual environments affected**
 - [ ] macOS 10.15
 - [ ] Ubuntu 16.04 LTS

--- a/.github/ISSUE_TEMPLATE/tool-request.md
+++ b/.github/ISSUE_TEMPLATE/tool-request.md
@@ -16,7 +16,7 @@ assignees: ''
   - Brief description of tool: <!--- Description -->
   - URL for tool's homepage: <!--- URL -->
 
-**Area for Triage**: See https://github.com/actions/virtual-environments/tree/master/.github/workflows/triage-rules.yaml for areas
+**Area for Triage**: See https://github.com/actions/virtual-environments/tree/master/triage-rules.yml for areas
 **Question, Bug, or Feature?**:
 
 **Virtual environments affected**

--- a/.github/ISSUE_TEMPLATE/tool-request.md
+++ b/.github/ISSUE_TEMPLATE/tool-request.md
@@ -16,6 +16,9 @@ assignees: ''
   - Brief description of tool: <!--- Description -->
   - URL for tool's homepage: <!--- URL -->
 
+**Area for Triage**: See https://github.com/actions/virtual-environments/tree/master/.github/workflows/triage-rules.yaml for areas
+**Question, Bug, or Feature?**:
+
 **Virtual environments affected**
 - [ ] macOS 10.15
 - [ ] Ubuntu 16.04 LTS

--- a/.github/workflows/issue-triager.yml
+++ b/.github/workflows/issue-triager.yml
@@ -1,0 +1,27 @@
+# Adapted from: https://github.com/microsoft/azure-pipelines-tasks/blob/master/.github/workflows/blank.yml
+# This action labels and assigns newly opened issues
+
+name: Issue triager
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: damccorm/tag-ur-it@master
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: "./triage-rules.yml"
+
+    - name: Set Node.js 10.x
+      uses: actions/setup-node@master
+      with:
+        version: 10.x
+
+    # Need to explicitly install @octokit/rest separately or else it will mess with our typings.
+    - run: npm install && npm install @octokit/rest

--- a/triage-rules.yml
+++ b/triage-rules.yml
@@ -1,0 +1,192 @@
+# Adapted from https://github.com/microsoft/azure-pipelines-tasks/blob/master/issue-rules.yml
+
+# Primary rules
+rules:
+
+# Area: .NET Core
+- valueFor: '**Area for Triage**'
+  contains: '.NET Core'
+  addLabels: ['Area: .NET Core']
+  assign: ['bishal-pdmsft', 'pulkitaggarwl']
+
+# Area: .NET Framework
+- valueFor: '**Area for Triage**'
+  contains: '.NET Framework'
+  addLabels: ['Area: .NET Framework']
+  assign: ['azuredaveops', 'wnjenkin']
+
+# Area: Android
+- valueFor: '**Area for Triage**'
+  contains: 'Android'
+  addLabels: ['Area: Android']
+  assign: ['madhurig']
+
+# Area: Apple
+- valueFor: '**Area for Triage**'
+  contains: 'Apple'
+  addLabels: ['Area: Apple']
+  assign: ['AlenaSviridenko']
+
+# Area: Artifacts
+- valueFor: '**Area for Triage**'
+  contains: 'Artifacts'
+  addLabels: ['Area: Artifacts']
+  assign: ['animania4ka']
+
+# Area: C/C++
+- valueFor: '**Area for Triage**'
+  contains: 'C/C++'
+  addLabels: ['Area: C/C++']
+  assign: ['azuredaveops', 'wnjenkin']
+
+# Area: Containers
+- valueFor: '**Area for Triage**'
+  contains: 'Containers'
+  addLabels: ['Area: Containers']
+  assign: ['bryanmacfarlane']
+
+# Area: Databases
+- valueFor: '**Area for Triage**'
+  contains: 'Databases'
+  addLabels: ['Area: Databases']
+  assign: ['kmkumaran', 'RoopeshNair']
+
+# Area: Deployment/Release
+- valueFor: '**Area for Triage**'
+  contains: 'Deployment/Release'
+  addLabels: ['Area: Deployment/Release']
+  assign: ['kmkumaran', 'RoopeshNair']
+
+# Area: Erlang / Elixir
+- valueFor: '**Area for Triage**'
+  contains: 'Erlang / Elixir'
+  addLabels: ['Area: Erlang / Elixir']
+  assign: ['andymckay']
+
+# Area: Git
+- valueFor: '**Area for Triage**'
+  contains: 'Git'
+  addLabels: ['Area: Git']
+  assign: ['alepauly','kaylangan']
+
+# Area: Go
+- valueFor: '**Area for Triage**'
+  contains: 'Go'
+  addLabels: ['Area: Go']
+  assign: ['bishal-pdmsft', 'pulkitaggarwl']
+
+# Area: Haskell
+- valueFor: '**Area for Triage**'
+  contains: 'Haskell'
+  addLabels: ['Area: Haskell']
+  assign: ['andymckay']
+
+# Area: Java
+- valueFor: '**Area for Triage**'
+  contains: 'Java'
+  addLabels: ['Area: Java']
+  assign: ['leantk','vijayma']
+
+# Area: JavaScript and Node.js
+- valueFor: '**Area for Triage**'
+  contains: 'JavaScript and Node.js'
+  addLabels: ['Area: JavaScript and Node.js']
+  assign: ['bryanmacfarlane']
+
+# Area: Packages
+- valueFor: '**Area for Triage**'
+  contains: 'Packages'
+  addLabels: ['Area: Packages']
+  assign: ['johnterickson', 'animania4ka']
+
+# Area: PHP
+- valueFor: '**Area for Triage**'
+  contains: 'PHP'
+  addLabels: ['Area: PHP']
+  assign: ['alepauly', 'kaylangan']
+
+# Area: Python
+- valueFor: '**Area for Triage**'
+  contains: 'Python'
+  addLabels: ['Area: Python']
+  assign: ['madhurig']
+
+# Area: Ruby
+- valueFor: '**Area for Triage**'
+  contains: 'Ruby'
+  addLabels: ['Area: Ruby']
+  assign: ['madhurig']
+
+# Area: Rust
+- valueFor: '**Area for Triage**'
+  contains: 'Rust'
+  addLabels: ['Area: Rust']
+  assign: ['AlenaSviridenko']
+
+# Area: Scala
+- valueFor: '**Area for Triage**'
+  contains: 'Scala'
+  addLabels: ['Area: Scala']
+  assign: ['leantk','vijayma']
+
+# Area: Scripting and command line
+- valueFor: '**Area for Triage**'
+  contains: 'Scripting and command line'
+  addLabels: ['Area: Scripting and command line']
+  assign: ['zachariahcox','vtbassmatt']
+
+# Area: Servers
+- valueFor: '**Area for Triage**'
+  contains: 'Servers'
+  addLabels: ['Area: Servers']
+  assign: ['kmkumaran', 'RoopeshNair']
+
+# Area: SSH
+- valueFor: '**Area for Triage**'
+  contains: 'SSH'
+  addLabels: ['Area: SSH']
+  assign: ['zachariahcox','vtbassmatt']
+
+# Area: Testing and code coverage (incl. browser testing)
+- valueFor: '**Area for Triage**'
+  contains: 'Testing and code coverage'
+  addLabels: ['Area: Testing and code coverage']
+  assign: ['sadagopanrajaram','PBoraMSFT']
+
+# Area: Xamarin
+- valueFor: '**Area for Triage**'
+  contains: 'Xamarin'
+  addLabels: ['Area: Xamarin']
+  assign: ['AlenaSviridenko']
+
+# Types
+- valueFor: '**Question, Bug, or Feature?**'
+  contains: Feature
+  addLabels: ['enhancement']
+- valueFor: '**Question, Bug, or Feature?**'
+  contains: Bug
+  addLabels: ['bug']
+- valueFor: '**Question, Bug, or Feature?**'
+  contains: Question
+  addLabels: ['question']
+
+# runs if first set had no matches
+# add likely teams to look at based on text searches
+nomatches:
+- contains: 'Xcode'
+  addLabels: ['Area: Apple']
+- contains: 'Bash'
+  addLabels: ['Area: Scripting and command line']
+- contains: 'Nuget'
+  addLabels: ['Area: Packages']
+- contains: 'Npm'
+  addLabels: ['Area: Packages']
+- contains: 'Docker'
+  addLabels: ['Area: Deployment/Release']
+
+# always runs after rules.  look for missing or invalid sets of tags
+tags:
+- noneIn: ['bug', 'enhancement', 'question']
+  addLabels: ['needs triage']
+- noneMatch: '\s*Area:\s*([^]*)'
+  addLabels: ['needs triage']


### PR DESCRIPTION
This is a first pass at adding an issue triager. It relies on the person filing the issue to provide an area and type (e.g. bug, question, feature). It will then apply area and type labels and try to assign it to the correct owner.