### PR TITLE
Set the execution policy in Packer to RemoteSigned

### DIFF
--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -238,7 +238,8 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-ServiceFabricSDK.ps1"
-            ]
+            ],
+            "execution_policy": "remotesigned"
         },
         {
             "type": "windows-restart",

--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -238,8 +238,7 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-ServiceFabricSDK.ps1"
-            ],
-            "execution_policy": "remotesigned"
+            ]
         },
         {
             "type": "windows-restart",

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -219,8 +219,7 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-ServiceFabricSDK.ps1"
-            ],
-            "execution_policy": "remotesigned"
+            ]
         },
         {
             "type": "windows-restart",

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -219,7 +219,8 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-ServiceFabricSDK.ps1"
-            ]
+            ],
+            "execution_policy": "remotesigned"
         },
         {
             "type": "windows-restart",

--- a/images/win/scripts/Installers/Install-ServiceFabricSDK.ps1
+++ b/images/win/scripts/Installers/Install-ServiceFabricSDK.ps1
@@ -8,4 +8,6 @@
 $temp_install_dir = 'C:\Windows\Installer'
 New-Item -Path $temp_install_dir -ItemType Directory -Force
 
+Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+
 WebpiCmd.exe /Install /Products:MicrosoftAzure-ServiceFabric-CoreSDK /AcceptEula /XML:https://webpifeed.blob.core.windows.net/webpifeed/5.1/WebProductList.xml

--- a/images/win/scripts/Installers/Install-ServiceFabricSDK.ps1
+++ b/images/win/scripts/Installers/Install-ServiceFabricSDK.ps1
@@ -8,6 +8,4 @@
 $temp_install_dir = 'C:\Windows\Installer'
 New-Item -Path $temp_install_dir -ItemType Directory -Force
 
-Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
-
 WebpiCmd.exe /Install /Products:MicrosoftAzure-ServiceFabric-CoreSDK /AcceptEula /XML:https://webpifeed.blob.core.windows.net/webpifeed/5.1/WebProductList.xml


### PR DESCRIPTION
Match the same ExecutioPolicy as in the Install-ServiceFabricSDK
This will solve the following error: 

==> vhd: Set-ExecutionPolicy : Windows PowerShell updated your execution policy successfully, but the setting is overridden by
==> vhd: a policy defined at a more specific scope.  Due to the override, your shell will retain its current effective
==> vhd: execution policy of Bypass. Type "Get-ExecutionPolicy -List" to view your execution policy settings. For more
==> vhd: information please see "Get-Help Set-ExecutionPolicy".
==> vhd: At C:\Windows\Temp\script-5e7b1f2e-71af-55d1-e9f9-b46c8a1fb26d.ps1:11 char:1
==> vhd: + Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
==> vhd: + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
==> vhd:     + CategoryInfo          : PermissionDenied: (:) [Set-ExecutionPolicy], SecurityException
==> vhd:     + FullyQualifiedErrorId : ExecutionPolicyOverride,Microsoft.PowerShell.Commands.SetExecutionPolicyCommand