### PR TITLE
macOS 10.15 software updates week 4

### DIFF
--- a/images/macos/macos-10.15-Readme.md
+++ b/images/macos/macos-10.15-Readme.md
@@ -1,10 +1,10 @@
 ---
 title: GitHub Hosted Github Mojave 10.15 VM Image Updates
 description: Software used on build machines
-date: Week 3
+date: Week 4
 ---
 
-#### ⚠️ We are going to change default Xcode to 11.3.1 in two weeks.
+#### ⚠️ We are going to change the default Xcode to 11.3.1 next week.
 #### Xcode 11.2.1 set by default
 ## Operating System
 
@@ -12,11 +12,11 @@ date: Week 3
 
 ## Installed Software
 ### Language and Runtime
-- Java 1.7: (Zulu 7.34.0.5-CA-macosx) (build 1.7.0_242-b7)
-- Java 1.8: (Zulu 8.42.0.23-CA-macosx) (build 1.8.0_232-b18) (default)
-- Java 11: Zulu11.35+15-CA (build 11.0.5+10-LTS)
+- Java 1.7: (Zulu 7.36.0.5-CA-macosx) (build 1.7.0_252-b10)
+- Java 1.8: (Zulu 8.44.0.9-CA-macosx) (build 1.8.0_242-b20) (default)
+- Java 11: Zulu11.37+17-CA (build 11.0.6+10-LTS)
 - Java 12: Zulu12.3+11-CA (build 12.0.2+3)
-- Java 13: Zulu13.28+11-CA (build 13.0.1+10-MTS)
+- Java 13: Zulu13.29+9-CA (build 13.0.2+6-MTS)
 - Node.js v12.14.1
 - NVM 0.33.11
 - NVM - Cached node versions: v6.17.1 v8.17.0 v10.18.1 v12.14.1 v13.6.0
@@ -24,6 +24,7 @@ date: Week 3
 - Python 2.7.17
 - Python 3.7.6
 - Ruby 2.6.5p114
+- Rust 1.40.0
 - .NET SDK 2.0.0 3.0.100 3.0.101 3.0.102 3.1.100 3.1.101
 - Go 1.13.6
 
@@ -31,17 +32,19 @@ date: Week 3
 - Bundler version 2.1.4
 - Carthage 0.34.0
 - CocoaPods 1.8.4
-- Homebrew 2.2.2
+- Homebrew 2.2.4
 - NPM 6.13.4
 - Yarn 1.21.1
 - NuGet 5.3.1.6268
 - Pip 19.3.1 (python 2.7)
 - Pip 19.3.1 (python 3.7)
+- Rustup 1.21.1
 - Miniconda 4.7.12
+- RubyGems 3.1.2
 
 ### Project Management
 - Apache Maven 3.6.3
-- Gradle 6.0.1
+- Gradle 6.1
 
 ### Utilities
 - Curl 7.68.0
@@ -61,7 +64,7 @@ date: Week 3
 - Azure CLI 2.0.80
 
 ### Browsers
-- Google Chrome 79.0.3945.117 
+- Google Chrome 79.0.3945.130
 - ChromeDriver 79.0.3945.36
 
 ### Toolcache
@@ -84,24 +87,26 @@ date: Week 3
 
 ### Xamarin
 #### Visual Studio for Mac
-- 8.4.0.2657
+- 8.4.1.4
 
 #### Mono
 - 6.6.0.155
 - 6.4.0.208
 
 #### Xamarin.iOS
+- 13.10.0.17
 - 13.8.3.0
 - 13.6.0.12
 - 13.4.0.2
 
 #### Xamarin.Mac
+- 6.10.0.17
 - 6.8.3.0
 - 6.6.0.12
 - 6.4.0.2
 
 #### Xamarin.Android
-- 10.1.1
+- 10.1.3
 - 10.0.6
 
 #### Unit Test Framework
@@ -110,6 +115,7 @@ date: Week 3
 ### Xcode
 | Version                        | Build                          | Path                           |
 | ------------------------------ | ------------------------------ | ------------------------------ |
