### PR TITLE
Add Images.CI for Windows and Ubuntu images (Azure DevOps)

### DIFF
--- a/images.CI/azure-pipelines/image-generation.yml
+++ b/images.CI/azure-pipelines/image-generation.yml
@@ -36,6 +36,18 @@ jobs:
                         -GitHubFeedToken $(GITHUB_TOKEN)
 
   - task: PowerShell@2
+    displayName: 'Create release for VM deployment'
+    inputs:
+      targetType: filePath
+      filePath: ./images.CI/create-release.ps1
+      arguments: -BuildId $(Build.BuildNumber) `
+                        -Organization $(RELEASE_TARGET_ORGANIZATION) `
+                        -DefinitionId $(RELEASE_TARGET_DEFINITION_ID) `
+                        -Project $(RELEASE_TARGET_PROJECT) `
+                        -ImageName ${{ parameters.image_type }} `
+                        -AccessToken $(RELEASE_TARGET_TOKEN)
+
+  - task: PowerShell@2
     displayName: 'Clean up resources'
     condition: always()
     inputs:

--- a/images.CI/azure-pipelines/image-generation.yml
+++ b/images.CI/azure-pipelines/image-generation.yml
@@ -1,3 +1,9 @@
+# Currently, we use Azure DevOps for Images.CI as a temporary solution until GitHub Actions supports our requirements
+# Since we have to use self-hosted machines to run image builds, we need the following features to use GitHub Actions for Images CI:
+# - https://github.community/t5/GitHub-Actions/Make-secrets-available-to-builds-of-forks/m-p/30678#M508
+# - https://github.community/t5/GitHub-Actions/GitHub-Actions-Manual-Trigger-Approvals/td-p/31504
+# - https://github.community/t5/GitHub-Actions/Protecting-github-workflows/td-p/30290
+
 jobs:
 - job:
   pool: ci-agent-pool
@@ -8,7 +14,7 @@ jobs:
   steps:
   - task: PowerShell@2
     displayName: 'Download custom repository'
-    condition: and(ne(variables['CUSTOM_REPOSITORY_BRANCH'], ''), ne(variables['CUSTOM_REPOSITORY_URL'], ''))
+    condition: and(ne(variables['CUSTOM_REPOSITORY_URL'], ''), ne(variables['CUSTOM_REPOSITORY_BRANCH'], ''))
     inputs:
       targetType: 'inline'
       script: |

--- a/images.CI/azure-pipelines/image-generation.yml
+++ b/images.CI/azure-pipelines/image-generation.yml
@@ -1,5 +1,5 @@
-# Currently, we use Azure DevOps for Images.CI as a temporary solution until GitHub Actions supports our requirements
-# Since we have to use self-hosted machines to run image builds, we need the following features to use GitHub Actions for Images CI:
+# Ideally we would use GitHub Actions for this, but since we use self-hosted machines to run image builds
+# we need the following features to use GitHub Actions for Images CI:
 # - https://github.community/t5/GitHub-Actions/Make-secrets-available-to-builds-of-forks/m-p/30678#M508
 # - https://github.community/t5/GitHub-Actions/GitHub-Actions-Manual-Trigger-Approvals/td-p/31504
 # - https://github.community/t5/GitHub-Actions/Protecting-github-workflows/td-p/30290
@@ -20,9 +20,12 @@ jobs:
       script: |
         Remove-Item -path './*' -Recurse -Force
         Write-Host "Download $(CUSTOM_REPOSITORY_BRANCH) branch from $(CUSTOM_REPOSITORY_URL)"
+        $env:GIT_REDIRECT_STDERR = '2>&1'
+        git clone $(CUSTOM_REPOSITORY_URL) . -b $(CUSTOM_REPOSITORY_BRANCH) --single-branch --depth 1
+        # git
         # git on self-hosted agent produces some output to stderr even during successful cloning
         # use cmd output redirect to overcome it
-        cmd /c "git clone $(CUSTOM_REPOSITORY_URL) . -b $(CUSTOM_REPOSITORY_BRANCH) --single-branch --depth 1 2>&1"
+        # cmd /c "git clone $(CUSTOM_REPOSITORY_URL) . -b $(CUSTOM_REPOSITORY_BRANCH) --single-branch --depth 1 2>&1"
 
   - task: PowerShell@2
     displayName: 'Build VM'

--- a/images.CI/azure-pipelines/image-generation.yml
+++ b/images.CI/azure-pipelines/image-generation.yml
@@ -23,7 +23,7 @@ jobs:
     inputs:
       targetType: filePath
       filePath: ./images.CI/build-image.ps1
-      arguments: -ResourcesNamePrefix $(Build.BuildNumber) `
+      arguments: -ResourcesNamePrefix $(Build.BuildId) `
                         -ClientId $(CLIENT_ID) `
                         -ClientSecret $(CLIENT_SECRET) `
                         -Image ${{ parameters.image_type }} `
