### PR TITLE
Add NSIS to the docs for Windows images

### DIFF
--- a/images/win/scripts/Installers/Validate-NSIS.ps1
+++ b/images/win/scripts/Installers/Validate-NSIS.ps1
@@ -28,5 +28,4 @@ $Description = @"
 _Version:_ $Version<br/>
 "@
 
-#Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description
-Write-Host $description
+Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description


### PR DESCRIPTION
Looks like NSIS version was missed in docs. Add it back.
Fix for #597 