### PR TITLE
Fix unattended installation some packages

### DIFF
--- a/images/linux/scripts/installers/dpkg-config.sh
+++ b/images/linux/scripts/installers/dpkg-config.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This is the anti-frontend. It never interacts with you  at  all,
+# and  makes  the  default  answers  be used for all questions. It
+# might mail error messages to root, but that's it;  otherwise  it
+# is  completely  silent  and  unobtrusive, a perfect frontend for
+# automatic installs. If you are using this front-end, and require
+# non-default  answers  to questions, you will need to preseed the
+# debconf database
+echo 'DEBIAN_FRONTEND=noninteractive' | tee -a /etc/environment
+
+# dpkg can be instructed not to ask for confirmation
+# when replacing a configuration file (with the --force-confdef --force-confold options)
+cat <<EOF >> /etc/apt/apt.conf.d/10dpkg-options
+Dpkg::Options {
+  "--force-confdef";
+  "--force-confold";
+}
+EOF

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -161,7 +161,9 @@
                 "{{template_dir}}/scripts/installers/subversion.sh",
                 "{{template_dir}}/scripts/installers/terraform.sh",
                 "{{template_dir}}/scripts/installers/vcpkg.sh",
-                "{{template_dir}}/scripts/installers/zeit-now.sh"
+                "{{template_dir}}/scripts/installers/zeit-now.sh",
+                "{{template_dir}}/scripts/installers/dpkg-config.sh"
+
             ],
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -164,7 +164,8 @@
                 "{{template_dir}}/scripts/installers/subversion.sh",
                 "{{template_dir}}/scripts/installers/terraform.sh",
                 "{{template_dir}}/scripts/installers/vcpkg.sh",
-                "{{template_dir}}/scripts/installers/zeit-now.sh"
+                "{{template_dir}}/scripts/installers/zeit-now.sh",
+                "{{template_dir}}/scripts/installers/dpkg-config.sh"
             ],
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",


### PR DESCRIPTION
Issue:
[apt-get install may ask questions and hang](https://github.com/actions/virtual-environments/issues/122)

As example `splapd` requests by default from the user during installation and block pipeline:
![slapd](https://user-images.githubusercontent.com/47745270/73823841-26707b00-480a-11ea-8c41-5c952d7d8a36.JPG)

Fix:
1. Suppress requests for information during package configuration
Debian packages can request information from the user during installation in order to generate customised configuration files. The preferred method for doing this is through the configuration management protocol provided by DebConf. One of the benefits of DebConf is that it provides a central point of control over how and whether any questions are asked.

The required effect in this instance can be obtained by setting the environment variable DEBIAN_FRONTEND to the value noninteractive

`export DEBIAN_FRONTEND=noninteractive`

2. Suppress prompts from dpkg to resolve conffile differences
Installing one package may cause other packages to be upgraded. If this involves upgrading a configuration file that has also been changed locally then dpkg normally asks the user what to do: keep the existing copy, overwrite it with the new copy, or resolve the conflict manually.

The safest course of action is to keep the existing configuration file if it has local changes, but otherwise allow the upgrade. This can be achieved using a combination of two dpkg options:

--force-confdef (upgrade the configuration file if there are no local changes), and
--force-confold (otherwise, preserve the existing configuration file).

