### PR TITLE
macOS 10.15 software updates week 3

### DIFF
--- a/images/macos/macos-10.15-Readme.md
+++ b/images/macos/macos-10.15-Readme.md
@@ -5,7 +5,7 @@ date: Week 3
 ---
 
 #### ⚠️ We are going to change default Xcode to 11.3.1 in two weeks.
-
+#### Xcode 11.2.1 set by default
 ## Operating System
 
 - OS X 10.15.2 (19C57) **Catalina**

--- a/images/macos/macos-10.15-Readme.md
+++ b/images/macos/macos-10.15-Readme.md
@@ -65,20 +65,20 @@ date: Week 3
 - ChromeDriver 79.0.3945.36
 
 ### Toolcache
-#### Ruby (available through the [Use Ruby Version](https://go.microsoft.com/fwlink/?linkid=2005989) task)
+#### Ruby
 - 2.4.9
 - 2.5.7
 - 2.6.5
 - 2.7.0
 
-#### Python (available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task)
+#### Python
 - 2.7.17
 - 3.5.9
 - 3.6.10
 - 3.7.6
 - 3.8.1
 
-#### PyPy (available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task)
+#### PyPy
 - 2.7.13
 - 3.6.9
 

--- a/images/macos/macos-10.15-Readme.md
+++ b/images/macos/macos-10.15-Readme.md
@@ -1,258 +1,231 @@
 ---
 title: GitHub Hosted Github Mojave 10.15 VM Image Updates
 description: Software used on build machines
-date: Week 2
+date: Week 3
 ---
 
-#### Xcode 11.2.1 set by default
+#### ⚠️ We are going to change default Xcode to 11.3.1 in two weeks.
 
 ## Operating System
 
 - OS X 10.15.2 (19C57) **Catalina**
 
 ## Installed Software
-
 ### Language and Runtime
-
-- Java 1.7 : OpenJDK Runtime Environment (Zulu 7.34.0.5-CA-macosx) (build 1.7.0_242-b7)
-- Java 1.8 : OpenJDK Runtime Environment (Zulu 8.42.0.23-CA-macosx) (build 1.8.0_232-b18) (default)
-- Java 11 : OpenJDK Runtime Environment Zulu11.35+15-CA (build 11.0.5+10-LTS)
-- Java 12 : OpenJDK Runtime Environment Zulu12.3+11-CA (build 12.0.2+3)
-- Java 13 : OpenJDK Runtime Environment Zulu13.28+11-CA (build 13.0.1+10-MTS)
-- Node.js v12.14.0
+- Java 1.7: (Zulu 7.34.0.5-CA-macosx) (build 1.7.0_242-b7)
+- Java 1.8: (Zulu 8.42.0.23-CA-macosx) (build 1.8.0_232-b18) (default)
+- Java 11: Zulu11.35+15-CA (build 11.0.5+10-LTS)
+- Java 12: Zulu12.3+11-CA (build 12.0.2+3)
+- Java 13: Zulu13.28+11-CA (build 13.0.1+10-MTS)
+- Node.js v12.14.1
 - NVM 0.33.11
-- NVM - Installed node versions:
-  v6.17.1  *
-  v8.17.0  *
-  v10.18.0 *
-  v12.14.0 *
-  v13.5.0  *
+- NVM - Cached node versions: v6.17.1 v8.17.0 v10.18.1 v12.14.1 v13.6.0
 - PowerShell 6.2.3
 - Python 2.7.17
 - Python 3.7.6
-- Ruby -2.6.5p114
-- .NET SDK 2.0.0 3.0.100 3.0.101
-- Go 1.13.5
+- Ruby 2.6.5p114
+- .NET SDK 2.0.0 3.0.100 3.0.101 3.0.102 3.1.100 3.1.101
+- Go 1.13.6
 
 ### Package Management
-
-- Bundler 2.1.3
+- Bundler version 2.1.4
 - Carthage 0.34.0
 - CocoaPods 1.8.4
 - Homebrew 2.2.2
 - NPM 6.13.4
 - Yarn 1.21.1
 - NuGet 5.3.1.6268
