### PR TITLE
Remove selenium from the CLASSPATH env variable

### DIFF
--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -61,7 +61,7 @@ SELENIUM_VERSION_MAJOR_MINOR=$(echo $SELENIUM_VERSION | cut -d '.' -f 1,2)
 
 # Download selenium standalone server
 echo "Downloading selenium-server-standalone v$SELENIUM_VERSION..."
-SELENIUM_JAR_NAME=selenium-server-standalone-$SELENIUM_VERSION.jar
+SELENIUM_JAR_NAME="selenium-server-standalone-$SELENIUM_VERSION.jar"
 wget https://selenium-release.storage.googleapis.com/$SELENIUM_VERSION_MAJOR_MINOR/$SELENIUM_JAR_NAME
 
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
@@ -70,8 +70,9 @@ if [ ! -f "$SELENIUM_JAR_NAME" ]; then
     exit 1
 fi
 
-mv "selenium-server-standalone-$SELENIUM_VERSION.jar" "/usr/share/java/selenium-server-standalone.jar"
-echo "CLASSPATH=/usr/share/java/selenium-server-standalone.jar:.:$CLASSPATH" | tee -a /etc/environment
+SELENIUM_JAR_PATH="/usr/share/java/selenium-server-standalone.jar"
+mv $SELENIUM_JAR_NAME $SELENIUM_JAR_PATH
+echo "SELENIUM_JAR_PATH=$SELENIUM_JAR_PATH" | tee -a /etc/environment
 
 echo "Lastly, documenting what we added to the metadata file"
 DocumentInstalledItem "Selenium server standalone"

--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -75,4 +75,4 @@ mv $SELENIUM_JAR_NAME $SELENIUM_JAR_PATH
 echo "SELENIUM_JAR_PATH=$SELENIUM_JAR_PATH" | tee -a /etc/environment
 
 echo "Lastly, documenting what we added to the metadata file"
-DocumentInstalledItem "Selenium server standalone"
+DocumentInstalledItem "Selenium server standalone (available via SELENIUM_JAR_PATH environment variable)"

--- a/images/win/scripts/Installers/Install-Selenium.ps1
+++ b/images/win/scripts/Installers/Install-Selenium.ps1
@@ -29,8 +29,7 @@ try {
     exit 1
 }
 
-Write-Host "Add selenium to CLASSPATH..."
-setx "CLASSPATH" "$($seleniumBinPath);$($env:CLASSPATH)" /M
-Write-Host "CLASSPATH: $($seleniumBinPath);$($env:CLASSPATH)"
+Write-Host "Add selenium jar to the environment variables..."
+setx "SELENIUM_JAR_PATH" "$($seleniumBinPath)" /M
 
 exit 0


### PR DESCRIPTION
This PR related to the #242 issue.

We have removed selenium jar from the `CLASSPATH` and declared new environment variable `SELENIUM_JAR_PATH` in order to give the client an ability to specify selenium in `-classpath` parameter of `java` command in order to run selenium tests