### PR TITLE
Update the download link for SSDT for win2016

### DIFF
--- a/images/win/scripts/Installers/Windows2016/Install-SSDT.ps1
+++ b/images/win/scripts/Installers/Windows2016/Install-SSDT.ps1
@@ -5,8 +5,9 @@
 
 Import-Module -Name ImageHelpers -Force
 
-#SSDT for Visual Studio 2017 (15.9.3)
-$InstallerURI = 'https://download.microsoft.com/download/e/c/f/ecfccf97-b32c-4c31-b2fc-bff558635096/SSDT-Setup-ENU.exe'
+#SSDT for Visual Studio 2017
+#The link down below points to the latest version of SSDT for Visual Studio 2017
+$InstallerURI = 'https://go.microsoft.com/fwlink/?linkid=2124518'
 $InstallerName = 'SSDT-Setup-ENU.exe'
 $logFilePath = "$env:TEMP\ssdtlog.txt"
 $ArgumentList = ('/install', 'INSTALLALL', '/passive', '/norestart', "/log `"$logFilePath`"")

--- a/images/win/scripts/Installers/Windows2016/Install-SSDT.ps1
+++ b/images/win/scripts/Installers/Windows2016/Install-SSDT.ps1
@@ -6,7 +6,7 @@
 Import-Module -Name ImageHelpers -Force
 
 #SSDT for Visual Studio 2017 (15.9.3)
-$InstallerURI = 'https://download.microsoft.com/download/5/2/D/52DEF429-5B17-470C-82D9-654116080B15/SSDT-Setup-ENU.exe'
+$InstallerURI = 'https://download.microsoft.com/download/e/c/f/ecfccf97-b32c-4c31-b2fc-bff558635096/SSDT-Setup-ENU.exe'
 $InstallerName = 'SSDT-Setup-ENU.exe'
 $logFilePath = "$env:TEMP\ssdtlog.txt"
 $ArgumentList = ('/install', 'INSTALLALL', '/passive', '/norestart', "/log `"$logFilePath`"")


### PR DESCRIPTION
In scope of this pull request we added the following changes:
- updated the download link for SSDT 15.9.4 for vs2017-win2016 image in `images/win/scripts/Installers/Windows2016/Install-SSDT.ps1` file.