-- pip 19.3.1
+- Pip 19.3.1 (python 2.7)
+- Pip 19.3.1 (python 3.7)
 - Miniconda 4.7.12
 
 ### Project Management
-
 - Apache Maven 3.6.3
 - Gradle 6.0.1
 
 ### Utilities
-
-- curl 7.67.0 (x86_64-apple-darwin19.0.0) libcurl/7.67.0 SecureTransport zlib/1.2.11
-- Git 2.24.1
-- Git LFS: git-lfs/2.9.2 (GitHub; darwin amd64; go 1.13.5)
+- Curl 7.68.0
+- Git: 2.25.0
+- Git LFS: 2.9.2
 - GNU Wget 1.20.3
 - Subversion (SVN) 1.13.0
 - GNU parallel 20191222
+- OpenSSL 1.0.2t  10 Sep 2019
+- jq 1.6
+- gpg (GnuPG) 2.2.19
 
 ### Tools
-
-- fastlane 2.139.0
+- Fastlane 2.140.0
+- Cmake 3.16.2
 - App Center CLI 2.3.3
-- Azure-Cli 2.0.78
-- CMake 3.16.2
-
-### Pre-cached tools
-
-- Python
-  - 2.7.16
-  - 3.5.7
-  - 3.6.9
-  - 3.7.4
-  - 3.8.0
-  - pypy2
-  - pypy3
-- Ruby
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
+- Azure CLI 2.0.80
 
 ### Browsers
-- Google Chrome 79.0.3945.88
+- Google Chrome 79.0.3945.117 
 - ChromeDriver 79.0.3945.36
 
+### Toolcache
+#### Ruby (available through the [Use Ruby Version](https://go.microsoft.com/fwlink/?linkid=2005989) task)
+- 2.4.9
+- 2.5.7
+- 2.6.5
+- 2.7.0
+
+#### Python (available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task)
+- 2.7.17
+- 3.5.9
+- 3.6.10
+- 3.7.6
+- 3.8.1
+
+#### PyPy (available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task)
+- 2.7.13
+- 3.6.9
+
+### Xamarin
+#### Visual Studio for Mac
+- 8.4.0.2657
+
+#### Mono
+- 6.6.0.155
+- 6.4.0.208
+
+#### Xamarin.iOS
+- 13.8.3.0
+- 13.6.0.12
+- 13.4.0.2
+
+#### Xamarin.Mac
+- 6.8.3.0
+- 6.6.0.12
+- 6.4.0.2
+
+#### Xamarin.Android
+- 10.1.1
+- 10.0.6
+
+#### Unit Test Framework
+- NUnit 3.6.1
+
 ### Xcode
+| Version                        | Build                          | Path                           |
+| ------------------------------ | ------------------------------ | ------------------------------ |
+| 11.3                           | 11C29                          | /Applications/Xcode_11.3.app   |
+| 11.2.1                         | 11B500                         | /Applications/Xcode_11.2.1.app |
+| 11.2                           | 11B52                          | /Applications/Xcode_11.2.app   |
+| 11.1                           | 11A1027                        | /Applications/Xcode_11.1.app   |
+| 11.0                           | 11A420a                        | /Applications/Xcode_11.app     |
 
-| Version                | Build   | Path                             |
-|------------------------|---------|----------------------------------|
-| 11.3                   | 11C29   | /Applications/Xcode_11.3.app     |
-| 11.2.1                 | 11B53   | /Applications/Xcode_11.2.1.app   |
-| 11.2                   | 11B52   | /Applications/Xcode_11.2.app     |
-| 11.1                   | 11A1027 | /Applications/Xcode_11.1.app     |
-| 11.0                   | 11A420a | /Applications/Xcode_11.app       |
-
-
-### Xcode Support Tools
-
+#### Xcode Support Tools
 - Nomad CLI 3.0.6
-- Nomad CLI IPA 0.14.3
+- Nomad CLI IPA ipa 0.14.3
 - xcpretty 0.3.0
 - xctool 0.3.7
 - xcversion 2.6.3
 
