### PR TITLE
Migrate /etc/environment modifications to helpers

### DIFF
--- a/images/linux/scripts/helpers/etc-environment.sh
+++ b/images/linux/scripts/helpers/etc-environment.sh
@@ -9,34 +9,34 @@
 #     The values containing '%' will break the functions
 
 function getEtcEnvironmentVar {
-    var_name="$1"
-    # remove `var_name=` and possible quotes from the line
-    grep "^${var_name}=" /etc/environment |sed -E "s%^${var_name}=\"?([^\"]+)\"?.*$%\1%"
+    variable_name="$1"
+    # remove `variable_name=` and possible quotes from the line
+    grep "^${variable_name}=" /etc/environment |sed -E "s%^${variable_name}=\"?([^\"]+)\"?.*$%\1%"
 }
 
 function addEtcEnvironmentVar {
-    var_name="$1"
-    var_value="$2"
+    variable_name="$1"
+    variable_value="$2"
 
-    echo "$var_name=\"$var_value\"" | sudo tee -a /etc/environment
+    echo "$variable_name=\"$variable_value\"" | sudo tee -a /etc/environment
 }
 
 function replaceEtcEnvironmentVar {
-    var_name="$1"
-    var_value="$2"
+    variable_name="$1"
+    variable_value="$2"
 
-    # modify /etc/environemnt in place by replacing a string that begins with var_name
-    sudo sed -ie "s%^${var_name}=.*$%${var_name}=\"${var_value}\"%" /etc/environment
+    # modify /etc/environemnt in place by replacing a string that begins with variable_name
+    sudo sed -ie "s%^${variable_name}=.*$%${variable_name}=\"${variable_value}\"%" /etc/environment
 }
 
 function setEtcEnvironmentVar {
-    var_name="$1"
-    var_value="$2"
+    variable_name="$1"
+    variable_value="$2"
 
-    if grep "$var_name" /etc/environment > /dev/null; then
-        replaceEtcEnvironmentVar $var_name $var_value
+    if grep "$variable_name" /etc/environment > /dev/null; then
+        replaceEtcEnvironmentVar $variable_name $variable_value
     else
-        addEtcEnvironmentVar $var_name $var_value
+        addEtcEnvironmentVar $variable_name $variable_value
     fi
 }
 

--- a/images/linux/scripts/helpers/etc-environment.sh
+++ b/images/linux/scripts/helpers/etc-environment.sh
@@ -40,10 +40,20 @@ function setEtcEnvironmentVariable {
     fi
 }
 
