### PR TITLE
[Azure] WinRM timeout with Windows 2019 Image

### DIFF
--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -62,7 +62,8 @@
             "communicator": "winrm",
             "winrm_use_ssl": "true",
             "winrm_insecure": "true",
-            "winrm_username": "packer"
+            "winrm_username": "packer",
+            "winrm_timeout": "30m"
         }
     ],
     "provisioners": [

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -62,7 +62,8 @@
             "communicator": "winrm",
             "winrm_use_ssl": "true",
             "winrm_insecure": "true",
-            "winrm_username": "packer"
+            "winrm_username": "packer",
+            "winrm_timeout": "30m"
         }
     ],
     "provisioners": [


### PR DESCRIPTION
# Description
We have faced with winrm timeout issue during Windows Server 2019 generation image process. Related issue: https://github.com/hashicorp/packer/issues/8658

> ==> Some builds didn't complete successfully and had errors:
> --> vhd: Error processing command: Error uploading ps script containing env vars: Error restoring file from $env:TEMP\winrmcp-98f21333-103e-4bbb-450c-03514ba8280e.tmp to c:\Windows\Temp\packer-ps-env-vars-5e7b18c6-858b-0199-55d4-22dd545b1a88.ps1: unknown error Post https://10.1.3.60:5986/wsman: read tcp 10.1.3.18:50267->10.1.3.60:5986: wsarecv: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.

Failed builds: https://github.visualstudio.com/virtual-environments/_build/results?buildId=63422&view=logs&j=50448a2f-9550-51a0-b6c4-5ec64224dd81&t=301ee57f-1f15-5a1f-450b-d1d367782be4

Fix:
Increase WinRM timeout to 30 minutes.

## Check list
- [ ] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
