### PR TITLE
Set a default value for BOOST_ROOT = C:\hostedtoolcache\windows

### DIFF
--- a/images/win/scripts/Installers/Install-Boost.ps1
+++ b/images/win/scripts/Installers/Install-Boost.ps1
@@ -4,7 +4,7 @@
 ##  Desc:  Install boost using tool cache
 ################################################################################
 
-$BoostDirectory = Join-Path -Path "C:\hostedtoolcache\window" -ChildPath "Boost"
+$BoostDirectory = Join-Path -Path "C:\hostedtoolcache\windows" -ChildPath "Boost"
 $BoostVersions = $env:BOOST_VERSIONS.split(',')
 $BoostDefault = $env:BOOST_DEFAULT
 

--- a/images/win/scripts/Installers/Install-Boost.ps1
+++ b/images/win/scripts/Installers/Install-Boost.ps1
@@ -4,7 +4,7 @@
 ##  Desc:  Install boost using tool cache
 ################################################################################
 
-$BoostDirectory = Join-Path -Path "C:\hostedtoolcache\windows" -ChildPath "Boost"
+$BoostDirectory = Join-Path -Path $Env:AGENT_TOOLSDIRECTORY -ChildPath "Boost"
 $BoostVersions = $env:BOOST_VERSIONS.split(',')
 $BoostDefault = $env:BOOST_DEFAULT
 

--- a/images/win/scripts/Installers/Install-Boost.ps1
+++ b/images/win/scripts/Installers/Install-Boost.ps1
@@ -4,7 +4,7 @@
 ##  Desc:  Install boost using tool cache
 ################################################################################
 
-$BoostDirectory = Join-Path -Path $env:ProgramFiles -ChildPath "Boost"
+$BoostDirectory = Join-Path -Path "C:\hostedtoolcache\window" -ChildPath "Boost"
 $BoostVersions = $env:BOOST_VERSIONS.split(',')
 $BoostDefault = $env:BOOST_DEFAULT
 

--- a/images/win/scripts/Installers/Validate-Boost.ps1
+++ b/images/win/scripts/Installers/Validate-Boost.ps1
@@ -54,7 +54,7 @@ $tmplMarkRoot = @"
 
 $SoftwareName = 'Boost'
 $Description = New-Object System.Text.StringBuilder
-$BoostRootDirectory = Join-Path -Path "C:\hostedtoolcache\windows" -ChildPath "Boost"
+$BoostRootDirectory = Join-Path -Path $Env:AGENT_TOOLSDIRECTORY -ChildPath "Boost"
 $BoostVersionsToInstall = $env:BOOST_VERSIONS.split(",")
 
 foreach($Boost in $BoostVersionsToInstall)

--- a/images/win/scripts/Installers/Validate-Boost.ps1
+++ b/images/win/scripts/Installers/Validate-Boost.ps1
@@ -54,7 +54,7 @@ $tmplMarkRoot = @"
 
 $SoftwareName = 'Boost'
 $Description = New-Object System.Text.StringBuilder
-$BoostRootDirectory = Join-Path -Path $env:ProgramFiles -ChildPath "Boost"
+$BoostRootDirectory = Join-Path -Path "C:\hostedtoolcache\window" -ChildPath "Boost"
 $BoostVersionsToInstall = $env:BOOST_VERSIONS.split(",")
 
 foreach($Boost in $BoostVersionsToInstall)

--- a/images/win/scripts/Installers/Validate-Boost.ps1
+++ b/images/win/scripts/Installers/Validate-Boost.ps1
@@ -54,7 +54,7 @@ $tmplMarkRoot = @"
 
 $SoftwareName = 'Boost'
 $Description = New-Object System.Text.StringBuilder
-$BoostRootDirectory = Join-Path -Path "C:\hostedtoolcache\window" -ChildPath "Boost"
+$BoostRootDirectory = Join-Path -Path "C:\hostedtoolcache\windows" -ChildPath "Boost"
 $BoostVersionsToInstall = $env:BOOST_VERSIONS.split(",")
 
 foreach($Boost in $BoostVersionsToInstall)


### PR DESCRIPTION
Issue:
b2.exe tool cannot properly handle with paths containing spaces, by default BOOST_ROOT = C:\Program Files\Boost\

Fix:
Set BOOST_ROOT=$Env:AGENT_TOOLSDIRECTORY(C:\hostedtoolcache\windows\Boost by default)