### PR TITLE
Install missing root certificates on windows-2019

### DIFF
--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -111,6 +111,12 @@
             ]
         },
         {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-RootCA.ps1"
+            ]
+        },
+        {
             "type": "windows-restart",
             "restart_timeout": "10m"
         },

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -111,12 +111,6 @@
             ]
         },
         {
-            "type": "powershell",
-            "scripts":[
-                "{{ template_dir }}/scripts/Installers/Install-RootCA.ps1"
-            ]
-        },
-        {
             "type": "windows-restart",
             "restart_timeout": "10m"
         },
@@ -575,6 +569,12 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-Bazel.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-RootCA.ps1"
             ]
         },
         {

--- a/images/win/scripts/Installers/Install-RootCA.ps1
+++ b/images/win/scripts/Installers/Install-RootCA.ps1
@@ -1,0 +1,24 @@
+# Serialized Certificate Store File
+$sstFile = "$env:TEMP\roots.sst"
+# Generate SST from Windows Update
+$result = certutil.exe -generateSSTFromWU $sstFile
+if ($LASTEXITCODE -eq 0) {
+    # Dump certificates
+    $result = certutil.exe -dump $sstFile
+    if ($LASTEXITCODE -eq 0) {
+        # Import Root CA into "Trusted Root Certification Authority"
+        try {
+            Import-Certificate -FilePath $sstFile -CertStoreLocation Cert:\LocalMachine\Root
+        } catch {
+            Write-Host "[Error]: failed to import ROOT CA`n$_"
+        }
+    }
+    else {
+        Write-Host "[Error]: failed to dump $sstFile sst file`n$result"
+    }
+}
+else {
+    Write-Host "[Error]: failed to generate $sstFile sst file`n$result"
+}
+
+exit $LASTEXITCODE

--- a/images/win/scripts/Installers/Install-RootCA.ps1
+++ b/images/win/scripts/Installers/Install-RootCA.ps1
@@ -2,23 +2,21 @@
 $sstFile = "$env:TEMP\roots.sst"
 # Generate SST from Windows Update
 $result = certutil.exe -generateSSTFromWU $sstFile
-if ($LASTEXITCODE -eq 0) {
-    # Dump certificates
-    $result = certutil.exe -dump $sstFile
-    if ($LASTEXITCODE -eq 0) {
-        # Import Root CA into "Trusted Root Certification Authority"
-        try {
-            Import-Certificate -FilePath $sstFile -CertStoreLocation Cert:\LocalMachine\Root
-        } catch {
-            Write-Host "[Error]: failed to import ROOT CA`n$_"
-        }
-    }
-    else {
-        Write-Host "[Error]: failed to dump $sstFile sst file`n$result"
-    }
-}
-else {
+if ($LASTEXITCODE -ne 0) {
     Write-Host "[Error]: failed to generate $sstFile sst file`n$result"
+    exit $LASTEXITCODE
 }
 
-exit $LASTEXITCODE
+$result = certutil.exe -dump $sstFile
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "[Error]: failed to dump $sstFile sst file`n$result"
+    exit $LASTEXITCODE
+}
+
+try {
+    Import-Certificate -FilePath $sstFile -CertStoreLocation Cert:\LocalMachine\Root
+} catch {
+    Write-Host "[Error]: failed to import ROOT CA`n$_"
+    exit 1
+}
+


### PR DESCRIPTION
# Description
On the windows-2019, not all root CA certificates are installed. Some are missing (for example Quo Vadis). This leads for some tools to the following error: X509: CERTIFICATE SIGNED BY UNKNOWN AUTHORITY when calling a API vis SSL.

**New tool, Bug fixing, Improvement?**  
CertUtil [Options] -generateSSTFromWU SSTFile 
 SSTFile is the name of the .sst file that is created. The generated .sst file contains the third-party root certificates that are downloaded from Windows Update.

**For new tools, please provide total size and installation time.**
Installation time: ~1min
Total size: ~ 2mb

#### Related issue:
https://github.com/actions/virtual-environments/issues/628
https://github.com/actions/virtual-environments/issues/577
## Check list
- [x] Related issue / work item is attached
- [x] Changes are tested and related VM images are successfully generated
