### PR TITLE
Fix incorrect display Clang 6.0 version in Ubuntu-README.md

### DIFF
--- a/images/linux/Ubuntu1604-README.md
+++ b/images/linux/Ubuntu1604-README.md
@@ -31,7 +31,7 @@ The following software is installed on machines with the 20191202.1 update.
   - tzdata
 - AWS CLI (aws-cli/1.16.293 Python/2.7.12 Linux/4.15.0-1063-azure botocore/1.13.29)
 - build-essential
-- Clang 6.0 (clang version 6.0.1-svn334776-1~exp1~20190309042730.123 (branches/release_60))
+- Clang 6.0 (clang version 6.0.1-svn334776-1\~exp1\~20190309042730.123 (branches/release_60))
 - CMake (cmake version 3.12.4)
 - Docker Compose (docker-compose version 1.22.0, build f46880fe)
 - Docker (Docker version 3.0.8, build 2355349d)

--- a/images/linux/Ubuntu1804-README.md
+++ b/images/linux/Ubuntu1804-README.md
@@ -31,7 +31,7 @@ The following software is installed on machines with the 20191202.1 update.
   - tzdata
 - AWS CLI (aws-cli/1.16.293 Python/2.7.15+ Linux/5.0.0-1025-azure botocore/1.13.29)
 - build-essential
-- Clang 6.0 (clang version 6.0.1-svn334776-1~exp1~20190309042703.125 (branches/release_60))
+- Clang 6.0 (clang version 6.0.1-svn334776-1\~exp1\~20190309042703.125 (branches/release_60))
 - CMake (cmake version 3.12.4)
 - Docker Compose (docker-compose version 1.22.0, build f46880fe)
 - Docker (Docker version 3.0.8, build 2355349d)

--- a/images/linux/scripts/installers/clang.sh
+++ b/images/linux/scripts/installers/clang.sh
@@ -28,4 +28,4 @@ done
 
 # Document what was added to the image
 echo "Lastly, documenting what we added to the metadata file"
-DocumentInstalledItem "Clang 6.0 ($(clang-6.0 --version | head -n 1))"
+DocumentInstalledItem "Clang 6.0 ($(clang-6.0 --version | head -n 1 | sed 's/~/\\~/g'))"


### PR DESCRIPTION
Issue:
https://github.com/actions/virtual-environments/issues/260

Fix:
Escape ~