### PR TITLE
mac OS 10.15 software updates week  13

### DIFF
--- a/images/macos/macos-10.15-Readme.md
+++ b/images/macos/macos-10.15-Readme.md
@@ -13,37 +13,38 @@ The following software is installed on machines with the 20200307.2 update.
 - Java 11: Zulu11.37+17-CA (build 11.0.6+10-LTS)
 - Java 12: Zulu12.3+11-CA (build 12.0.2+3)
 - Java 13: Zulu13.29+9-CA (build 13.0.2+6-MTS)
-- Rust 1.41.1
+- Java 14: Zulu14.27+1-CA (build 14+36)
+- Rust 1.42.0
 - Clang/LLVM 9.0.1
-- gcc-8 (Homebrew GCC 8.3.0_2) 8.3.0
-- gcc-9 (Homebrew GCC 9.2.0_3) 9.2.0
-- GNU Fortran (Homebrew GCC 8.3.0_2) 8.3.0
-- GNU Fortran (Homebrew GCC 9.2.0_3) 9.2.0
+- gcc-8 (Homebrew GCC 8.4.0) 8.4.0
+- gcc-9 (Homebrew GCC 9.3.0) 9.3.0
+- GNU Fortran (Homebrew GCC 8.4.0) 8.4.0
+- GNU Fortran (Homebrew GCC 9.3.0) 9.3.0
 - Node.js v12.16.1
 - NVM 0.33.11
-- NVM - Cached node versions: v6.17.1 v8.17.0 v10.19.0 v12.16.1 v13.10.1
+- NVM - Cached node versions: v6.17.1 v8.17.0 v10.19.0 v12.16.1 v13.11.0
 - PowerShell 7.0.0
 - Python 2.7.17
-- Python 3.7.6
+- Python 3.7.7
 - Ruby 2.6.5p114
-- .NET SDK 2.0.0 3.0.100 3.0.101 3.0.102 3.0.103 3.1.100 3.1.101
+- .NET SDK 2.0.0 3.0.100 3.0.101 3.0.102 3.0.103 3.1.100 3.1.101 3.1.200
 - Go 1.14
-- PHP 7.4.3
-- julia 1.3.1
+- PHP 7.4.4
+- julia 1.4.0
 
 ### Package Management
 - Rustup 1.21.1
 - Vcpkg 2020.02.04
 - Bundler version 2.1.4
 - Carthage 0.34.0
-- CocoaPods 1.9.0
-- Homebrew 2.2.9
+- CocoaPods 1.9.1
+- Homebrew 2.2.10
 - NPM 6.13.4
-- Yarn 1.22.1
+- Yarn 1.22.4
 - NuGet 5.4.0.6315
 - Pip 19.3.1 (python 2.7)
-- Pip 19.3.1 (python 3.7)
-- Miniconda 4.7.12
+- Pip 20.0.2 (python 3.7)
+- Miniconda 4.8.2
 - RubyGems 3.1.2
 
 ### Project Management
@@ -51,9 +52,10 @@ The following software is installed on machines with the 20200307.2 update.
 - Gradle 6.2.2
 
 ### Utilities
-- Curl 7.69.0
-- Git: 2.25.1
+- Curl 7.69.1
+- Git: 2.25.2
 - Git LFS: 2.10.0
+- Hub CLI: 2.14.2
 - GNU Wget 1.20.3
 - Subversion (SVN) 1.13.0
 - Packer 1.5.4
@@ -67,19 +69,23 @@ The following software is installed on machines with the 20200307.2 update.
 - zstd 1.4.4
 - bazel 2.2.0
 - bazelisk v1.3.0
+- helm v3.1.2+gd878d4d
+- Docker 19.03.8
+- docker-machine 0.16.2
+- docker-compose 1.25.4
 
 ### Tools
 - Fastlane 2.143.0
 - Cmake 3.16.5
-- App Center CLI 2.3.3
-- Azure CLI 2.1.0
+- App Center CLI 2.3.4
+- Azure CLI 2.2.0
 
 ### Browsers
-- Google Chrome 80.0.3987.132 
+- Google Chrome 80.0.3987.149
 - ChromeDriver 80.0.3987.106
-- Microsoft Edge 80.0.361.66 
+- Microsoft Edge 80.0.361.69
 - MSEdgeDriver 80.0.361.66
-- Mozilla Firefox 73.0.1
+- Mozilla Firefox 74.0
 - geckodriver 0.26.0
 
 ### Toolcache

--- a/images/macos/macos-10.15-Readme.md
+++ b/images/macos/macos-10.15-Readme.md
@@ -1,5 +1,5 @@
 # macOS Catalina 10.15.3 (19D76)
-The following software is installed on machines with the 20200307.2 update.
+The following software is installed on machines with the 20200321.1 update.
 
 #### Xcode 11.3.1 set by default
 ## Operating System


### PR DESCRIPTION
## Installed Software
### Language and Runtime
- Java 14: Zulu14.27+1-CA (build 14+36)
- Rust 1.42.0
- gcc-8 (Homebrew GCC 8.4.0) 8.4.0
- gcc-9 (Homebrew GCC 9.3.0) 9.3.0
- GNU Fortran (Homebrew GCC 8.4.0) 8.4.0
- GNU Fortran (Homebrew GCC 9.3.0) 9.3.0
- NVM - Cached node versions: v13.11.0
- Python 3.7.7
- .NET SDK 3.1.200
- PHP 7.4.3
- julia 1.3.1
### Package Management
- CocoaPods 1.9.1
- Homebrew 2.2.10
- Yarn 1.22.4
- Pip 20.0.2 (python 3.7)
- Miniconda 4.8.2
### Utilities
- Curl 7.69.1
- Git: 2.25.2
- Hub CLI: 2.14.2
- helm v3.1.2+gd878d4d
- Docker 19.03.8
- docker-machine 0.16.2
- docker-compose 1.25.4
### Tools
- App Center CLI 2.3.4
- Azure CLI 2.2.0
### Browsers
- Google Chrome 80.0.3987.149
- Microsoft Edge 80.0.361.69
- Mozilla Firefox 74.0