### PR TITLE
Switch Windows hostedtoolcache provisioner to GitHub Actions NPM registry

### DIFF
--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -28,7 +28,7 @@
         "image_version": "dev",
         "github_feed_token": "{{env `GITHUB_FEED_TOKEN`}}"
     },
-    "sensitive-variables": ["install_password", "ssh_password", "client_secret","github_feed_token"],
+    "sensitive-variables": ["install_password", "ssh_password", "client_secret", "github_feed_token"],
     "builders": [
         {
             "name": "vhd",

--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -283,7 +283,7 @@
         },
         {
             "type": "file",
-            "source": "{{template_dir}}/toolcache.json",
+            "source": "{{template_dir}}/toolcache-2016.json",
             "destination": "{{user `root_folder`}}/toolcache.json"
         },
         {
@@ -477,7 +477,7 @@
         {
             "type": "powershell",
             "environment_vars": [
-                "BOOST_VERSIONS=1.69.0",
+                "BOOST_VERSIONS=1.69.0,1.72.0",
                 "BOOST_DEFAULT=1.69.0"
             ],
             "scripts":[

--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -26,6 +26,7 @@
         "install_password": null,
         "capture_name_prefix": "packer",
         "image_version": "dev",
+        "toolcache_config_version": "toolcache-2016",
         "github_feed_token": "{{env `GITHUB_FEED_TOKEN`}}"
     },
     "sensitive-variables": ["install_password", "ssh_password", "client_secret", "github_feed_token"],
@@ -282,15 +283,10 @@
             ]
         },
         {
-            "type": "file",
-            "source": "{{template_dir}}/toolcache-2016.json",
-            "destination": "{{user `root_folder`}}/toolcache.json"
-        },
-        {
             "type": "powershell",
             "environment_vars":[
                 "GITHUB_FEED_TOKEN={{ user `github_feed_token` }}",
-                "ROOT_FOLDER={{user `root_folder`}}"
+                "TOOLCACHE_CONFIG={{ template_dir }}/{{ user `toolcache_config_version` }}.json"
             ],
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Download-ToolCache.ps1"
@@ -581,7 +577,7 @@
         {
             "type": "powershell",
             "environment_vars":[
-                "ROOT_FOLDER={{user `root_folder`}}"
+                "TOOLCACHE_CONFIG={{ template_dir }}/{{ user `toolcache_config_version` }}.json"
             ],
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-ToolCache.ps1"

--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -612,7 +612,7 @@
         {
             "type": "powershell",
             "environment_vars": [
-                "BOOST_VERSIONS=1.69.0",
+                "BOOST_VERSIONS=1.69.0,1.72.0",
                 "BOOST_DEFAULT=1.69.0"
             ],
             "scripts":[

--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -26,7 +26,6 @@
         "install_password": null,
         "capture_name_prefix": "packer",
         "image_version": "dev",
-        "toolcache_config_version": "toolcache-2016",
         "github_feed_token": "{{env `GITHUB_FEED_TOKEN`}}"
     },
     "sensitive-variables": ["install_password", "ssh_password", "client_secret", "github_feed_token"],
@@ -283,10 +282,15 @@
             ]
         },
         {
+            "type": "file",
+            "source": "{{template_dir}}/toolcache-2016.json",
+            "destination": "{{user `root_folder`}}/toolcache.json"
+        },
+        {
             "type": "powershell",
             "environment_vars":[
                 "GITHUB_FEED_TOKEN={{ user `github_feed_token` }}",
-                "TOOLCACHE_CONFIG={{ template_dir }}/{{ user `toolcache_config_version` }}.json"
+                "ROOT_FOLDER={{user `root_folder`}}"
             ],
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Download-ToolCache.ps1"
@@ -577,7 +581,7 @@
         {
             "type": "powershell",
             "environment_vars":[
-                "TOOLCACHE_CONFIG={{ template_dir }}/{{ user `toolcache_config_version` }}.json"
+                "ROOT_FOLDER={{user `root_folder`}}"
             ],
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-ToolCache.ps1"

--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -26,9 +26,9 @@
         "install_password": null,
         "capture_name_prefix": "packer",
         "image_version": "dev",
-        "toolcache_registry": "https://buildcanary.pkgs.visualstudio.com/PipelineCanary/_packaging/hostedtoolcache/npm/registry/"
+        "github_feed_token": "{{env `GITHUB_FEED_TOKEN`}}"
     },
-    "sensitive-variables": ["install_password", "ssh_password", "client_secret"],
+    "sensitive-variables": ["install_password", "ssh_password", "client_secret","github_feed_token"],
     "builders": [
         {
             "name": "vhd",
@@ -289,7 +289,7 @@
         {
             "type": "powershell",
             "environment_vars":[
-                "TOOLCACHE_REGISTRY={{ user `toolcache_registry` }}",
+                "GITHUB_FEED_TOKEN={{ user `github_feed_token` }}",
                 "ROOT_FOLDER={{user `root_folder`}}"
             ],
             "scripts":[

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -581,8 +581,8 @@
         {
             "type": "powershell",
             "environment_vars": [
-                "BOOST_VERSIONS=1.69.0",
-                "BOOST_DEFAULT=1.69.0"
+                "BOOST_VERSIONS=1.69.0,1.72.0",
+                "BOOST_DEFAULT=1.72.0"
             ],
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-Boost.ps1"

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -446,7 +446,7 @@
         {
             "type": "powershell",
             "environment_vars": [
-                "BOOST_VERSIONS=1.72.0",
+                "BOOST_VERSIONS=1.69.0,1.72.0",
                 "BOOST_DEFAULT=1.72.0"
             ],
             "scripts":[

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -26,7 +26,6 @@
         "install_password": null,
         "capture_name_prefix": "packer",
         "image_version": "dev",
-        "toolcache_config_version": "toolcache-2019",
         "github_feed_token": "{{env `GITHUB_FEED_TOKEN`}}"
     },
     "sensitive-variables": ["install_password", "ssh_password", "client_secret", "github_feed_token"],
@@ -252,10 +251,15 @@
             ]
         },
         {
+            "type": "file",
+            "source": "{{template_dir}}/toolcache-2019.json",
+            "destination": "{{user `root_folder`}}/toolcache.json"
+        },
+        {
             "type": "powershell",
             "environment_vars":[
                 "GITHUB_FEED_TOKEN={{ user `github_feed_token` }}",
-                "TOOLCACHE_CONFIG={{ template_dir }}/{{ user `toolcache_config_version` }}.json"
+                "ROOT_FOLDER={{user `root_folder`}}"
             ],
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Download-ToolCache.ps1"
@@ -546,7 +550,7 @@
         {
             "type": "powershell",
             "environment_vars":[
-                "TOOLCACHE_CONFIG={{ template_dir }}/{{ user `toolcache_config_version` }}.json"
+                "ROOT_FOLDER={{user `root_folder`}}"
             ],
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-ToolCache.ps1"

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -26,9 +26,9 @@
         "install_password": null,
         "capture_name_prefix": "packer",
         "image_version": "dev",
-        "toolcache_registry": "https://buildcanary.pkgs.visualstudio.com/PipelineCanary/_packaging/hostedtoolcache/npm/registry/"
+        "github_feed_token": "{{env `GITHUB_FEED_TOKEN`}}"
     },
-    "sensitive-variables": ["install_password", "ssh_password", "client_secret"],
+    "sensitive-variables": ["install_password", "ssh_password", "client_secret", "github_feed_token"],
     "builders": [
         {
             "name": "vhd",
@@ -258,7 +258,7 @@
         {
             "type": "powershell",
             "environment_vars":[
-                "TOOLCACHE_REGISTRY={{ user `toolcache_registry` }}",
+                "GITHUB_FEED_TOKEN={{ user `github_feed_token` }}",
                 "ROOT_FOLDER={{user `root_folder`}}"
             ],
             "scripts":[

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -252,7 +252,7 @@
         },
         {
             "type": "file",
-            "source": "{{template_dir}}/toolcache.json",
+            "source": "{{template_dir}}/toolcache-2019.json",
             "destination": "{{user `root_folder`}}/toolcache.json"
         },
         {
@@ -446,8 +446,8 @@
         {
             "type": "powershell",
             "environment_vars": [
-                "BOOST_VERSIONS=1.69.0",
-                "BOOST_DEFAULT=1.69.0"
+                "BOOST_VERSIONS=1.72.0",
+                "BOOST_DEFAULT=1.72.0"
             ],
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-Boost.ps1"

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -26,6 +26,7 @@
         "install_password": null,
         "capture_name_prefix": "packer",
         "image_version": "dev",
+        "toolcache_config_version": "toolcache-2019",
         "github_feed_token": "{{env `GITHUB_FEED_TOKEN`}}"
     },
     "sensitive-variables": ["install_password", "ssh_password", "client_secret", "github_feed_token"],
@@ -251,15 +252,10 @@
             ]
         },
         {
-            "type": "file",
-            "source": "{{template_dir}}/toolcache-2019.json",
-            "destination": "{{user `root_folder`}}/toolcache.json"
-        },
-        {
             "type": "powershell",
             "environment_vars":[
                 "GITHUB_FEED_TOKEN={{ user `github_feed_token` }}",
-                "ROOT_FOLDER={{user `root_folder`}}"
+                "TOOLCACHE_CONFIG={{ template_dir }}/{{ user `toolcache_config_version` }}.json"
             ],
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Download-ToolCache.ps1"
@@ -550,7 +546,7 @@
         {
             "type": "powershell",
             "environment_vars":[
-                "ROOT_FOLDER={{user `root_folder`}}"
+                "TOOLCACHE_CONFIG={{ template_dir }}/{{ user `toolcache_config_version` }}.json"
             ],
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-ToolCache.ps1"

--- a/images/win/Windows2019-Readme.md
+++ b/images/win/Windows2019-Readme.md
@@ -1,6 +1,6 @@
-# Azure Pipelines Hosted Windows 2019 with VS2019 image
+# Windows Server 2019
 
-The following software is installed on machines in the Azure Pipelines **Hosted Windows 2019 with VS2019** (v20200102.1) pool.
+The following software is installed on machines with the 20200113.1 update.
 
 Components marked with **\*** have been upgraded since the previous version of the image.
 
@@ -309,7 +309,7 @@ _Description:_ .NET has been configured to use TLS 1.2 by default
 
 ## Azure CLI
 
-_Version:_ 2.0.78
+_Version:_ 2.0.80
 _Environment:_
 * PATH: contains location of az.cmd
 
@@ -319,7 +319,11 @@ _Version:_ azure-devops                      0.16.0
 
 ## Python
 
-_Version:_ 2.7.16 (x64)<br/>_Version:_ 2.7.16 (x86)<br/>_Version:_ 3.5.4 (x64)<br/>_Version:_ 3.5.4 (x86)<br/>_Version:_ 3.6.8 (x64)<br/>_Version:_ 3.6.8 (x86)<br/>_Version:_ 3.7.5 (x64)<br/>_Version:_ 3.7.5 (x86)<br/>_Version:_ 3.8.0 (x64)<br/>_Version:_ 3.8.0 (x86)<br/>
+_Version:_ 2.7.17 (x64)<br/>_Version:_ 3.5.4 (x64)<br/>_Version:_ 3.6.8 (x64)<br/>_Version:_ 3.7.6 (x64)<br/>_Version:_ 3.8.1 (x64)<br/>
+
+## Python
+
+_Version:_ 2.7.17 (x64)<br/>_Version:_ 3.5.4 (x64)<br/>_Version:_ 3.6.8 (x64)<br/>_Version:_ 3.7.6 (x64)<br/>_Version:_ 3.8.1 (x64)<br/>_Version:_ 2.7.17 (x86)<br/>_Version:_ 3.5.4 (x86)<br/>_Version:_ 3.6.8 (x86)<br/>_Version:_ 3.7.6 (x86)<br/>_Version:_ 3.8.1 (x86)<br/>
 
 ## PyPy
 
@@ -327,15 +331,15 @@ _Version:_ 2.7.13 (x86)<br/>_Version:_ 3.6.9 (x86)<br/>
 
 ## Ruby
 
-_Version:_ 2.4.6 (x64)<br/>_Version:_ 2.5.5 (x64)<br/>_Version:_ 2.6.3 (x64)<br/>
+_Version:_ 2.4.9 (x64)<br/>_Version:_ 2.5.7 (x64)<br/>_Version:_ 2.6.5 (x64)<br/>_Version:_ 2.7.0 (x64)<br/>
 
 ## Python (64 bit)
 
-#### Python 3.7.5
+#### Python 3.7.6
 _Environment:_
 * PATH: contains location of python.exe
 
-#### Python 2.7.16
+#### Python 2.7.17
 
 _Location:_ C:/hostedtoolcache/windows/Python/2.7*/x64
 
@@ -396,10 +400,10 @@ _Environment:_
 
 ## Ruby (x64)
 
-#### 2.5.5p157
+#### 2.5.7p206
 _Environment:_
-* Location: C:\hostedtoolcache\windows\Ruby\2.5.5\x64\bin
-* PATH: contains the location of ruby.exe version 2.5.5p157
+* Location: C:\hostedtoolcache\windows\Ruby\2.5.7\x64\bin
+* PATH: contains the location of ruby.exe version 2.5.7p206
 
 ## Rust (64-bit)
 
@@ -421,12 +425,12 @@ _Environment:_
 ## Google Chrome
 
 _version:_
-79.0.3945.88
+79.0.3945.117
 
 ## Mozilla Firefox
 
 _version:_
-71.0
+72.0.1
 
 ## Selenium Web Drivers
 
@@ -458,7 +462,7 @@ _Environment:_
 
 ## Node.js
 
-_Version:_ 12.14.0<br/>
+_Version:_ 12.14.1<br/>
 _Architecture:_ x64<br/>
 _Environment:_
 * PATH: contains location of node.exe<br/>
@@ -669,11 +673,11 @@ _Version:_ 5.1.3.0<br/>
 
 ## OpenSSL
 
-_Version:_ 1.1.1d at C:\Program Files\Git\usr\bin\openssl.exe<br/>_Version:_ 1.1.1d at C:\Program Files\Git\mingw64\bin\openssl.exe<br/>_Version:_ 1.0.2j at C:\Program Files (x86)\Subversion\bin\openssl.exe<br/>_Version:_ 1.1.1c at C:\Strawberry\c\bin\openssl.exe<br/>_Version:_ 1.1.1 at C:\Program Files\OpenSSL\bin\openssl.exe<br/>
+_Version:_ 1.1.1d at C:\Program Files\Git\mingw64\bin\openssl.exe<br/>_Version:_ 1.1.1d at C:\Program Files\Git\usr\bin\openssl.exe<br/>_Version:_ 1.0.2j at C:\Program Files (x86)\Subversion\bin\openssl.exe<br/>_Version:_ 1.1.1c at C:\Strawberry\c\bin\openssl.exe<br/>_Version:_ 1.1.1 at C:\Program Files\OpenSSL\bin\openssl.exe<br/>
 
 ## Cloud Foundry CLI
 
-_Version:_ 6.48.0<br/>
+_Version:_ 6.49.0<br/>
 
 ## Vcpkg
 

--- a/images/win/scripts/Installers/Download-ToolCache.ps1
+++ b/images/win/scripts/Installers/Download-ToolCache.ps1
@@ -17,9 +17,9 @@ Function Install-NpmPackage {
 
     npm install $Name
 
-    $exit_code = $LASTEXITCODE
-    if($exit_code -ne 0) {
-        Write-Host "$Name installation failure;  Error:${exit_code}"
+    $exitCode = $LASTEXITCODE
+    if($exitCode -ne 0) {
+        Write-Host "$Name installation failure;  Error:${exitCode}"
 
         exit 1
     }

--- a/images/win/scripts/Installers/Download-ToolCache.ps1
+++ b/images/win/scripts/Installers/Download-ToolCache.ps1
@@ -30,9 +30,13 @@ Function Install-NpmPackage {
 Function NPMFeed-Auth {
     [String] $AccessToken
 
+    Write-Host
     $feedPrefix = "npm.pkg.github.com"
     $npmrcContent = "//${feedPrefix}/:_authToken=${AccessToken}"
     $npmrcContent | Out-File -FilePath "$($env:TEMP)/.npmrc" -Encoding utf8
+
+    Write-Host "Configure npm to use github package registry for '@actions' scope"
+    npm config set @actions:registry "https://${feedPrefix}"
 }
 
 # HostedToolCache Path

--- a/images/win/scripts/Installers/Download-ToolCache.ps1
+++ b/images/win/scripts/Installers/Download-ToolCache.ps1
@@ -30,7 +30,7 @@ Function Install-NpmPackage {
     Pop-Location
 }
 
-Function NPMFeed-Auth {
+Function NPMFeed-AuthSetup {
     param(
         [Parameter(Mandatory=$true)]
         [System.String] $AccessToken,
@@ -61,7 +61,7 @@ setx AGENT_TOOLSDIRECTORY $ToolsDirectory /M
 $ToolVersionsFileContent = Get-Content -Path "$env:ROOT_FOLDER/toolcache.json" -Raw
 $ToolVersions = ConvertFrom-Json -InputObject $ToolVersionsFileContent
 
-NPMFeed-Auth -AccessToken $AccessToken -FeedPrefix $FeedPrefix
+NPMFeed-AuthSetup -AccessToken $AccessToken -FeedPrefix $FeedPrefix
 
 $ToolVersions.PSObject.Properties | ForEach-Object {
     $PackageName = $_.Name

--- a/images/win/scripts/Installers/Download-ToolCache.ps1
+++ b/images/win/scripts/Installers/Download-ToolCache.ps1
@@ -29,14 +29,14 @@ Function Install-NpmPackage {
 
 Function NPMFeed-Auth {
     [String] $AccessToken
-
-    Write-Host
-    $feedPrefix = "npm.pkg.github.com"
-    $npmrcContent = "//${feedPrefix}/:_authToken=${AccessToken}"
-    $npmrcContent | Out-File -FilePath "$($env:TEMP)/.npmrc" -Encoding utf8
+    [String] $FeedPrefix
 
     Write-Host "Configure npm to use github package registry for '@actions' scope"
-    npm config set @actions:registry "https://${feedPrefix}"
+    npm config set @actions:registry "https://${FeedPrefix}"
+
+    Write-Host "Configure auth for github package registry"
+    $npmrcContent = "//${FeedPrefix}/:_authToken=${AccessToken}"
+    $npmrcContent | Out-File -FilePath "$($env:TEMP)/.npmrc" -Encoding utf8
 }
 
 # HostedToolCache Path
@@ -52,7 +52,7 @@ setx AGENT_TOOLSDIRECTORY $ToolsDirectory /M
 $ToolVersionsFileContent = Get-Content -Path "$env:ROOT_FOLDER/toolcache.json" -Raw
 $ToolVersions = ConvertFrom-Json -InputObject $ToolVersionsFileContent
 
-NPMFeed-Auth -AccessToken $env:GITHUB_FEED_TOKEN
+NPMFeed-Auth -AccessToken $env:GITHUB_FEED_TOKEN -FeedPrefix "npm.pkg.github.com"
 
 $ToolVersions.PSObject.Properties | ForEach-Object {
     $PackageName = $_.Name

--- a/images/win/scripts/Installers/Download-ToolCache.ps1
+++ b/images/win/scripts/Installers/Download-ToolCache.ps1
@@ -38,7 +38,16 @@ $ToolVersions.PSObject.Properties | ForEach-Object {
     $PackageVersions = $_.Value
     $NpmPackages = $PackageVersions | ForEach-Object { "$PackageName@$_" }
     foreach($NpmPackage in $NpmPackages) {
+        Write-Host "Install ${PackageName}@${PackageVersions}"
+
         Install-NpmPackage -Name $NpmPackage -NpmRegistry $env:TOOLCACHE_REGISTRY
+
+        $exit_code = $LASTEXITCODE
+        if($exit_code -ne 0) {
+            Write-Host "${PackageName}@${PackageVersions} installation failure;  Error:${exit_code}"
+
+            exit 1
+        }
     }
 }
 

--- a/images/win/scripts/Installers/Download-ToolCache.ps1
+++ b/images/win/scripts/Installers/Download-ToolCache.ps1
@@ -58,7 +58,7 @@ $env:AGENT_TOOLSDIRECTORY = $ToolsDirectory
 setx AGENT_TOOLSDIRECTORY $ToolsDirectory /M
 
 # Install HostedToolCache tools via NPM
-$ToolVersionsFileContent = Get-Content -Path "$env:ROOT_FOLDER/toolcache.json" -Raw
+$ToolVersionsFileContent = Get-Content -Path "$env:TOOLCACHE_CONFIG" -Raw
 $ToolVersions = ConvertFrom-Json -InputObject $ToolVersionsFileContent
 
 NPMFeed-Auth -AccessToken $AccessToken -FeedPrefix $FeedPrefix

--- a/images/win/scripts/Installers/Download-ToolCache.ps1
+++ b/images/win/scripts/Installers/Download-ToolCache.ps1
@@ -20,9 +20,8 @@ Function Install-NpmPackage {
     Write-Host "Installing npm $PackageName from ${FeedUri}"
     npm install $PackageName --registry "${FeedUri}"
 
-    $exitCode = $LASTEXITCODE
-    if($exitCode -ne 0) {
-        Write-Host "$PackageName installation failure;  Error: ${exitCode}"
+    if($LASTEXITCODE) {
+        Write-Host "$PackageName installation failure;  Error: ${LASTEXITCODE}"
 
         exit 1
     }

--- a/images/win/scripts/Installers/Download-ToolCache.ps1
+++ b/images/win/scripts/Installers/Download-ToolCache.ps1
@@ -58,7 +58,7 @@ $env:AGENT_TOOLSDIRECTORY = $ToolsDirectory
 setx AGENT_TOOLSDIRECTORY $ToolsDirectory /M
 
 # Install HostedToolCache tools via NPM
-$ToolVersionsFileContent = Get-Content -Path "$env:TOOLCACHE_CONFIG" -Raw
+$ToolVersionsFileContent = Get-Content -Path "$env:ROOT_FOLDER/toolcache.json" -Raw
 $ToolVersions = ConvertFrom-Json -InputObject $ToolVersionsFileContent
 
 NPMFeed-Auth -AccessToken $AccessToken -FeedPrefix $FeedPrefix

--- a/images/win/scripts/Installers/Download-ToolCache.ps1
+++ b/images/win/scripts/Installers/Download-ToolCache.ps1
@@ -28,8 +28,12 @@ Function Install-NpmPackage {
 }
 
 Function NPMFeed-Auth {
-    [String] $AccessToken
-    [String] $FeedPrefix
+    param (
+        [Parameter(Mandatory=$true)]
+        [String] $AccessToken,
+        [Parameter(Mandatory=$true)]
+        [String] $FeedPrefix
+    )
 
     Write-Host "Configure npm to use github package registry for '@actions' scope"
     npm config set @actions:registry "https://${FeedPrefix}"

--- a/images/win/scripts/Installers/Validate-Boost.ps1
+++ b/images/win/scripts/Installers/Validate-Boost.ps1
@@ -13,10 +13,10 @@ function Validate-BoostVersion
 
     $ReleasePath = Join-Path -Path $BoostRootPath -ChildPath $BoostRelease
 
-    if ((Test-Path "$ReleasePath\b2.exe") -and (Test-Path "$ReleasePath\bjam.exe"))
+    if (Test-Path "$ReleasePath\b2.exe")
     {
         Write-Host "Boost.Build $BoostRelease is successfully installed"
-        Write-Host "Boost.Jam $BoostRelease is successfully installed"
+
         return
     }
 
@@ -25,7 +25,7 @@ function Validate-BoostVersion
 }
 
 # Verify that Boost is on the path
-if ((Get-Command -Name 'b2') -and (Get-Command -Name 'bjam'))
+if (Get-Command -Name 'b2')
 {
     Write-Host "Boost is on the path"
 }

--- a/images/win/scripts/Installers/Validate-Boost.ps1
+++ b/images/win/scripts/Installers/Validate-Boost.ps1
@@ -57,12 +57,12 @@ $Description = New-Object System.Text.StringBuilder
 $BoostRootDirectory = Join-Path -Path $env:AGENT_TOOLSDIRECTORY -ChildPath "Boost"
 $BoostVersionsToInstall = $env:BOOST_VERSIONS.split(",")
 
-foreach($Boost in $BoostVersionsToInstall)
+foreach($BoostVersion in $BoostVersionsToInstall)
 {
-    Validate-BoostVersion -BoostRootPath $BoostRootDirectory -BoostRelease $Boost
-    $BoostVersionTag = "BOOST_ROOT_{0}" -f $Boost.Replace('.', '_')
+    Validate-BoostVersion -BoostRootPath $BoostRootDirectory -BoostRelease $BoostVersion
+    $BoostVersionTag = "BOOST_ROOT_{0}" -f $BoostVersion.Replace('.', '_')
 
-    if($boost -eq $env:BOOST_DEFAULT)
+    if($BoostVersion -eq $env:BOOST_DEFAULT)
     {
         $null = $Description.AppendLine(($tmplMarkRoot -f $BoostVersion, $BoostVersionTag))
     }

--- a/images/win/scripts/Installers/Validate-ToolCache.ps1
+++ b/images/win/scripts/Installers/Validate-ToolCache.ps1
@@ -82,7 +82,6 @@ function ToolcacheTest {
         [string[]]$ExecTests
     )
 
-    $markdownDescription = ""
     $softwarePath = "$env:AGENT_TOOLSDIRECTORY\$SoftwareName"
 
     if (-Not (Test-Path $softwarePath))
@@ -98,6 +97,7 @@ function ToolcacheTest {
         exit 1
     }
 
+    $markdownDescription = ""
     $tools = GetToolsByName -SoftwareName $SoftwareName
     foreach($tool in $tools)
     {
@@ -123,8 +123,8 @@ function ToolcacheTest {
 
             $markdownDescription = UpdateMarkdownDescription -Description $markdownDescription -SoftwareVersion $foundVersion -SoftwareArchitecture $requiredArchitecture
         }
-        Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $markdownDescription
     }
+    Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $markdownDescription
 }
 
 # Python test

--- a/images/win/scripts/Installers/Validate-ToolCache.ps1
+++ b/images/win/scripts/Installers/Validate-ToolCache.ps1
@@ -13,7 +13,8 @@ function GetChildFolders {
 }
 
 function Get-ToolcachePackages {
-    return Get-Content $env:TOOLCACHE_CONFIG -Raw | ConvertFrom-Json
+    $toolcachePath = Join-Path $env:ROOT_FOLDER "toolcache.json"
+    return Get-Content -Raw $toolcachePath | ConvertFrom-Json
 }
 
 $toolcachePackages = (Get-ToolcachePackages).PSObject.Properties | ForEach-Object {

--- a/images/win/scripts/Installers/Validate-ToolCache.ps1
+++ b/images/win/scripts/Installers/Validate-ToolCache.ps1
@@ -13,8 +13,7 @@ function GetChildFolders {
 }
 
 function Get-ToolcachePackages {
-    $toolcachePath = Join-Path $env:ROOT_FOLDER "toolcache.json"
-    return Get-Content -Raw $toolcachePath | ConvertFrom-Json
+    return Get-Content $env:TOOLCACHE_CONFIG -Raw | ConvertFrom-Json
 }
 
 $toolcachePackages = (Get-ToolcachePackages).PSObject.Properties | ForEach-Object {

--- a/images/win/scripts/Installers/Validate-ToolCache.ps1
+++ b/images/win/scripts/Installers/Validate-ToolCache.ps1
@@ -114,7 +114,7 @@ function ToolcacheTest {
             $requiredArchitecture = $tool.Architecture
             if (-Not ($installedArchitecture -Contains $requiredArchitecture))
             {
-                Write-Host "$softwarePath\$foundVersion does not include required architecture"
+                Write-Host "$softwarePath\$foundVersion does not include the $requiredArchitecture architecture"
                 exit 1
             }
 

--- a/images/win/scripts/Installers/Validate-ToolCache.ps1
+++ b/images/win/scripts/Installers/Validate-ToolCache.ps1
@@ -63,15 +63,14 @@ function RunTestsByPath {
     }
 }
 
-function UpdateMarkdownDescription {
+function GetMarkdownDescription {
     param (
-        [string]$Description,
         [Parameter(Mandatory = $True)]
         [string]$SoftwareVersion,
         [Parameter(Mandatory = $True)]
         [string]$SoftwareArchitecture
     )
-    return $Description += "_Version:_ $SoftwareVersion ($SoftwareArchitecture)<br/>"
+    return "_Version:_ $SoftwareVersion ($SoftwareArchitecture)<br/>"
 }
 
 function ToolcacheTest {
@@ -121,7 +120,7 @@ function ToolcacheTest {
             $path = "$softwarePath\$foundVersion\$requiredArchitecture"
             RunTestsByPath -ExecTests $ExecTests -Path $path -SoftwareName $SoftwareName -SoftwareVersion $foundVersion -SoftwareArchitecture $requiredArchitecture
 
-            $markdownDescription = UpdateMarkdownDescription -Description $markdownDescription -SoftwareVersion $foundVersion -SoftwareArchitecture $requiredArchitecture
+            $markdownDescription += GetMarkdownDescription -SoftwareVersion $foundVersion -SoftwareArchitecture $requiredArchitecture
         }
     }
     Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $markdownDescription

--- a/images/win/toolcache-2016.json
+++ b/images/win/toolcache-2016.json
@@ -1,0 +1,17 @@
+{
+    "@actions/toolcache-python-windows-x64": [
+        "2.7", "3.5", "3.6", "3.7", "3.8"
+    ],
+    "@actions/toolcache-python-windows-x86": [
+        "2.7", "3.5", "3.6", "3.7", "3.8"
+    ],
+    "@actions/toolcache-ruby-windows-x64": [
+        "2.4", "2.5", "2.6", "2.7"
+    ],
+    "@actions/toolcache-pypy-windows-x86": [
+        "2", "3"
+    ],
+    "@actions/toolcache-boost-windows-msvc-14.1-x32-x64": [
+        "1.69", "1.72"
+    ]
+}

--- a/images/win/toolcache-2019.json
+++ b/images/win/toolcache-2019.json
@@ -12,6 +12,6 @@
         "2", "3"
     ],
     "@actions/toolcache-boost-windows-msvc-14.2-x32-x64": [
-        "1.72"
+        "1.69", "1.72"
     ]
 }

--- a/images/win/toolcache-2019.json
+++ b/images/win/toolcache-2019.json
@@ -11,7 +11,10 @@
     "@actions/toolcache-pypy-windows-x86": [
         "2", "3"
     ],
+    "@actions/toolcache-boost-windows-msvc-14.1-x32-x64": [
+        "1.69"
+    ],
     "@actions/toolcache-boost-windows-msvc-14.2-x32-x64": [
-        "1.69", "1.72"
+        "1.72"
     ]
 }

--- a/images/win/toolcache-2019.json
+++ b/images/win/toolcache-2019.json
@@ -1,17 +1,17 @@
 {
-    "toolcache-python-windows-x64": [
+    "@actions/toolcache-python-windows-x64": [
         "2.7", "3.5", "3.6", "3.7", "3.8"
     ],
-    "toolcache-python-windows-x86": [
+    "@actions/toolcache-python-windows-x86": [
         "2.7", "3.5", "3.6", "3.7", "3.8"
     ],
-    "toolcache-ruby-windows-x64": [
+    "@actions/toolcache-ruby-windows-x64": [
         "2.4", "2.5", "2.6", "2.7"
     ],
-    "toolcache-pypy-windows-x86": [
+    "@actions/toolcache-pypy-windows-x86": [
         "2", "3"
     ],
-    "toolcache-boost-windows-msvc-14.2-x32-x64": [
+    "@actions/toolcache-boost-windows-msvc-14.2-x32-x64": [
         "1.72"
     ]
 }

--- a/images/win/toolcache-2019.json
+++ b/images/win/toolcache-2019.json
@@ -11,7 +11,7 @@
     "toolcache-pypy-windows-x86": [
         "2", "3"
     ],
-    "toolcache-boost-windows-x64": [
-        "1.69"
+    "toolcache-boost-windows-msvc-14.2-x32-x64": [
+        "1.72"
     ]
 }


### PR DESCRIPTION
This PR switch Windows2016, Windows2019 toolcache provisioner to use Github Actions NPM registry. 

**Additional:**
- Issue https://github.com/actions/virtual-environments/issues/74 was fixed
- Toolcache provisioner for windows was improved
- Windows Toolcache tests are improved
- Boost 1.72 - msvc 14.1 added to Win2016
- Boost 1.72 - msvc 14.2 added to Win2019