### PR TITLE
Include ghc version 8.8.2

### DIFF
--- a/images/linux/scripts/installers/haskell.sh
+++ b/images/linux/scripts/installers/haskell.sh
@@ -24,6 +24,7 @@ apt-get install -y \
     ghc-8.6.4 \
     ghc-8.6.5 \
     ghc-8.8.1 \
+    ghc-8.8.2 \
     cabal-install-2.0 \
     cabal-install-2.2 \
     cabal-install-2.4 \
@@ -35,7 +36,7 @@ curl -sSL https://raw.githubusercontent.com/commercialhaskell/stack/v2.1.3/etc/s
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
 # Check all ghc versions
-for version in 8.0.2 8.2.2 8.4.4 8.6.2 8.6.3 8.6.4 8.6.5 8.8.1; do
+for version in 8.0.2 8.2.2 8.4.4 8.6.2 8.6.3 8.6.4 8.6.5 8.8.1 8.8.2; do
     if ! command -v /opt/ghc/$version/bin/ghc; then
         echo "ghc $version was not installed"
         exit 1
@@ -58,7 +59,7 @@ echo "Lastly, documenting what we added to the metadata file"
 for version in 2.0 2.2 2.4 3.0; do
     DocumentInstalledItem "Haskell Cabal ($(/opt/cabal/$version/bin/cabal --version))"
 done
-for version in 8.0.2 8.2.2 8.4.4 8.6.2 8.6.3 8.6.4 8.6.5 8.8.1; do
+for version in 8.0.2 8.2.2 8.4.4 8.6.2 8.6.3 8.6.4 8.6.5 8.8.1 8.8.2; do
     DocumentInstalledItem "GHC ($(/opt/ghc/$version/bin/ghc --version))"
 done
 DocumentInstalledItem "Haskell Stack ($(stack --version))"


### PR DESCRIPTION
Fixes https://github.com/actions/setup-haskell/issues/6 by adding [GHC 8.8.2](https://www.haskell.org/ghc/blog/20200116-ghc-8.8.2-released.html) to the virtual environment so that https://github.com/actions/setup-haskell can select this version.