### PR TITLE
Fix PowerShell Core installation in ubuntu16

### DIFF
--- a/images/linux/scripts/base/repos.sh
+++ b/images/linux/scripts/base/repos.sh
@@ -5,7 +5,6 @@
 ################################################################################
 
 LSB_RELEASE=$(lsb_release -rs)
-echo "Ubuntu release: $LSB_RELEASE"
 
 # Install Microsoft repository
 wget https://packages.microsoft.com/config/ubuntu/$LSB_RELEASE/packages-microsoft-prod.deb

--- a/images/linux/scripts/base/repos.sh
+++ b/images/linux/scripts/base/repos.sh
@@ -5,6 +5,7 @@
 ################################################################################
 
 LSB_RELEASE=$(lsb_release -rs)
+echo "Ubuntu release: $LSB_RELEASE"
 
 # Install Microsoft repository
 wget https://packages.microsoft.com/config/ubuntu/$LSB_RELEASE/packages-microsoft-prod.deb

--- a/images/linux/scripts/installers/1604/powershellcore.sh
+++ b/images/linux/scripts/installers/1604/powershellcore.sh
@@ -8,9 +8,9 @@
 source $HELPER_SCRIPTS/document.sh
 
 LSB_RELEASE=$(lsb_release -rs)
-echo "Installing the libicu60 library"
-wget http://security.ubuntu.com/ubuntu/pool/main/i/icu/libicu60_60.2-3ubuntu3_amd64.deb
-dpkg -i libicu60_60.2-3ubuntu3_amd64.deb
+#echo "Installing the libicu60 library"
+#wget http://security.ubuntu.com/ubuntu/pool/main/i/icu/libicu60_60.2-3ubuntu3_amd64.deb
+#dpkg -i libicu60_60.2-3ubuntu3_amd64.deb
 
 echo "Installing the PowerShell Core"
 apt-get install -y powershell

--- a/images/linux/scripts/installers/1604/powershellcore.sh
+++ b/images/linux/scripts/installers/1604/powershellcore.sh
@@ -8,14 +8,11 @@
 source $HELPER_SCRIPTS/document.sh
 
 LSB_RELEASE=$(lsb_release -rs)
+echo "Installing the libicu60 library"
+wget http://security.ubuntu.com/ubuntu/pool/main/i/icu/libicu60_60.2-3ubuntu3_amd64.deb
+dpkg -i libicu60_60.2-3ubuntu3_amd64.deb
 
-#Restore repository
-dpkg -i packages-microsoft-prod.deb
-apt-get update
-
-# Install Microsoft GPG public key
-curl -L https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-# Install Powershell
+echo "Installing the PowerShell Core"
 apt-get install -y powershell
 
 # Run tests to determine that the software installed as expected

--- a/images/linux/scripts/installers/1604/powershellcore.sh
+++ b/images/linux/scripts/installers/1604/powershellcore.sh
@@ -9,6 +9,12 @@ source $HELPER_SCRIPTS/document.sh
 
 LSB_RELEASE=$(lsb_release -rs)
 
+#Restore repository
+dpkg -i packages-microsoft-prod.deb
+apt-get update
+
+# Install Microsoft GPG public key
+curl -L https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 # Install Powershell
 apt-get install -y powershell
 

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -116,6 +116,7 @@
         {
             "type": "shell",
             "scripts": [
+                "{{template_dir}}/scripts/installers/1604/dotnetcore-sdk.sh",
                 "{{template_dir}}/scripts/installers/1604/powershellcore.sh",
                 "{{template_dir}}/scripts/installers/7-zip.sh",
                 "{{template_dir}}/scripts/installers/ansible.sh",
@@ -130,7 +131,6 @@
                 "{{template_dir}}/scripts/installers/docker-compose.sh",
                 "{{template_dir}}/scripts/installers/docker-moby.sh",
                 "{{template_dir}}/scripts/installers/docker.sh",
-                "{{template_dir}}/scripts/installers/1604/dotnetcore-sdk.sh",
                 "{{template_dir}}/scripts/installers/erlang.sh",
                 "{{template_dir}}/scripts/installers/firefox.sh",
                 "{{template_dir}}/scripts/installers/gcc.sh",

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -116,6 +116,7 @@
         {
             "type": "shell",
             "scripts": [
+                "{{template_dir}}/scripts/installers/1604/powershellcore.sh",
                 "{{template_dir}}/scripts/installers/7-zip.sh",
                 "{{template_dir}}/scripts/installers/ansible.sh",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
@@ -153,7 +154,6 @@
                 "{{template_dir}}/scripts/installers/phantomjs.sh",
                 "{{template_dir}}/scripts/installers/1604/php.sh",
                 "{{template_dir}}/scripts/installers/pollinate.sh",
-                "{{template_dir}}/scripts/installers/1604/powershellcore.sh",
                 "{{template_dir}}/scripts/installers/ruby.sh",
                 "{{template_dir}}/scripts/installers/rust.sh",
                 "{{template_dir}}/scripts/installers/sbt.sh",


### PR DESCRIPTION
Issue: https://github.com/actions/virtual-environments/issues/353
"packages-microsoft-prod.deb" package contains link to PowerShell Core for Ubuntu 18.04.
This release of PowerShell Core doesn't work without libicu60 library, which is not present in Ubuntu 16.04, therefore we had a Ubuntu 16 build faults.
For prevention of this issue, libicu60 installation has been added to powershellcore.sh script