### PR TITLE
Don't bloat the PATH when installing git

### DIFF
--- a/images/win/scripts/Installers/Install-Git.ps1
+++ b/images/win/scripts/Installers/Install-Git.ps1
@@ -12,7 +12,4 @@ choco install git -y --package-parameters="/GitAndUnixToolsOnPath /WindowsTermin
 # Disable GCM machine-wide
 [Environment]::SetEnvironmentVariable("GCM_INTERACTIVE", "Never", [System.EnvironmentVariableTarget]::Machine)
 
-Add-MachinePathItem "C:\Program Files\Git\mingw64\bin"
-Add-MachinePathItem "C:\Program Files\Git\usr\bin"
-Add-MachinePathItem "C:\Program Files\Git\bin"
 exit 0


### PR DESCRIPTION
Especially the mingw folder conflicts with other mingw installs. I don't think installing git should put a compiler on the PATH, especially since the Windows virtual environment by default already has a separate chocolatey mingw installed (at least according to the documentation).

I'm not sure why the \bin and \usr\bin paths are put on the PATH manually since that should already be done by chocolatey so I removed those as well. Any pointers on how I can actually test these changes would be appreciated (the link to setting up an azure in the contributing docs gives a 404).