### PR TITLE
[Ubuntu] Workaround for vcpkg installation

### DIFF
--- a/images/linux/scripts/installers/vcpkg.sh
+++ b/images/linux/scripts/installers/vcpkg.sh
@@ -12,7 +12,10 @@ VCPKG_INSTALLATION_ROOT=/usr/local/share/vcpkg
 echo "VCPKG_INSTALLATION_ROOT=${VCPKG_INSTALLATION_ROOT}" | tee -a /etc/environment
 
 # Install vcpkg
-git clone --depth=1 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT
+git clone https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT
+# Workaround to avoid issues caused by this PR https://github.com/microsoft/vcpkg/pull/10834
+git checkout 1e19af09e53e5f306ed89c2033817a21e5ee0bcf
+
 $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh
 $VCPKG_INSTALLATION_ROOT/vcpkg integrate install
 chmod 0777 -R $VCPKG_INSTALLATION_ROOT


### PR DESCRIPTION
Vcpkg bootstrap failed with `2020/04/15 08:34:22 ui error: ==> azure-arm: CMake Error: The source directory "/home/packer/toolsrc" does not exist.`after this PR https://github.com/microsoft/vcpkg/pull/10834 
Changed vcpkg installation to the previous commit to unblock image generation.