### PR TITLE
Added path to installed global modules of composer to $PATH

### DIFF
--- a/images/linux/scripts/installers/1604/php.sh
+++ b/images/linux/scripts/installers/1604/php.sh
@@ -276,6 +276,9 @@ php composer-setup.php
 sudo mv composer.phar /usr/bin/composer
 php -r "unlink('composer-setup.php');"
 
+# Add composer bin folder to path
+echo 'export PATH="$PATH:$HOME/.config/composer/vendor/bin"' >> /etc/skel/.bashrc
+
 # Install phpunit (for PHP)
 wget -q -O phpunit https://phar.phpunit.de/phpunit-7.phar
 chmod +x phpunit

--- a/images/linux/scripts/installers/1804/php.sh
+++ b/images/linux/scripts/installers/1804/php.sh
@@ -193,6 +193,9 @@ php composer-setup.php
 sudo mv composer.phar /usr/bin/composer
 php -r "unlink('composer-setup.php');"
 
+# Add composer bin folder to path
+echo 'export PATH="$PATH:$HOME/.config/composer/vendor/bin"' >> /etc/skel/.bashrc
+
 # Install phpunit (for PHP)
 wget -q -O phpunit https://phar.phpunit.de/phpunit-7.phar
 chmod +x phpunit


### PR DESCRIPTION
Composer's path to global executable modules: `~/.config/composer/vendor/bin` 
Adding this path to $PATH variable allow to invoke these modules without full path.

Issue: [#118](https://github.com/actions/virtual-environments/issues/118)
