### PR TITLE
Put necessary directories to the PATH

### DIFF
--- a/images/win/scripts/Installers/Install-Git.ps1
+++ b/images/win/scripts/Installers/Install-Git.ps1
@@ -12,4 +12,6 @@ choco install git -y --package-parameters="/GitAndUnixToolsOnPath /WindowsTermin
 # Disable GCM machine-wide
 [Environment]::SetEnvironmentVariable("GCM_INTERACTIVE", "Never", [System.EnvironmentVariableTarget]::Machine)
 
+Add-MachinePathItem "C:\Program Files\Git\bin"
+
 exit 0


### PR DESCRIPTION
In #211  the `C:\Program Files\Git\bin` was removed from the `PATH`. This folder contains a lot of bash tools such as `find` and its removing makes all these tools unreachable from `bash`(#263 ). 

Despite the assumption that `choco` must add this folder t the `PATH` while installing `git` - it was not done automatically so we have to add this folder to `PATH` manually.