### PR TITLE
Fix Julia destination folder

### DIFF
--- a/images/win/scripts/Installers/Install-Julia.ps1
+++ b/images/win/scripts/Installers/Install-Julia.ps1
@@ -3,4 +3,4 @@
 ##  Desc:  Install Julia
 ################################################################################
 
-choco install julia -y --ia "/D=C:\Julia"
+choco install julia -y --ia "/DIR=C:\Julia"

--- a/images/win/scripts/Installers/Validate-Julia.ps1
+++ b/images/win/scripts/Installers/Validate-Julia.ps1
@@ -4,7 +4,7 @@
 ################################################################################
 
 # Verify that julia.exe is on the path
-if(Get-Command -Name 'julia')
+if((Get-Command -Name 'julia') -and (Test-Path -Path 'C:\Julia'))
 {
     Write-Host "$(julia --version) is on the path."
 }


### PR DESCRIPTION
# Description
Julia 1.3.1 was packed using NSIS  installer with parameter /D to overrides destination folder. After updating Julia to version Julia 1.4.0  installer was updated to use Inno Setup with a new parameter /DIR:
```
/DIR="x:\dirname"
Overrides the default directory name displayed on the Select Destination Location wizard page. A fully qualified pathname must be specified. May include an "expand:" prefix which instructs Setup to expand any constants in the name. For example: '/DIR=expand:{autopf}\My Program'.
```

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
