### PR TITLE
Fix geckodriver url parse

### DIFF
--- a/images/linux/scripts/installers/firefox.sh
+++ b/images/linux/scripts/installers/firefox.sh
@@ -25,8 +25,8 @@ HOME=/root
 DocumentInstalledItem "Firefox ($(firefox --version))"
 
 # Download and unpack latest release of geckodriver
-URL=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest|grep 'browser_download_url.*linux64.tar.gz'|sed -E 's/^.*(https:.+)".*/\1/g')
-echo "Downloading geckodriver $URL..."
+URL=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r '.assets[].browser_download_url | select(contains("linux64.tar.gz"))')
+echo "Downloading geckodriver $URL"
 wget "$URL" -O geckodriver.tar.gz
 tar -xzf geckodriver.tar.gz
 rm geckodriver.tar.gz


### PR DESCRIPTION
# Description
Time to time we have errors  with incorrect parsing geckodriver url during ubuntu image generation process.  For example, last build failed with incorrect `https://github.com/vladikoff` url instead of something like `https://github-production-release-asset-2e65be.s3.amazonaws.com.`

https://github.visualstudio.com/virtual-environments/_build/results?buildId=64162&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=486c0909-f67d-5748-80b3-bb1d531e7b43

```
azure-arm: Downloading geckodriver https://github.com/vladikoff...
azure-arm: --2020-04-03 02:14:54--  https://github.com/vladikoff
azure-arm: Resolving github.com (github.com)... 192.30.255.112
azure-arm: Connecting to github.com (github.com)|192.30.255.112|:443... connected.
azure-arm: HTTP request sent, awaiting response... 200 OK
azure-arm: Length: unspecified [text/html]
azure-arm: Saving to: â€˜geckodriver.tar.gzâ€™
azure-arm:      0K .......... .......... .......... .......... .......... 4.61M
azure-arm:     50K .......... .......... .......... .......... .......... 10.3M
azure-arm:    100K .......... .......... .......... .......... .......... 9.80M
azure-arm:    150K .......... .......... .......... .......               7.44M=0.03s
```

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
