### PR TITLE
Add installation of libs for default Clang on Ubuntu 16.04

### DIFF
--- a/images/linux/scripts/installers/1604/basic.sh
+++ b/images/linux/scripts/installers/1604/basic.sh
@@ -19,6 +19,8 @@ apt-fast install -y --no-install-recommends \
     iproute2 \
     iputils-ping \
     jq \
+    libc++-dev \
+    libc++abi-dev \
     libcurl3 \
     libicu55 \
     libunwind8 \
@@ -75,6 +77,8 @@ DocumentInstalledItemIndent "ftp"
 DocumentInstalledItemIndent "iproute2"
 DocumentInstalledItemIndent "iputils-ping"
 DocumentInstalledItemIndent "jq"
+DocumentInstalledItemIndent "libc++-dev"
+DocumentInstalledItemIndent "libc++abi-dev"
 DocumentInstalledItemIndent "libcurl3"
 DocumentInstalledItemIndent "libicu55"
 DocumentInstalledItemIndent "libunwind8"


### PR DESCRIPTION
PR for Issue #72 
Added `libc++-dev` and `libc++abi-dev` installation for Ubuntu 16.04