### PR TITLE
macOS 10.15 software updates week2

### DIFF
--- a/images/macos/macos-10.15-Readme.md
+++ b/images/macos/macos-10.15-Readme.md
@@ -1,14 +1,14 @@
 ---
 title: GitHub Hosted Github Mojave 10.15 VM Image Updates
 description: Software used on build machines
-date: Week 51
+date: Week 2
 ---
 
-#### Xcode 11.1 set by default
+#### Xcode 11.2.1 set by default
 
 ## Operating System
 
-- OS X 10.15.1 (19B88) **Catalina**
+- OS X 10.15.2 (19C57) **Catalina**
 
 ## Installed Software
 
@@ -19,29 +19,29 @@ date: Week 51
 - Java 11 : OpenJDK Runtime Environment Zulu11.35+15-CA (build 11.0.5+10-LTS)
 - Java 12 : OpenJDK Runtime Environment Zulu12.3+11-CA (build 12.0.2+3)
 - Java 13 : OpenJDK Runtime Environment Zulu13.28+11-CA (build 13.0.1+10-MTS)
-- Node.js v12.13.1
+- Node.js v12.14.0
 - NVM 0.33.11
 - NVM - Installed node versions:
   v6.17.1  *
-  v8.16.2  *
-  v10.17.0 *
-  v12.13.1 *
-  v13.3.0  *
+  v8.17.0  *
+  v10.18.0 *
+  v12.14.0 *
+  v13.5.0  *
 - PowerShell 6.2.3
 - Python 2.7.17
-- Python 3.7.5
+- Python 3.7.6
 - Ruby -2.6.5p114
 - .NET SDK 2.0.0 3.0.100 3.0.101
-- Go 1.13.4
+- Go 1.13.5
 
 ### Package Management
 
-- Bundler 2.0.2
+- Bundler 2.1.3
 - Carthage 0.34.0
 - CocoaPods 1.8.4
-- Homebrew 2.2.0
-- NPM 6.12.1
-- Yarn 1.19.2
+- Homebrew 2.2.2
+- NPM 6.13.4
+- Yarn 1.21.1
 - NuGet 5.3.1.6268
 - pip 19.3.1
 - Miniconda 4.7.12
@@ -54,17 +54,18 @@ date: Week 51
 ### Utilities
 
 - curl 7.67.0 (x86_64-apple-darwin19.0.0) libcurl/7.67.0 SecureTransport zlib/1.2.11
-- Git 2.24.0
-- Git LFS: git-lfs/2.8.0 (GitHub; darwin amd64; go 1.12.7)
+- Git 2.24.1
+- Git LFS: git-lfs/2.9.2 (GitHub; darwin amd64; go 1.13.5)
 - GNU Wget 1.20.3
 - Subversion (SVN) 1.13.0
-- GNU parallel 20191122
+- GNU parallel 20191222
 
 ### Tools
 
-- fastlane 2.137.0
-- App Center CLI 2.3.2
-- Azure-Cli 2.0.77
+- fastlane 2.139.0
+- App Center CLI 2.3.3
+- Azure-Cli 2.0.78
+- CMake 3.16.2
 
 ### Pre-cached tools
 
@@ -81,11 +82,15 @@ date: Week 51
   - 2.5.5
   - 2.6.3
 
+### Browsers
+- Google Chrome 79.0.3945.88
+- ChromeDriver 79.0.3945.36
+
 ### Xcode
 
 | Version                | Build   | Path                             |
 |------------------------|---------|----------------------------------|
-| 11.3_beta              | 11C24b  | /Applications/Xcode_11.3_beta.app|
+| 11.3                   | 11C29   | /Applications/Xcode_11.3.app     |
 | 11.2.1                 | 11B53   | /Applications/Xcode_11.2.1.app   |
 | 11.2                   | 11B52   | /Applications/Xcode_11.2.app     |
 | 11.1                   | 11A1027 | /Applications/Xcode_11.1.app     |
@@ -97,29 +102,29 @@ date: Week 51
 - Nomad CLI 3.0.6
 - Nomad CLI IPA 0.14.3
 - xcpretty 0.3.0
-- xctool 0.3.6
+- xctool 0.3.7
 - xcversion 2.6.3
 
 ### Installed SDKs
 
 | SDK                       | SDK name    |Xcode Version |
 |---------------------------|-------------|--------------|
-| macOS 10.15               | macosx10.15 | 11.0, 11.1, 11.2, 11.2.1 |
+| macOS 10.15               | macosx10.15 | 11.0, 11.1, 11.2, 11.2.1, 11.3 |
 | iOS 13.0                  | iphoneos13.0 | 11.0        |
 | iOS 13.1                  | iphoneos13.1 | 11.1        |
-| iOS 13.2                  | iphoneos13.2 | 11.2, 11.2.1        |
+| iOS 13.2                  | iphoneos13.2 | 11.2, 11.2.1, 11.3       |
 | iOS Simulator 13.0        | iphonesimulator13.0 | 11.0     |
 | iOS Simulator 13.1        | iphonesimulator13.1 | 11.1     |
-| iOS Simulator 13.2        | iphonesimulator13.2 | 11.2, 11.2.1     |
+| iOS Simulator 13.2        | iphonesimulator13.2 | 11.2, 11.2.1, 11.3     |
 | tvOS 13.0                 | appletvos13.0 | 11.0, 11.1     |
 | tvOS 13.2                 | appletvos13.2 | 11.2, 11.2.1   |
 | tvOS Simulator 13.0       | appletvsimulator13.0 | 11.0, 11.1 |
