### PR TITLE
tk installation has been added to Ubuntu 16/18 basic.sh

### DIFF
--- a/images/linux/scripts/installers/1604/basic.sh
+++ b/images/linux/scripts/installers/1604/basic.sh
@@ -47,6 +47,7 @@ apt-fast install -y --no-install-recommends \
     dbus \
     xvfb \
     libgtk-3-0 \
+    tk \
     fakeroot \
     dpkg \
     rpm \

--- a/images/linux/scripts/installers/1804/basic.sh
+++ b/images/linux/scripts/installers/1804/basic.sh
@@ -97,6 +97,9 @@ apt-get install -y --no-install-recommends xvfb
 echo "Install libgtk"
 apt-get install -y --no-install-recommends libgtk-3-0
 
+echo "Install tk"
+apt install -y tk
+
 echo "Install fakeroot"
 apt-get install -y --no-install-recommends fakeroot
 


### PR DESCRIPTION
According to https://github.com/actions/virtual-environments/issues/275, tk library installation has been added to Ubuntu 16/18.
This library is used for correct tkniter work in Ubuntu.