### PR TITLE
Remove duplicate install curl on linux 18.04

### DIFF
--- a/images/linux/scripts/installers/1804/basic.sh
+++ b/images/linux/scripts/installers/1804/basic.sh
@@ -115,9 +115,6 @@ apt-get install -y --no-install-recommends xorriso
 echo "Install zsync"
 apt-get install -y --no-install-recommends zsync
 
-echo "Install curl"
-apt-get install -y --no-install-recommends curl
-
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
 for cmd in curl file ftp jq netcat ssh rsync shellcheck sudo telnet time unzip wget zip; do


### PR DESCRIPTION
It's duplicate on https://github.com/actions/virtual-environments/blob/fef47980696fd0fa4f0d013c18618544d27c4e38/images/linux/scripts/installers/1804/basic.sh#L13-L14