### PR TITLE
Fix usage of ambiguous hosted term in readmes and scripts.

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -62,7 +62,7 @@ Function GenerateResourcesAndImage {
             Delete the resource group if it exists without user confirmation.
 
         .EXAMPLE
-            GenerateResourcesAndImage -SubscriptionId {YourSubscriptionId} -ResourceGroupName "shsamytest1" -ImageGenerationRepositoryRoot "C:\azure-pipelines-image-generation" -ImageType Ubuntu1604 -AzureLocation "East US"
+            GenerateResourcesAndImage -SubscriptionId {YourSubscriptionId} -ResourceGroupName "shsamytest1" -ImageGenerationRepositoryRoot "C:\virtual-environments" -ImageType Ubuntu1604 -AzureLocation "East US"
     #>
     param (
         [Parameter(Mandatory = $True)]

--- a/images/linux/Ubuntu1604-README.md
+++ b/images/linux/Ubuntu1604-README.md
@@ -1,5 +1,5 @@
-# Hosted Ubuntu 1604 Image (Ubuntu 16.04.6 LTS)
-The following software is installed on machines in the Hosted Ubuntu 1604 (20191202.1) pool
+# Ubuntu 16.04.6 LTS
+The following software is installed on machines with the 20191202.1 update.
 ***
 - 7-Zip 9.20
 - Ansible (ansible 2.9.1)

--- a/images/linux/Ubuntu1804-README.md
+++ b/images/linux/Ubuntu1804-README.md
@@ -1,5 +1,5 @@
-# Hosted Ubuntu 1804 Image (Ubuntu 18.04.3 LTS)
-The following software is installed on machines in the Hosted Ubuntu 1804 (v20191202.1) pool
+# Ubuntu 18.04.3 LTS
+The following software is installed on machines with the 20191202.1 update.
 ***
 - 7-Zip 16.02
 - Ansible (ansible 2.9.1)

--- a/images/linux/config/ubuntu1604.conf
+++ b/images/linux/config/ubuntu1604.conf
@@ -1,2 +1,2 @@
-# Name of the hosted pool this image will support
-POOL_NAME="Hosted Ubuntu 1604"
+# Name of the pool supported by this image
+POOL_NAME="Ubuntu 1604"

--- a/images/linux/config/ubuntu1804.conf
+++ b/images/linux/config/ubuntu1804.conf
@@ -1,2 +1,2 @@
-# Name of the hosted pool this image will support
-POOL_NAME="Hosted Ubuntu 1804"
+# Name of pool supported by this image
+POOL_NAME="Ubuntu 1804"

--- a/images/linux/scripts/installers/1604/preparemetadata.sh
+++ b/images/linux/scripts/installers/1604/preparemetadata.sh
@@ -7,6 +7,6 @@
 
 source $HELPER_SCRIPTS/document.sh
 
-AddTitle "Hosted Ubuntu 1604 Image ($(lsb_release -ds))"
-WriteItem "The following software is installed on machines in the Hosted Ubuntu 1604 ($IMAGE_VERSION) pool"
+AddTitle "$(lsb_release -ds)"
+WriteItem "The following software is installed on machines with the $IMAGE_VERSION update."
 WriteItem "***"

--- a/images/linux/scripts/installers/1804/preparemetadata.sh
+++ b/images/linux/scripts/installers/1804/preparemetadata.sh
@@ -7,6 +7,6 @@
 
 source $HELPER_SCRIPTS/document.sh
 
-AddTitle "Hosted Ubuntu 1804 Image ($(lsb_release -ds))"
-WriteItem "The following software is installed on machines in the Hosted Ubuntu 1804 (v$IMAGE_VERSION) pool"
+AddTitle "$(lsb_release -ds)"
+WriteItem "The following software is installed on machines with the $IMAGE_VERSION update."
 WriteItem "***"

--- a/images/win/Windows2016-Readme.md
+++ b/images/win/Windows2016-Readme.md
@@ -1,6 +1,6 @@
-# Hosted Windows2016 image
+# Windows Server 2016
 
-The following software is installed on machines in the Azure Pipelines **Hosted Windows2016** (v20191009.1) pool.
+The following software is installed on machines with the 20191009.1 update.
 
 Components marked with **\*** have been upgraded since the previous version of the image.
 
@@ -518,8 +518,6 @@ _Environment:_
 * Grunt grunt-cli v1.3.2<br/>
 * Bower 1.8.8<br/>
 * Yarn 1.19.1<br/>
-
-> Note: You can install and use another version of Node.js on Microsoft-hosted agent pools using the [Node tool installer](https://docs.microsoft.com/vsts/pipelines/tasks/tool/node-js) task.
 
 ## npm
 

--- a/images/win/Windows2019-Readme.md
+++ b/images/win/Windows2019-Readme.md
@@ -1,6 +1,6 @@
-# Hosted Windows 2019
+# Windows Server 2019
 
-The following software is installed on machines in the **Hosted Windows 2019** (v20191009.1) pool.
+The following software is installed on machines with the 20191009.1 update.
 
 Components marked with **\*** have been upgraded since the previous version of the image.
 
@@ -485,8 +485,6 @@ _Environment:_
 * Grunt grunt-cli v1.3.2<br/>
 * Bower 1.8.8<br/>
 * Yarn 1.19.1<br/>
-
-> Note: You can install and use another version of Node.js on Microsoft-hosted agent pools using the [Node tool installer](https://docs.microsoft.com/vsts/pipelines/tasks/tool/node-js) task.
 
 ## npm
 

--- a/images/win/scripts/Installers/Windows2016/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/Windows2016/Initialize-VM.ps1
@@ -119,9 +119,9 @@ wmic logicaldisk get size,freespace,caption
 # Adding description of the software to Markdown
 
 $Content = @"
-# Azure Pipelines Hosted VS2017 image
+# Windows Server 2016
 
-The following software is installed on machines in the Azure Pipelines **Hosted VS2017** (v$env:ImageVersion) pool.
+The following software is installed on machines with the $env:ImageVersion update.
 
 Components marked with **\*** have been upgraded since the previous version of the image.
 

--- a/images/win/scripts/Installers/Windows2019/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/Windows2019/Initialize-VM.ps1
@@ -118,9 +118,9 @@ wmic logicaldisk get size,freespace,caption
 # Adding description of the software to Markdown
 
 $Content = @"
-# Azure Pipelines Hosted Windows 2019 with VS2019 image
+# Windows Server 2019
 
-The following software is installed on machines in the Azure Pipelines **Hosted Windows 2019 with VS2019** (v$env:ImageVersion) pool.
+The following software is installed on machines with the $env:ImageVersion update.
 
 Components marked with **\*** have been upgraded since the previous version of the image.
 


### PR DESCRIPTION
Found a few "hosted" usages that were ambiguous in the current context so I decided to remove them for clarity. Also cleaned up one usage of the previous repo name that could cause confusion.