### PR TITLE
Add retry logic for VS19 extensions installation

### DIFF
--- a/images/win/scripts/ImageHelpers/ImageHelpers.psm1
+++ b/images/win/scripts/ImageHelpers/ImageHelpers.psm1
@@ -18,5 +18,6 @@ Export-ModuleMember -Function @(
     'Add-SoftwareDetailsToMarkdown'
     'Stop-SvcWithErrHandling'
     'Set-SvcWithErrHandling'
+    'Install-VsixExtension'
     'Get-VS19ExtensionVersion'
 )

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -170,7 +170,6 @@ function Install-VsixExtension
     )
 
     $FilePath = "${env:Temp}\$Name"
-    $exitCode = -1
     $retries = 20
 
     while($retries -gt 0)

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -161,6 +161,74 @@ Hashtable for service arguments
     }
 }
 
+function Install-VsixExtension
+{
+    Param
+    (
+        [String]$Url,
+        [String]$Name
+    )
+
+    $FilePath = "${env:Temp}\$Name"
+    $ReleaseInPath = 'Enterprise'
+    $exitCode = -1
+    $retries = 20
+
+    while($true)
+    {
+        try
+        {
+            Write-Host "Downloading $Name..."
+            (New-Object System.Net.WebClient).DownloadFile($Url, $FilePath)
+            break
+        }
+        catch
+        {
+            Write-Host "There is an error during $Name downloading"
+            $_
+            if ($retries -gt 0)
+            {
+                $retries--
+                Write-Host "Waiting 30 seconds before retrying. Retries left: $retries"
+                Start-Sleep -Seconds 30
+            }
+            else {
+                Write-Host "File can't be downloaded"
+                $_
+                exit 1
+            }
+        }
+    }
+
+    $ArgumentList = ('/quiet', $FilePath)
+
+    Write-Host "Starting Install $Name..."
+    try
+    {
+        $process = Start-Process -FilePath "C:\Program Files (x86)\Microsoft Visual Studio\2019\$ReleaseInPath\Common7\IDE\VSIXInstaller.exe" -ArgumentList $ArgumentList -Wait -PassThru
+    }
+    catch
+    {
+        Write-Host "There is an error during $Name installation"
+        $_
+        exit 1
+    }
+
+    $exitCode = $process.ExitCode
+
+    if ($exitCode -eq 0 -or $exitCode -eq 1001) # 1001 means the extension is already installed
+    {
+        Write-Host "$Name installed successfully"
+    }
+    else
+    {
+        Write-Host "Unsuccessful exit code returned by the installation process: $exitCode."
+        exit 1
+    }
+
+    #Cleanup installation files
+    Remove-Item -Force -Confirm:$false $FilePath
+}
 function Get-VS19ExtensionVersion
 {
     param (

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -170,11 +170,10 @@ function Install-VsixExtension
     )
 
     $FilePath = "${env:Temp}\$Name"
-    $ReleaseInPath = 'Enterprise'
     $exitCode = -1
     $retries = 20
 
-    while($true)
+    while($retries -gt 0)
     {
         try
         {
@@ -186,17 +185,18 @@ function Install-VsixExtension
         {
             Write-Host "There is an error during $Name downloading"
             $_
-            if ($retries -gt 0)
+
+            $retries--
+
+            if ($retries -eq 0)
             {
-                $retries--
-                Write-Host "Waiting 30 seconds before retrying. Retries left: $retries"
-                Start-Sleep -Seconds 30
-            }
-            else {
                 Write-Host "File can't be downloaded"
                 $_
                 exit 1
             }
+
+            Write-Host "Waiting 30 seconds before retrying. Retries left: $retries"
+            Start-Sleep -Seconds 30
         }
     }
 
@@ -205,7 +205,7 @@ function Install-VsixExtension
     Write-Host "Starting Install $Name..."
     try
     {
-        $process = Start-Process -FilePath "C:\Program Files (x86)\Microsoft Visual Studio\2019\$ReleaseInPath\Common7\IDE\VSIXInstaller.exe" -ArgumentList $ArgumentList -Wait -PassThru
+        $process = Start-Process -FilePath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\VSIXInstaller.exe" -ArgumentList $ArgumentList -Wait -PassThru
     }
     catch
     {

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -229,6 +229,7 @@ function Install-VsixExtension
     #Cleanup installation files
     Remove-Item -Force -Confirm:$false $FilePath
 }
+
 function Get-VS19ExtensionVersion
 {
     param (

--- a/images/win/scripts/Installers/Windows2019/Install-AnalysisExtenstion.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-AnalysisExtenstion.ps1
@@ -3,42 +3,9 @@
 ##  Desc:  Install the Microsoft Analysis Services Projects Visual Studio extension
 ###################################################################################
 
+Import-Module -Name ImageHelpers -Force;
 
 $extensionUrl = "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ProBITools/vsextensions/MicrosoftAnalysisServicesModelingProjects/2.9.5/vspackage"
-$extensionDownloadPath = Join-Path $Env:TEMP "Microsoft.DataTools.AnalysisServices.vsix"
-Write-Host "Downloading Microsoft.DataTools.AnalysisServices.vsix extension"
-(New-Object System.Net.WebClient).DownloadFile($extensionUrl, $extensionDownloadPath)
+$extensionName = "Microsoft.DataTools.AnalysisServices.vsix"
 
-Write-Host "Installing Microsoft.DataTools.AnalysisServices.vsix extension"
-try
-{
-     $process = Start-Process `
-    -FilePath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\VSIXInstaller.exe" `
-    -ArgumentList ("/quiet", "$extensionDownloadPath") `
-    -Wait `
-    -PassThru
-}
-catch
-{
-    Write-Host "There is an error during Microsoft.DataTools.AnalysisServices.vsix installation"
-    $_
-    exit 1
-}
-
-
-$exitCode = $process.ExitCode
-
-if ($exitCode -eq 0 -or $exitCode -eq 1001) # 1001 means the extension is already installed
-{
-    Write-Host "Microsoft.DataTools.AnalysisServices.vsix installed successfully"
-}
-else
-{
-    Write-Host "Unsuccessful exit code returned by the installation process: $exitCode."
-    exit 1
-}
-
-#Cleanup installation files
-Remove-Item -Force -Confirm:$false $extensionDownloadPath
-
-exit $exitCode
+Install-VsixExtension -Url $extensionUrl -Name $extensionName

--- a/images/win/scripts/Installers/Windows2019/Install-Wix.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-Wix.ps1
@@ -2,52 +2,11 @@
 ##  File:  Install-Wix.ps1
 ##  Desc:  Install WIX.
 ################################################################################
-function Install-VsixExtension
-{
-    Param
-    (
-        [String]$Url,
-        [String]$Name
-    )
 
-    $ReleaseInPath = 'Enterprise'
-    $exitCode = -1
-
-    try
-    {
-        Write-Host "Downloading $Name..."
-        $FilePath = "${env:Temp}\$Name"
-
-        Invoke-WebRequest -Uri $Url -OutFile $FilePath
-
-        $ArgumentList = ('/quiet', $FilePath)
-
-        Write-Host "Starting Install $Name..."
-        $process = Start-Process -FilePath "C:\Program Files (x86)\Microsoft Visual Studio\2019\$ReleaseInPath\Common7\IDE\VSIXInstaller.exe" -ArgumentList $ArgumentList -Wait -PassThru
-        $exitCode = $process.ExitCode
-
-        if ($exitCode -eq 0 -or $exitCode -eq 3010)
-        {
-            Write-Host -Object 'Installation successful'
-            return $exitCode
-        }
-        else
-        {
-            Write-Host -Object "Non zero exit code returned by the installation process : $exitCode."
-            return $exitCode
-        }
-    }
-    catch
-    {
-        Write-Host -Object "Failed to install the Extension $Name"
-        Write-Host -Object $_.Exception.Message
-        return -1
-    }
-}
-
+Import-Module -Name ImageHelpers -Force;
 
 choco install wixtoolset -y --force
 
 #Installing VS extension 'Wix Toolset Visual Studio 2019 Extension'
-$exitCode = Install-VsixExtension -Url 'https://wixtoolset.gallerycdn.vsassets.io/extensions/wixtoolset/wixtoolsetvisualstudio2019extension/1.0.0.4/1563296438961/Votive2019.vsix' -Name 'Votive2019.vsix'
+Install-VsixExtension -Url 'https://wixtoolset.gallerycdn.vsassets.io/extensions/wixtoolset/wixtoolsetvisualstudio2019extension/1.0.0.4/1563296438961/Votive2019.vsix' -Name 'Votive2019.vsix'
 #return $exitCode

--- a/images/win/scripts/Installers/Windows2019/Install-Wix.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-Wix.ps1
@@ -7,6 +7,8 @@ Import-Module -Name ImageHelpers -Force;
 
 choco install wixtoolset -y --force
 
+$extensionUrl = "https://wixtoolset.gallerycdn.vsassets.io/extensions/wixtoolset/wixtoolsetvisualstudio2019extension/1.0.0.4/1563296438961/Votive2019.vsix"
+$extensionName = "Votive2019.vsix"
+
 #Installing VS extension 'Wix Toolset Visual Studio 2019 Extension'
-Install-VsixExtension -Url 'https://wixtoolset.gallerycdn.vsassets.io/extensions/wixtoolset/wixtoolsetvisualstudio2019extension/1.0.0.4/1563296438961/Votive2019.vsix' -Name 'Votive2019.vsix'
-#return $exitCode
+Install-VsixExtension -Url $extensionUrl -Name $extensionName


### PR DESCRIPTION
The last 2 days VS extension marketplace returns Error 429, which breaks image building.
```
==> vhd: Provisioning with powershell script: C:\agent\_work\2\s\images\win/scripts/Installers/Windows2019/Install-AnalysisExtenstion.ps1
    vhd: Downloading Microsoft.DataTools.AnalysisServices.vsix extension
    vhd: Installing Microsoft.DataTools.AnalysisServices.vsix extension
    vhd: Exception calling "DownloadFile" with "2" argument(s): "The remote server returned an error: (429)."
```
This PR adds retry logic for extension download process.

Changes:
- Add Install-VsixExtension function
- Change Install-Wix and Install-AnalysisExtenstion scripts to use the helper function