### PR TITLE
Fix Git installer to download directly from release

### DIFF
--- a/images/win/scripts/Installers/Install-Git.ps1
+++ b/images/win/scripts/Installers/Install-Git.ps1
@@ -5,9 +5,33 @@
 
 Import-Module -Name ImageHelpers
 
-# Install the latest version of Git which is bundled with Git LFS.
-# See https://chocolatey.org/packages/git
-choco install git -y --package-parameters="/GitAndUnixToolsOnPath /WindowsTerminal /NoShellIntegration"
+function getSimpleValue([string] $url, [string] $filename ) {
+    $fullpath = "${env:Temp}\$filename"
+    Invoke-WebRequest -Uri $url -OutFile $fullpath
+    $value = Get-Content $fullpath -Raw
+
+    return $value
+}
+
+# Install the latest version of Git for Windows
+$gitTag = getSimpleValue("https://gitforwindows.org/latest-tag.txt", "gitlatesttag.txt");
+$gitVersion = getSimpleValue("https://gitforwindows.org/latest-version.txt", "gitlatestversion.txt");
+
+$installerFile = "Git-$gitVersion-64-bit.exe";
+$downloadUrl = "https://github.com/git-for-windows/git/releases/download/$gitTag/$installerFile";
+Install-Exe -Url $downloadUrl `
+            -Name $installerFile `
+            -ArgumentList (
+                "/VERYSILENT", `
+                "/NORESTART", `
+                "/NOCANCEL", `
+                "/SP-", `
+                "/CLOSEAPPLICATIONS", `
+                "/RESTARTAPPLICATIONS", `
+                "/o:PathOption=CmdTools", `
+                "/o:BashTerminalOption=ConHost", `
+                "/COMPONENTS=gitlfs")
+
 choco install hub
 
 # Disable GCM machine-wide

--- a/images/win/scripts/Installers/Install-Git.ps1
+++ b/images/win/scripts/Installers/Install-Git.ps1
@@ -14,8 +14,8 @@ function getSimpleValue([string] $url, [string] $filename ) {
 }
 
 # Install the latest version of Git for Windows
-$gitTag = getSimpleValue("https://gitforwindows.org/latest-tag.txt", "gitlatesttag.txt");
-$gitVersion = getSimpleValue("https://gitforwindows.org/latest-version.txt", "gitlatestversion.txt");
+$gitTag = getSimpleValue -url "https://gitforwindows.org/latest-tag.txt" -filename "gitlatesttag.txt"
+$gitVersion = getSimpleValue -url "https://gitforwindows.org/latest-version.txt" -filename "gitlatestversion.txt";
 
 $installerFile = "Git-$gitVersion-64-bit.exe";
 $downloadUrl = "https://github.com/git-for-windows/git/releases/download/$gitTag/$installerFile";


### PR DESCRIPTION
# Description
I'm updating the Git install script for Windows images to use the release from the official GitHub for Windows repo. The main reason for this is to be able to move the version without being attached to what chocolatey provides.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
