### PR TITLE
Add Az 3.5.0 PowerShell module to Windows Server 2016/2019

### DIFF
--- a/images/win/scripts/Installers/Install-AzureModules.ps1
+++ b/images/win/scripts/Installers/Install-AzureModules.ps1
@@ -53,7 +53,7 @@ foreach($psmoduleName in $psAzureModulesToInstall.Keys)
         Write-Host " - $psmoduleVersion [$psmodulePath]"
         try
         {
-            Save-Module -Path $psmodulePath -Name $psmoduleName -RequiredVersion $psmoduleVersion -Force -err
+            Save-Module -Path $psmodulePath -Name $psmoduleName -RequiredVersion $psmoduleVersion -Force -ErrorAction Stop
         }
         catch
         {

--- a/images/win/scripts/Installers/Install-AzureModules.ps1
+++ b/images/win/scripts/Installers/Install-AzureModules.ps1
@@ -64,5 +64,5 @@ foreach($psmoduleName in $psAzureModulesToInstall.Keys)
 }
 
 # Add AzureRM and Azure modules to the PSModulePath
-$finalModulePath = '{0};{1};{2}' -f "${installPSModulePath}\azurerm_6.13.1", "${installPSModulePath}\azure_5.3.0", $env:PSModulePath
+$finalModulePath = '{0};{1};{2}' -f "${installPSModulePath}\azurerm_2.1.0", "${installPSModulePath}\azure_2.1.0", $env:PSModulePath
 [Environment]::SetEnvironmentVariable("PSModulePath", $finalModulePath, "Machine")

--- a/images/win/scripts/Installers/Install-AzureModules.ps1
+++ b/images/win/scripts/Installers/Install-AzureModules.ps1
@@ -3,195 +3,66 @@
 ##  Desc:  Install Azure PowerShell modules
 ################################################################################
 
-Add-Type -AssemblyName System.IO.Compression.FileSystem
-
-function Download-Zip
-{
-    [CmdletBinding()]
-    Param(
-        [Parameter(
-            Mandatory = $true
-        )]
-        [string]
-        $BlobUri
-    )
-
-    Write-Host "Downloading the zip from blob: '$BlobUri'"
-    $fileName = "azureps_" + "$(Get-Random)" + ".zip"
-    $targetLocation = Join-Path $ENV:Temp -ChildPath $fileName
-    Write-Host "Download target location: '$targetLocation'"
-    $webClient = New-Object Net.WebClient
-    $null = $webClient.DownloadFileAsync($BlobUri, $targetLocation)
-    while ($webClient.IsBusy) { }
-    Write-Host "Download complete. Target Location: '$targetLocation'"
-    return $targetLocation
-}
-
-function Extract-Zip
-{
-    [CmdletBinding()]
-    Param(
-        [Parameter(
-            Mandatory = $true
-        )]
-        [string]
-        $ZipFilePath,
-
-        [Parameter(
-            Mandatory = $true
-        )]
-        [string]
-        $TargetLocation
-    )
-
-    Write-Host "Expanding the Zip File: '$ZipFilePath'. Target: '$TargetLocation'"
-    $null = [System.IO.Compression.ZipFile]::ExtractToDirectory($ZipFilePath, $TargetLocation)
-    Write-Host "Extraction completed successfully."
-}
-
 Set-PSRepository -InstallationPolicy Trusted -Name PSGallery
 
