### PR TITLE
Disable mysql.service by default on Ubuntu images

### DIFF
--- a/images/linux/scripts/installers/mysql.sh
+++ b/images/linux/scripts/installers/mysql.sh
@@ -44,3 +44,7 @@ echo "Lastly, documenting what we added to the metadata file"
 DocumentInstalledItem "MySQL ($(mysql --version))"
 DocumentInstalledItem "MySQL Server (user:root password:root)"
 DocumentInstalledItem "MS SQL Server Client Tools"
+
+# Disable mysql.service
+systemctl is-active --quiet service && systemctl stop mysql.service 
+systemctl disable mysql.service 

--- a/images/linux/scripts/installers/mysql.sh
+++ b/images/linux/scripts/installers/mysql.sh
@@ -46,5 +46,5 @@ DocumentInstalledItem "MySQL Server (user:root password:root)"
 DocumentInstalledItem "MS SQL Server Client Tools"
 
 # Disable mysql.service
-systemctl is-active --quiet service && systemctl stop mysql.service 
+systemctl is-active --quiet mysql.service && systemctl stop mysql.service 
 systemctl disable mysql.service 


### PR DESCRIPTION
Issue:
https://github.com/actions/virtual-environments/issues/348 and announce https://github.com/actions/virtual-environments/issues/375

Fix:
Disable autostart mysql.service.  We don't want to mask service: `This will prevent the MySQL service from being started, automatically or manually, for as long as it is masked.`