### PR TITLE
Restore Git bash utilities to the PATH

### DIFF
--- a/images/win/scripts/Installers/Install-Git.ps1
+++ b/images/win/scripts/Installers/Install-Git.ps1
@@ -12,6 +12,7 @@ choco install git -y --package-parameters="/GitAndUnixToolsOnPath /WindowsTermin
 # Disable GCM machine-wide
 [Environment]::SetEnvironmentVariable("GCM_INTERACTIVE", "Never", [System.EnvironmentVariableTarget]::Machine)
 
+Add-MachinePathItem "C:\Program Files\Git\usr\bin"
 Add-MachinePathItem "C:\Program Files\Git\bin"
 
 exit 0


### PR DESCRIPTION
This is a quick fix for issue https://github.com/actions/virtual-environments/issues/282
In [#211](https://github.com/actions/virtual-environments/pull/211) C:\Program Files\Git\usr\bin was removed from the PATH caused to using [Windows tar](https://devblogs.microsoft.com/commandline/tar-and-curl-come-to-windows/)(C:\Windows\System32\tar.exe) instead of the tar comes along with Git. Windows doesn't have xz support by default, tries to use mingw xz utility and hangs.

Changes:
- Restore `"C:\Program Files\Git\usr\bin"` in the PATH, until MSYS2 is added(https://github.com/actions/virtual-environments/issues/30)