### PR TITLE
Restore ubuntu 18 php-intl installation

### DIFF
--- a/images/linux/scripts/installers/1804/powershellcore.sh
+++ b/images/linux/scripts/installers/1804/powershellcore.sh
@@ -12,9 +12,6 @@ LSB_RELEASE=$(lsb_release -rs)
 # Install Powershell
 apt-get install -y powershell
 
-# Temp fix based on: https://github.com/PowerShell/PowerShell/issues/9746 
-sudo apt remove libicu64
-
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
 if ! command -v pwsh; then

--- a/images/linux/scripts/installers/1804/powershellcore.sh
+++ b/images/linux/scripts/installers/1804/powershellcore.sh
@@ -11,7 +11,7 @@ LSB_RELEASE=$(lsb_release -rs)
 # libicu64, which comes with php-intl module, has powershell breaking issue https://github.com/PowerShell/PowerShell/issues/9746
 # Fix - install additional libicu65 where the issue is fixed
 echo "install libicu65"
-sudo apt get install libicu65
+apt get install libicu65
 
 # Install Powershell
 apt-get install -y powershell

--- a/images/linux/scripts/installers/1804/powershellcore.sh
+++ b/images/linux/scripts/installers/1804/powershellcore.sh
@@ -10,6 +10,7 @@ source $HELPER_SCRIPTS/document.sh
 LSB_RELEASE=$(lsb_release -rs)
 # libicu64, which comes with php-intl module, has powershell breaking issue https://github.com/PowerShell/PowerShell/issues/9746
 # Fix - install additional libicu65 where the issue is fixed
+echo "install libicu65"
 sudo apt get install libicu65
 
 # Install Powershell

--- a/images/linux/scripts/installers/1804/powershellcore.sh
+++ b/images/linux/scripts/installers/1804/powershellcore.sh
@@ -8,6 +8,9 @@
 source $HELPER_SCRIPTS/document.sh
 
 LSB_RELEASE=$(lsb_release -rs)
+# libicu64, which comes with php-intl module, has powershell breaking issue https://github.com/PowerShell/PowerShell/issues/9746
+# Fix - install additional libicu65 where the issue is fixed
+sudo apt get install libicu65
 
 # Install Powershell
 apt-get install -y powershell


### PR DESCRIPTION
libicu64, which comes with php-intl module, has powershell breaking issue:https://github.com/PowerShell/PowerShell/issues/9746
As a workaround, this library was removed, but php-intl modules were also removed. The following issue has been received as a result.
https://github.com/actions/virtual-environments/issues/432
 
Changes:
- Install new libicu version 6.5 where the breaking issue is fixed