### PR TITLE
Build boost from a tarball and bump version to 1.72.0

### DIFF
--- a/images/linux/Ubuntu1604-README.md
+++ b/images/linux/Ubuntu1604-README.md
@@ -261,4 +261,4 @@ the
 - pip3 (pip 8.1.1 from /usr/lib/python3/dist-packages (python 3.5))
 - PyPy2 ([PyPy 7.1.0 with GCC 6.2.0 20160901])
 - PyPy3 ([PyPy 7.2.0 with GCC 6.2.0 20160901])
-- Boost C++ Libraries 1.69.0
+- Boost C++ Libraries 1.69.0, 1.72.0

--- a/images/linux/Ubuntu1804-README.md
+++ b/images/linux/Ubuntu1804-README.md
@@ -252,4 +252,4 @@ the
 - pip3 (pip 9.0.1 from /usr/lib/python3/dist-packages (python 3.6))
 - PyPy2 ([PyPy 7.1.0 with GCC 6.2.0 20160901])
 - PyPy3 ([PyPy 7.2.0 with GCC 6.2.0 20160901])
-- Boost C++ Libraries 1.69.0
+- Boost C++ Libraries 1.69.0, 1.72.0

--- a/images/linux/scripts/installers/boost.sh
+++ b/images/linux/scripts/installers/boost.sh
@@ -15,6 +15,12 @@ do
     BOOST_SYMLINK_VER=`echo "${BOOST_VERSION//[.]/_}"`
     BOOST_ROOT="BOOST_ROOT_$BOOST_SYMLINK_VER"
 
+    wget -q https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_SYMLINK_VER}.tar.bz2
+    tar -xf boost_${BOOST_SYMLINK_VER}.tar.bz2
+    cd boost_${BOOST_SYMLINK_VER}
+    ./bootstrap.sh --prefix=$BOOST_LIB/$BOOST_VERSION
+    ./b2 install
+
     echo "$BOOST_ROOT=$BOOST_LIB/$BOOST_VERSION" | tee -a /etc/environment
     if [[ $BOOST_VERSION == $BOOST_DEFAULT ]]; then
         echo "BOOST_ROOT=$BOOST_LIB/$BOOST_VERSION" | tee -a /etc/environment

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -200,8 +200,8 @@
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",
                 "HELPER_SCRIPTS={{user `helper_script_folder`}}",
-                "BOOST_VERSIONS=1.69.0",
-                "BOOST_DEFAULT=1.69.0"
+                "BOOST_VERSIONS=1.69.0,1.72.0",
+                "BOOST_DEFAULT=1.72.0"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -203,8 +203,8 @@
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",
                 "HELPER_SCRIPTS={{user `helper_script_folder`}}",
-                "BOOST_VERSIONS=1.69.0",
-                "BOOST_DEFAULT=1.69.0"
+                "BOOST_VERSIONS=1.69.0,1.72.0",
+                "BOOST_DEFAULT=1.72.0"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },


### PR DESCRIPTION
#83 indicates that installation of Boost on Ubuntu 18.04 have a trouble.
I'm not sure if zip archives including 1.72.0, the latest release, are always available, and just 3f4654678a4ddcdb46c1f2d7c6194be7d835415e works.
So a1ac83b64573104105973e476f6e2c185a049445 was added, where Boost is built from a tarball, but it will take up time.

Anyway, I would appreciate if the newer versions are available.