### PR TITLE
Deprecate BOOST_ROOT environment variable on Ubuntu 16.04/18.04

### DIFF
--- a/images/linux/scripts/installers/boost.sh
+++ b/images/linux/scripts/installers/boost.sh
@@ -7,18 +7,16 @@
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/document.sh
 
+TOOLSET_PATH="$INSTALLER_SCRIPT_FOLDER/toolcache.json"
 BOOST_LIB=/usr/local/share/boost
+BOOST_VERSIONS=$(cat toolset.json | jq -r 'to_entries[] | select(.key | match("boost")) | .value[] +".0"')
 
 # Install Boost
-for BOOST_VERSION in ${BOOST_VERSIONS//,/ }
+for BOOST_VERSION in ${BOOST_VERSIONS}
 do
-    BOOST_SYMLINK_VER=`echo "${BOOST_VERSION//[.]/_}"`
-    BOOST_ROOT="BOOST_ROOT_$BOOST_SYMLINK_VER"
+    BOOST_SYMLINK_VER=$(echo "${BOOST_VERSION//[.]/_}")
+    BOOST_ROOT_VERSION="BOOST_ROOT_$BOOST_SYMLINK_VER"
 
-    echo "$BOOST_ROOT=$BOOST_LIB/$BOOST_VERSION" | tee -a /etc/environment
-    if [[ $BOOST_VERSION == $BOOST_DEFAULT ]]; then
-        echo "BOOST_ROOT=$BOOST_LIB/$BOOST_VERSION" | tee -a /etc/environment
-    fi
-
+    echo "$BOOST_ROOT_VERSION=$BOOST_LIB/$BOOST_VERSION" | tee -a /etc/environment
     DocumentInstalledItem "Boost C++ Libraries $BOOST_VERSION"
 done

--- a/images/linux/scripts/installers/boost.sh
+++ b/images/linux/scripts/installers/boost.sh
@@ -9,7 +9,7 @@ source $HELPER_SCRIPTS/document.sh
 
 TOOLSET_PATH="$INSTALLER_SCRIPT_FOLDER/toolcache.json"
 BOOST_LIB=/usr/local/share/boost
-BOOST_VERSIONS=$(cat toolset.json | jq -r 'to_entries[] | select(.key | match("boost")) | .value[] +".0"')
+BOOST_VERSIONS=$(cat $TOOLSET_PATH | jq -r 'to_entries[] | select(.key | match("boost")) | .value[] +".0"')
 
 # Install Boost
 for BOOST_VERSION in ${BOOST_VERSIONS}

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -240,8 +240,7 @@
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",
                 "HELPER_SCRIPTS={{user `helper_script_folder`}}",
-                "BOOST_VERSIONS=1.69.0",
-                "BOOST_DEFAULT=1.69.0"
+                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -242,8 +242,7 @@
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",
                 "HELPER_SCRIPTS={{user `helper_script_folder`}}",
-                "BOOST_VERSIONS=1.69.0",
-                "BOOST_DEFAULT=1.69.0"
+                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },


### PR DESCRIPTION
Request: [Environment variable BOOST_ROOT will be deprecated in 2 month.](https://github.com/actions/virtual-environments/issues/319)

Updates:
1. Remove BOOST_ROOT environment variable
2. Update documentation to add all missing boost versions based on `toolcache.json` file (missing entry Boost C++ Libraries 1.72.0)
3. Update missing BOOST_ROOT_VERSION environment variables based on `toolcache.json` file( BOOST_ROOT_1_72_0 is currently missing)

Example output:
- Boost C++ Libraries 1.69.0
- Boost C++ Libraries 1.72.0
