### PR TITLE
Add libmysqlclient-dev installation on Ubuntu

### DIFF
--- a/images/linux/scripts/installers/mysql.sh
+++ b/images/linux/scripts/installers/mysql.sh
@@ -13,7 +13,7 @@ export ACCEPT_EULA=Y
 apt-get install mysql-client -y
 
 # InstallMySQL database development files
-apt-get install libmysqlclient-dev
+apt-get install libmysqlclient-dev -y
 
 # Install MySQL Server
 MYSQL_ROOT_PASSWORD=root

--- a/images/linux/scripts/installers/mysql.sh
+++ b/images/linux/scripts/installers/mysql.sh
@@ -12,6 +12,9 @@ export ACCEPT_EULA=Y
 # Install MySQL Client
 apt-get install mysql-client -y
 
+# InstallMySQL database development files
+apt-get install libmysqlclient-dev
+
 # Install MySQL Server
 MYSQL_ROOT_PASSWORD=root
 echo "mysql-server mysql-server/root_password password $MYSQL_ROOT_PASSWORD" | debconf-set-selections


### PR DESCRIPTION
We have several complaints about libmysqlclient-dev installation on Ubuntu images. 
https://github.com/actions/virtual-environments/issues/337
https://github.com/microsoft/azure-pipelines-image-generation/issues/1410
This happens when MySQL version is superseded in ubuntu repositories, but we still have an older one on the deployed VM and it requires the same outdated libmysqlclient-dev version, which is no longer available via apt-get.
The solution is to install libmysqlclient-dev during image generation to have the same versions of packages at the end of the build. 

Changes:
- Add libmysqlclient-dev installation to MySQL Client installation script