### PR TITLE
Update Install-PHP.ps1 to include Composer

### DIFF
--- a/images/win/scripts/Installers/Install-PHP.ps1
+++ b/images/win/scripts/Installers/Install-PHP.ps1
@@ -10,8 +10,11 @@ Import-Module -Name ImageHelpers
 $installDir = "c:\tools\php"
 choco install php -y --force --params "/InstallDir:$installDir"
 
-# update path to extensions and enable curl and mbstring extensions
-((Get-Content -path $installDir\php.ini -Raw) -replace ';extension=curl','extension=curl' -replace ';extension=mbstring','extension=mbstring' -replace ';extension_dir = "ext"','extension_dir = "ext"') | Set-Content -Path $installDir\php.ini
+# Install latest Composer in chocolatey
+choco install composer --ia "/DEV=$installDir /PHP=$installDir"
+
+# update path to extensions and enable curl and mbstring extensions, and enable php openssl extensions.
+((Get-Content -path $installDir\php.ini -Raw) -replace ';extension=curl','extension=curl' -replace ';extension=mbstring','extension=mbstring' -replace ';extension_dir = "ext"','extension_dir = "ext"' -replace 'extension=";php_openssl.dll"','extension_dir = "php_openssl.dll"') | Set-Content -Path $installDir\php.ini
 
 # Set the PHPROOT environment variable.
 setx PHPROOT $installDir /M

--- a/images/win/scripts/Installers/Validate-PHP.ps1
+++ b/images/win/scripts/Installers/Validate-PHP.ps1
@@ -33,6 +33,32 @@ else
     exit 1
 }
 
+# Verify that composer.exe is on the path
+if(Get-Command -Name 'composer')
+{
+    Write-Host "$(composer --version) is on the path."
+}
+else
+{
+    Write-Host "composer is not on the path."
+    exit 1
+}
+
+# Get the composer version.
+$composerVersion = $(composer --version)
+
+# Add composer version details in Markdown
+$SoftwareName = "Composer"
+$Description = @"
+#### $composerVersion
+
+_Environment:_
+* PATH: contains the location of composer.exe version $composerVersion
+* PHPROOT: root directory of the Composer $composerVersion installation
+"@
+
+Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description
+
 # Get available versions of PHP
 $phpVersionOnPath = Get-PHPVersion -phpRootPath "C:\tools\php72"
 


### PR DESCRIPTION
1. Install Composer from Chocolatey. PHP needs its dependency manager.
2. Enable php_openssl.dll - believe this is necessary in the case someone wants to update Composer. 

**Reference**
https://chocolatey.org/packages/composer
https://github.com/actions/virtual-environments/issues/587
https://superuser.com/questions/1010080/the-openssl-extension-is-missing-on-windows-while-installing-composer