-### Installed SDKs
+#### Installed SDKs
+| SDK                            | SDK Name                       | Xcode Version                  |
+| ------------------------------ | ------------------------------ | ------------------------------ |
+| macOS 10.15                    | macosx10.15                    | 11.0, 11.1, 11.2, 11.2.1, 11.3 |
+| iOS 13.0                       | iphoneos13.0                   | 11.0                           |
+| iOS 13.1                       | iphoneos13.1                   | 11.1                           |
+| iOS 13.2                       | iphoneos13.2                   | 11.2, 11.2.1, 11.3             |
+| Simulator - iOS 13.0           | iphonesimulator13.0            | 11.0                           |
+| Simulator - iOS 13.1           | iphonesimulator13.1            | 11.1                           |
+| Simulator - iOS 13.2           | iphonesimulator13.2            | 11.2, 11.2.1, 11.3             |
+| tvOS 13.0                      | appletvos13.0                  | 11.0, 11.1                     |
+| tvOS 13.2                      | appletvos13.2                  | 11.2, 11.2.1, 11.3             |
+| Simulator - tvOS 13.0          | appletvsimulator13.0           | 11.0, 11.1                     |
+| Simulator - tvOS 13.2          | appletvsimulator13.2           | 11.2, 11.2.1, 11.3             |
+| watchOS 6.0                    | watchos6.0                     | 11.0, 11.1                     |
+| watchOS 6.1                    | watchos6.1                     | 11.2, 11.2.1, 11.3             |
+| Simulator - watchOS 6.0        | watchsimulator6.0              | 11.0, 11.1                     |
+| Simulator - watchOS 6.1        | watchsimulator6.1              | 11.2, 11.2.1, 11.3             |
+| DriverKit 19.0                 | driverkit.macosx19.0           | 11.0, 11.1, 11.2, 11.2.1, 11.3 |
 
-| SDK                       | SDK name    |Xcode Version |
-|---------------------------|-------------|--------------|
-| macOS 10.15               | macosx10.15 | 11.0, 11.1, 11.2, 11.2.1, 11.3 |
-| iOS 13.0                  | iphoneos13.0 | 11.0        |
-| iOS 13.1                  | iphoneos13.1 | 11.1        |
-| iOS 13.2                  | iphoneos13.2 | 11.2, 11.2.1, 11.3       |
-| iOS Simulator 13.0        | iphonesimulator13.0 | 11.0     |
-| iOS Simulator 13.1        | iphonesimulator13.1 | 11.1     |
-| iOS Simulator 13.2        | iphonesimulator13.2 | 11.2, 11.2.1, 11.3     |
-| tvOS 13.0                 | appletvos13.0 | 11.0, 11.1     |
-| tvOS 13.2                 | appletvos13.2 | 11.2, 11.2.1   |
-| tvOS Simulator 13.0       | appletvsimulator13.0 | 11.0, 11.1 |
-| tvOS Simulator 13.2       | appletvsimulator13.2 | 11.2, 11.2.1, 11.3    |
-| watchOS 6.0               | watchos6.0 | 11.0, 11.1    |
-| watchOS 6.1               | watchos6.1 | 11.2, 11.2.1, 11.3  |
-| watchOS Simulator 6.0     | watchsimulator6.0 | 11.0, 11.1    |
-| watchOS Simulator 6.1     | watchsimulator6.1 | 11.2, 11.2.1, 11.3  |
-| DriverKit 19.0            | driverkit.macosx19.0 | 11.0, 11.1, 11.2, 11.2.1, 11.3 |
+#### Installed Simulators
+| OS                                                                                                                                                                                                                       | Xcode Version                                                                                                                                                                                                            | Simulators                                                                                                                                                                                                               |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| iOS 13.0                                                                                                                                                                                                                 | 11.0                                                                                                                                                                                                                     | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                          |
+| iOS 13.1                                                                                                                                                                                                                 | 11.1                                                                                                                                                                                                                     | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                          |
+| iOS 13.2                                                                                                                                                                                                                 | 11.2<br>11.2.1                                                                                                                                                                                                           | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad (7th generation)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation) |
+| iOS 13.3                                                                                                                                                                                                                 | 11.3                                                                                                                                                                                                                     | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad (7th generation)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation) |
+| tvOS 13.0                                                                                                                                                                                                                | 11.0<br>11.1                                                                                                                                                                                                             | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                        |
+| tvOS 13.2                                                                                                                                                                                                                | 11.2<br>11.2.1                                                                                                                                                                                                           | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                        |
+| tvOS 13.3                                                                                                                                                                                                                | 11.3                                                                                                                                                                                                                     | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                        |
+| watchOS 6.0                                                                                                                                                                                                              | 11.0<br>11.1                                                                                                                                                                                                             | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                 |
+| watchOS 6.1                                                                                                                                                                                                              | 11.2<br>11.2.1<br>11.3                                                                                                                                                                                                   | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                 |
 
