### PR TITLE
Add Microsoft Analysis Services Projects extension for VS19

### DIFF
--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -174,6 +174,12 @@
         },
         {
             "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Windows2019/Install-AnalysisExtenstion.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
             "valid_exit_codes": [
                 0,
                 3010
@@ -202,6 +208,12 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Windows2019/Validate-Wix.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Windows2019/Validate-AnalysisExtenstion.ps1"
             ]
         },
         {

--- a/images/win/scripts/Installers/Windows2019/Install-AnalysisExtenstion.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-AnalysisExtenstion.ps1
@@ -1,0 +1,44 @@
+###################################################################################
+##  File:  Install-AnalysisExtenstion.ps1
+##  Desc:  Install the Microsoft Analysis Services Projects Visual Studio extension
+###################################################################################
+
+
+$extensionUrl = "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ProBITools/vsextensions/MicrosoftAnalysisServicesModelingProjects/2.9.5/vspackage"
+$extensionDownloadPath = Join-Path $Env:TEMP "Microsoft.DataTools.AnalysisServices.vsix"
+Write-Host "Downloading Microsoft.DataTools.AnalysisServices.vsix extension"
+(New-Object System.Net.WebClient).DownloadFile($extensionUrl, $extensionDownloadPath)
+
+Write-Host "Installing Microsoft.DataTools.AnalysisServices.vsix extension"
+try
+{
+     $process = Start-Process `
+    -FilePath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\VSIXInstaller.exe" `
+    -ArgumentList ("/quiet", "$extensionDownloadPath") `
+    -Wait `
+    -PassThru
+}
+catch
+{
+    Write-Host "There is an error during Microsoft.DataTools.AnalysisServices.vsix installation"
+    $_
+    exit 1
+}
+
+
+$exitCode = $process.ExitCode
+
+if ($exitCode -eq 0 -or $exitCode -eq 1001) # 1001 means the extension is already installed
+{
+    Write-Host "Microsoft.DataTools.AnalysisServices.vsix installed successfully"
+}
+else
+{
+    Write-Host "Unsuccessful exit code returned by the installation process: $exitCode."
+    exit 1
+}
+
+#Cleanup installation files
+Remove-Item -Force -Confirm:$false $extensionDownloadPath
+
+exit $exitCode

--- a/images/win/scripts/Installers/Windows2019/Validate-AnalysisExtenstion.ps1
+++ b/images/win/scripts/Installers/Windows2019/Validate-AnalysisExtenstion.ps1
@@ -1,0 +1,18 @@
+################################################################################
+##  File:  Validate-AnalysisExtenstion.ps1
+##  Desc:  Validate Microsoft Analysis Services Projects Visual Studio extension
+################################################################################
+
+Import-Module -Name ImageHelpers -Force
+
+#AnalysisPackage doesn't have any proper name in the state.packages.json file, only id is available
+$AnalysisPackageVersion = Get-VS19ExtensionVersion -packageName "04a86fc2-dbd5-4222-848e-911638e487fe"
+
+# Adding description of the software to Markdown
+$SoftwareName = "Microsoft Analysis Services Projects Visual Studio Extension"
+
+$Description = @"
+_Version:_ $AnalysisPackageVersion<br/>
+"@
+
+Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description


### PR DESCRIPTION
Analysis Services Project extension is included in a standalone SSDT installer for VS17, but there is no such installer for VS19. With Visual Studio 2019, the required functionality to enable Analysis Services, Integration Services, and Reporting Services projects has moved into the respective Visual Studio (VSIX) extensions only. It blocks migration to VS19 for some customers https://github.com/actions/virtual-environments/issues/510

Changes:
- Add Install-AnalysisExtenstion script for VS19
