### PR TITLE
Fix windows 2019 readme name

### DIFF
--- a/images.CI/azure-pipelines/windows2019.yml
+++ b/images.CI/azure-pipelines/windows2019.yml
@@ -17,4 +17,4 @@ jobs:
 - template: image-generation.yml
   parameters:
     image_type: Windows2019-Azure
-    image_readme_name: Windows2016-Readme.md
+    image_readme_name: Windows2019-Readme.md


### PR DESCRIPTION
There is an error in  PR https://github.com/actions/virtual-environments/pull/536 Windows 2019 contains readme for Windows 2016.