### PR TITLE
Add the CI environment variable in GitHub Actions 

### DIFF
--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -123,7 +123,8 @@
             "type": "shell",
             "inline": [
                 "echo ImageVersion={{user `image_version`}} | tee -a /etc/environment",
-                "echo ImageOS={{user `image_os`}} | tee -a /etc/environment"
+                "echo ImageOS={{user `image_os`}} | tee -a /etc/environment",
+                "echo CI=true | tee -a /etc/environment"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -126,7 +126,8 @@
             "type": "shell",
             "inline": [
                 "echo ImageVersion={{user `image_version`}} | tee -a /etc/environment",
-                "echo ImageOS={{user `image_os`}} | tee -a /etc/environment"
+                "echo ImageOS={{user `image_os`}} | tee -a /etc/environment",
+                "echo CI=true | tee -a /etc/environment"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },

--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -118,7 +118,8 @@
             "type": "powershell",
             "inline": [
               "setx ImageVersion {{user `image_version` }} /m",
-              "setx ImageOS {{user `image_os` }} /m"
+              "setx ImageOS {{user `image_os` }} /m",
+              "setx CI true /m"
             ]
         },
         {

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -118,7 +118,8 @@
             "type": "powershell",
             "inline": [
               "setx ImageVersion {{user `image_version` }} /m",
-              "setx ImageOS {{user `image_os` }} /m"
+              "setx ImageOS {{user `image_os` }} /m",
+              "setx CI true /m"
             ]
         },
         {


### PR DESCRIPTION
Issue:
The CI environment variable is not set in GitHub Actions (https://github.com/actions/virtual-environments/issues/520)

Fix:
Add the CI environment variable
| OS | Env | Value|
|-----|-----|------|
| Windows Server 2016 | CI | true
| Windows Server 2019 | CI | true
| Ubuntu 16.04 | CI | true
| Ubuntu 19.04 | CI | true
| macOS 10.15 | CI | true