### PR TITLE
Ubuntu16 build has been fixed

### DIFF
--- a/images/linux/scripts/installers/1604/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/1604/dotnetcore-sdk.sh
@@ -34,11 +34,6 @@ for latest_package in ${LATEST_DOTNET_PACKAGES[@]}; do
     echo "Determing if .NET Core ($latest_package) is installed"
     if ! IsInstalled $latest_package; then
         echo "Could not find .NET Core ($latest_package), installing..."
-        #curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
-        #mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
-        #sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-bionic-prod bionic main" > /etc/apt/sources.list.d/dotnetdev.list'
-        #apt-get install apt-transport-https
-        #apt-get update
         apt-get install $latest_package -y
     else
         echo ".NET Core ($latest_package) is already installed"

--- a/images/linux/scripts/installers/1604/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/1604/dotnetcore-sdk.sh
@@ -34,11 +34,11 @@ for latest_package in ${LATEST_DOTNET_PACKAGES[@]}; do
     echo "Determing if .NET Core ($latest_package) is installed"
     if ! IsInstalled $latest_package; then
         echo "Could not find .NET Core ($latest_package), installing..."
-        curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
-        mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
-        sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-bionic-prod bionic main" > /etc/apt/sources.list.d/dotnetdev.list'
-        apt-get install apt-transport-https
-        apt-get update
+        #curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+        #mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
+        #sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-bionic-prod bionic main" > /etc/apt/sources.list.d/dotnetdev.list'
+        #apt-get install apt-transport-https
+        #apt-get update
         apt-get install $latest_package -y
     else
         echo ".NET Core ($latest_package) is already installed"

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -116,6 +116,8 @@
         {
             "type": "shell",
             "scripts": [
+                "{{template_dir}}/scripts/installers/1604/dotnetcore-sdk.sh",
+                "{{template_dir}}/scripts/installers/1604/powershellcore.sh",
                 "{{template_dir}}/scripts/installers/7-zip.sh",
                 "{{template_dir}}/scripts/installers/ansible.sh",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
@@ -129,7 +131,6 @@
                 "{{template_dir}}/scripts/installers/docker-compose.sh",
                 "{{template_dir}}/scripts/installers/docker-moby.sh",
                 "{{template_dir}}/scripts/installers/docker.sh",
-                "{{template_dir}}/scripts/installers/1604/dotnetcore-sdk.sh",
                 "{{template_dir}}/scripts/installers/erlang.sh",
                 "{{template_dir}}/scripts/installers/firefox.sh",
                 "{{template_dir}}/scripts/installers/gcc.sh",
@@ -154,7 +155,6 @@
                 "{{template_dir}}/scripts/installers/1604/php.sh",
                 "{{template_dir}}/scripts/installers/pollinate.sh",
                 "{{template_dir}}/scripts/installers/postgresql.sh",
-                "{{template_dir}}/scripts/installers/1604/powershellcore.sh",
                 "{{template_dir}}/scripts/installers/ruby.sh",
                 "{{template_dir}}/scripts/installers/rust.sh",
                 "{{template_dir}}/scripts/installers/sbt.sh",

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -116,8 +116,6 @@
         {
             "type": "shell",
             "scripts": [
-                "{{template_dir}}/scripts/installers/1604/dotnetcore-sdk.sh",
-                "{{template_dir}}/scripts/installers/1604/powershellcore.sh",
                 "{{template_dir}}/scripts/installers/7-zip.sh",
                 "{{template_dir}}/scripts/installers/ansible.sh",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
@@ -131,6 +129,7 @@
                 "{{template_dir}}/scripts/installers/docker-compose.sh",
                 "{{template_dir}}/scripts/installers/docker-moby.sh",
                 "{{template_dir}}/scripts/installers/docker.sh",
+                "{{template_dir}}/scripts/installers/1604/dotnetcore-sdk.sh",
                 "{{template_dir}}/scripts/installers/erlang.sh",
                 "{{template_dir}}/scripts/installers/firefox.sh",
                 "{{template_dir}}/scripts/installers/gcc.sh",
@@ -155,6 +154,7 @@
                 "{{template_dir}}/scripts/installers/1604/php.sh",
                 "{{template_dir}}/scripts/installers/pollinate.sh",
                 "{{template_dir}}/scripts/installers/postgresql.sh",
+                "{{template_dir}}/scripts/installers/1604/powershellcore.sh",
                 "{{template_dir}}/scripts/installers/ruby.sh",
                 "{{template_dir}}/scripts/installers/rust.sh",
                 "{{template_dir}}/scripts/installers/sbt.sh",


### PR DESCRIPTION
According to https://github.com/actions/virtual-environments/issues/353, dotnetcore-sdk.sh has been modified.
Addition of extra repository 'microsoft-ubuntu-bionic-prod' has been removed from this script (right microsoft package already is added through repos.sh script), because it impacted to PowerShell Core installation and build has been broken
After this modification Ubuntu16 build is successful.