### PR TITLE
Install AWS SAM CLI

### DIFF
--- a/images/linux/scripts/installers/aws-sam-cli.sh
+++ b/images/linux/scripts/installers/aws-sam-cli.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+################################################################################
+##  File:  aws-sam-cli.sh
+##  Desc:  Installs AWS SAM CLI
+##         Must be run as non-root user after homebrew and clang
+################################################################################
+
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/document.sh
+
+# Install aws sam cli
+brew tap aws/tap
+brew install aws-sam-cli
+
+# Run tests to determine that the software installed as expected
+echo "Testing to make sure that script performed as expected, and basic scenarios work"
+if ! sam --version; then
+    echo "AWS SAM CLI was not installed"
+    exit 1
+fi
+
+# Document what was added to the image
+echo "Lastly, documenting what we added to the metadata file"
+DocumentInstalledItem "AWS $(sam --version)"

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -232,6 +232,18 @@
         {
             "type": "shell",
             "scripts": [
+                "{{template_dir}}/scripts/installers/aws-sam-cli.sh"
+            ],
+            "environment_vars": [
+                "METADATA_FILE={{user `metadata_file`}}",
+                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
+                "DEBIAN_FRONTEND=noninteractive"
+            ],
+            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "scripts": [
                 "{{template_dir}}/scripts/installers/go.sh"
             ],
             "environment_vars": [

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -236,6 +236,18 @@
         {
             "type": "shell",
             "scripts": [
+                "{{template_dir}}/scripts/installers/aws-sam-cli.sh"
+            ],
+            "environment_vars": [
+                "METADATA_FILE={{user `metadata_file`}}",
+                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
+                "DEBIAN_FRONTEND=noninteractive"
+            ],
+            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "scripts": [
                 "{{template_dir}}/scripts/installers/go.sh"
             ],
             "environment_vars": [


### PR DESCRIPTION
# Description

Install AWS SAM CLI on Ubuntu images
New Tool.

Adds _sam_ utility according to the installation instructions https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install-mac.html

This PR does not include adding the AWS SAM docker container.

**Total size (including related brew tap) 650Kb. Installation time: between 5 and 10 minutes**

#### Related issue:
https://github.com/actions/virtual-environments/issues/94

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