-### Installed Simulators
+### Android
+#### Android SDK Tools
+| Package Name                       | Description                        |
+| ---------------------------------- | ---------------------------------- |
+| tools                              | Android SDK Tools, Revision 26.1.1 |
 
-#### Runtimes
+#### Android SDK Platform-Tools
+| Package Name                                | Description                                 |
+| ------------------------------------------- | ------------------------------------------- |
+| platform-tools                              | Android SDK Platform-Tools, Revision 29.0.5 |
 
-| OS      | Xcode Version                   | Simulators |
-|---------|---------------------------------|------------|
-| iOS 13.0 (17A577a) | 11         | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation) |
-| iOS 13.1 (17A844) | 11.1        | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation) |
-| iOS 13.2 (17B102) <br> iOS 13.3 (17C45) | 11.2, 11.2.1 <br> 11.3 | iPhone 8 <br> iPhone 8 Plus <br> iPhone 11 <br> iPhone 11 Pro <br> iPhone 11 Pro Max <br> iPad Pro (9.7-inch) <br> iPad (7th generation) <br> iPad Pro <br> iPad Pro (12.9-inch) (3rd generation) <br> iPad Air (3rd generation) |
-| tvOS 13.0 (17J559)<br>tvOS 13.2 (17K90)<br>tvOS 13.3 (17K446) | 11.2, 11.2.1<br> 11.3        | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p) |
-| watchOS 6.0 (17R566)<br><br>watchOS 6.1 (17S80)<br>watchOS 6.1.1 (17S445) | 11.0<br>11.1<br>11.2, 11.2.1<br> 11.3     | Apple Watch Series 4 40mm<br>Apple Watch Series 4 44mm<br>Apple Watch Series 5 40mm<br>Apple Watch Series 5 44mm |
+#### Android SDK Platforms
+| Package Name                        | Description                         |
+| ----------------------------------- | ----------------------------------- |
+| android-24                          | Android SDK Platform 24, Revision 2 |
+| android-25                          | Android SDK Platform 25, Revision 3 |
+| android-26                          | Android SDK Platform 26, Revision 2 |
+| android-27                          | Android SDK Platform 27, Revision 3 |
+| android-28                          | Android SDK Platform 28, Revision 6 |
+| android-29                          | Android SDK Platform 29, Revision 4 |
 
+#### Android SDK Build-Tools
+| Package Name                             | Description                              |
+| ---------------------------------------- | ---------------------------------------- |
+| build-tools-24.0.0                       | Android SDK Build-Tools, Revision 24.0.0 |
+| build-tools-24.0.1                       | Android SDK Build-Tools, Revision 24.0.1 |
+| build-tools-24.0.2                       | Android SDK Build-Tools, Revision 24.0.2 |
+| build-tools-24.0.3                       | Android SDK Build-Tools, Revision 24.0.3 |
+| build-tools-25.0.0                       | Android SDK Build-Tools, Revision 25.0.0 |
+| build-tools-25.0.1                       | Android SDK Build-Tools, Revision 25.0.1 |
+| build-tools-25.0.2                       | Android SDK Build-Tools, Revision 25.0.2 |
+| build-tools-25.0.3                       | Android SDK Build-Tools, Revision 25.0.3 |
+| build-tools-26.0.0                       | Android SDK Build-Tools, Revision 26.0.0 |
+| build-tools-26.0.1                       | Android SDK Build-Tools, Revision 26.0.1 |
+| build-tools-26.0.2                       | Android SDK Build-Tools, Revision 26.0.2 |
+| build-tools-26.0.3                       | Android SDK Build-Tools, Revision 26.0.3 |
+| build-tools-27.0.0                       | Android SDK Build-Tools, Revision 27.0.0 |
+| build-tools-27.0.1                       | Android SDK Build-Tools, Revision 27.0.1 |
+| build-tools-27.0.2                       | Android SDK Build-Tools, Revision 27.0.2 |
+| build-tools-27.0.3                       | Android SDK Build-Tools, Revision 27.0.3 |
+| build-tools-28.0.0                       | Android SDK Build-Tools, Revision 28.0.0 |
+| build-tools-28.0.1                       | Android SDK Build-Tools, Revision 28.0.1 |
+| build-tools-28.0.2                       | Android SDK Build-Tools, Revision 28.0.2 |
+| build-tools-28.0.3                       | Android SDK Build-Tools, Revision 28.0.3 |
+| build-tools-29.0.0                       | Android SDK Build-Tools, Revision 29.0.0 |
+| build-tools-29.0.1                       | Android SDK Build-Tools, Revision 29.0.1 |
+| build-tools-29.0.2                       | Android SDK Build-Tools, Revision 29.0.2 |
 
