### PR TITLE
Ubuntu 16.04/18.04 image generation failed while installing clang-8

### DIFF
--- a/images/linux/scripts/installers/clang.sh
+++ b/images/linux/scripts/installers/clang.sh
@@ -12,13 +12,11 @@ function InstallClang {
     version=$1
 
     echo "Installing clang-$version..."
-    # Clang 6.0 is not supported by automatic installation script (`llvm.sh`)
-    # Thus we have to install it explicitly
-    if [[ $version == 6* ]]; then
-        apt-get install -y "clang-$version" "lldb-$version" "lld-$version"
-    else
+    if [[ $version =~ 9 ]]; then
         ./llvm.sh $version
         apt-get install -y "clang-format-$version"
+    else
+        apt-get install -y "clang-$version" "lldb-$version" "lld-$version" "clang-format-$version"
     fi
 
     # Run tests to determine that the software installed as expected
@@ -34,11 +32,6 @@ function InstallClang {
     echo "Documenting clang-$version..."
     DocumentInstalledItem "Clang $version ($(clang-$version --version | head -n 1 | cut -d ' ' -f 3 | cut -d '-' -f 1))"
 }
-
-# Install Clang compiler
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-apt-add-repository "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-6.0 main"
-apt-get update -y
 
 # Download script for automatic installation
 wget https://apt.llvm.org/llvm.sh


### PR DESCRIPTION
# Description
Ubuntu 16.04/18.04 image generation failed while installing clang-8. We use the `llvm.sh` script to install clang-8 version that script  stopped to  support installation clang-8(only 9,10,11 versions are supported).

```
==> azure-arm: Installing clang-8...
==> azure-arm: + LLVM_VERSION=9
==> azure-arm: + '[' 1 -eq 1 ']'
==> azure-arm: + LLVM_VERSION=8
==> azure-arm: ++ lsb_release -is
==> azure-arm: + DISTRO=Ubuntu
==> azure-arm: ++ lsb_release -sr
==> azure-arm: + VERSION=18.04
==> azure-arm: + DIST_VERSION=Ubuntu_18.04
==> azure-arm: + [[ 0 -ne 0 ]]
==> azure-arm: This script does not support LLVM version 8
```

#### Related issue:
https://github.com/actions/virtual-environments/issues/623

#### Fix:
Use standard Ubuntu repositories to install clang-8

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
