### PR TITLE
Improve automated triage process

### DIFF
--- a/.github/workflows/issue-triager.yml
+++ b/.github/workflows/issue-triager.yml
@@ -25,7 +25,7 @@ jobs:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           github.issues.addLabels({
-            issue_number: context.issue,
+            issue_number: context.issue.number,
             owner: context.owner,
             repo: context.repo,
             labels: ['needs triage']

--- a/.github/workflows/issue-triager.yml
+++ b/.github/workflows/issue-triager.yml
@@ -26,7 +26,7 @@ jobs:
         script: |
           github.issues.addLabels({
             issue_number: context.issue.number,
-            owner: context.owner,
-            repo: context.repo,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
             labels: ['needs triage']
           })

--- a/triage-rules.yml
+++ b/triage-rules.yml
@@ -157,10 +157,3 @@ nomatches:
   addLabels: ['Area: Packages']
 - contains: 'Docker'
   addLabels: ['Area: Deployment/Release']
-
-# always runs after rules.  look for missing or invalid sets of tags
-tags:
-- noneIn: ['bug', 'enhancement', 'question']
-  addLabels: ['needs triage']
-- noneMatch: '\s*Area:\s*([^]*)'
-  addLabels: ['needs triage']


### PR DESCRIPTION
# Issue
Current rules for triage bot doesn't satisfy our triaging process. The purpose of this PR is improving it a bit.

# Changes:
- Put `needs triage` label on all issues (even area path is determined successfully). We should add `needs triage` always to make sure that issue will be triaged properly by DRI.
Unfortunately, it is impossible to put needs triage tag always via `damccorm/tag-ur-it` action so I just changed condition for `actions/github-script` to run always and put this tag.
- Fix parameters of `actions/github-script` step because it looks like it has never worked due to invalid parameters
- Remove unused steps at the end of pipeline. Not sure why we need them, tested on my fork and everything works as expected without it.
- Disable assigning to particular people, Not sure that we really need it because our team is 1 tier support for all issues and looking at all issues (escalate them manually if needs)