### PR TITLE
Removed installing 2.2 dotnetcore version in linux and windows images

### DIFF
--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -48,7 +48,7 @@ for latest_package in ${LATEST_DOTNET_PACKAGES[@]}; do
 done
 
 # Get list of all released SDKs from channels which are not end-of-life or preview
-release_urls=("https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json" "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.2/releases.json" "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.0/releases.json" "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json")
+release_urls=("https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json" "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.0/releases.json" "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json")
 sdks=()
 for release_url in ${release_urls[@]}; do
     echo "${release_url}"

--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -54,8 +54,7 @@ function InstallAllValidSdks()
 
     # Consider all channels except preview/eol channels.
     # Sort the channels in ascending order
-    # HACK: Explicitly adding eol channel 2.2 for a grace period as this channel is wierdly marked as eol with no higher 2.x channel
-    $dotnetChannels = $dotnetChannels.'releases-index' | Where-Object { (!$_."support-phase".Equals('preview') -and !$_."support-phase".Equals('eol')) -or ($_."channel-version" -eq "2.2") } | Sort-Object { [Version] $_."channel-version" }
+    $dotnetChannels = $dotnetChannels.'releases-index' | Where-Object { (!$_."support-phase".Equals('preview') -and !$_."support-phase".Equals('eol')) } | Sort-Object { [Version] $_."channel-version" }
 
     # Download installation script.
     Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -UseBasicParsing -OutFile 'dotnet-install.ps1'


### PR DESCRIPTION
This change is because 2.2 version of .NET Core has been deprecated in January, 2020. As we try only to keep the versions which are not End Of Line (2.1, 3.0 and 3.1)

We have also added a message in .NET Core CLI task in Azure DevOps, which states that 2.2 is EOL and will be removed by end of March 2020. The users can however still choose to use this version by using UseDotNet V2 task to download the required version by them.

In .NET Core, its recommended to always build using the latest SDK, if however a specific version of the SDK is required, than use of UseDotNet task is recommended.