@@ -42,7 +42,7 @@ jobs:
     inputs:
       targetType: filePath
       filePath: ./images.CI/create-release.ps1
-      arguments: -BuildId $(Build.BuildNumber) `
+      arguments: -BuildId $(Build.BuildId) `
                         -Organization $(RELEASE_TARGET_ORGANIZATION) `
                         -DefinitionId $(RELEASE_TARGET_DEFINITION_ID) `
                         -Project $(RELEASE_TARGET_PROJECT) `
@@ -55,7 +55,7 @@ jobs:
     inputs:
       targetType: filePath
       filePath: ./images.CI/cleanup.ps1
-      arguments: -ResourcesNamePrefix $(Build.BuildNumber) `
+      arguments: -ResourcesNamePrefix $(Build.BuildId) `
                      -ClientId $(CLIENT_ID) `
                      -ClientSecret $(CLIENT_SECRET) `
                      -Image ${{ parameters.image_type }} `

--- a/images.CI/azure-pipelines/image-generation.yml
+++ b/images.CI/azure-pipelines/image-generation.yml
@@ -18,14 +18,11 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
+        Write-Host "Clean up default repository"
         Remove-Item -path './*' -Recurse -Force
         Write-Host "Download $(CUSTOM_REPOSITORY_BRANCH) branch from $(CUSTOM_REPOSITORY_URL)"
         $env:GIT_REDIRECT_STDERR = '2>&1'
         git clone $(CUSTOM_REPOSITORY_URL) . -b $(CUSTOM_REPOSITORY_BRANCH) --single-branch --depth 1
-        # git
-        # git on self-hosted agent produces some output to stderr even during successful cloning
-        # use cmd output redirect to overcome it
-        # cmd /c "git clone $(CUSTOM_REPOSITORY_URL) . -b $(CUSTOM_REPOSITORY_BRANCH) --single-branch --depth 1 2>&1"
 
   - task: PowerShell@2
     displayName: 'Build VM'

--- a/images.CI/azure-pipelines/ubuntu1604.yml
+++ b/images.CI/azure-pipelines/ubuntu1604.yml
@@ -1,10 +1,10 @@
-# schedules:
-# - cron: "0 0 * * *"
-#   displayName: Daily
-#   branches:
-#     include:
-#     - master
-#   always: true
+schedules:
+- cron: "0 0 * * *"
+  displayName: Daily
+  branches:
+    include:
+    - master
+  always: true
 
 trigger: none
 pr:

--- a/images.CI/azure-pipelines/ubuntu1804.yml
+++ b/images.CI/azure-pipelines/ubuntu1804.yml
@@ -1,10 +1,10 @@
-# schedules:
-# - cron: "0 0 * * *"
-#   displayName: Daily
-#   branches:
-#     include:
-#     - master
-#   always: true
+schedules:
+- cron: "0 0 * * *"
+  displayName: Daily
+  branches:
+    include:
+    - master
+  always: true
 
 trigger: none
 pr:

--- a/images.CI/azure-pipelines/windows2016.yml
+++ b/images.CI/azure-pipelines/windows2016.yml
@@ -1,10 +1,10 @@
-# schedules:
-# - cron: "0 0 * * *"
-#   displayName: Daily
-#   branches:
-#     include:
-#     - master
-#   always: true
+schedules:
+- cron: "0 0 * * *"
+  displayName: Daily
+  branches:
+    include:
+    - master
+  always: true
 
 trigger: none
 pr:

--- a/images.CI/azure-pipelines/windows2019.yml
+++ b/images.CI/azure-pipelines/windows2019.yml
@@ -1,10 +1,10 @@
-# schedules:
-# - cron: "0 0 * * *"
-#   displayName: Daily
-#   branches:
-#     include:
-#     - master
-#   always: true
+schedules:
+- cron: "0 0 * * *"
+  displayName: Daily
+  branches:
+    include:
+    - master
+  always: true
 
 trigger: none
 pr:

--- a/images.CI/create-release.ps1
+++ b/images.CI/create-release.ps1
@@ -1,0 +1,31 @@
+param(
+    [UInt32] [Parameter (Mandatory)] $BuildId,
+    [String] [Parameter (Mandatory)] $Organization,
+    [String] [Parameter (Mandatory)] $Project,
+    [String] [Parameter (Mandatory)] $ImageName,
+    [String] [Parameter (Mandatory)] $DefinitionId,
+    [String] [Parameter (Mandatory)] $AccessToken
+)
+
+$Body = @{
+    definitionId = $DefinitionId
+    variables = @{
+      ImageBuildId = @{
+        value = $BuildId
+      }
+      ImageName = @{
+        value = $ImageName
+      }
+    }
+    isDraft = "false"
+} | ConvertTo-Json -Depth 3
+
+$URL = "https://vsrm.dev.azure.com/$Organization/$Project/_apis/release/releases?api-version=5.1"
+$base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("'':${AccessToken}"))
+$headers = @{
+    Authorization = "Basic ${base64AuthInfo}"
+}
+
+$NewRelease = Invoke-RestMethod $URL -Body $Body -Method "POST" -Headers $headers -ContentType "application/json"
+
+Write-Host "Created release: $($NewRelease._links.web.href)"

