### PR TITLE
Update PATH environment variable to add .dotnet and php composer default folder

### DIFF
--- a/images/linux/scripts/installers/rust.sh
+++ b/images/linux/scripts/installers/rust.sh
@@ -15,7 +15,6 @@ export CARGO_HOME=/usr/share/rust/.cargo
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 # Add Cargo and Rust binaries to the machine path
-echo "PATH=${CARGO_HOME}/bin:$PATH" | tee -a /etc/environment
 source $CARGO_HOME/env
 
 # Install common tools

--- a/images/linux/scripts/installers/rust.sh
+++ b/images/linux/scripts/installers/rust.sh
@@ -14,7 +14,7 @@ export CARGO_HOME=/usr/share/rust/.cargo
 
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 
-# Add Cargo and Rust binaries to the machine path
+# Initialize environment variables
 source $CARGO_HOME/env
 
 # Install common tools

--- a/images/linux/scripts/installers/updatepath.sh
+++ b/images/linux/scripts/installers/updatepath.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+CARGO_HOME=/usr/share/rust/.cargo
+DOTNET_TOOLS_HOME=/home/runner/.dotnet/tools
+PHP_COMPOSER_HOME=/home/runner/.config/composer/vendor/bin
+echo "PATH=${CARGO_HOME}/bin:${PATH}:${DOTNET_TOOLS_HOME}:${PHP_COMPOSER_HOME}" | tee -a /etc/environment

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -168,6 +168,7 @@
                 "{{template_dir}}/scripts/installers/terraform.sh",
                 "{{template_dir}}/scripts/installers/vcpkg.sh",
                 "{{template_dir}}/scripts/installers/zeit-now.sh",
+                "{{template_dir}}/scripts/installers/updatepath.sh",
                 "{{template_dir}}/scripts/installers/dpkg-config.sh"
 
             ],

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -171,6 +171,7 @@
                 "{{template_dir}}/scripts/installers/terraform.sh",
                 "{{template_dir}}/scripts/installers/vcpkg.sh",
                 "{{template_dir}}/scripts/installers/zeit-now.sh",
+                "{{template_dir}}/scripts/installers/updatepath.sh",
                 "{{template_dir}}/scripts/installers/dpkg-config.sh"
             ],
             "environment_vars": [


### PR DESCRIPTION
Customers requested to add  .dotnet and php composer default folders to the PATH to eliminate manual update `PATH` environment variable to the workflows.

Fix add updatepath.sh  script to update all paths at the single place:
1. `/home/runner/.dotnet/tools` - customer request https://github.com/actions/virtual-environments/issues/213
2. `/home/runner/.config/composer/vendor/bin` -  customer request https://github.com/actions/virtual-environments/issues/118
3. move ${CARGO_HOME} from `rust.sh` to `updatepath.sh`

PS. `/home/runner` - is the $HOME folder for `runner` user under that user all builds run.