### PR TITLE
Add ChromeWebDriver env variable on Ubuntu

### DIFF
--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -53,7 +53,7 @@ if ! command -v chromedriver; then
 fi
 
 echo "Lastly, documenting what we added to the metadata file"
-DocumentInstalledItem "Chromedriver ($(chromedriver --version))"
+DocumentInstalledItem "Chromedriver ($(chromedriver --version)); Chrome Driver is available via CHROMEWEBDRIVER environment variable"
 
 # Determine latest selenium standalone server version
 SELENIUM_LATEST_VERSION_URL=https://api.github.com/repos/SeleniumHQ/selenium/releases/latest

--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -43,7 +43,7 @@ CHROMEDRIVER_BIN="/usr/bin/chromedriver"
 mv "chromedriver" $CHROMEDRIVER_BIN
 chown root:root $CHROMEDRIVER_BIN
 chmod +x $CHROMEDRIVER_BIN
-echo "ChromeWebDriver=$CHROMEDRIVER_BIN" | tee -a /etc/environment
+echo "CHROMEWEBDRIVER=$CHROMEDRIVER_BIN" | tee -a /etc/environment
 
 # Run tests to determine that the chromedriver installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"

--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -41,9 +41,9 @@ rm chromedriver_linux64.zip
 
 CHROMEDRIVER_BIN="/usr/bin/chromedriver"
 mv "chromedriver" $CHROMEDRIVER_BIN
-echo "ChromeWebDriver=$CHROMEDRIVER_BIN" | tee -a /etc/environment
 chown root:root $CHROMEDRIVER_BIN
 chmod +x $CHROMEDRIVER_BIN
+echo "ChromeWebDriver=$CHROMEDRIVER_BIN" | tee -a /etc/environment
 
 # Run tests to determine that the chromedriver installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"

--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -41,6 +41,7 @@ rm chromedriver_linux64.zip
 
 CHROMEDRIVER_BIN="/usr/bin/chromedriver"
 mv "chromedriver" $CHROMEDRIVER_BIN
+echo "ChromeWebDriver=$CHROMEDRIVER_BIN" | tee -a /etc/environment
 chown root:root $CHROMEDRIVER_BIN
 chmod +x $CHROMEDRIVER_BIN
 


### PR DESCRIPTION
In scope of this Pull Request we've fixed [this bug](https://github.com/actions/virtual-environments/issues/262)