### PR TITLE
Change default Openssl on Windows Images

### DIFF
--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -326,6 +326,12 @@
         {
             "type": "powershell",
             "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-OpenSSL.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-Perl.ps1"
             ]
         },
@@ -550,12 +556,6 @@
         {
             "type": "powershell",
             "scripts":[
-                "{{ template_dir }}/scripts/Installers/Install-OpenSSL.ps1"
-            ]
-        },
-        {
-            "type": "powershell",
-            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-NSIS.ps1"
             ]
         },
@@ -618,6 +618,12 @@
             ],
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-ToolCache.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-OpenSSL.ps1"
             ]
         },
         {
@@ -818,12 +824,6 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-GitVersion.ps1"
-            ]
-        },
-        {
-            "type": "powershell",
-            "scripts":[
-                "{{ template_dir }}/scripts/Installers/Validate-OpenSSL.ps1"
             ]
         },
         {

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -301,6 +301,12 @@
         {
             "type": "powershell",
             "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-OpenSSL.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-Perl.ps1"
             ]
         },
@@ -531,12 +537,6 @@
         {
             "type": "powershell",
             "scripts":[
-                "{{ template_dir }}/scripts/Installers/Install-OpenSSL.ps1"
-            ]
-        },
-        {
-            "type": "powershell",
-            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-NSIS.ps1"
             ]
         },
@@ -605,6 +605,12 @@
             ],
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-ToolCache.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-OpenSSL.ps1"
             ]
         },
         {
@@ -799,12 +805,6 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-GitVersion.ps1"
-            ]
-        },
-        {
-            "type": "powershell",
-            "scripts":[
-                "{{ template_dir }}/scripts/Installers/Validate-OpenSSL.ps1"
             ]
         },
         {


### PR DESCRIPTION
As a result of PR https://github.com/actions/virtual-environments/pull/494 OpenSSL from Perl bin directory became the default. However that OpenSSL isn't fully functional - issue https://github.com/actions/virtual-environments/issues/547

Changes:
- Moved OpenSSL installation before Perl to change directories order in the Path

