### PR TITLE
Remove choco alias cpack.exe that conflicts with CMake cpack

### DIFF
--- a/images/win/scripts/Installers/Windows2016/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/Windows2016/Initialize-VM.ps1
@@ -104,6 +104,10 @@ Invoke-Expression ((new-object net.webclient).DownloadString('https://chocolatey
 # Turn off confirmation
 choco feature enable -n allowGlobalConfirmation
 
+# https://github.com/chocolatey/choco/issues/89
+# Remove some of the command aliases, like `cpack` #89
+Remove-Item -Path $env:ChocolateyInstall\bin\cpack.exe -Force
+
 # Install webpi
 choco install webpicmd -y
 

--- a/images/win/scripts/Installers/Windows2019/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/Windows2019/Initialize-VM.ps1
@@ -104,6 +104,10 @@ Invoke-Expression ((new-object net.webclient).DownloadString('https://chocolatey
 # Turn off confirmation
 choco feature enable -n allowGlobalConfirmation
 
+# https://github.com/chocolatey/choco/issues/89
+# Remove some of the command aliases, like `cpack` #89
+Remove-Item -Path $env:ChocolateyInstall\bin\cpack.exe -Force
+
 # Install webpi
 choco install webpicmd -y
 


### PR DESCRIPTION
# Description

There are two cpack.exe in PATH
1. The alias of choco pack for Chocolatey
2. The pack module of the CMake suite

The first one (placed in `%ChocolateyInstall%\bin\`) is in front of the second one (`%ProgramFiles%\CMake\bin\`), so when use cpack, it will call the `%ChocolateyInstall%\bin\cpack.exe` . But actually, the `%ChocolateyInstall%\bin\cpack.exe` is just an alias, while `%ProgramFiles%\CMake\bin\cpack.exe` is an important program, and the second one is more important the the first one.

https://github.com/chocolatey/choco/commit/e9dcb0cc12d49791511e8456b6e94438b81c369c
```
NOTE: `cpack` has been deprecated as it has a name collision with CMake. Please 
 use `choco pack` instead. The shortcut will be removed in v1.
```

#### Related issue:
https://github.com/actions/virtual-environments/issues/649
https://github.com/chocolatey/choco/issues/89
## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
