### PR TITLE
Update docs and pass GitHub token

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Please use the issue templates to submit requests and bug reports related to the
 If you need help with how to set up your workflow file or use a specific tool,
 check out the [GitHub Actions Community Forum](https://github.community/t5/GitHub-Actions/bd-p/actions).
 
+If you need help with how to build VM machine from source code, check out the [documentation](./help/CreateImageAndAzureResources.md).
+
 ## OS's offered
 We currently offer Linux, macOS, and Windows virtual environments:
 

--- a/help/CreateImageAndAzureResources.md
+++ b/help/CreateImageAndAzureResources.md
@@ -1,0 +1,11 @@
+# Build an image.
+
+## Create required Azure resources and generate an image
+
+1. Generating required Azure resources and running a packer build for a targeted image is automated [here](../helpers/GenerateResourcesAndImage.ps1).
+
+## Create a VM based on the template created by Packer
+
+1. At the end of the output from running Packer above is a URL to the VM resource template with a read access token. It ends with `.json` plus a query string. Note this URL. For now, it seems like there is an [Az CLI bug](https://github.com/Azure/azure-cli/issues/5899) with specifying the template through a URI. So download the template locally and note the path of the template file.
+1. Generating the required Azure resources and creating the VM is automated [here](../helpers/CreateAzureVMFromPackerTemplate.ps1).
+1. After the VM is created, remote into it using its public IP address. You can test the installed tools or install the Azure Pipelines agent and connect it to your Azure DevOps organization.

--- a/help/CreateImageAndAzureResources.md
+++ b/help/CreateImageAndAzureResources.md
@@ -8,4 +8,5 @@
 
 1. At the end of the output from running Packer above is a URL to the VM resource template with a read access token. It ends with `.json` plus a query string. Note this URL. For now, it seems like there is an [Az CLI bug](https://github.com/Azure/azure-cli/issues/5899) with specifying the template through a URI. So download the template locally and note the path of the template file.
 1. Generating the required Azure resources and creating the VM is automated [here](../helpers/CreateAzureVMFromPackerTemplate.ps1).
+1. Building VM machines based on packer template is automated [here](../helpers/GenerateResourcesAndImage.ps1).
 1. After the VM is created, remote into it using its public IP address. You can test the installed tools or install the Azure Pipelines agent and connect it to your Azure DevOps organization.

--- a/help/CreateImageAndAzureResources.md
+++ b/help/CreateImageAndAzureResources.md
@@ -8,5 +8,4 @@
 
 1. At the end of the output from running Packer above is a URL to the VM resource template with a read access token. It ends with `.json` plus a query string. Note this URL. For now, it seems like there is an [Az CLI bug](https://github.com/Azure/azure-cli/issues/5899) with specifying the template through a URI. So download the template locally and note the path of the template file.
 1. Generating the required Azure resources and creating the VM is automated [here](../helpers/CreateAzureVMFromPackerTemplate.ps1).
-1. Building VM machines based on packer template is automated [here](../helpers/GenerateResourcesAndImage.ps1).
 1. After the VM is created, remote into it using its public IP address. You can test the installed tools or install the Azure Pipelines agent and connect it to your Azure DevOps organization.

--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -86,10 +86,10 @@ Function GenerateResourcesAndImage {
         [Switch] $Force
     )
 
-    if (([string]::IsNullOrEmpty($version)))
+    if (([string]::IsNullOrEmpty($GithubFeedToken)))
     {
-        Write-Error "You have to specify valid GitHub PAT to dowload tool packages from GitHub Package Registry"
-        exit 0
+        Write-Error "You have to specify valid GitHub PAT to download tool packages from GitHub Package Registry"
+        exit 1
     }
 
     $builderScriptPath = Get-PackerTemplatePath -RepositoryRoot $ImageGenerationRepositoryRoot -ImageType $ImageType

--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -80,7 +80,7 @@ Function GenerateResourcesAndImage {
         [string] $AzureLocation,
         [Parameter(Mandatory = $False)]
         [int] $SecondsToWaitForServicePrincipalSetup = 30,
-        [Parameter(Mandatory = $True)]
+        [Parameter(Mandatory = $False)]
         [string] $GithubFeedToken,
         [Parameter(Mandatory = $False)]
         [Switch] $Force
@@ -88,7 +88,7 @@ Function GenerateResourcesAndImage {
 
     if (([string]::IsNullOrEmpty($GithubFeedToken)))
     {
-        Write-Error "You have to specify valid GitHub PAT to download tool packages from GitHub Package Registry"
+        Write-Error "'-GithubFeedToken' parameter is not specified. You have to specify valid GitHub PAT to download tool packages from GitHub Package Registry"
         exit 1
     }
 


### PR DESCRIPTION
- add docs page for image generation
- help page was moved from [here](https://github.com/microsoft/azure-pipelines-image-generation/blob/master/help/CreateImageAndAzureResources.md) (I think that the file was lost after migration to virtual environments, that is why I returned it back).
- pass GitHub access token to script `helpers/GenerateResourcesAndImage.ps1`