### PR TITLE
Upsize Win19 to 256 GB

### DIFF
--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -38,7 +38,7 @@
             "subscription_id": "{{user `subscription_id`}}",
             "object_id": "{{user `object_id`}}",
             "tenant_id": "{{user `tenant_id`}}",
-            "os_disk_size_gb": "128",
+            "os_disk_size_gb": "256",
             "location": "{{user `location`}}",
             "vm_size": "{{user `vm_size`}}",
             "resource_group_name": "{{user `resource_group`}}",


### PR DESCRIPTION
The Windows Server 2019 has less than 10GB left in C: after the current rollout, we need to increase the disk size.