-# We try to detect the whether Azure PowerShell is installed using .msi file. If it is installed, we find it's version, then it needs to be uninstalled manually (because the uninstallation requires the PowerShell session to be closed)
-$regKey = "HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
-$installedApplications = Get-ItemProperty -Path $regKey
-$SdkVersion = ($installedApplications | Where-Object { $_.DisplayName -and $_.DisplayName.toLower().Contains("microsoft azure powershell") } | Select-Object -First 1).DisplayVersion
-
-if($SdkVersion -eq $null)
-{
-    Write-Host "No .msi Installation Present"
-}
-else
-{
-    Write-Host "An Azure PowerShell Installation through installer has been detected. Please close this powershell session and manually uninstall the Azure PowerShell from the Add or Remove Programs in the Control Panel. Then, rerun this script from an Admin PowerShell"
-    throw "An Azure PowerShell Installation through installer has been detected. Please close this powershell session and manually uninstall the Azure PowerShell from the Add or Remove Programs in the Control Panel. Then, rerun this script from an Admin PowerShell"
-}
-
-# We will try to uninstall any installation of Azure PowerShell
-
-$modules = Get-Module -Name Azure -ListAvailable
-Write-Host "The Azure Modules initially present are:"
-$modules | Select-Object Name,Version,Path | Format-Table
-
-foreach($module in $modules)
-{
-    # add logging for telling what module we are working on now
-    if(Test-Path -LiteralPath $module.Path)
-    {
-        try
-        {
-            Uninstall-Module -Name Azure -RequiredVersion $module.Version.tostring() -Force
-        }
-        catch
-        {
-            Write-Host "The Uninstallation of Azure Module version: $($module.Version.tostring()) failed with the error: $($_.Exception.Message) . Please Check if there isn't any other PowerShell session open."
-            throw $_.Exception.Message
-        }
-    }
-}
-
-$modules = Get-Module -Name AzureRM -ListAvailable
-Write-Host "The AzureRM Modules initially present are:"
-$modules | Select-Object Name,Version,Path | Format-Table
-
-foreach($module in $modules)
-{
-    # add logging for telling what module we are working on now
-    if(Test-Path -LiteralPath $module.Path)
-    {
-        try
-        {
-            Uninstall-Module -Name AzureRM -RequiredVersion $module.Version.tostring() -Force
-        }
-        catch
-        {
-            Write-Host "The Uninstallation of AzureRM Module version: $($module.Version.tostring()) failed with the error: $($_.Exception.Message) . Please Check if there isn't any other PowerShell session open."
-            throw $_.Exception.Message
-        }
-    }
-}
-
-#after this, the only installations available through a Get-Module cmdlet should be nothing
-
-$modules = Get-Module -Name Azure -ListAvailable
-
-foreach($module in $modules)
-{
-    Write-Host "Module found: $($module.Name)  Module Version: $($module.Version)"
-    if($module.Version.ToString() -ne " ")
-    {
-        Write-Host "Another installation of Azure module is detected with version $($module.Version.ToString()) at path: $($module.Path)"
-        throw "Azure module uninstallation unsuccessful"
-    }
-}
-
-$modules = Get-Module -Name AzureRM -ListAvailable
-
-foreach($module in $modules)
-{
-    write-host "Module found: $($module.Name)  Module Version: $($module.Version)"
-    if($module.Version.ToString() -ne " ")
-    {
-        Write-Host "Another installation of AzureRM module is detected with version $($module.Version.ToString()) at path: $($module.Path)"
-        throw "AzureRM module uninstallation unsuccessful"
-    }
-}
-
 #### NOW The correct Modules need to be saved in C:\Modules
-
-if($(Test-Path -LiteralPath "C:\Modules") -eq $true)
+$installPSModulePath = 'C:\Modules'
+if(-not (Test-Path -LiteralPath $installPSModulePath))
 {
-    Write-Host "C:\Modules directory is already present. Beginning to clear it up completely"
-    Remove-Item -Path "C:\Modules" -Recurse -Force
+    Write-Host "Creating '$installPSModulePath' folder to store PowerShell Azure modules"
+    $null = New-Item -Path $installPSModulePath -ItemType Directory
 }
 