-| tvOS Simulator 13.2       | appletvsimulator13.2 | 11.2, 11.2.1    |
+| tvOS Simulator 13.2       | appletvsimulator13.2 | 11.2, 11.2.1, 11.3    |
 | watchOS 6.0               | watchos6.0 | 11.0, 11.1    |
-| watchOS 6.1               | watchos6.1 | 11.2, 11.2.1  |
+| watchOS 6.1               | watchos6.1 | 11.2, 11.2.1, 11.3  |
 | watchOS Simulator 6.0     | watchsimulator6.0 | 11.0, 11.1    |
-| watchOS Simulator 6.1     | watchsimulator6.1 | 11.2, 11.2.1  |
-| DriverKit 19.0            | driverkit.macosx19.0 | 11.0, 11.1, 11.2, 11.2.1 |
+| watchOS Simulator 6.1     | watchsimulator6.1 | 11.2, 11.2.1, 11.3  |
+| DriverKit 19.0            | driverkit.macosx19.0 | 11.0, 11.1, 11.2, 11.2.1, 11.3 |
 
 ### Installed Simulators
 
@@ -129,23 +134,15 @@ date: Week 51
 |---------|---------------------------------|------------|
 | iOS 13.0 (17A577a) | 11         | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation) |
 | iOS 13.1 (17A844) | 11.1        | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation) |
-| iOS 13.2 (17B102) | 11.2, 11.2.1     | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad (7th generation)<br>iPad Pro<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation) |
-| tvOS 11.4 (15L576)<br>tvOS 12.0 (16J5283n)<br>tvOS 12.1 (16J602)<br>tvOS 12.2 (16L225)<br>tvOS 12.4 (16M567)<br>tvOS 13.0 (17J559)<br>tvOS 13.2 (17K90) | 11.0, 11.1<br>11.2, 11.2.1        | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p) |
-| watchOS 6.0 (17R566)<br><br>watchOS 6.1 (17S80) | 11.0<br>11.1<br>11.2, 11.2.1     | Apple Watch Series 4 40mm<br>Apple Watch Series 4 44mm<br>Apple Watch Series 5 40mm<br>Apple Watch Series 5 44mm |
+| iOS 13.2 (17B102) <br> iOS 13.3 (17C45) | 11.2, 11.2.1 <br> 11.3 | iPhone 8 <br> iPhone 8 Plus <br> iPhone 11 <br> iPhone 11 Pro <br> iPhone 11 Pro Max <br> iPad Pro (9.7-inch) <br> iPad (7th generation) <br> iPad Pro <br> iPad Pro (12.9-inch) (3rd generation) <br> iPad Air (3rd generation) |
+| tvOS 13.0 (17J559)<br>tvOS 13.2 (17K90)<br>tvOS 13.3 (17K446) | 11.2, 11.2.1<br> 11.3        | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p) |
+| watchOS 6.0 (17R566)<br><br>watchOS 6.1 (17S80)<br>watchOS 6.1.1 (17S445) | 11.0<br>11.1<br>11.2, 11.2.1<br> 11.3     | Apple Watch Series 4 40mm<br>Apple Watch Series 4 44mm<br>Apple Watch Series 5 40mm<br>Apple Watch Series 5 44mm |
 
 
 ### Device Pairs
 
 | Watch                       | Phone             |
 |-----------------------------|-------------------|
-| Apple Watch - 38mm          | iPhone 6s         |
-| Apple Watch - 42mm          | iPhone 6s Plus    |
-| Apple Watch Series 2 - 38mm | iPhone 7          |
-| Apple Watch Series 2 - 42mm | iPhone 7 Plus     |
-| Apple Watch Series 3 - 38mm | iPhone 8          |
-| Apple Watch Series 3 - 42mm | iPhone 8 Plus     |
-| Apple Watch Series 4 - 40mm | iPhone XS         |
-| Apple Watch Series 4 - 44mm | iPhone XS Max     |
 | Apple Watch Series 5 - 40mm | iPhone 11 Pro     |
 | Apple Watch Series 5 - 44mm | iPhone 11 Pro Max |
 
@@ -210,7 +207,7 @@ date: Week 51
 | lldb                  | 2.3.3614996                               |
 | ndk-bundle            | 18.1.5063045                              |
 | ProGuard              | 5.3.3                                     |
-| Android Emulator      | 29.2.11                                   |
+| Android Emulator      | 29.3.2                                    |
 
 ### Google APIs
 
@@ -234,7 +231,7 @@ date: Week 51
 
 ### Visual Studio for Mac
 
-- 8.3.10.2
+- 8.3.11.1
 
 
 ### Mono


### PR DESCRIPTION
macOS Catalina **10.15.2 (19C57)**

- Xcode 11.3(11C29)
- Python 3.7.6
- Node.js v12.14.0
- NPM 6.13.4
- Git: git version 2.24.1
- Git LFS: git-lfs/2.9.2 (GitHub; darwin amd64; go 1.13.5)
- Homebrew 2.2.2
- CMake 3.16.2
- xctool 0.3.7
- Bundler version 2.1.3
- App Center CLI 2.3.3
- fastlane 2.139.0
- Yarn 1.21.1
- azure-cli 2.0.78
- Go 1.13.5
- NVM - Installed node versions:
     - v8.17.0 
     - v10.18.0 
     - v12.14.0 
     - v13.5.0 
- GNU parallel 20191222
- Google Chrome 79.0.3945.88 
- ChromeDriver 79.0.3945.36
- Android Emulator 29.3.2

Xamarin:
- Visual Studio for Mac: 8.3.11.1
