### PR TITLE
Fix SeleniumWebDrivers error

### DIFF
--- a/images/win/scripts/Installers/Install-SeleniumWebDrivers.ps1
+++ b/images/win/scripts/Installers/Install-SeleniumWebDrivers.ps1
@@ -17,7 +17,7 @@ catch {
 Expand-Archive -Path $DriversZipFile -DestinationPath $DestinationPath -Force;
 Remove-Item $DriversZipFile;
 
-$ChromeDriverPath = "$DestinationPath\SeleniumWebDrivers\ChromeDriver";
+$ChromeDriverPath = "${DestinationPath}SeleniumWebDrivers\ChromeDriver";
 Write-Host "Chrome driver path: [$ChromeDriverPath]";
 Remove-Item -Path "$ChromeDriverPath\*" -Force;
 
@@ -48,7 +48,7 @@ Remove-Item -Path "$ChromeDriverPath\chromedriver_win32.zip" -Force;
 
 # Install Microsoft Edge Web Driver
 Write-Host "Microsoft Edge driver download...."
-$EdgeDriverPath = "$DestinationPath\SeleniumWebDrivers\EdgeDriver"
+$EdgeDriverPath = "${DestinationPath}SeleniumWebDrivers\EdgeDriver"
 if (-not (Test-Path -Path $EdgeDriverPath)) {
     New-Item -Path $EdgeDriverPath -ItemType "directory"
 }


### PR DESCRIPTION
Fixes #351, related to #338.

Here is a fix for some doubled `\` in `Install-SeleniumWebDrivers.ps1` that make `Validate-SeleniumWebDrivers.ps1` to fail.