### PR TITLE
Fix vswhere version in the output file

### DIFF
--- a/images/win/scripts/Installers/Validate-VSWhere.ps1
+++ b/images/win/scripts/Installers/Validate-VSWhere.ps1
@@ -15,7 +15,7 @@ else
 
 # Adding description of the software to Markdown
 $SoftwareName = "VSWhere"
-$VswhereVersion = $(vswhere)
+$VswhereVersion = (Get-Command -Name vswhere).FileVersionInfo.ProductVersion
 
 $Description = @"
 _Version_: $VswhereVersion<br/>


### PR DESCRIPTION
Issue:
VsWhere version description contains a lot of noise in the output - https://github.com/actions/virtual-environments/blob/releases/win19/20200301/images/win/Windows2019-Readme.md

Fix:
Get ProductVersion in format: `2.8.4+ff0de50053 - shim 0.8.1`
