### PR TITLE
Move the Update-DotnetTLS.ps1 script to the top

### DIFF
--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -103,6 +103,12 @@
             ]
         },
         {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Update-DotnetTLS.ps1"
+            ]
+        },
+        {
             "type": "windows-restart",
             "restart_timeout": "30m"
         },
@@ -264,12 +270,6 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-ServiceFabricSDK.ps1"
-            ]
-        },
-        {
-            "type": "powershell",
-            "scripts":[
-                "{{ template_dir }}/scripts/Installers/Update-DotnetTLS.ps1"
             ]
         },
         {

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -103,6 +103,12 @@
             ]
         },
         {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Update-DotnetTLS.ps1"
+            ]
+        },
+        {
             "type": "windows-restart",
             "restart_timeout": "10m"
         },
@@ -245,12 +251,6 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-ServiceFabricSDK.ps1"
-            ]
-        },
-        {
-            "type": "powershell",
-            "scripts":[
-                "{{ template_dir }}/scripts/Installers/Update-DotnetTLS.ps1"
             ]
         },
         {


### PR DESCRIPTION
Issue:
We have faced with the `Failed to install Visual Studio. Check the logs for details in` exception in the Install-VS2017.ps1 script while building Windows Server 2016 image .  We already have got the `Update-DotnetTLS.ps1` script  which allow to enable TLS1.2 to whole system via updating `SchUseStrongCrypto=1` registry key, but we apply at the end of build generation process.

Failed build - https://github.visualstudio.com/virtual-environments/_build/results?buildId=62133&view=logs&j=50448a2f-9550-51a0-b6c4-5ec64224dd81&t=301ee57f-1f15-5a1f-450b-d1d367782be4

Fix:
Move the `Update-DotnetTLS.ps1` script at the top of packer config.