-### Device Pairs
+#### Android Utils
+| Package Name     | Version          |
+| ---------------- | ---------------- |
+| cmake            | 3.6.4111459      |
+| lldb             | 3.1.4508709      |
+| ndk-bundle       | 18.1.5063045     |
+| Android Emulator | 29.3.4           |
 
-| Watch                       | Phone             |
-|-----------------------------|-------------------|
-| Apple Watch Series 5 - 40mm | iPhone 11 Pro     |
-| Apple Watch Series 5 - 44mm | iPhone 11 Pro Max |
+#### Android Google APIs
+| Package Name                | Description                 |
+| --------------------------- | --------------------------- |
+| addon-google_apis-google-21 | Google APIs, Revision 1     |
+| addon-google_apis-google-22 | Google APIs, Revision 1     |
+| addon-google_apis-google-23 | Google APIs, Revision 1     |
+| addon-google_apis-google-24 | Google APIs, Revision 1     |
 
-## Android
-
-### Android SDK Tools
-
-| Package name          | Description                                 |
-|-----------------------|---------------------------------------------|
-| tools                 | Android SDK Tools, revision 26.1.1          |
-
-### Android SDK Platform-tools
-
-| Package name          | Description                                 |
-|-----------------------|---------------------------------------------|
-| platform-tools        | Android SDK Platform-tools, revision 29.0.5 |
-
-### Android SDK Platforms
-
-| Package name          | Description                               |
-|-----------------------|-------------------------------------------|
-| android-24            | Android SDK Platform 24, Revision 2       |
-| android-25            | Android SDK Platform 25, Revision 3       |
-| android-26            | Android SDK Platform 26, Revision 2       |
-| android-27            | Android SDK Platform 27, Revision 3       |
-| android-28            | Android SDK Platform 28, Revision 6       |
-| android-29            | Android SDK Platform 29, Revision 4       |
-
-### Android SDK Build-tools
-
-| Package name          | Description                               |
-|-----------------------|-------------------------------------------|
-| build-tools-24.0.0    | Android SDK Build-tools, Revision 24.0.0  |
-| build-tools-24.0.1    | Android SDK Build-tools, Revision 24.0.1  |
-| build-tools-24.0.2    | Android SDK Build-tools, Revision 24.0.2  |
-| build-tools-24.0.3    | Android SDK Build-tools, Revision 24.0.3  |
-| build-tools-25.0.0    | Android SDK Build-tools, Revision 25.0.0  |
-| build-tools-25.0.1    | Android SDK Build-tools, Revision 25.0.1  |
-| build-tools-25.0.2    | Android SDK Build-tools, Revision 25.0.2  |
-| build-tools-25.0.3    | Android SDK Build-tools, Revision 25.0.3  |
-| build-tools-26.0.0    | Android SDK Build-tools, Revision 26.0.0  |
-| build-tools-26.0.1    | Android SDK Build-tools, Revision 26.0.1  |
-| build-tools-26.0.2    | Android SDK Build-tools, Revision 26.0.2  |
-| build-tools-26.0.3    | Android SDK Build-tools, Revision 26.0.3  |
-| build-tools-27.0.0    | Android SDK Build-tools, Revision 27.0.0  |
-| build-tools-27.0.1    | Android SDK Build-tools, Revision 27.0.1  |
-| build-tools-27.0.2    | Android SDK Build-tools, Revision 27.0.2  |
-| build-tools-27.0.3    | Android SDK Build-tools, Revision 27.0.3  |
-| build-tools-28.0.0    | Android SDK Build-tools, Revision 28.0.0  |
-| build-tools-28.0.1    | Android SDK Build-tools, Revision 28.0.1  |
-| build-tools-28.0.2    | Android SDK Build-tools, Revision 28.0.2  |
-| build-tools-28.0.3    | Android SDK Build-tools, Revision 28.0.3  |
-| build-tools-29.0.0    | Android SDK Build-tools, Revision 29.0.0  |
-| build-tools-29.0.1    | Android SDK Build-tools, Revision 29.0.1  |
-| build-tools-29.0.2    | Android SDK Build-tools, Revision 29.0.2  |
-
-### Utils
-
-| Package name          | Description                               |
-|-----------------------|-------------------------------------------|
-| cmake                 | 3.15.5                                    |
-| lldb                  | 2.3.3614996                               |
-| ndk-bundle            | 18.1.5063045                              |
-| ProGuard              | 5.3.3                                     |
-| Android Emulator      | 29.3.2                                    |
-
-### Google APIs
-
-| Package name          | Description                               |
-|-----------------------|-------------------------------------------|
-| google_apis-google-21 | Google APIs, Android API 21, revision 1   |
-| google_apis-google-22 | Google APIs, Android API 22, revision 1   |
-| google_apis-google-23 | Google APIs, Android API 23, revision 1   |
-| google_apis-google-24 | Google APIs, Android API 24, revision 1   |
-
-### Extra packages
-
-| Package name                      | Description                              |
-|-----------------------------------|------------------------------------------|
-| extra-android-m2repository        | Android Support Repository, revision 47  |
-| extra-google-google_play_services | Google Play services, revision 49        |
-| extra-google-m2repository         | Google Repository, revision 58           |
-| Hardware_Accelerated_Execution_Manager | Intel x86 Emulator Accelerator 7.3.2 |
-
-## Xamarin
-
-### Visual Studio for Mac
-
-- 8.3.11.1
+#### Extra Packages
+| Package Name                                    | Version                                         |
+| ----------------------------------------------- | ----------------------------------------------- |
+| Android Support Repository                      | 47.0.0                                          |
+| Google Play services                            | 49                                              |
+| Google Repository                               | 58                                              |
+| Intel x86 Emulator Accelerator (HAXM installer) | 7.5.1                                           |
 
 
-### Mono
-
-- 6.4.0
-
-### Xamarin.iOS SDK
-
-- 13.6.0.12
-- 13.4.0.2
-
-### Xamarin.Android SDK
-
-- 10.0.6.2
-- 10.0.3.0
-
-### Xamarin.Mac SDK
-
-- 6.6.0.12
-- 6.4.0.2
-
-### Unit Test Framework
-
-- NUnit: 3.6.1


### PR DESCRIPTION
Software updates:
- Node.js v12.14.1
- NVM v8.17.0 *,v10.18.0 *,v12.14.0
- .NET SDK  3.1.100 3.1.101
- Go 1.13.6
- Bundler version 2.1.4
- Curl 7.68.0
- Git: 2.25.0
- gpg (GnuPG) 2.2.19
- Fastlane 2.140.0
- Azure CLI 2.0.80
- Google Chrome 79.0.3945.117 
- ChromeDriver 79.0.3945.36
- macOS toolcache Python 2.7.17 3.5.9 3.6.10 3.7.6 3.8.1
- macOS toolcache Ruby 2.4.9 2.5.7 2.6.5
- Android Emulator 29.3.4  

Xamarin:
- Visual Studio for Mac 8.4.0.2657
- Mono 6.6.0.155
- Xamarin.iOS 13.8.3.0
- Xamarin.Mac 6.8.3.0
- Xamarin.Android 10.1.1