--- a/images/win/Windows2016-Readme.md
+++ b/images/win/Windows2016-Readme.md
@@ -1,6 +1,6 @@
 # Windows Server 2016
 
-The following software is installed on machines with the 20200120.1 update.
+The following software is installed on machines with the 20200130.1 update.
 
 Components marked with **\*** have been upgraded since the previous version of the image.
 
@@ -19,13 +19,14 @@ _Environment:_
 
 ## Docker-compose
 
-_Version:_ 1.25.1<br/>
+_Version:_ 1.25.3<br/>
 _Environment:_
 * PATH: contains location of docker-compose.exe
 
 ## Powershell Core
 
-_Version:_ 6.2.3<br/>
+_Version:_ 6.2.4
+<br/>
 
 ## Docker images
 
@@ -342,10 +343,6 @@ _Version:_ azure-devops                      0.17.0
 
 ## Python
 
-_Version:_ 2.7.17 (x64)<br/>_Version:_ 3.5.4 (x64)<br/>_Version:_ 3.6.8 (x64)<br/>_Version:_ 3.7.6 (x64)<br/>_Version:_ 3.8.1 (x64)<br/>
-
-## Python
-
 _Version:_ 2.7.17 (x64)<br/>_Version:_ 3.5.4 (x64)<br/>_Version:_ 3.6.8 (x64)<br/>_Version:_ 3.7.6 (x64)<br/>_Version:_ 3.8.1 (x64)<br/>_Version:_ 2.7.17 (x86)<br/>_Version:_ 3.5.4 (x86)<br/>_Version:_ 3.6.8 (x86)<br/>_Version:_ 3.7.6 (x86)<br/>_Version:_ 3.8.1 (x86)<br/>
 
 ## PyPy
@@ -411,20 +408,25 @@ _Environment:_
 
 ## Boost
 
-#### 
+#### 1.69.0
 
-* PATH: contains the location of Boost version 
-* BOOST_ROOT: root directory of the Boost version  installation
-* BOOST_ROOT_1_69_0: root directory of the Boost version  installation
+* PATH: contains the location of Boost version 1.69.0
+* BOOST_ROOT: root directory of the Boost version 1.69.0 installation
+* BOOST_ROOT_1_69_0: root directory of the Boost version 1.69.0 installation
+#### 1.72.0
+
+_Environment:_
+* BOOST_ROOT_1_72_0: root directory of the Boost version 1.72.0 installation
+
 
 
 ## PHP (x64)
 
-#### 7.4.1
+#### 7.4.2
 
 _Environment:_
-* PATH: contains the location of php.exe version 7.4.1
-* PHPROOT: root directory of the PHP 7.4.1 installation
+* PATH: contains the location of php.exe version 7.4.2
+* PHPROOT: root directory of the PHP 7.4.2 installation
 
 ## Ruby (x64)
 
@@ -432,6 +434,7 @@ _Environment:_
 _Environment:_
 * Location: C:\hostedtoolcache\windows\Ruby\2.5.7\x64\bin
 * PATH: contains the location of ruby.exe version 2.5.7p206
+* Gem Version: 3.1.2
 
 ## Rust (64-bit)
 
@@ -517,9 +520,9 @@ _Environment:_
 
 _Location:_ C:\Program Files\Java\zulu-7-azure-jdk_7.31.0.5-7.0.232-win_x64
 
-#### 1.7.0_232
+#### 11.0.4
 
-_Location:_ 
+_Location:_ C:\Program Files\Java\zulu-11-azure-jdk_11.33.15-11.0.4-win_x64
 
 ## Ant
 
@@ -685,7 +688,7 @@ _Environment:_
 
 ## Azure CosmosDb Emulator
 
-_Version:_ 2.7.2.0<br/>
+_Version:_ 2.9.0.0<br/>
 _Location:_ C:\Program Files\Azure Cosmos DB Emulator\
 
 ## 7zip
@@ -735,6 +738,6 @@ _Environment:_
 
 ## Kind
 
-_Version:_ v0.5.1<br/>
+_Version:_ kind v0.7.0 go1.13.6 windows/amd64<br/>
 _Environment:_
 * PATH: contains location of kind.exe


### PR DESCRIPTION
This PR adds `images.CI` folder in the root of repository. This folder contains set of scripts and yml files to run image generation builds in Azure DevOps CI.

Builds will be run on `https://dev.azure.com/github/virtual-environments`

