### PR TITLE
Fix nuget installation on Windows Server 2016

### DIFF
--- a/images/win/scripts/Installers/Windows2016/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/Windows2016/Initialize-VM.ps1
@@ -30,6 +30,9 @@ function Disable-UserAccessControl {
     Write-Host "User Access Control (UAC) has been disabled."
 }
 
+# Set TLS1.2
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor "Tls12"
+
 Import-Module -Name ImageHelpers -Force
 
 Write-Host "Setup PowerShellGet"
@@ -98,7 +101,6 @@ else {
 }
 
 # Run the installer
-[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor "Tls12"
 Invoke-Expression ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
 
 # Turn off confirmation


### PR DESCRIPTION
# Description
Microsoft deprecated support SSL/old TLS to compliant version 1.2. In that case we should manually set `Tls12` before nuget installation to fix Windows Server 2016  image generation process.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/338
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
