### PR TITLE
Increase max number of open files

### DIFF
--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -77,10 +77,10 @@
                 "systemctl disable apt-daily.timer",
                 "systemctl disable apt-daily-upgrade.timer",
                 "systemctl disable apt-daily-upgrade.service",
-                "echo '* soft nofile 50000 \n* hard nofile 50000' >> /etc/security/limits.conf",
+                "echo '* soft nofile 65536 \n* hard nofile 65536' >> /etc/security/limits.conf",
                 "echo 'session required pam_limits.so' >> /etc/pam.d/common-session",
                 "echo 'session required pam_limits.so' >> /etc/pam.d/common-session-noninteractive",
-                "echo 'DefaultLimitNOFILE=50000' >> /etc/systemd/system.conf"
+                "echo 'DefaultLimitNOFILE=65536' >> /etc/systemd/system.conf"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -79,7 +79,8 @@
                 "systemctl disable apt-daily-upgrade.service",
                 "echo '* soft nofile 50000 \n* hard nofile 50000' >> /etc/security/limits.conf",
                 "echo 'session required pam_limits.so' >> /etc/pam.d/common-session",
-                "echo 'session required pam_limits.so' >> /etc/pam.d/common-session-noninteractive"
+                "echo 'session required pam_limits.so' >> /etc/pam.d/common-session-noninteractive",
+                "echo 'DefaultLimitNOFILE=50000' >> /etc/systemd/system.conf"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -82,7 +82,8 @@
                 "systemctl disable apt-daily-upgrade.service",
                 "echo '* soft nofile 50000 \n* hard nofile 50000' >> /etc/security/limits.conf",
                 "echo 'session required pam_limits.so' >> /etc/pam.d/common-session",
-                "echo 'session required pam_limits.so' >> /etc/pam.d/common-session-noninteractive"
+                "echo 'session required pam_limits.so' >> /etc/pam.d/common-session-noninteractive",
+                "echo 'DefaultLimitNOFILE=50000' >> /etc/systemd/system.conf"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -80,10 +80,10 @@
                 "systemctl disable apt-daily.timer",
                 "systemctl disable apt-daily-upgrade.timer",
                 "systemctl disable apt-daily-upgrade.service",
-                "echo '* soft nofile 50000 \n* hard nofile 50000' >> /etc/security/limits.conf",
+                "echo '* soft nofile 65536 \n* hard nofile 65536' >> /etc/security/limits.conf",
                 "echo 'session required pam_limits.so' >> /etc/pam.d/common-session",
                 "echo 'session required pam_limits.so' >> /etc/pam.d/common-session-noninteractive",
-                "echo 'DefaultLimitNOFILE=50000' >> /etc/systemd/system.conf"
+                "echo 'DefaultLimitNOFILE=65536' >> /etc/systemd/system.conf"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },


### PR DESCRIPTION
According to https://github.com/actions/virtual-environments/issues/268, we have modified Ubuntu 16/18 images for adding the [DefaultLimitNOFILE=50000] setting to /etc/systemd/system.conf.
This setting will be used in non-interactive sessions for increasing the max open files limit