### PR TITLE
Fix Azure CLI DevOps installation on Ubuntu images

### DIFF
--- a/images/linux/scripts/installers/azure-cli.sh
+++ b/images/linux/scripts/installers/azure-cli.sh
@@ -7,13 +7,8 @@
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/document.sh
 
-LSB_CODENAME=$(lsb_release -cs)
-
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
-echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $LSB_CODENAME main" | tee /etc/apt/sources.list.d/azure-cli.list
-apt-key adv --keyserver packages.microsoft.com --recv-keys B02C46DF417A0893
-apt-get update
-apt-get install -y --no-install-recommends apt-transport-https azure-cli
+curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"

--- a/images/linux/scripts/installers/azure-devops-cli.sh
+++ b/images/linux/scripts/installers/azure-devops-cli.sh
@@ -7,6 +7,11 @@
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/document.sh
 
+# AZURE_EXTENSION_DIR shell variable defines where modules are installed
+# https://docs.microsoft.com/en-us/cli/azure/azure-cli-extensions-overview
+export AZURE_EXTENSION_DIR=/opt/az/azcliextensions
+echo "AZURE_EXTENSION_DIR=$AZURE_EXTENSION_DIR" | tee -a /etc/environment
+
 # install azure devops Cli extension
 az extension add -n azure-devops
 


### PR DESCRIPTION
Issue:
Once an extension is installed, it's found under the value of the `$AZURE_EXTENSION_DIR` shell variable. If this variable is unset, by default the value is `$HOME/.azure/cliextensions` on Linux and macOS. After image build is successfully finished, user profile is deleted with `.azure/cliextensions ` and we don't have any azure-cli extensions on an image.

Fix:
Define `AZURE_EXTENSION_DIR` set up to `/opt/az/azcliextensions` (default azure-cli folder) as global for all users

```
~$ az -v
azure-cli                          2.1.0

command-modules-nspkg              2.0.3
core                               2.1.0
nspkg                              3.0.4
telemetry                          1.0.4

Extensions:
azure-devops                      0.17.0

Python location '/opt/az/bin/python3'
Extensions directory '/opt/az/azcliextensions'
```