### PR TITLE
Fix vsix installation

### DIFF
--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -14,7 +14,7 @@
         "virtual_network_resource_group_name": "{{env `VNET_RESOURCE_GROUP`}}",
         "virtual_network_subnet_name": "{{env `VNET_SUBNET`}}",
         "private_virtual_network_with_public_ip": "{{env `PRIVATE_VIRTUAL_NETWORK_WITH_PUBLIC_IP`}}",
-        "vm_size": "Standard_DS4_v2",
+        "vm_size": "Standard_D4_v2",
         "run_scan_antivirus": "false",
 
         "root_folder": "C:",

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -169,35 +169,36 @@ function Start-DownloadWithRetry
         [Parameter(Mandatory)]
         [string] $Name,
         [string] $DownloadPath = "${env:Temp}",
-        [int] $retries = 20
-        )
-    $FilePath = Join-Path $DownloadPath $Name
-    #Default retry logic for the package.
-    while($retries -gt 0)
-        {
-            try
-            {
-                Write-Host "Downloading package from: $Url to path $FilePath ."
-                (New-Object System.Net.WebClient).DownloadFile($Url, $FilePath)
-                break
-            }
-            catch
-            {
-                Write-Host "There is an error during package downloading"
-                $_
-                $retries--
+        [int] $Retries = 20
+    )
 
-                if ($retries -eq 0)
-                {
-                    Write-Host "File can't be downloaded. Please try later or check that file exists by url: $Url"
-                    $_
-                    exit 1
-                }
-                Write-Host "Waiting 30 seconds before retrying. Retries left: $retries"
-                Start-Sleep -Seconds 30
-            }
+    $FilePath = Join-Path -Path $DownloadPath -ChildPath $Name
+    #Default retry logic for the package.
+    while ($retries -gt 0)
+    {
+        try
+        {
+            Write-Host "Downloading package from: $Url to path $FilePath ."
+            (New-Object System.Net.WebClient).DownloadFile($Url, $FilePath)
+            break
         }
-   return $FilePath
+        catch
+        {
+            Write-Host "There is an error during package downloading:`n $_"
+            $retries--
+
+            if ($retries -eq 0)
+            {
+                Write-Host "File can't be downloaded. Please try later or check that file exists by url: $Url"
+                exit 1
+            }
+
+            Write-Host "Waiting 30 seconds before retrying. Retries left: $retries"
+            Start-Sleep -Seconds 30
+        }
+    }
+
+    return $FilePath
 }
 
 


### PR DESCRIPTION
# Changes

1. Change Azure VM Size Standard_DS4_v2  to Standard_D4_v2 to decrease packer winrm timeout with Windows Server 2019 - https://github.com/hashicorp/packer/issues/8658

One of packer contributor provide - https://github.com/hashicorp/packer/issues/8658#issuecomment-605376740

My findings are as follows:

1. v1.5.5 using Standard_D2_v2 resulted in a successful build every time.
2. v1.5.5 patched to use <machinename>.<location>.cloudapp.azure.com using Standard_D2_v2 resulted in a succesful build every time.
3. v1.5.5 using Standard_DS2_v2 timed out 60% of the time.
4. v1.5.5 patched to use <machinename>.<location>.cloudapp.azure.com using Standard_DS2_v2 timed out 80% of the time (seems like a lot, so maybe be something else going on; will retest)

As we can see there is no any difference between in the compute resources Standard_DS4_v2  vs Standard_D4_v2 - https://azureprice.net/

VM name | # Cores | Memory (GiB) | Max # disks | Linux price | Windows price
-- | -- | -- | -- | -- | --
Standard_DS4_v2 | 8 | 28 | 32 | 0.559 | 1.008
Standard_D4_v2 | 8 | 28 | 32 | 0.559 | 1.008

2. Update `Start-DownloadWithRetry` function to return correct value of the `$FilePath`when an output stream contains errors

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/338

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
