### PR TITLE
Add Spectre-mitigated libraries for MSVC v141 in Visual Studion 2019

### DIFF
--- a/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
@@ -112,6 +112,7 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.VisualStudio.Component.VC.TestAdapterForGoogleTest ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141 ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.x86.x64 ' + `
+              '--add Microsoft.VisualStudio.Component.VC.v141.x86.x64.Spectre ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.ATL.ARM.Spectre ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.ATL.ARM64.Spectre ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.ATL.Spectre ' + `

--- a/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
@@ -112,6 +112,12 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.VisualStudio.Component.VC.TestAdapterForGoogleTest ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141 ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.x86.x64 ' + `
+              '--add Microsoft.VisualStudio.Component.VC.v141.ATL.ARM.Spectre ' + `
+              '--add Microsoft.VisualStudio.Component.VC.v141.ATL.ARM64.Spectre ' + `
+              '--add Microsoft.VisualStudio.Component.VC.v141.ATL.Spectre ' + `
+              '--add Microsoft.VisualStudio.Component.VC.v141.MFC.ARM.Spectre ' + `
+              '--add Microsoft.VisualStudio.Component.VC.v141.MFC.ARM64.Spectre ' + `
+              '--add Microsoft.VisualStudio.Component.VC.v141.MFC.Spectre ' + `
               '--add Microsoft.VisualStudio.Component.Windows10SDK.16299 ' + `
               '--add Microsoft.VisualStudio.Component.Windows10SDK.17134 ' + `
               '--add Microsoft.VisualStudio.Component.Windows10SDK.17763 ' + `

--- a/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
@@ -113,6 +113,8 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141 ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.x86.x64 ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.x86.x64.Spectre ' + `
+              '--add Microsoft.VisualStudio.Component.VC.v141.ARM.Spectre ' + `
+              '--add Microsoft.VisualStudio.Component.VC.v141.ARM64.Spectre ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.ATL.ARM.Spectre ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.ATL.ARM64.Spectre ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.ATL.Spectre ' + `


### PR DESCRIPTION
After WDK installation was fixed in https://github.com/actions/virtual-environments/pull/431 Spectre mitigation flag is enabled by default - [related thread on Developer Community.](https://developercommunity.visualstudio.com/content/problem/348985/installing-wdk-1809-enabled-spectre-mitigation-fla.html)
That causes build failures for some users because Spectre-mitigated libraries for MSVC v141 are not installed  - https://github.com/actions/virtual-environments/issues/488

**Changes:**
- Add Spectre-mitigated components for MSVC v141 in Visual Studio 2019