-mkdir "C:\Modules"
+# Powershell Azure modules to install
+$psAzureModulesToInstall = @{
+    "azurerm" = @(
+        "2.1.0"
+        "3.8.0"
+        "4.2.1"
+        "5.1.1"
+        "6.7.0"
+        "6.13.1"
+    )
 
-$directoryListing = Get-ChildItem -Path "C:\Modules"
+    "azure" = @(
+        "2.1.0"
+        "3.8.0"
+        "4.2.1"
+        "5.1.1"
+        "5.3.0"
+    )
 
-if($directoryListing.Length -gt 0)
+    "az" = @(
+        "1.0.0"
+        "1.6.0"
+        "2.3.2"
+        "2.6.0"
+        "3.1.0"
+        "3.5.0"
+    )
+}
+
+# Download Azure PowerShell modules
+foreach($psmoduleName in $psAzureModulesToInstall.Keys)
 {
-     Write-Host "C:\Modules was not deleted properly. It still has the following contents:"
-     $directoryListing
-}
-else {
-    Write-Host "The Directory is clean. There are no contents present in it"
-}
-
-# Download and unzip the stored AzurePSModules from the vstsagentools public blob
-$extractLocation = "C:\Modules"
-$azurePsUri = @(
-    "https://vstsagenttools.blob.core.windows.net/tools/azurepowershellmodules/AzurePSModules.M157.20190808.27979.zip",
-    "https://vstsagenttools.blob.core.windows.net/tools/azurepowershellmodules/AzureRmPSModules.M157.20190808.27379.zip",
-    "https://vstsagenttools.blob.core.windows.net/tools/azurepowershellmodules/AzPSModules.M163.20191211.17769.zip"
-)
-
-$azureRMModulePath = "C:\Modules\azurerm_2.1.0"
-$azureModulePath = "C:\Modules\azure_2.1.0"
-$finalPath = ""
-$environmentPSModulePath = [Environment]::GetEnvironmentVariable("PSModulePath", "Machine")
-$existingPaths = $environmentPSModulePath -split ';' -replace '\\$',''
-
-if ($existingPaths -notcontains $azureRMModulePath) {
-    $finalPath = $azureRMModulePath
-}
-
-if ($existingPaths -notcontains $azureModulePath) {
-    if($finalPath -ne "") {
-        $finalPath = $finalPath + ";" + $azureModulePath
+    Write-Host "Installing '$psmoduleName' to the '$installPSModulePath' path:"
+    $psmoduleVersions = $psAzureModulesToInstall[$psmoduleName]
+    foreach($psmoduleVersion in $psmoduleVersions)
+    {
+        $psmodulePath = Join-Path $installPSModulePath "${psmoduleName}_${psmoduleVersion}"
+        Write-Host " - $psmoduleVersion [$psmodulePath]"
+        try
+        {
+            Save-Module -Path $psmodulePath -Name $psmoduleName -RequiredVersion $psmoduleVersion -Force -err
+        }
+        catch
+        {
+            Write-Host "Error: $_"
+            exit 1
+        }
     }
-    else {
-        $finalPath = $azureModulePath
-    }
 }
 
-if($finalPath -ne "") {
-    [Environment]::SetEnvironmentVariable("PSModulePath", $finalPath + ";" + $env:PSModulePath, "Machine")
-}
-
-$env:PSModulePath = $env:PSModulePath.TrimStart(';')
-
-foreach ($uri in $azurePsUri)
-{
-    $targetFile = Download-Zip -BlobUri $uri
-    Extract-Zip -ZipFilePath $targetFile -TargetLocation $extractLocation
-}
+# Add AzureRM and Azure modules to the PSModulePath
+$finalModulePath = '{0};{1};{2}' -f "${installPSModulePath}\azurerm_6.13.1", "${installPSModulePath}\azure_5.3.0", $env:PSModulePath
+[Environment]::SetEnvironmentVariable("PSModulePath", $finalModulePath, "Machine")

--- a/images/win/scripts/Installers/Validate-AzureModules.ps1
+++ b/images/win/scripts/Installers/Validate-AzureModules.ps1
@@ -29,12 +29,14 @@ This version is installed and is available via ``Get-Module -ListAvailable``
     Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description
     if($ModuleName -eq 'Az')
     {
-        $azureModules = Get-ChildItem C:\Modules\az_*\Az\*\*.psd1 | Select @{n="Version";e={[Version]$_.Directory.Name}},@{n="Path";e={$_.FullName}}
+        $prop = @{n="Version";e={[Version]$_.Directory.Name}},@{n="Path";e={$_.FullName}}
+        $azureModules = Get-ChildItem C:\Modules\az_*\Az\*\Az.psd1 | Select-Object $prop
     }
     else
     {
         $azureModules = Get-Module -Name $ModuleName -ListAvailable | Sort-Object Version -Unique
     }
+
     foreach($module in $azureModules)
     {
         if($module.Version -ne $DefaultModule.Version)
@@ -57,15 +59,15 @@ function Validate-AzureModule
 
     if ($ModuleName -eq 'Az')
     {
-        $installedVersions = Get-ChildItem C:\Modules\az_*\Az\* -Name
         $prop = @{n="Name";e={"Az"}},@{n="Version";e={[Version]$_.Directory.Name}},@{n="Path";e={$_.FullName}}
-        $azureModules = Get-ChildItem C:\Modules\az_*\Az\*\*.psd1 | Select $prop
+        $azureModules = Get-ChildItem C:\Modules\az_*\Az\*\Az.psd1 | Select-object $prop
     }
     else
     {
         $azureModules = Get-Module -Name $ModuleName -ListAvailable
-        $installedVersions = $azureModules | Foreach-Object {$_.Version.ToString()}
     }
+
+    $installedVersions = $azureModules | Foreach-Object {$_.Version.ToString()}
 
     Write-Host "The $ModuleName module finally present are:"
     $azureModules | Select-Object Name,Version,Path | Format-Table | Out-String

--- a/images/win/scripts/Installers/Validate-AzureModules.ps1
+++ b/images/win/scripts/Installers/Validate-AzureModules.ps1
@@ -15,11 +15,7 @@ function Add-ModuleDescription
 
     if ($DefaultModule)
     {
-        $Description = @"
-#### $($DefaultModule.Version)
-
-This version is installed and is available via ``Get-Module -ListAvailable``
-"@
+        $Description = "#### $($DefaultModule.Version)`n`nThis version is installed and is available via ``Get-Module -ListAvailable``"
     }
     else
     {
@@ -42,12 +38,7 @@ This version is installed and is available via ``Get-Module -ListAvailable``
         if($module.Version -ne $DefaultModule.Version)
         {
 
-            $CurrentModule = @"
-#### $($module.Version)
-
-This version is saved but not installed
-_Location:_ $($module.Path)
-"@
+            $CurrentModule = "#### $($module.Version)`n`nThis version is saved but not installed`n_Location:_ $($module.Path)"
             Add-ContentToMarkdown -Content $CurrentModule
         }
     }


### PR DESCRIPTION
Add Az 3.5.0 Modules to Windows Server 2016/2019 images. Customer request -  https://github.com/actions/virtual-environments/issues/440

1. Can we remove old versions?
No. This can break existing customers who has written there scripts based on the old AzurePS commands and using that specific version in the task.

2. Can we change default versions?
There are breaking changes between V2.1.0 and V5.13.0, V6.13.1. There are many third party custom tasks that may have taken dependency on V2.1.0 which will break if we change the default version.
