### PR TITLE
Fixing packer version description for Windows

### DIFF
--- a/images/win/scripts/Installers/Validate-Packer.ps1
+++ b/images/win/scripts/Installers/Validate-Packer.ps1
@@ -15,10 +15,10 @@ else
 
 # Adding description of the software to Markdown
 $SoftwareName = "Packer"
-$PackerVersion = (packer version).Split("")
+$PackerVersion = packer --version
 
 $Description = @"
-_Version:_ $PackerVersion.Item(1)<br/>
+_Version:_ $PackerVersion<br/>
 "@
 
 Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description


### PR DESCRIPTION
Issue:
`"_Version:_ $PackerVersion.Item(1)"` output will contain not only packer version, but additional   `.Item(1)`  element, for example: `_Version:_ Packer v1.5.4.Item(1)`

Fix:
We don't need using split statement, because `packer --version` = `1.3.4` command displays only version: `_Version:_ 1.3.4` compare to the command `packer version` = `Packer v1.3.4`

