### PR TITLE
Do not reinstall moby in docker.sh, pull images only

### DIFF
--- a/images/linux/scripts/installers/docker-images.sh
+++ b/images/linux/scripts/installers/docker-images.sh
@@ -1,18 +1,11 @@
 #!/bin/bash
 ################################################################################
-##  File:  docker.sh
-##  Desc:  Installs the correct version of docker onto the image, and pulls
-##         down the default docker image used for building on ubuntu
+##  File:  docker-images.sh
+##  Desc:  Pulls down the default docker images used for building on ubuntu
 ################################################################################
 
 source $HELPER_SCRIPTS/apt.sh
 source $HELPER_SCRIPTS/document.sh
-
-DOCKER_PACKAGE=moby
-
-apt-get remove -y moby-engine mobi-cli
-apt-get update
-apt-get install -y moby-engine mobi-cli
 
 docker pull node:10
 docker pull node:12
@@ -25,8 +18,3 @@ docker pull alpine:3.7
 docker pull alpine:3.8
 docker pull alpine:3.9
 docker pull alpine:3.10
-
-## Add version information to the metadata file
-echo "Documenting Docker version"
-DOCKER_VERSION=`docker -v`
-DocumentInstalledItem "Docker ($DOCKER_VERSION)"

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -131,7 +131,7 @@
                 "{{template_dir}}/scripts/installers/cmake.sh",
                 "{{template_dir}}/scripts/installers/docker-compose.sh",
                 "{{template_dir}}/scripts/installers/docker-moby.sh",
-                "{{template_dir}}/scripts/installers/docker.sh",
+                "{{template_dir}}/scripts/installers/docker-images.sh",
                 "{{template_dir}}/scripts/installers/dotnetcore-sdk.sh",
                 "{{template_dir}}/scripts/installers/erlang.sh",
                 "{{template_dir}}/scripts/installers/firefox.sh",

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -134,7 +134,7 @@
                 "{{template_dir}}/scripts/installers/cmake.sh",
                 "{{template_dir}}/scripts/installers/docker-compose.sh",
                 "{{template_dir}}/scripts/installers/docker-moby.sh",
-                "{{template_dir}}/scripts/installers/docker.sh",
+                "{{template_dir}}/scripts/installers/docker-images.sh",
                 "{{template_dir}}/scripts/installers/dotnetcore-sdk.sh",
                 "{{template_dir}}/scripts/installers/erlang.sh",
                 "{{template_dir}}/scripts/installers/firefox.sh",


### PR DESCRIPTION
docker.sh script re-installs moby. This is unnecessary as the moby is installed in the docker-moby.sh called just shortly before (on Ubuntu 16 and 18). Moreover, the moby-cli is misspelled to mobi-cli.

The script has been renamed to docker-images.sh as it only pull images now. 

Fixes #474 