### PR TITLE
[Cmake] has been changed to [CMake]

### DIFF
--- a/images/macos/macos-10.15-Readme.md
+++ b/images/macos/macos-10.15-Readme.md
@@ -76,7 +76,7 @@ The following software is installed on machines with the 20200321.1 update.
 
 ### Tools
 - Fastlane 2.143.0
-- Cmake 3.16.5
+- CMake 3.16.5
 - App Center CLI 2.3.4
 - Azure CLI 2.2.0
 

--- a/images/win/Windows2016-Readme.md
+++ b/images/win/Windows2016-Readme.md
@@ -31,7 +31,8 @@ _Environment:_
 
 ## Powershell Core
 
-_Version:_ 7.0.0<br/>
+_Version:_ 7.0.0
+<br/>
 
 ## Docker images
 
@@ -640,7 +641,7 @@ _Version:_ 6.2.2<br/>
 _Environment:_
 * PATH: contains location of gradle
 
-## Cmake
+## CMake
 
 _Version:_ 3.17.0<br/>
 _Environment:_

--- a/images/win/Windows2019-Readme.md
+++ b/images/win/Windows2019-Readme.md
@@ -31,7 +31,8 @@ _Environment:_
 
 ## Powershell Core
 
-_Version:_ 7.0.0<br/>
+_Version:_ 7.0.0
+<br/>
 
 ## Docker images
 
@@ -632,7 +633,7 @@ _Version:_ 6.2.2<br/>
 _Environment:_
 * PATH: contains location of gradle
 
-## Cmake
+## CMake
 
 _Version:_ 3.16.5<br/>
 _Environment:_


### PR DESCRIPTION
# Description
Bug fixing.
According to https://github.com/actions/virtual-environments/issues/641 "Cmake" has been changed to "CMake" in Windows2016-Readme.md, Windows2019-Readme.md, macos-10.15-Readme.md.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [X] Tests are written (if applicable)
- [X] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
