### PR TITLE
Add dotnet 4.7.2 developer tools

### DIFF
--- a/images/win/scripts/Installers/Windows2016/Install-VS2017.ps1
+++ b/images/win/scripts/Installers/Windows2016/Install-VS2017.ps1
@@ -69,6 +69,8 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
                 '--add Microsoft.Net.Component.4.7.1.SDK ' + `
                 '--add Microsoft.Net.Component.4.7.1.TargetingPack ' + `
                 '--add Microsoft.Net.ComponentGroup.4.7.1.DeveloperTools ' + `
+                '--add Microsoft.Net.Component.4.7.2.SDK ' + `
+                '--add Microsoft.Net.Component.4.7.2.TargetingPack ' + `
                 '--add Microsoft.Net.ComponentGroup.4.7.2.DeveloperTools ' + `
                 '--add Microsoft.Net.Core.Component.SDK.1x ' + `
                 '--add Microsoft.NetCore.1x.ComponentGroup.Web ' + `

--- a/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
@@ -73,6 +73,9 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.Component.VC.Runtime.UCRTSDK ' + `
               '--add Microsoft.Net.ComponentGroup.4.6.2.DeveloperTools ' + `
               '--add Microsoft.Net.ComponentGroup.4.7.1.DeveloperTools ' + `
+              '--add Microsoft.Net.Component.4.7.2.SDK ' + `
+              '--add Microsoft.Net.Component.4.7.2.TargetingPack ' + `
+              '--add Microsoft.Net.ComponentGroup.4.7.2.DeveloperTools ' + `
               '--add Microsoft.Net.ComponentGroup.4.7.DeveloperTools ' + `
               '--add Microsoft.VisualStudio.Component.AspNet45 ' + `
               '--add Microsoft.VisualStudio.Component.Azure.Kubernetes.Tools ' + `
@@ -89,7 +92,7 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.VisualStudio.Component.TestTools.CodedUITest ' + `
               '--add Microsoft.VisualStudio.Component.TestTools.WebLoadTest ' + `
               '--add Microsoft.VisualStudio.Component.UWP.VC.ARM64 ' + `
-              '--add Microsoft.VisualStudio.Component.VC.140 ' + `             
+              '--add Microsoft.VisualStudio.Component.VC.140 ' + `
               '--add Microsoft.VisualStudio.Component.VC.ATL.ARM ' + `
               '--add Microsoft.VisualStudio.Component.VC.ATLMFC ' + `
               '--add Microsoft.VisualStudio.Component.VC.ATLMFC.Spectre ' + `


### PR DESCRIPTION
This PR fixes issue https://github.com/actions/virtual-environments/issues/363 and it adds .NET framework 4.7.2 SDK, Targeting Pack and Developer tools as visual studio components to VS17 and VS19