-function addEtcEnvironmentPathElement {
-    element="$1"
-    etc_path=$(getEtcEnvironmentVariable PATH)
-    setEtcEnvironmentVariable PATH "${element}:${etc_path}"
+function prependEtcEnvironmentVariable {
+    variable_name="$1"
+    element="$2"
+    # TODO: handle the case if the variable does not exist
+    existing_value=$(getEtcEnvironmentVariable "${variable_name}")
+    setEtcEnvironmentVariable "${variable_name}" "${element}:${existing_value}"
+}
+
+function appendEtcEnvironmentVariable {
+    variable_name="$1"
+    element="$2"
+    # TODO: handle the case if the variable does not exist
+    existing_value=$(getEtcEnvironmentVariable "${variable_name}")
+    setEtcEnvironmentVariable "${variable_name}" "${existing_value}:${element}"
 }
 
 function addEtcEnvironmentPathElement {

--- a/images/linux/scripts/helpers/etc-environment.sh
+++ b/images/linux/scripts/helpers/etc-environment.sh
@@ -8,20 +8,20 @@
 #     values containg slashes (i.e. directory path)
 #     The values containing '%' will break the functions
 
-function getEtcEnvironmentVar {
+function getEtcEnvironmentVariable {
     variable_name="$1"
     # remove `variable_name=` and possible quotes from the line
     grep "^${variable_name}=" /etc/environment |sed -E "s%^${variable_name}=\"?([^\"]+)\"?.*$%\1%"
 }
 
-function addEtcEnvironmentVar {
+function addEtcEnvironmentVariable {
     variable_name="$1"
     variable_value="$2"
 
     echo "$variable_name=\"$variable_value\"" | sudo tee -a /etc/environment
 }
 
-function replaceEtcEnvironmentVar {
+function replaceEtcEnvironmentVariable {
     variable_name="$1"
     variable_value="$2"
 
@@ -29,21 +29,27 @@ function replaceEtcEnvironmentVar {
     sudo sed -ie "s%^${variable_name}=.*$%${variable_name}=\"${variable_value}\"%" /etc/environment
 }
 
-function setEtcEnvironmentVar {
+function setEtcEnvironmentVariable {
     variable_name="$1"
     variable_value="$2"
 
     if grep "$variable_name" /etc/environment > /dev/null; then
-        replaceEtcEnvironmentVar $variable_name $variable_value
+        replaceEtcEnvironmentVariable $variable_name $variable_value
     else
-        addEtcEnvironmentVar $variable_name $variable_value
+        addEtcEnvironmentVariable $variable_name $variable_value
     fi
 }
 
 function addEtcEnvironmentPathElement {
     element="$1"
-    etc_path=$(getEtcEnvironmentVar PATH)
-    setEtcEnvironmentVar PATH "${element}:${etc_path}"
+    etc_path=$(getEtcEnvironmentVariable PATH)
+    setEtcEnvironmentVariable PATH "${element}:${etc_path}"
+}
+
+function addEtcEnvironmentPathElement {
+    element="$1"
+    etc_path=$(getEtcEnvironmentVariable PATH)
+    setEtcEnvironmentVariable PATH "${element}:${etc_path}"
 }
 
 # Process /etc/environment as if it were shell script with `export VAR=...` expressions
@@ -59,7 +65,7 @@ function  reloadEtcEnvironment {
     # add `export ` to every variable of /etc/environemnt except PATH and eval the result shell script
     eval $(grep -v '^PATH=' /etc/environment | sed -e 's%^%export %')
     # handle PATH specially
-    etc_path=$(getEtcEnvironmentVar PATH)
+    etc_path=$(getEtcEnvironmentVariable PATH)
     export PATH="$PATH:$etc_path"
 }
 

--- a/images/linux/scripts/helpers/etc-environment.sh
+++ b/images/linux/scripts/helpers/etc-environment.sh
@@ -56,10 +56,9 @@ function appendEtcEnvironmentVariable {
     setEtcEnvironmentVariable "${variable_name}" "${existing_value}:${element}"
 }
 
-function addEtcEnvironmentPathElement {
+function prependEtcEnvironmentPath {
     element="$1"
-    etc_path=$(getEtcEnvironmentVariable PATH)
-    setEtcEnvironmentVariable PATH "${element}:${etc_path}"
+    prependEtcEnvironmentVariable PATH "${element}"
 }
 
 # Process /etc/environment as if it were shell script with `export VAR=...` expressions

--- a/images/linux/scripts/installers/1604/php.sh
+++ b/images/linux/scripts/installers/1604/php.sh
@@ -5,6 +5,7 @@
 ################################################################################
 
 # Source the helpers for use with the script
+source $HELPER_SCRIPTS/etc-environment.sh
 source $HELPER_SCRIPTS/document.sh
 
 LSB_RELEASE=$(lsb_release -rs)
@@ -276,6 +277,9 @@ php composer-setup.php
 sudo mv composer.phar /usr/bin/composer
 php -r "unlink('composer-setup.php');"
 
+# Update /etc/environment
+addEtcEnvironmentPathElement /home/runner/.config/composer/vendor/bin
+
 # Add composer bin folder to path
 echo 'export PATH="$PATH:$HOME/.config/composer/vendor/bin"' >> /etc/skel/.bashrc
 
@@ -292,6 +296,7 @@ for cmd in php php5.6 php7.0 php7.1 php7.2 php7.3 php7.4 composer phpunit; do
         exit 1
     fi
 done
+
 
 # Document what was added to the image
 echo "Lastly, documenting what we added to the metadata file"

--- a/images/linux/scripts/installers/1604/php.sh
+++ b/images/linux/scripts/installers/1604/php.sh
@@ -278,7 +278,7 @@ sudo mv composer.phar /usr/bin/composer
 php -r "unlink('composer-setup.php');"
 
 # Update /etc/environment
-addEtcEnvironmentPathElement /home/runner/.config/composer/vendor/bin
+prependEtcEnvironmentPath /home/runner/.config/composer/vendor/bin
 
 # Add composer bin folder to path
 echo 'export PATH="$PATH:$HOME/.config/composer/vendor/bin"' >> /etc/skel/.bashrc

--- a/images/linux/scripts/installers/1804/php.sh
+++ b/images/linux/scripts/installers/1804/php.sh
@@ -5,6 +5,7 @@
 ################################################################################
 
 # Source the helpers for use with the script
+source $HELPER_SCRIPTS/etc-environment.sh
 source $HELPER_SCRIPTS/document.sh
 
 LSB_RELEASE=$(lsb_release -rs)
@@ -192,6 +193,9 @@ php -r "if (hash_file('sha384', 'composer-setup.php') === file_get_contents('htt
 php composer-setup.php
 sudo mv composer.phar /usr/bin/composer
 php -r "unlink('composer-setup.php');"
+
+# Update /etc/environment
+addEtcEnvironmentPathElement /home/runner/.config/composer/vendor/bin
 
 # Add composer bin folder to path
 echo 'export PATH="$PATH:$HOME/.config/composer/vendor/bin"' >> /etc/skel/.bashrc

--- a/images/linux/scripts/installers/1804/php.sh
+++ b/images/linux/scripts/installers/1804/php.sh
@@ -195,7 +195,7 @@ sudo mv composer.phar /usr/bin/composer
 php -r "unlink('composer-setup.php');"
 
 # Update /etc/environment
-addEtcEnvironmentPathElement /home/runner/.config/composer/vendor/bin
+prependEtcEnvironmentPath /home/runner/.config/composer/vendor/bin
 
 # Add composer bin folder to path
 echo 'export PATH="$PATH:$HOME/.config/composer/vendor/bin"' >> /etc/skel/.bashrc

--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -96,6 +96,6 @@ done
 
 # NuGetFallbackFolder at /usr/share/dotnet/sdk/NuGetFallbackFolder is warmed up by smoke test
 # Additional FTE will just copy to ~/.dotnet/NuGet which provides no benefit on a fungible machine
-setEtcEnvironmentVar DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1
+setEtcEnvironmentVariable DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1
 addEtcEnvironmentPathElement /home/runner/.dotnet/tools
 echo 'export PATH="$PATH:$HOME/.dotnet/tools"' | tee -a /etc/skel/.bashrc

--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -3,6 +3,7 @@
 ##  File:  dotnetcore-sdk.sh
 ##  Desc:  Installs .NET Core SDK
 ################################################################################
+source $HELPER_SCRIPTS/etc-environment.sh
 source $HELPER_SCRIPTS/apt.sh
 source $HELPER_SCRIPTS/document.sh
 
@@ -95,5 +96,6 @@ done
 
 # NuGetFallbackFolder at /usr/share/dotnet/sdk/NuGetFallbackFolder is warmed up by smoke test
 # Additional FTE will just copy to ~/.dotnet/NuGet which provides no benefit on a fungible machine
-echo "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" | tee -a /etc/environment
+setEtcEnvironmentVar DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1
+addEtcEnvironmentPathElement /home/runner/.dotnet/tools
 echo 'export PATH="$PATH:$HOME/.dotnet/tools"' | tee -a /etc/skel/.bashrc

--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -97,5 +97,5 @@ done
 # NuGetFallbackFolder at /usr/share/dotnet/sdk/NuGetFallbackFolder is warmed up by smoke test
 # Additional FTE will just copy to ~/.dotnet/NuGet which provides no benefit on a fungible machine
 setEtcEnvironmentVariable DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1
-addEtcEnvironmentPathElement /home/runner/.dotnet/tools
+prependEtcEnvironmentPath /home/runner/.dotnet/tools
 echo 'export PATH="$PATH:$HOME/.dotnet/tools"' | tee -a /etc/skel/.bashrc

--- a/images/linux/scripts/installers/homebrew.sh
+++ b/images/linux/scripts/installers/homebrew.sh
@@ -20,7 +20,7 @@ sudo chmod -R o+w $HOMEBREW_PREFIX
 brew shellenv|grep 'export HOMEBREW'|sed -E 's/^export (.*);$/\1/' | sudo tee -a /etc/environment
 # add brew executables locations to PATH
 brew_path=$(brew shellenv|grep  '^export PATH' |sed -E 's/^export PATH="([^$]+)\$.*/\1/')
-addEtcEnvironmentPathElement "$brew_path"
+prependEtcEnvironmentPath "$brew_path"
 
 # Validate the installation ad hoc
 echo "Validate the installation reloading /etc/environment"

--- a/images/linux/scripts/installers/rust.sh
+++ b/images/linux/scripts/installers/rust.sh
@@ -33,7 +33,7 @@ for cmd in rustup rustc rustdoc cargo rustfmt cargo-clippy bindgen cbindgen; do
 done
 
 # Update /etc/environemnt
-addEtcEnvironmentPathElement "${CARGO_HOME}/bin"
+prependEtcEnvironmentPath "${CARGO_HOME}/bin"
 
 # Rust Symlinks are added to a default profile /etc/skel
 pushd /etc/skel

--- a/images/linux/scripts/installers/rust.sh
+++ b/images/linux/scripts/installers/rust.sh
@@ -5,9 +5,8 @@
 ################################################################################
 
 # Source the helpers for use with the script
+source $HELPER_SCRIPTS/etc-environment.sh
 source $HELPER_SCRIPTS/document.sh
-
-set -e
 
 export RUSTUP_HOME=/usr/share/rust/.rustup
 export CARGO_HOME=/usr/share/rust/.cargo
@@ -32,6 +31,9 @@ for cmd in rustup rustc rustdoc cargo rustfmt cargo-clippy bindgen cbindgen; do
         exit 1
     fi
 done
+
+# Update /etc/environemnt
+addEtcEnvironmentPathElement "${CARGO_HOME}/bin"
 
 # Rust Symlinks are added to a default profile /etc/skel
 pushd /etc/skel

--- a/images/linux/scripts/installers/updatepath.sh
+++ b/images/linux/scripts/installers/updatepath.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-CARGO_HOME=/usr/share/rust/.cargo
-DOTNET_TOOLS_HOME=/home/runner/.dotnet/tools
-PHP_COMPOSER_HOME=/home/runner/.config/composer/vendor/bin
-BREW_PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin
-echo "PATH=${BREW_PATH}:${CARGO_HOME}/bin:${PATH}:${DOTNET_TOOLS_HOME}:${PHP_COMPOSER_HOME}" | tee -a /etc/environment

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -217,7 +217,6 @@
                 "{{template_dir}}/scripts/installers/packer.sh",
                 "{{template_dir}}/scripts/installers/vcpkg.sh",
                 "{{template_dir}}/scripts/installers/zeit-now.sh",
-                "{{template_dir}}/scripts/installers/updatepath.sh",
                 "{{template_dir}}/scripts/installers/dpkg-config.sh",
                 "{{template_dir}}/scripts/installers/mongodb.sh",
                 "{{template_dir}}/scripts/installers/rndgenerator.sh"

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -221,7 +221,6 @@
                 "{{template_dir}}/scripts/installers/packer.sh",
                 "{{template_dir}}/scripts/installers/vcpkg.sh",
                 "{{template_dir}}/scripts/installers/zeit-now.sh",
-                "{{template_dir}}/scripts/installers/updatepath.sh",
                 "{{template_dir}}/scripts/installers/dpkg-config.sh",
                 "{{template_dir}}/scripts/installers/mongodb.sh",
                 "{{template_dir}}/scripts/installers/rndgenerator.sh"


### PR DESCRIPTION
# Description
Improvement
Use functions from `helpers/etc-environment.sh` in order to

* modify `/etc/environment` from install scripts:
    - installers/rust.sh
    - installers/1604/php.sh
    - installers/1604/php.sh
    - installers/dotnetcore-sdk.sh
* remove legacy `updatepath.sh` used to modify `/etc/environment` 
* rename the helpers functions for better readability

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/334 

## Check list
- [x ] Related issue / work item is attached
- [x ] Changes are tested and related VM images are successfully generated
