### PR TITLE
Add SqlLocalDb to windows19 readme file

### DIFF
--- a/images/win/scripts/Installers/Validate-DACFx.ps1
+++ b/images/win/scripts/Installers/Validate-DACFx.ps1
@@ -15,6 +15,15 @@ else
     throw "DACFx is not installed!"
 }
 
+if(Get-Command -Name 'SqlLocalDB')
+{
+    $localDbPath = (Get-Command -Name 'SqlLocalDB').Source
+}
+else
+{
+    throw "SqlLocalDB is not installed!"
+}
+
 function Get-DacFxVersion
 {
     $regKey = "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Data-Tier Application Framework\CurrentVersion"
@@ -28,6 +37,7 @@ $SoftwareName = "SQL Server Data Tier Application Framework (x64)"
 
 $Description = @"
 _Version:_ $(Get-DacFxVersion)<br/>
+* SqlLocalDB is available at $localDbPath
 "@
 
 Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description

--- a/images/win/scripts/Installers/Validate-DACFx.ps1
+++ b/images/win/scripts/Installers/Validate-DACFx.ps1
@@ -37,7 +37,7 @@ $SoftwareName = "SQL Server Data Tier Application Framework (x64)"
 
 $Description = @"
 _Version:_ $(Get-DacFxVersion)<br/>
-* SqlLocalDB is available at $localDbPath
+* SQL Server Express LocalDB is available at $localDbPath
 "@
 
 Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description


### PR DESCRIPTION
There is [a complaint](https://github.com/actions/virtual-environments/issues/413) that Microsoft SQL Server Express is not mentioned in the readme.
This PR simply adds SqlLocalDb path to the SoftwareMd file.