### PR TITLE
Fix android sdkmanager installation path

### DIFF
--- a/images/linux/scripts/installers/1604/android.sh
+++ b/images/linux/scripts/installers/1604/android.sh
@@ -4,6 +4,8 @@
 ##  Desc:  Installs Android SDK
 ################################################################################
 
+set -e
+
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/document.sh
 source $HELPER_SCRIPTS/apt.sh

--- a/images/linux/scripts/installers/1604/android.sh
+++ b/images/linux/scripts/installers/1604/android.sh
@@ -16,6 +16,9 @@ source $HELPER_SCRIPTS/apt.sh
 # ANDROID_HOME is deprecated, but older versions of Gradle rely on it
 echo "ANDROID_HOME=${ANDROID_SDK_ROOT}" | tee -a /etc/environment
 
+# Create android sdk directory
+mkdir -p ${ANDROID_SDK_ROOT}
+
 # Download the latest command line tools so that we can accept all of the licenses.
 # See https://developer.android.com/studio/#command-tools
 wget -O android-sdk.zip https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip

--- a/images/linux/scripts/installers/1604/android.sh
+++ b/images/linux/scripts/installers/1604/android.sh
@@ -23,7 +23,7 @@ unzip android-sdk.zip -d ${ANDROID_SDK_ROOT}
 rm -f android-sdk.zip
 
 # Check sdk manager installation
-${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --list 1>/dev/null
+/usr/local/lib/android/tools/bin/sdkmanager --list 1>/dev/null
 if [ $? -eq 0 ]
 then
     echo "Android SDK manager was installed"

--- a/images/linux/scripts/installers/1604/android.sh
+++ b/images/linux/scripts/installers/1604/android.sh
@@ -22,8 +22,19 @@ wget -O android-sdk.zip https://dl.google.com/android/repository/sdk-tools-linux
 unzip android-sdk.zip -d ${ANDROID_SDK_ROOT}
 rm -f android-sdk.zip
 
+# Check sdk manager installation
+${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --list 1>/dev/null
+if [ $? -eq 0 ]
+then
+    echo "Android SDK manager was installed"
+else
+    echo "Android SDK manager was not installed"
+    exit 1
+fi
+
+
 # Install the following SDKs and build tools, passing in "y" to accept licenses.
-echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} \
+echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager \
     "ndk-bundle" \
     "platform-tools" \
     "platforms;android-29" \

--- a/images/linux/scripts/installers/1604/android.sh
+++ b/images/linux/scripts/installers/1604/android.sh
@@ -19,11 +19,11 @@ echo "ANDROID_HOME=${ANDROID_SDK_ROOT}" | tee -a /etc/environment
 # Download the latest command line tools so that we can accept all of the licenses.
 # See https://developer.android.com/studio/#command-tools
 wget -O android-sdk.zip https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip
-unzip android-sdk.zip -d ${ANDROID_ROOT}
+unzip android-sdk.zip -d ${ANDROID_SDK_ROOT}
 rm -f android-sdk.zip
 
 # Install the following SDKs and build tools, passing in "y" to accept licenses.
-echo "y" | ${ANDROID_ROOT}/tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} \
+echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} \
     "ndk-bundle" \
     "platform-tools" \
     "platforms;android-29" \

--- a/images/linux/scripts/installers/1604/android.sh
+++ b/images/linux/scripts/installers/1604/android.sh
@@ -23,7 +23,7 @@ unzip android-sdk.zip -d ${ANDROID_SDK_ROOT}
 rm -f android-sdk.zip
 
 # Check sdk manager installation
-/usr/local/lib/android/tools/bin/sdkmanager --list 1>/dev/null
+/usr/local/lib/android/sdk/tools/bin/sdkmanager --list 1>/dev/null
 if [ $? -eq 0 ]
 then
     echo "Android SDK manager was installed"

--- a/images/linux/scripts/installers/1804/android.sh
+++ b/images/linux/scripts/installers/1804/android.sh
@@ -4,6 +4,8 @@
 ##  Desc:  Installs Android SDK
 ################################################################################
 