+| 11.3.1                         | 11C505                         | /Applications/Xcode_11.3.1.app |
 | 11.3                           | 11C29                          | /Applications/Xcode_11.3.app   |
 | 11.2.1                         | 11B500                         | /Applications/Xcode_11.2.1.app |
 | 11.2                           | 11B52                          | /Applications/Xcode_11.2.app   |
@@ -117,31 +123,31 @@ date: Week 3
 | 11.0                           | 11A420a                        | /Applications/Xcode_11.app     |
 
 #### Xcode Support Tools
-- Nomad CLI 3.0.6
+- Nomad CLI 3.1.2
 - Nomad CLI IPA ipa 0.14.3
 - xcpretty 0.3.0
 - xctool 0.3.7
 - xcversion 2.6.3
 
 #### Installed SDKs
-| SDK                            | SDK Name                       | Xcode Version                  |
-| ------------------------------ | ------------------------------ | ------------------------------ |
-| macOS 10.15                    | macosx10.15                    | 11.0, 11.1, 11.2, 11.2.1, 11.3 |
-| iOS 13.0                       | iphoneos13.0                   | 11.0                           |
-| iOS 13.1                       | iphoneos13.1                   | 11.1                           |
-| iOS 13.2                       | iphoneos13.2                   | 11.2, 11.2.1, 11.3             |
-| Simulator - iOS 13.0           | iphonesimulator13.0            | 11.0                           |
-| Simulator - iOS 13.1           | iphonesimulator13.1            | 11.1                           |
-| Simulator - iOS 13.2           | iphonesimulator13.2            | 11.2, 11.2.1, 11.3             |
-| tvOS 13.0                      | appletvos13.0                  | 11.0, 11.1                     |
-| tvOS 13.2                      | appletvos13.2                  | 11.2, 11.2.1, 11.3             |
-| Simulator - tvOS 13.0          | appletvsimulator13.0           | 11.0, 11.1                     |
-| Simulator - tvOS 13.2          | appletvsimulator13.2           | 11.2, 11.2.1, 11.3             |
-| watchOS 6.0                    | watchos6.0                     | 11.0, 11.1                     |
-| watchOS 6.1                    | watchos6.1                     | 11.2, 11.2.1, 11.3             |
-| Simulator - watchOS 6.0        | watchsimulator6.0              | 11.0, 11.1                     |
-| Simulator - watchOS 6.1        | watchsimulator6.1              | 11.2, 11.2.1, 11.3             |
-| DriverKit 19.0                 | driverkit.macosx19.0           | 11.0, 11.1, 11.2, 11.2.1, 11.3 |
+| SDK                                    | SDK Name                               | Xcode Version                          |
+| -------------------------------------- | -------------------------------------- | -------------------------------------- |
+| macOS 10.15                            | macosx10.15                            | 11.0, 11.1, 11.2, 11.2.1, 11.3, 11.3.1 |
+| iOS 13.0                               | iphoneos13.0                           | 11.0                                   |
+| iOS 13.1                               | iphoneos13.1                           | 11.1                                   |
+| iOS 13.2                               | iphoneos13.2                           | 11.2, 11.2.1, 11.3, 11.3.1             |
+| Simulator - iOS 13.0                   | iphonesimulator13.0                    | 11.0                                   |
+| Simulator - iOS 13.1                   | iphonesimulator13.1                    | 11.1                                   |
+| Simulator - iOS 13.2                   | iphonesimulator13.2                    | 11.2, 11.2.1, 11.3, 11.3.1             |
+| tvOS 13.0                              | appletvos13.0                          | 11.0, 11.1                             |
+| tvOS 13.2                              | appletvos13.2                          | 11.2, 11.2.1, 11.3, 11.3.1             |
+| Simulator - tvOS 13.0                  | appletvsimulator13.0                   | 11.0, 11.1                             |
+| Simulator - tvOS 13.2                  | appletvsimulator13.2                   | 11.2, 11.2.1, 11.3, 11.3.1             |
+| watchOS 6.0                            | watchos6.0                             | 11.0, 11.1                             |
+| watchOS 6.1                            | watchos6.1                             | 11.2, 11.2.1, 11.3, 11.3.1             |
+| Simulator - watchOS 6.0                | watchsimulator6.0                      | 11.0, 11.1                             |
+| Simulator - watchOS 6.1                | watchsimulator6.1                      | 11.2, 11.2.1, 11.3, 11.3.1             |
+| DriverKit 19.0                         | driverkit.macosx19.0                   | 11.0, 11.1, 11.2, 11.2.1, 11.3, 11.3.1 |
 
 #### Installed Simulators
 | OS                                                                                                                                                                                                                       | Xcode Version                                                                                                                                                                                                            | Simulators                                                                                                                                                                                                               |
