### PR TITLE
Change default locale for Firefox on Ubuntu

### DIFF
--- a/images/linux/scripts/installers/firefox.sh
+++ b/images/linux/scripts/installers/firefox.sh
@@ -19,11 +19,13 @@ fi
 
 # Home directory is cleaned up before creation, we need create in skell to copy directories.
 echo "Move .mozilla directory to skel"
-mv $HOME/.mozilla /etc/skel/.mozilla
+xvfb-run firefox -CreateProfile default
 # Locale on firefox differs from other browsers, en_GB instead of en_US
-profile_dir=$(find /etc/skel/.mozilla/firefox -name "*.deafult-release" -type d)
+profile_dir=$(find .mozilla/firefox -name "*.default" -type d)
+echo "profile_dir is $profile_dir"
 echo 'user_pref("intl.accept_languages","en_US");' >> "$profile_dir/user.js"
 echo 'user_pref("intl.locale.requested","en_US");' >> "$profile_dir/user.js"
+mv $HOME/.mozilla /etc/skel/.mozilla
 
 # Document what was added to the image
 echo "Lastly, documenting what we added to the metadata file"

--- a/images/linux/scripts/installers/firefox.sh
+++ b/images/linux/scripts/installers/firefox.sh
@@ -17,15 +17,7 @@ if ! command -v firefox; then
     exit 1
 fi
 
-# Home directory is cleaned up before creation, we need create in skell to copy directories.
-echo "Move .mozilla directory to skel"
-xvfb-run firefox -CreateProfile default
-# Locale on firefox differs from other browsers, en_GB instead of en_US
-profile_dir=$(find .mozilla/firefox -name "*.default" -type d)
-echo "profile_dir is $profile_dir"
-echo 'user_pref("intl.accept_languages","en_US");' >> "$profile_dir/user.js"
-echo 'user_pref("intl.locale.requested","en_US");' >> "$profile_dir/user.js"
-mv $HOME/.mozilla /etc/skel/.mozilla
+echo 'pref("intl.locale.requested","en_US");' >> "/usr/lib/firefox/browser/defaults/preferences/syspref.js"
 
 # Document what was added to the image
 echo "Lastly, documenting what we added to the metadata file"

--- a/images/linux/scripts/installers/firefox.sh
+++ b/images/linux/scripts/installers/firefox.sh
@@ -17,6 +17,13 @@ if ! command -v firefox; then
     exit 1
 fi
 
+# Home directory is cleaned up before creation, we need create in skell to copy directories.
+echo "Move .mozilla directory to skel"
+mv .mozilla /etc/skel/.mozilla
+profile_dir=$(find /etc/skel/.mozilla/firefox -name "*.deafult-release" -type d)
+echo 'user_pref("intl.accept_languages","en_US");' >> "$profile_dir/user.js"
+echo 'user_pref("intl.locale.requested","en_US");' >> "$profile_dir/user.js"
+
 # Document what was added to the image
 echo "Lastly, documenting what we added to the metadata file"
 # Resolves: Running Firefox as root in a regular user's session is not supported.

--- a/images/linux/scripts/installers/firefox.sh
+++ b/images/linux/scripts/installers/firefox.sh
@@ -17,6 +17,8 @@ if ! command -v firefox; then
     exit 1
 fi
 
+# add to gloabl system preferences for firefox locale en_US, because other browsers have en_US local.
+# Default firefox local is en_GB
 echo 'pref("intl.locale.requested","en_US");' >> "/usr/lib/firefox/browser/defaults/preferences/syspref.js"
 
 # Document what was added to the image

--- a/images/linux/scripts/installers/firefox.sh
+++ b/images/linux/scripts/installers/firefox.sh
@@ -19,7 +19,8 @@ fi
 
 # Home directory is cleaned up before creation, we need create in skell to copy directories.
 echo "Move .mozilla directory to skel"
-mv .mozilla /etc/skel/.mozilla
+mv $HOME/.mozilla /etc/skel/.mozilla
+# Locale on firefox differs from other browsers, en_GB instead of en_US
 profile_dir=$(find /etc/skel/.mozilla/firefox -name "*.deafult-release" -type d)
 echo 'user_pref("intl.accept_languages","en_US");' >> "$profile_dir/user.js"
 echo 'user_pref("intl.locale.requested","en_US");' >> "$profile_dir/user.js"


### PR DESCRIPTION
<h1>Description</h1>
Firefox on ubuntu has different locales compared with other browsers, en_GB instead of en_US
- mv .mozilla to skel
- add user.js profile with its changes
<h4>Related issue:</h4>
https://github.com/actions/virtual-environments/issues/614
<h4>Link image</h4>
https://github.visualstudio.com/virtual-environments/_build/results?buildId=64369&view=results
<h2>Check list</h2>
- [x] Related issue / work item is attached</br>
- [ ] Tests are written (if applicable)</br>
- [ ] Documentation is updated (if applicable)</br>
- [ ] Changes are tested and related VM images are successfully generated