### PR TITLE
Add zstd to win19 image

### DIFF
--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -500,6 +500,12 @@
         {
             "type": "powershell",
             "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-Zstd.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-InnoSetup.ps1"
             ]
         },
@@ -774,6 +780,12 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-Jq.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-Zstd.ps1"
             ]
         },
         {

--- a/images/win/scripts/Installers/Validate-Zstd.ps1
+++ b/images/win/scripts/Installers/Validate-Zstd.ps1
@@ -15,7 +15,7 @@ else
 
 # Adding description of the software to Markdown
 $SoftwareName = "zstd"
-$zstdVersion = $(zstd --version).Split(' ')[6].Split(',')[0]
+$zstdVersion = $(zstd --version).Split(' ')[6].Split(',')[0].Substring(1)
 
 $Description = @"
 _Version:_ $zstdVersion<br/>


### PR DESCRIPTION
In this PR zstd was added to win16 only, however, it's supposed to be presented on all images
https://github.com/actions/virtual-environments/pull/414
Related issue
https://github.com/actions/virtual-environments/issues/89

Changes:
- Add zstd to win19
- Minor version output fix to get rid of 'v' before the version number