### PR TITLE
Fix errors in Initialize-VM.ps1

### DIFF
--- a/images.CI/build-image.ps1
+++ b/images.CI/build-image.ps1
@@ -36,6 +36,9 @@ $SensitiveData = @(
     ':  ->'
 )
 
+Write-Host "Show Packer Version"
+packer --version
+
 Write-Host "Build $Image VM"
 packer build    -var "capture_name_prefix=$ResourcesNamePrefix" `
                 -var "client_id=$ClientId" `

--- a/images/win/scripts/Installers/Windows2016/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/Windows2016/Initialize-VM.ps1
@@ -8,7 +8,13 @@ function Disable-InternetExplorerESC {
     $UserKey = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A8-37EF-4b3f-8CFC-4F3A74704073}"
     Set-ItemProperty -Path $AdminKey -Name "IsInstalled" -Value 0 -Force
     Set-ItemProperty -Path $UserKey -Name "IsInstalled" -Value 0 -Force
-    Stop-Process -Name Explorer -Force -ErrorAction Continue
+
+    $ieProcess = Get-Process -Name Explorer -ErrorAction SilentlyContinue
+
+    if ($ieProcess){
+        Stop-Process -Name Explorer -Force -ErrorAction Continue
+    }
+
     Write-Host "IE Enhanced Security Configuration (ESC) has been disabled."
 }
 

--- a/images/win/scripts/Installers/Windows2019/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/Windows2019/Initialize-VM.ps1
@@ -8,7 +8,13 @@ function Disable-InternetExplorerESC {
     $UserKey = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A8-37EF-4b3f-8CFC-4F3A74704073}"
     Set-ItemProperty -Path $AdminKey -Name "IsInstalled" -Value 0 -Force
     Set-ItemProperty -Path $UserKey -Name "IsInstalled" -Value 0 -Force
-    Stop-Process -Name Explorer -Force -ErrorAction Continue
+
+    $ieProcess = Get-Process -Name Explorer -ErrorAction SilentlyContinue
+
+    if ($ieProcess){
+        Stop-Process -Name Explorer -Force -ErrorAction Continue
+    }
+
     Write-Host "IE Enhanced Security Configuration (ESC) has been disabled."
 }
 


### PR DESCRIPTION
With this pull request the following errors will be solved when running the Initialize-VM.ps1:

Error 1: 

``` 
Stop-Process : Cannot find a process with the name "Explorer". Verify the process name and call the cmdlet again.
Stop-Process -Name Explorer -Force -ErrorAction Continue
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (Explorer:String) [Stop-Process], ProcessCommandException
    + FullyQualifiedErrorId : NoProcessFoundForGivenName,Microsoft.PowerShell.Commands.StopProcessCommand

```
Error 2: 

```

+ Set-ExecutionPolicy Unrestricted
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : PermissionDenied: (:) [Set-ExecutionPolicy], SecurityException
    + FullyQualifiedErrorId : ExecutionPolicyOverride,Microsoft.PowerShell.Commands.SetExecutionPolicyCommand
```