@@ -149,12 +155,12 @@ date: Week 3
 | iOS 13.0                                                                                                                                                                                                                 | 11.0                                                                                                                                                                                                                     | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                          |
 | iOS 13.1                                                                                                                                                                                                                 | 11.1                                                                                                                                                                                                                     | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                          |
 | iOS 13.2                                                                                                                                                                                                                 | 11.2<br>11.2.1                                                                                                                                                                                                           | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad (7th generation)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation) |
-| iOS 13.3                                                                                                                                                                                                                 | 11.3                                                                                                                                                                                                                     | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad (7th generation)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation) |
+| iOS 13.3                                                                                                                                                                                                                 | 11.3<br>11.3.1                                                                                                                                                                                                           | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad (7th generation)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation) |
 | tvOS 13.0                                                                                                                                                                                                                | 11.0<br>11.1                                                                                                                                                                                                             | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                        |
 | tvOS 13.2                                                                                                                                                                                                                | 11.2<br>11.2.1                                                                                                                                                                                                           | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                        |
-| tvOS 13.3                                                                                                                                                                                                                | 11.3                                                                                                                                                                                                                     | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                        |
+| tvOS 13.3                                                                                                                                                                                                                | 11.3<br>11.3.1                                                                                                                                                                                                           | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                        |
 | watchOS 6.0                                                                                                                                                                                                              | 11.0<br>11.1                                                                                                                                                                                                             | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                 |
-| watchOS 6.1                                                                                                                                                                                                              | 11.2<br>11.2.1<br>11.3                                                                                                                                                                                                   | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                 |
+| watchOS 6.1                                                                                                                                                                                                              | 11.2<br>11.2.1<br>11.3<br>11.3.1                                                                                                                                                                                         | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                 |
 
 ### Android
 #### Android SDK Tools


### PR DESCRIPTION
### Language and Runtime
- Java 1.7: (Zulu 7.36.0.5-CA-macosx) (build 1.7.0_252-b10)
- Java 1.8: (Zulu 8.44.0.9-CA-macosx) (build 1.8.0_242-b20) (default)
- Java 11: Zulu11.37+17-CA (build 11.0.6+10-LTS)
- Java 13: Zulu13.29+9-CA (build 13.0.2+6-MTS)
- Rust 1.40.0
### Package Management
- Homebrew 2.2.4
- Rustup 1.21.1
- RubyGems 3.1.2
### Project Management
- Gradle 6.1
### Utilities
- Git: 2.25.0
- gpg (GnuPG) 2.2.19
### Tools
- Azure CLI 2.0.80
### Browsers
- Google Chrome 79.0.3945.130 
### Xamarin
#### Visual Studio for Mac
- 8.4.1.4
#### Xamarin.iOS
- 13.10.0.17
#### Xamarin.Mac
- 6.10.0.17
#### Xamarin.Android
- 10.1.3
### Xcode
| Version                        | Build                          | Path                           |
| ------------------------------ | ------------------------------ | ------------------------------ |
| 11.3.1                         | 11C505                         | /Applications/Xcode_11.3.1.app |
#### Xcode Support Tools
- Nomad CLI 3.1.2


