### PR TITLE
WDK installation fix for win19

### DIFF
--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -154,12 +154,6 @@
         },
         {
             "type": "powershell",
-            "scripts": [
-                "{{ template_dir }}/scripts/Installers/Windows2019/Install-WDK.ps1"
-            ]
-        },
-        {
-            "type": "powershell",
             "valid_exit_codes": [
                 0,
                 3010
@@ -184,6 +178,12 @@
             ],
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-NET48.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts": [
+                "{{ template_dir }}/scripts/Installers/Windows2019/Install-WDK.ps1"
             ]
         },
         {

--- a/images/win/scripts/ImageHelpers/ImageHelpers.psm1
+++ b/images/win/scripts/ImageHelpers/ImageHelpers.psm1
@@ -18,4 +18,5 @@ Export-ModuleMember -Function @(
     'Add-SoftwareDetailsToMarkdown'
     'Stop-SvcWithErrHandling'
     'Set-SvcWithErrHandling'
+    'Get-VS19ExtensionVersion'
 )

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -83,8 +83,8 @@ function Install-EXE
 }
 
 function Stop-SvcWithErrHandling
-<# 
-.DESCRIPTION 
+<#
+.DESCRIPTION
 Function for stopping the Windows Service with error handling
 
 .AUTHOR
@@ -98,7 +98,7 @@ Switch for stopping the script and exit from PowerShell if one service is absent
 #>
 {
     param (
-        [Parameter(Mandatory, ValueFromPipeLine = $true)] [string] $ServiceName, 
+        [Parameter(Mandatory, ValueFromPipeLine = $true)] [string] $ServiceName,
         [Parameter()] [switch] $StopOnError
     )
 
@@ -126,8 +126,8 @@ Switch for stopping the script and exit from PowerShell if one service is absent
 }
 
 function Set-SvcWithErrHandling
-<# 
-.DESCRIPTION 
+<#
+.DESCRIPTION
 Function for setting the Windows Service parameter with error handling
 
 .AUTHOR
@@ -140,7 +140,7 @@ The name of stopping service
 Hashtable for service arguments
 #>
 {
-    
+
     param (
         [Parameter(Mandatory, ValueFromPipeLine = $true)] [string] $ServiceName,
         [Parameter(Mandatory)] [hashtable] $Arguments
@@ -159,4 +159,32 @@ Hashtable for service arguments
             $_ | Out-String | Write-Error;
         }
     }
+}
+
+function Get-VS19ExtensionVersion
+{
+    param (
+        [string] [Parameter(Mandatory=$true)] $packageName
+    )
+
+    $vsProgramData = Get-Item -Path "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances"
+    $instanceFolders = Get-ChildItem -Path $vsProgramData.FullName
+
+    if($instanceFolders -is [array])
+    {
+        Write-Host "More than one instance installed"
+        exit 1
+    }
+
+    $stateContent = Get-Content -Path ($instanceFolders.FullName + '\state.packages.json')
+    $state = $stateContent | ConvertFrom-Json
+    $packageVersion = ($state.packages | Where-Object { $_.id -eq $packageName }).version
+
+    if (!$packageVersion)
+    {
+        Write-Host "installed package $packageName for Visual Studio 2019 was not found"
+        exit 1
+    }
+
+    return $packageVersion
 }

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -170,7 +170,7 @@ function Get-VS19ExtensionVersion
     $vsProgramData = Get-Item -Path "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances"
     $instanceFolders = Get-ChildItem -Path $vsProgramData.FullName
 
-    if($instanceFolders -is [array])
+    if ($instanceFolders -is [array])
     {
         Write-Host "More than one instance installed"
         exit 1

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -167,8 +167,7 @@ function Get-VS19ExtensionVersion
         [string] [Parameter(Mandatory=$true)] $packageName
     )
 
-    $vsProgramData = Get-Item -Path "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances"
-    $instanceFolders = Get-ChildItem -Path $vsProgramData.FullName
+    $instanceFolders = Get-ChildItem -Path "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances"
 
     if ($instanceFolders -is [array])
     {
@@ -176,7 +175,7 @@ function Get-VS19ExtensionVersion
         exit 1
     }
 