+set -e
+
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/document.sh
 source $HELPER_SCRIPTS/apt.sh

--- a/images/linux/scripts/installers/1804/android.sh
+++ b/images/linux/scripts/installers/1804/android.sh
@@ -23,7 +23,7 @@ unzip android-sdk.zip -d ${ANDROID_SDK_ROOT}
 rm -f android-sdk.zip
 
 # Check sdk manager installation
-${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --list 1>/dev/null
+/usr/local/lib/android/tools/bin/sdkmanager --list 1>/dev/null
 if [ $? -eq 0 ]
 then
     echo "Android SDK manager was installed"

--- a/images/linux/scripts/installers/1804/android.sh
+++ b/images/linux/scripts/installers/1804/android.sh
@@ -19,11 +19,11 @@ echo "ANDROID_HOME=${ANDROID_SDK_ROOT}" | tee -a /etc/environment
 # Download the latest command line tools so that we can accept all of the licenses.
 # See https://developer.android.com/studio/#command-tools
 wget -O android-sdk.zip https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip
-unzip android-sdk.zip -d ${ANDROID_ROOT}
+unzip android-sdk.zip -d ${ANDROID_SDK_ROOT}
 rm -f android-sdk.zip
 
 # Install the following SDKs and build tools, passing in "y" to accept licenses.
-echo "y" | ${ANDROID_ROOT}/tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} \
+echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} \
     "ndk-bundle" \
     "platform-tools" \
     "platforms;android-29" \

--- a/images/linux/scripts/installers/1804/android.sh
+++ b/images/linux/scripts/installers/1804/android.sh
@@ -22,8 +22,18 @@ wget -O android-sdk.zip https://dl.google.com/android/repository/sdk-tools-linux
 unzip android-sdk.zip -d ${ANDROID_SDK_ROOT}
 rm -f android-sdk.zip
 
+# Check sdk manager installation
+${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --list 1>/dev/null
+if [ $? -eq 0 ]
+then
+    echo "Android SDK manager was installed"
+else
+    echo "Android SDK manager was not installed"
+    exit 1
+fi
+
 # Install the following SDKs and build tools, passing in "y" to accept licenses.
-echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} \
+echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager \
     "ndk-bundle" \
     "platform-tools" \
     "platforms;android-29" \

--- a/images/linux/scripts/installers/1804/android.sh
+++ b/images/linux/scripts/installers/1804/android.sh
@@ -23,7 +23,7 @@ unzip android-sdk.zip -d ${ANDROID_SDK_ROOT}
 rm -f android-sdk.zip
 
 # Check sdk manager installation
-/usr/local/lib/android/tools/bin/sdkmanager --list 1>/dev/null
+/usr/local/lib/android/sdk/tools/bin/sdkmanager --list 1>/dev/null
 if [ $? -eq 0 ]
 then
     echo "Android SDK manager was installed"

--- a/images/linux/scripts/installers/1804/android.sh
+++ b/images/linux/scripts/installers/1804/android.sh
@@ -16,6 +16,9 @@ echo "ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT}" | tee -a /etc/environment
 # ANDROID_HOME is deprecated, but older versions of Gradle rely on it
 echo "ANDROID_HOME=${ANDROID_SDK_ROOT}" | tee -a /etc/environment
 
+# Create android sdk directory
+mkdir -p ${ANDROID_SDK_ROOT}
+
 # Download the latest command line tools so that we can accept all of the licenses.
 # See https://developer.android.com/studio/#command-tools
 wget -O android-sdk.zip https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip


### PR DESCRIPTION
Issue: [#60](https://github.com/actions/virtual-environments/issues/60)

It fixes installation process to install sdkmanager to the correct directory. It changes directory for sdk manager from `/usr/local/lib/android` to `/usr/local/lib/android/sdk` ($ANDROID_HOME).

Builds:
[Ubuntu 1604](https://dev.azure.com/github/virtual-environments/_build/results?buildId=62040)
[Ubuntu 1804](https://dev.azure.com/github/virtual-environments/_build/results?buildId=62041)