### PR TITLE
[Cmake] has been changed to [CMake]

### DIFF
--- a/images/win/scripts/Installers/Validate-Cmake.ps1
+++ b/images/win/scripts/Installers/Validate-Cmake.ps1
@@ -5,11 +5,11 @@
 
 if(Get-Command -Name 'cmake')
 {
-    Write-Host "Cmake $(cmake -version) on path"
+    Write-Host "CMake $(cmake -version) on path"
 }
 else
 {
-    Write-Host 'cmake not on path'
+    Write-Host 'CMake not on path'
     exit 1
 }
 
@@ -20,7 +20,7 @@ if( $( $(cmake -version) | Out-String) -match  'cmake version (?<version>.*).*' 
 }
 
 # Adding description of the software to Markdown
-$SoftwareName = "Cmake"
+$SoftwareName = "CMake"
 
 $Description = @"
 _Version:_ $cmakeVersion<br/>


### PR DESCRIPTION
# Description
Bug fixing.  
According to https://github.com/actions/virtual-environments/issues/641 "Cmake" has been changed to "CMake" in Validate-Cmake.ps1.
## Check list
- [ ] Related issue / work item is attached
- [X] Tests are written (if applicable)
- [X] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