-    $stateContent = Get-Content -Path ($instanceFolders.FullName + '\state.packages.json')
+    $stateContent = Get-Content -Path (Join-Path $instanceFolders '\state.packages.json')
     $state = $stateContent | ConvertFrom-Json
     $packageVersion = ($state.packages | Where-Object { $_.id -eq $packageName }).version
 

--- a/images/win/scripts/Installers/Windows2019/Install-WDK.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-WDK.ps1
@@ -3,10 +3,6 @@
 ##  Desc:  Install the Windows Driver Kit
 ################################################################################
 
-# Version: 10.0.18362.0
-# Update Validate-WDK.ps1 if the version changes!
-# There doesn't seem to be any way to check the version programmatically
-
 # Requires Windows SDK with the same version number as the WDK
 $winSdkUrl = "https://go.microsoft.com/fwlink/p/?linkid=2083338"
 $wdkUrl = "https://go.microsoft.com/fwlink/?linkid=2085767"
@@ -31,11 +27,20 @@ if ($wdkExitCode -ne 0)
 
 # Need to install the VSIX to get the build targets when running VSBuild
 # Write-Host "Installing WDK.vsix"
- $process = Start-Process `
+try
+{
+     $process = Start-Process `
     -FilePath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\VSIXInstaller.exe" `
     -ArgumentList ("/quiet", '"C:\Program Files (x86)\Windows Kits\10\Vsix\VS2019\WDK.vsix"') `
     -Wait `
     -PassThru
+}
+catch
+{
+    Write-Host "There is an error during WDK.vsix installation"
+    $_
+}
+
 
  $exitCode = $process.ExitCode
 

--- a/images/win/scripts/Installers/Windows2019/Install-WDK.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-WDK.ps1
@@ -39,6 +39,7 @@ catch
 {
     Write-Host "There is an error during WDK.vsix installation"
     $_
+    exit 1
 }
 
 

--- a/images/win/scripts/Installers/Windows2019/Validate-WDK.ps1
+++ b/images/win/scripts/Installers/Windows2019/Validate-WDK.ps1
@@ -3,28 +3,7 @@
 ##  Desc:  Validate the installation of the Windows Driver Kit
 ################################################################################
 
-function Get-WDKExtensionPackage {
-    $vsProgramData = Get-Item -Path "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances"
-    $instanceFolders = Get-ChildItem -Path $vsProgramData.FullName
-
-    if($instanceFolders -is [array])
-    {
-        Write-Host "More than one instance installed"
-        exit 1
-    }
-
-    $stateContent = Get-Content -Path ($instanceFolders.FullName + '\state.packages.json')
-    $state = $stateContent | ConvertFrom-Json
-    $WDKPackageVersion = ($state.packages | where { $_.id -eq "Microsoft.Windows.DriverKit" }).version
-
-    if (!$WDKPackageVersion)
-    {
-        Write-Host "WDK package for Visual studio was not found"
-        exit 1
-    }
-
-    return $WDKPackageVersion
-}
+Import-Module -Name ImageHelpers -Force
 
 function Get-WDKVersion
 {
@@ -40,7 +19,7 @@ function Get-WDKVersion
 }
 
 $WDKVersion = Get-WDKVersion
-$WDKPackageVersion = Get-WDKExtensionPackage
+$WDKPackageVersion = Get-VS19ExtensionVersion -packageName "Microsoft.Windows.DriverKit"
 
 # Adding description of the software to Markdown
 $SoftwareName = "Windows Driver Kit"

--- a/images/win/scripts/Installers/Windows2019/Validate-WDK.ps1
+++ b/images/win/scripts/Installers/Windows2019/Validate-WDK.ps1
@@ -3,11 +3,51 @@
 ##  Desc:  Validate the installation of the Windows Driver Kit
 ################################################################################
 
