### PR TITLE
Added cabal-install 3.2.0.0.

### DIFF
--- a/images/linux/scripts/installers/haskell.sh
+++ b/images/linux/scripts/installers/haskell.sh
@@ -30,7 +30,8 @@ apt-get install -y \
     cabal-install-2.0 \
     cabal-install-2.2 \
     cabal-install-2.4 \
-    cabal-install-3.0
+    cabal-install-3.0 \
+    cabal-install-3.2
 
 # Install haskell stack, pinned to v2.1.3
 curl -sSL https://raw.githubusercontent.com/commercialhaskell/stack/v2.1.3/etc/scripts/get-stack.sh | sh
@@ -45,7 +46,7 @@ for version in 8.0.2 8.2.2 8.4.4 8.6.2 8.6.3 8.6.4 8.6.5 8.8.1 8.8.2 8.8.3 8.10.
     fi
 done
 # Check all cabal versions
-for version in 2.0 2.2 2.4 3.0; do
+for version in 2.0 2.2 2.4 3.0 3.2; do
     if ! command -v /opt/cabal/$version/bin/cabal; then
         echo "cabal $version was not installed"
         exit 1
@@ -58,7 +59,7 @@ fi
 
 # Document what was added to the image
 echo "Lastly, documenting what we added to the metadata file"
-for version in 2.0 2.2 2.4 3.0; do
+for version in 2.0 2.2 2.4 3.0 3.2; do
     DocumentInstalledItem "Haskell Cabal ($(/opt/cabal/$version/bin/cabal --version))"
 done
 for version in 8.0.2 8.2.2 8.4.4 8.6.2 8.6.3 8.6.4 8.6.5 8.8.1 8.8.2 8.8.3 8.10.1; do


### PR DESCRIPTION
`cabal-install 3.2.0.0` was [released](https://hackage.haskell.org/package/cabal-install-3.2.0.0). This PR adds this version of `cabal-install` to the virtual environments.
