### PR TITLE
Add haveged random generator tool on Ubuntu images

### DIFF
--- a/images/linux/scripts/installers/rndgenerator.sh
+++ b/images/linux/scripts/installers/rndgenerator.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+################################################################################
+##  File:  rndgenerator.sh
+##  Desc:  Install random number generator
+################################################################################
+
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/document.sh
+
+# Install haveged
+apt-get -y install haveged
+
+# Run tests to determine that the software installed as expected
+echo "Testing to make sure that script performed as expected, and basic scenarios work"
+for cmd in haveged; do
+    if ! command -v $cmd; then
+        echo "$cmd was not installed or not found on PATH"
+        exit 1
+    fi
+done
+
+# Document what was added to the image
+echo "Lastly, documenting what we added to the metadata file"
+DocumentInstalledItem "Haveged $(dpkg-query --showformat='${Version}' --show haveged)"

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -189,7 +189,8 @@
                 "{{template_dir}}/scripts/installers/zeit-now.sh",
                 "{{template_dir}}/scripts/installers/updatepath.sh",
                 "{{template_dir}}/scripts/installers/dpkg-config.sh",
-                "{{template_dir}}/scripts/installers/mongodb.sh"
+                "{{template_dir}}/scripts/installers/mongodb.sh",
+                "{{template_dir}}/scripts/installers/rndgenerator.sh"
 
             ],
             "environment_vars": [

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -192,7 +192,8 @@
                 "{{template_dir}}/scripts/installers/zeit-now.sh",
                 "{{template_dir}}/scripts/installers/updatepath.sh",
                 "{{template_dir}}/scripts/installers/dpkg-config.sh",
-                "{{template_dir}}/scripts/installers/mongodb.sh"
+                "{{template_dir}}/scripts/installers/mongodb.sh",
+                "{{template_dir}}/scripts/installers/rndgenerator.sh"
             ],
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",


### PR DESCRIPTION
# Description
The build hangs forever with a [cryptographic library](https://github.com/uio-bmi/crypt4gh) , because the library can’t generate encryption keys due to the issue [GPG does not have enough entropy](https://serverfault.com/questions/214605/gpg-does-not-have-enough-entropy)

> We need to generate a lot of random bytes. It is a good idea to perform
> some other action (type on the keyboard, move the mouse, utilize the
> disks) during the prime generation; this gives the random number
> generator a better chance to gain enough entropy.
> Not enough random bytes available.  Please do some other work to give
> the OS a chance to collect more entropy!

 **For new tools, please provide total size and installation time.**
Haveged - 200kb (~10 seconds)

#### Related issue:
https://github.com/actions/virtual-environments/issues/672

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
