### PR TITLE
Install node-sass module since it doesn't come with Node anymore

### DIFF
--- a/images/win/scripts/Installers/Install-NodeLts.ps1
+++ b/images/win/scripts/Installers/Install-NodeLts.ps1
@@ -32,3 +32,4 @@ npm install -g parcel-bundler
 npm install -g --save-dev webpack webpack-cli
 npm install -g yarn
 npm install -g lerna
+npm install -g node-sass


### PR DESCRIPTION
For feedback ticket: https://developercommunity.visualstudio.com/content/problem/815166/cannot-find-module-node-sass-on-npm-build.html