### PR TITLE
compare php composer against latest signature

### DIFF
--- a/images/linux/scripts/installers/1604/php.sh
+++ b/images/linux/scripts/installers/1604/php.sh
@@ -271,7 +271,7 @@ apt-fast install -y --no-install-recommends snmp
 
 # Install composer
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-php -r "if (hash_file('sha384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+php -r "if (hash_file('sha384', 'composer-setup.php') === file_get_contents('https://composer.github.io/installer.sig')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
 php composer-setup.php
 sudo mv composer.phar /usr/bin/composer
 php -r "unlink('composer-setup.php');"

--- a/images/linux/scripts/installers/1804/php.sh
+++ b/images/linux/scripts/installers/1804/php.sh
@@ -188,7 +188,7 @@ apt-fast install -y --no-install-recommends snmp
 
 # Install composer
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-php -r "if (hash_file('sha384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+php -r "if (hash_file('sha384', 'composer-setup.php') === file_get_contents('https://composer.github.io/installer.sig')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
 php composer-setup.php
 sudo mv composer.phar /usr/bin/composer
 php -r "unlink('composer-setup.php');"


### PR DESCRIPTION
As originally submitted by @ropnop in #152 (I'm just cherry-picking his change into a clean branch):

This addresses #146

The SHA384 hash of the composer-setup.php script is hardcoded in the build script for the Ubuntu images. This means that whenever the install script is updated, the entire packer build fails and errors out on that step.

According to this page from Composer, the better way is to fetch the latest signature dynamically and compare it against the downloaded installer file.

I modified the php steps slightly to compare the hash against the latest official one from https://composer.github.io/installer.sig

Let me know if you think this is the best approach. The other approach would be to pin the installer to a specific hash and then downloading it by reference like https://raw.githubusercontent.com/composer/getcomposer.org/76a7060ccb93902cd7576b67264ad91c8a2700e2/web/installer