+function Get-WDKExtensionPackage {
+    $vsProgramData = Get-Item -Path "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances"
+    $instanceFolders = Get-ChildItem -Path $vsProgramData.FullName
+
+    if($instanceFolders -is [array])
+    {
+        Write-Host "More than one instance installed"
+        exit 1
+    }
+
+    $stateContent = Get-Content -Path ($instanceFolders.FullName + '\state.packages.json')
+    $state = $stateContent | ConvertFrom-Json
+    $WDKPackageVersion = ($state.packages | where { $_.id -eq "Microsoft.Windows.DriverKit" }).version
+
+    if (!$WDKPackageVersion)
+    {
+        Write-Host "WDK package for Visual studio was not found"
+        exit 1
+    }
+
+    return $WDKPackageVersion
+}
+
+function Get-WDKVersion
+{
+    $WDKVersion = (Get-WmiObject Win32_Product -Filter "Name = 'Windows Driver Kit'").version
+
+    if (!$WDK)
+    {
+        Write-Host "WDK was not found"
+        exit 1
+    }
+
+    return $WDKVersion
+}
+
+$WDKVersion = Get-WDKVersion
+$WDKPackageVersion = Get-WDKExtensionPackage
+
 # Adding description of the software to Markdown
 $SoftwareName = "Windows Driver Kit"
 
 $Description = @"
-_Version:_ 10.0.18362.0<br/>
+_WDK Version:_ $WDKVersion<br/>
+_WDK Visual Studio Extension Version:_ $WDKPackageVersion<br/>
 "@
 
 Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description

--- a/images/win/scripts/Installers/Windows2019/Validate-WDK.ps1
+++ b/images/win/scripts/Installers/Windows2019/Validate-WDK.ps1
@@ -30,7 +30,7 @@ function Get-WDKVersion
 {
     $WDKVersion = (Get-WmiObject Win32_Product -Filter "Name = 'Windows Driver Kit'").version
 
-    if (!$WDK)
+    if (!$WDKVersion)
     {
         Write-Host "WDK was not found"
         exit 1

--- a/images/win/scripts/Installers/Windows2019/Validate-Wix.ps1
+++ b/images/win/scripts/Installers/Windows2019/Validate-Wix.ps1
@@ -11,23 +11,6 @@ function Get-WixVersion {
     return $Version
 }
 
-#Gets the extension details from state.json
-function Get-WixExtensionPackage {
-    $vsProgramData = Get-Item -Path "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances"
-    $instanceFolders = Get-ChildItem -Path $vsProgramData.FullName
-
-    if($instanceFolders -is [array])
-    {
-        Write-Host "More than one instance installed"
-        exit 1
-    }
-
-    $stateContent = Get-Content -Path ($instanceFolders.FullName + '\state.packages.json')
-    $state = $stateContent | ConvertFrom-Json
-    $WixPackage = $state.packages | where { $_.id -eq "WixToolset.VisualStudioExtension.Dev16" }
-    return $WixPackage
-}
-
 $WixToolSetVersion = Get-WixVersion
 
 if($WixToolSetVersion) {
@@ -38,22 +21,14 @@ else {
     exit 1
 }
 
-$WixPackage = Get-WixExtensionPackage
-
-if($WixPackage) {
-    Write-Host "Wix Extension version" $WixPackage.version "installed"
-}
-else {
-    Write-Host "Wix Extension is not installed"
-    exit 1
-}
+$WixPackageVersion = Get-VS19ExtensionVersion -packageName "WixToolset.VisualStudioExtension.Dev16"
 
 # Adding description of the software to Markdown
 $SoftwareName = "WIX Tools"
 
 $Description = @"
 _Toolset Version:_ $WixToolSetVersion<br/>
-_WIX Toolset Visual Studio Extension Version:_ $($WixPackage.version)<br/>
+_WIX Toolset Visual Studio Extension Version:_ $WixPackageVersion<br/>
 _Environment:_
 * WIX: Installation root of WIX
 "@


### PR DESCRIPTION
We have several issues related to WDK:
https://github.com/actions/virtual-environments/issues/259
https://github.com/actions/virtual-environments/issues/428
The root cause is an incorrect installation order - WDK is supposed to be installed after VS19, not before so that the extension can be added to VS.

Changes:
- Installation order changed
- Try-catch on package installation added in order to break the build if the package is not installed
- Validate-WDK script works properly now, previously it's just put hardcoded value to the softwarelist(the same can be done for windows16 if needed)
- Get-VS19ExtensionVersion function created to use it in both Validate-WDK and Validate-Wix scripts