### PR TITLE
fix(Validate-AzureModules): additional line in description fixes terminator character issues

### DIFF
--- a/images/win/scripts/Installers/Validate-AzureModules.ps1
+++ b/images/win/scripts/Installers/Validate-AzureModules.ps1
@@ -49,7 +49,7 @@ $SoftwareName = "Azure/AzureRM Powershell modules"
 $Description = @"
 #### $($DefaultModule.Version)
 
-This version is installed and is available via `Get-Module -ListAvailable`
+This version is installed and is available via ``Get-Module -ListAvailable``
 "@
 
 Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description


### PR DESCRIPTION
```
==> vhd: Provisioning with powershell script: C:\agent1\_work\225\s\images\win/scripts/Installers/Validate-AzureModules.ps1
==> vhd: At C:\Windows\Temp\script-5e1dc318-9b9d-d017-fea0-68186c6d47f4.ps1:70 char:5
==> vhd: +     }
==> vhd: +     ~
==> vhd: Unexpected token '}' in expression or statement.
==> vhd: At C:\Windows\Temp\script-5e1dc318-9b9d-d017-fea0-68186c6d47f4.ps1:71 char:1
==> vhd: + }
==> vhd: + ~
==> vhd: Unexpected token '}' in expression or statement.
==> vhd:     + CategoryInfo          : ParserError: (:) [], ParseException
==> vhd:     + FullyQualifiedErrorId : UnexpectedToken
```