### PR TITLE
Disable telemetry before dotnet installation to prevent Segmentation fault

### DIFF
--- a/images/linux/scripts/installers/1804/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/1804/dotnetcore-sdk.sh
@@ -30,6 +30,9 @@ mksamples()
 
 set -e
 
+# Disable telemetry
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+
 for latest_package in ${LATEST_DOTNET_PACKAGES[@]}; do
     echo "Determing if .NET Core ($latest_package) is installed"
     if ! IsInstalled $latest_package; then


### PR DESCRIPTION
Issue:
[Segmentation fault (core dumped) - NetCore 3.0 ](https://github.com/dotnet/core/issues/3620) - Segmentation fault    (core dumped) dotnet new [Ubuntu 18.04]

Fix:
Set DOTNET_CLI_TELEMETRY_OPTOUT=1 before installing