### PR TITLE
Remove default boost version directory with binaries from path on Windows Server 2016/2019

### DIFF
--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -30,8 +30,7 @@
         "image_os": "win16",
         "github_feed_token": "{{env `GITHUB_FEED_TOKEN`}}",
         "go_versions": "1.9, 1.10, 1.11, 1.12, 1.13, 1.14",
-        "go_default": "1.14",
-        "boost_default": "1.69.0"
+        "go_default": "1.14"
     },
     "sensitive-variables": ["install_password", "ssh_password", "client_secret", "github_feed_token"],
     "builders": [
@@ -517,8 +516,7 @@
         {
             "type": "powershell",
             "environment_vars": [
-                "ROOT_FOLDER={{user `root_folder`}}",
-                "BOOST_DEFAULT={{user `boost_default`}}"
+                "ROOT_FOLDER={{user `root_folder`}}"
             ],
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-Boost.ps1"
@@ -652,8 +650,7 @@
         {
             "type": "powershell",
             "environment_vars": [
-                "ROOT_FOLDER={{user `root_folder`}}",
-                "BOOST_DEFAULT={{user `boost_default`}}"
+                "ROOT_FOLDER={{user `root_folder`}}"
             ],
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-Boost.ps1"

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -30,8 +30,7 @@
         "image_os": "win19",
         "github_feed_token": "{{env `GITHUB_FEED_TOKEN`}}",
         "go_versions": "1.9, 1.10, 1.11, 1.12, 1.13, 1.14",
-        "go_default": "1.14",
-        "boost_default": "1.72.0"
+        "go_default": "1.14"
     },
     "sensitive-variables": ["install_password", "ssh_password", "client_secret", "github_feed_token"],
     "builders": [
@@ -498,8 +497,7 @@
         {
             "type": "powershell",
             "environment_vars": [
-                "ROOT_FOLDER={{user `root_folder`}}",
-                "BOOST_DEFAULT={{user `boost_default`}}"
+                "ROOT_FOLDER={{user `root_folder`}}"
             ],
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-Boost.ps1"

--- a/images/win/scripts/Installers/Install-Boost.ps1
+++ b/images/win/scripts/Installers/Install-Boost.ps1
@@ -9,7 +9,6 @@ Import-Module -Name ImageHelpers
 $SoftwareName = "Boost"
 $BoostDirectory = Join-Path -Path $env:AGENT_TOOLSDIRECTORY -ChildPath $SoftwareName
 $BoostVersions = (Get-ToolsByName -SoftwareName $SoftwareName).Versions | Foreach-Object {"{0}.0" -f $_}
-$BoostDefault = $env:BOOST_DEFAULT
 
 foreach($BoostVersion in $BoostVersions)
 {
@@ -17,11 +16,4 @@ foreach($BoostVersion in $BoostVersions)
 
     $EnvBoostPath = "BOOST_ROOT_{0}" -f ($BoostVersion.Replace('.', '_'))
     setx $EnvBoostPath $BoostInstallationDir /M | Out-Null
-
-    if ($BoostVersion -eq $BoostDefault)
-    {
-        Write-Host "Adding Boost $BoostVersion to the path..."
-        # Add the Boost binaries to the path
-        Add-MachinePathItem $BoostInstallationDir | Out-Null
-    }
 }

--- a/images/win/scripts/Installers/Validate-Boost.ps1
+++ b/images/win/scripts/Installers/Validate-Boost.ps1
@@ -18,22 +18,10 @@ function Validate-BoostVersion
     if (Test-Path "$ReleasePath\b2.exe")
     {
         Write-Host "Boost.Build $BoostRelease is successfully installed"
-
         return
     }
 
     Write-Host "$BoostRelease not found"
-    exit 1
-}
-
-# Verify that Boost is on the path
-if (Get-Command -Name 'b2')
-{
-    Write-Host "Boost is on the path"
-}
-else
-{
-    Write-Host "Boost is not on the path"
     exit 1
 }
 
@@ -44,14 +32,6 @@ $tmplMark = @"
 _Environment:_
 * {1}: root directory of the Boost version {0} installation
 
-"@
-
-$tmplMarkRoot = @"
-#### {0} [{2}]
-
-_Environment:_
-* PATH: contains the location of Boost version {0}
-* {1}: root directory of the Boost version {0} installation
 "@
 
 $Description = New-Object System.Text.StringBuilder
@@ -68,14 +48,7 @@ foreach ($BoostTool in $BoostTools)
         Validate-BoostVersion -BoostRootPath $BoostRootDirectory -BoostRelease $BoostVersion
         $BoostVersionTag = "BOOST_ROOT_{0}" -f $BoostVersion.Replace('.', '_')
 
-        if($BoostVersion -eq $env:BOOST_DEFAULT)
-        {
-            $null = $Description.AppendLine(($tmplMarkRoot -f $BoostVersion, $BoostVersionTag, $BoostToolsetName))
-        }
-        else
-        {
-            $null = $Description.AppendLine(($tmplMark -f $BoostVersion, $BoostVersionTag, $BoostToolsetName))
-        }
+        $null = $Description.AppendLine(($tmplMark -f $BoostVersion, $BoostVersionTag, $BoostToolsetName))
     }
 }
 


### PR DESCRIPTION
Request: [Environment variable BOOST_ROOT will be deprecated in 2 month.](https://github.com/actions/virtual-environments/issues/319)

Updates:
To be in consistence with Ubuntu images and related with deprecation the `BOOT_ROOT` environment variable. We decided to:
- Remove default boost version directory with binaries(b2.exe, bootstrap) from path on Windows Server 2016 and Windows Server 2019
