### PR TITLE
Fix user environment  PATH variable

### DIFF
--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -100,10 +100,10 @@ function RunPostInstallationSteps()
 {
     Add-MachinePathItem "C:\Program Files\dotnet"
     # Run script at startup for all users
-    $cmdDotNetPath = @"
+    $cmdDotNetPath = @'
 @echo off
-SETX PATH "%USERPROFILE%\.dotnet\tools;%PATH%"
-"@
+powershell -executionpolicy bypass -noprofile -command "[System.Environment]::SetEnvironmentVariable('PATH',"""$env:USERPROFILE\.dotnet\tools;$env:PATH""", 'USER')"
+'@
 
     $cmdPath = "C:\Program Files\dotnet\userpath.bat"
     $cmdDotNetPath | Out-File -Encoding ascii -FilePath $cmdPath

--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -100,16 +100,10 @@ function RunPostInstallationSteps()
 {
     Add-MachinePathItem "C:\Program Files\dotnet"
     # Run script at startup for all users
-    $cmdDotNetPath = @'
-@echo off
-powershell -executionpolicy bypass -noprofile -command "[System.Environment]::SetEnvironmentVariable('PATH',"""$env:USERPROFILE\.dotnet\tools;$env:PATH""", 'USER')"
-'@
-
-    $cmdPath = "C:\Program Files\dotnet\userpath.bat"
-    $cmdDotNetPath | Out-File -Encoding ascii -FilePath $cmdPath
+    $cmdDotNet = 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -Command "[System.Environment]::SetEnvironmentVariable(''PATH'',"""$env:USERPROFILE\.dotnet\tools;$env:PATH""", ''USER'')"'
 
     # Update Run key to run a script at logon
-    Set-ItemProperty -Path "HKLM:\Software\Microsoft\Windows\CurrentVersion\Run" -Name "DOTNETUSERPATH" -Value $cmdPath
+    Set-ItemProperty -Path "HKLM:\Software\Microsoft\Windows\CurrentVersion\Run" -Name "DOTNETUSERPATH" -Value $cmdDotNet
 }
 
 InstallAllValidSdks


### PR DESCRIPTION
# Description
Environment variable Path has a space as the last character in a folder name. Windows will not accept a  name with a trailing space character.

`Caused by: java.nio.file.InvalidPathException: Trailing char < > at index 36: C:\Program Files (x86)\Microsoft SQL `

The root cause of the issue is in the `setx` command limitation: `WARNING: The data being saved is truncated to 1024 characters.` In the script `Install-DotnetSDK.ps1` we are trying to update PATH variable using `setx` after truncation there is a chance to  have names with a trailing space at the end.

PowerShell  `[System.Environment]::SetEnvironmentVariable` static method doesn't have this limitation and support 32767 characters.
#### Related issue:
https://github.com/actions/virtual-environments/issues/635
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
