### PR TITLE
Update Install-DACFx.ps1

### DIFF
--- a/images/win/scripts/Installers/Install-DACFx.ps1
+++ b/images/win/scripts/Installers/Install-DACFx.ps1
@@ -5,6 +5,7 @@
 
 Import-Module -Name ImageHelpers -Force
 
-$exitcode = Install-MSI -MsiUrl "https://download.microsoft.com/download/f/1/9/f19eaee6-0728-4a0b-9755-9808acc8af0b/EN/x64/DacFramework.msi" -MsiName "DacFramework.msi"
+# DacFx version 18.4.1
+$exitcode = Install-MSI -MsiUrl "https://download.microsoft.com/download/0/9/6/096a3fac-40ec-4dee-ae9d-6fc0fb3cfa81/x64/DacFramework.msi" -MsiName "DacFramework.msi"
 
 exit $exitcode


### PR DESCRIPTION
Update DacFx (sqlpackage.exe) to version 18.4.1. The installation link can be found here: https://docs.microsoft.com/en-us/sql/tools/sqlpackage-download?view=sql-server-ver15 . The link mentioned in the doc is a forward link. To get the actual download link, I ran this in powershell:

`
$a = wget https://go.microsoft.com/fwlink/?linkid=2113703 -MaximumRedirection 0 -PassThru
$a.headers.location
`