### PR TITLE
Add Android SDK cmake 3.10.2 component to ubuntu16.04, 18.04 and windows.

### DIFF
--- a/images/linux/scripts/installers/1604/android.sh
+++ b/images/linux/scripts/installers/1604/android.sh
@@ -82,6 +82,7 @@ echo "y" | ${ANDROID_ROOT}/tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} \
     "add-ons;addon-google_apis-google-22" \
     "add-ons;addon-google_apis-google-21" \
     "cmake;3.6.4111459" \
+    "cmake;3.10.2.4988404" \
     "patcher;v4"
 
 # Document what was added to the image

--- a/images/linux/scripts/installers/1804/android.sh
+++ b/images/linux/scripts/installers/1804/android.sh
@@ -76,6 +76,7 @@ echo "y" | ${ANDROID_ROOT}/tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} \
     "add-ons;addon-google_apis-google-22" \
     "add-ons;addon-google_apis-google-21" \
     "cmake;3.6.4111459" \
+    "cmake;3.10.2.4988404" \
     "patcher;v4"
 
 # Document what was added to the image

--- a/images/win/scripts/Installers/Update-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Update-AndroidSDK.ps1
@@ -110,6 +110,7 @@ Push-Location -Path $sdk.FullName
     "add-ons;addon-google_apis-google-22" `
     "add-ons;addon-google_apis-google-21" `
     "cmake;3.6.4111459" `
+    "cmake;3.10.2.4988404" `
     "patcher;v4"
 
 Pop-Location


### PR DESCRIPTION
Android SDK gradle plugin supports fixed versions of cmake, which are
either 3.6.4111459 or 3.10.2. 4988404, and on Github Actions our apps
fail to build if their build.gradle specify cmake 3.10.2 because
Android Gradle Plugin tries to download and install it if it's missing
(and causes file write access violation, at least on Ubuntu).