### PR TITLE
Improve Windows browsers provisioners stability

### DIFF
--- a/images/win/scripts/Installers/Install-Chrome.ps1
+++ b/images/win/scripts/Installers/Install-Chrome.ps1
@@ -5,14 +5,9 @@
 
 Import-Module -Name ImageHelpers -Force
 
-<<<<<<< HEAD
 # Download and install latest Chrome browser
 $ChromeInstallerFile = "chrome_installer.exe"
 $ChromeInstallerUrl = "https://dl.google.com/chrome/install/375.126/${ChromeInstallerFile}"
-=======
-$ChromeInstallerFile = "chrome_installer.exe";
-$ChromeInstallerUrl = "https://dl.google.com/chrome/install/375.126/${ChromeInstallerFile}";
->>>>>>> master
 Install-Binary -Url $ChromeInstallerUrl -Name $ChromeInstallerFile -ArgumentList ("/silent", "/install")
 
 # Prepare firewall rules

--- a/images/win/scripts/Installers/Install-Chrome.ps1
+++ b/images/win/scripts/Installers/Install-Chrome.ps1
@@ -3,23 +3,25 @@
 ##  Desc:  Install Google Chrome
 ################################################################################
 
-Import-Module -Name ImageHelpers -Force;
+Import-Module -Name ImageHelpers -Force
 
-$ChromeInstallerFile = "chrome_installer.exe";
-$ChromeInstallerUri = "https://dl.google.com/chrome/install/375.126/${ChromeInstallerFile}";
-Install-Exe -Url $ChromeInstallerUri -Name $ChromeInstallerFile -ArgumentList ("/silent", "/install")
+# Download and install latest Chrome browser
+$ChromeInstallerFile = "chrome_installer.exe"
+$ChromeInstallerUrl = "https://dl.google.com/chrome/install/375.126/${ChromeInstallerFile}"
+Install-Binary -Url $ChromeInstallerUrl -Name $ChromeInstallerFile -ArgumentList ("/silent", "/install")
 
-Write-Host "Adding the firewall rule for Google update blocking";
-New-NetFirewallRule -DisplayName "BlockGoogleUpdate" -Direction Outbound -Action Block -Program "C:\Program Files (x86)\Google\Update\GoogleUpdate.exe";
+# Prepare firewall rules
+Write-Host "Adding the firewall rule for Google update blocking..."
+New-NetFirewallRule -DisplayName "BlockGoogleUpdate" -Direction Outbound -Action Block -Program "C:\Program Files (x86)\Google\Update\GoogleUpdate.exe"
 
-$GoogleSvcs = ('gupdate','gupdatem');
-$GoogleSvcs | Stop-SvcWithErrHandling -StopOnError;
-$GoogleSvcs | Set-SvcWithErrHandling -Arguments @{StartupType = "Disabled"};
+$GoogleSvcs = ('gupdate','gupdatem')
+$GoogleSvcs | Stop-SvcWithErrHandling -StopOnError
+$GoogleSvcs | Set-SvcWithErrHandling -Arguments @{StartupType = "Disabled"}
 
-$regGoogleUpdatePath = "HKLM:\SOFTWARE\Policies\Google\Update";
-$regGoogleUpdateChrome = "HKLM:\SOFTWARE\Policies\Google\Chrome";
+$regGoogleUpdatePath = "HKLM:\SOFTWARE\Policies\Google\Update"
+$regGoogleUpdateChrome = "HKLM:\SOFTWARE\Policies\Google\Chrome"
 ($regGoogleUpdatePath, $regGoogleUpdateChrome) | ForEach-Object {
-    New-Item -Path $_ -Force;
+    New-Item -Path $_ -Force
 }
 
 $regGoogleParameters = @(
@@ -31,52 +33,45 @@ $regGoogleParameters = @(
 )
 
 $regGoogleParameters | ForEach-Object {
-    $Arguments = $_;
-    if (-not ($Arguments.Path)) {
-        $Arguments.Add("Path", $regGoogleUpdatePath);
+    $Arguments = $_
+    if (-not ($Arguments.Path))
+    {
+        $Arguments.Add("Path", $regGoogleUpdatePath)
     }
-    $Arguments.Add("Force", $true);
-    New-ItemProperty @Arguments;
+    $Arguments.Add("Force", $true)
+    New-ItemProperty @Arguments
 }
 
-# Reinstall Chrome Web Driver
-Write-Host "Install Chrome WebDriver"
-$DestinationPath = "$($env:SystemDrive)\";
-$ChromeDriverPath = "${DestinationPath}SeleniumWebDrivers\ChromeDriver";
-
-if (-not (Test-Path -Path $ChromeDriverPath)) {
-    New-Item -Path $ChromeDriverPath -ItemType "directory"
+# Install Chrome WebDriver
+Write-Host "Install Chrome WebDriver..."
+$ChromeDriverPath = "$($env:SystemDrive)\SeleniumWebDrivers\ChromeDriver"
+if (-not (Test-Path -Path $ChromeDriverPath))
+{
+    New-Item -Path $ChromeDriverPath -ItemType Directory -Force
 }
 
+Write-Host "Get the Chrome WebDriver version..."
 $RegistryPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths"
-$ChromePath = (Get-ItemProperty "$RegistryPath\chrome.exe").'(default)';
-[version]$ChromeVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($ChromePath).ProductVersion;
-Write-Host "Chrome version: [$ChromeVersion]";
+$ChromePath = (Get-ItemProperty "$RegistryPath\chrome.exe").'(default)'
+[version]$ChromeVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($ChromePath).ProductVersion
+$ChromeDriverVersionUrl = "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$($ChromeVersion.Major).$($ChromeVersion.Minor).$($ChromeVersion.Build)"
 
-$ChromeDriverVersionUri = "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$($ChromeVersion.Major).$($ChromeVersion.Minor).$($ChromeVersion.Build)";
-Write-Host "Chrome driver version Uri [$ChromeDriverVersionUri]";
-Write-Host "Getting the Chrome driver version...";
-$ChromeDriverVersion = Invoke-WebRequest -Uri $ChromeDriverVersionUri;
-Write-Host "Current Chrome driver version: [$ChromeDriverVersion]";
+$ChromeDriverVersionFile = Start-DownloadWithRetry -Url $ChromeDriverVersionUrl -Name "versioninfo.txt" -DownloadPath $ChromeDriverPath
 
-$ChromeDriverZipDownloadUri = "https://chromedriver.storage.googleapis.com/$($ChromeDriverVersion.ToString())/chromedriver_win32.zip";
-Write-Host "Chrome driver zip file download Uri: [$ChromeDriverZipDownloadUri]";
+Write-Host "Download Chrome WebDriver..."
+$ChromeDriverVersion = Get-Content -Path $ChromeDriverVersionFile
+$ChromeDriverArchName = "chromedriver_win32.zip"
+$ChromeDriverZipDownloadUrl = "https://chromedriver.storage.googleapis.com/${ChromeDriverVersion}/${ChromeDriverArchName}"
 
-$DestFile= "$ChromeDriverPath\chromedriver_win32.zip";
-$ChromeDriverVersion.Content | Out-File -FilePath "$ChromeDriverPath\versioninfo.txt" -Force;
+$ChromeDriverArchPath = Start-DownloadWithRetry -Url $ChromeDriverZipDownloadUrl -Name $ChromeDriverArchName
 
-Write-Host "Chrome driver download....";
-Invoke-WebRequest -Uri $ChromeDriverZipDownloadUri -OutFile $DestFile;
+Write-Host "Expand Chrome WebDriver archive..."
+Expand-Archive -Path $ChromeDriverArchPath -DestinationPath $ChromeDriverPath -Force
 
-Write-Host "Chrome driver install....";
-Expand-Archive -Path "$ChromeDriverPath\chromedriver_win32.zip" -DestinationPath $ChromeDriverPath -Force;
-Remove-Item -Path "$ChromeDriverPath\chromedriver_win32.zip" -Force;
+Write-Host "Setting the environment variables..."
+setx ChromeWebDriver "$ChromeDriverPath" /M
 
-Write-Host "Setting the environment variables"
-
-setx ChromeWebDriver "$ChromeDriverPath" /M;
-
-$regEnvKey = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\';
-$PathValue = Get-ItemPropertyValue -Path $regEnvKey -Name 'Path';
-$PathValue += ";$ChromeDriverPath\";
-Set-ItemProperty -Path $regEnvKey -Name 'Path' -Value $PathValue;
+$regEnvKey = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\'
+$PathValue = Get-ItemPropertyValue -Path $regEnvKey -Name 'Path'
+$PathValue += ";$ChromeDriverPath\"
+Set-ItemProperty -Path $regEnvKey -Name 'Path' -Value $PathValue

--- a/images/win/scripts/Installers/Install-Edge.ps1
+++ b/images/win/scripts/Installers/Install-Edge.ps1
@@ -5,37 +5,36 @@
 
 choco install microsoft-edge -y
 
-# Install Microsoft Edge Web Driver
-Write-Host "Install Edge WebDriver"
-$DestinationPath = "$($env:SystemDrive)\";
-
-$EdgeDriverPath = "${DestinationPath}SeleniumWebDrivers\EdgeDriver"
-if (-not (Test-Path -Path $EdgeDriverPath)) {
-    New-Item -Path $EdgeDriverPath -ItemType "directory"
+# Install Microsoft Edge WebDriver
+Write-Host "Install Edge WebDriver..."
+$EdgeDriverPath = "$($env:SystemDrive)\SeleniumWebDrivers\EdgeDriver"
+if (-not (Test-Path -Path $EdgeDriverPath))
+{
+    New-Item -Path $EdgeDriverPath -ItemType Directory -Force
 }
 
+Write-Host "Get the Microsoft Edge WebDriver version..."
 $RegistryPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths"
 $EdgePath = (Get-ItemProperty "$RegistryPath\msedge.exe").'(default)'
 [version]$EdgeVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($EdgePath).ProductVersion
 $EdgeDriverVersionUrl = "https://msedgedriver.azureedge.net/LATEST_RELEASE_$($EdgeVersion.Major)"
-$EdgeDriverVersionFile = "$EdgeDriverPath\versioninfo.txt"
-Invoke-WebRequest -Uri $EdgeDriverVersionUrl -OutFile $EdgeDriverVersionFile
 
-Write-Host "Microsoft Edge driver download started"
+$EdgeDriverVersionFile = Start-DownloadWithRetry -Url $EdgeDriverVersionUrl -Name "versioninfo.txt" -DownloadPath $EdgeDriverPath
+
+Write-Host "Download Microsoft Edge WebDriver..."
 $EdgeDriverLatestVersion = Get-Content -Path $EdgeDriverVersionFile
-$EdgeDriverDownloadUrl="https://msedgedriver.azureedge.net/${EdgeDriverLatestVersion}/edgedriver_win64.zip"
-$DestFile = "$EdgeDriverPath\edgedriver_win64.zip"
-Invoke-WebRequest -Uri $EdgeDriverDownloadUrl -OutFile $DestFile
+$EdgeDriverArchName = "edgedriver_win64.zip"
+$EdgeDriverDownloadUrl="https://msedgedriver.azureedge.net/${EdgeDriverLatestVersion}/${EdgeDriverArchName}"
 
-Write-Host "Microsoft Edge driver installation started"
-Expand-Archive -Path $DestFile -DestinationPath $EdgeDriverPath -Force
-Remove-Item -Path $DestFile -Force
+$EdgeDriverArchPath = Start-DownloadWithRetry -Url $EdgeDriverDownloadUrl -Name $EdgeDriverArchName
 
-Write-Host "Setting the environment variables"
+Write-Host "Expand Microsoft Edge WebDriver archive..."
+Expand-Archive -Path $EdgeDriverArchPath -DestinationPath $EdgeDriverPath -Force
 
-setx EdgeWebDriver "$EdgeDriverPath" /M;
+Write-Host "Setting the environment variables..."
+setx EdgeWebDriver "$EdgeDriverPath" /M
 
-$regEnvKey = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\';
-$PathValue = Get-ItemPropertyValue -Path $regEnvKey -Name 'Path';
-$PathValue += ";$EdgeDriverPath\";
-Set-ItemProperty -Path $regEnvKey -Name 'Path' -Value $PathValue;
+$regEnvKey = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\'
+$PathValue = Get-ItemPropertyValue -Path $regEnvKey -Name 'Path'
+$PathValue += ";$EdgeDriverPath\"
+Set-ItemProperty -Path $regEnvKey -Name 'Path' -Value $PathValue

--- a/images/win/scripts/Installers/Install-Firefox.ps1
+++ b/images/win/scripts/Installers/Install-Firefox.ps1
@@ -5,71 +5,48 @@
 
 Import-Module -Name ImageHelpers -Force
 
-$temp_install_dir = 'C:\Windows\Installer'
-New-Item -Path $temp_install_dir -ItemType Directory -Force
+# Install and configure Firefox browser
+Write-Host "Install latest Firefox browser..."
+$VersionsManifest = Invoke-RestMethod "https://product-details.mozilla.org/1.0/firefox_versions.json"
+$InstallerName = "firefox-browser.exe"
+$InstallerUrl = "https://download.mozilla.org/?product=firefox-$($VersionsManifest.LATEST_FIREFOX_VERSION)&os=win64&lang=en-US"
+$ArgumentList = ("/silent", "/install")
 
-$versionsJson = Invoke-RestMethod  "https://product-details.mozilla.org/1.0/firefox_versions.json"
-$latestVersion = $versionsJson.LATEST_FIREFOX_VERSION
-Write-Host "Firefox latest version: $latestVersion"
+Install-Binary -Url $InstallerUrl -Name $InstallerName -ArgumentList $ArgumentList
 
-# url for latest version of firefox
-$urlLatestVersion = "https://download.mozilla.org/?product=firefox-${latestVersion}&os=win64&lang=en-US"
-Install-EXE -Url $urlLatestVersion -Name "Firefox Setup $latestVersion.exe" -ArgumentList ("/silent", "/install")
-
-# Disable autoupdate
-$firefoxDirectoryPath = Join-Path $env:ProgramFiles "Mozilla Firefox"
-New-Item -path $firefoxDirectoryPath -Name 'mozilla.cfg' -Value '//
+Write-Host "Disable autoupdate..."
+$FirefoxDirectoryPath = Join-Path $env:ProgramFiles "Mozilla Firefox"
+New-Item -path $FirefoxDirectoryPath -Name 'mozilla.cfg' -Value '//
 pref("browser.shell.checkDefaultBrowser", false);
 pref("app.update.enabled", false);' -ItemType file -force
 
-$firefoxPreferencesFolder = Join-Path $firefoxDirectoryPath "defaults\pref"
-New-Item -path $firefoxPreferencesFolder -Name 'local-settings.js' -Value 'pref("general.config.obscure_value", 0);
+$FirefoxPreferencesFolder = Join-Path $FirefoxDirectoryPath "defaults\pref"
+New-Item -path $FirefoxPreferencesFolder -Name 'local-settings.js' -Value 'pref("general.config.obscure_value", 0);
 pref("general.config.filename", "mozilla.cfg");' -ItemType file -force
 
-# Install Firefox gecko Web Driver
-Write-Host "Install Firefox WebDriver"
-$DestinationPath = "$($env:SystemDrive)\";
-$SeleniumWebDriverPath = Join-Path $DestinationPath "SeleniumWebDrivers"
-
-$geckodriverJson = Invoke-RestMethod "https://api.github.com/repos/mozilla/geckodriver/releases/latest"
-$geckodriverWindowsAsset = $geckodriverJson.assets | Where-Object { $_.name -Match "win64" } | Select-Object -First 1
-
-$geckodriverVersion = $geckodriverJson.tag_name
-Write-Host "Geckodriver version: $geckodriverVersion"
-
-$DriversZipFile = $geckodriverWindowsAsset.name
-Write-Host "Selenium drivers download and install..."
-
-$FirefoxDriverPath = Join-Path $SeleniumWebDriverPath "GeckoDriver"
-
-if (-not (Test-Path -Path $FirefoxDriverPath)) {
-    New-Item -Path $FirefoxDriverPath -ItemType "directory"
+# Download and install Gecko WebDriver
+Write-Host "Install Gecko WebDriver..."
+$GeckoDriverPath = "$($env:SystemDrive)\SeleniumWebDrivers\GeckoDriver"
+if (-not (Test-Path -Path $GeckoDriverPath))
+{
+    New-Item -Path $GeckoDriverPath -ItemType Directory -Force
 }
 
-$geckodriverVersion.Substring(1) | Out-File -FilePath "$FirefoxDriverPath\versioninfo.txt" -Force;
+Write-Host "Get the Gecko WebDriver version..."
+$GeckoDriverJson = Invoke-RestMethod "https://api.github.com/repos/mozilla/geckodriver/releases/latest"
+$GeckoDriverWindowsAsset = $GeckoDriverJson.assets | Where-Object { $_.name -Match "win64" } | Select-Object -First 1
+$GeckoDriverVersion = $GeckoDriverJson.tag_name
+$GeckoDriverVersion.Substring(1) | Out-File -FilePath "$GeckoDriverPath\versioninfo.txt" -Force;
 
-# Install Firefox Web Driver
-Write-Host "FireFox driver download...."
-if (-not (Test-Path -Path $FireFoxDriverPath)) {
-    New-Item -Path $FireFoxDriverPath -ItemType "directory"
-}
+Write-Host "Download Gecko WebDriver WebDriver..."
+$GeckoDriverArchName = $GeckoDriverWindowsAsset.name
+$GeckoDriverDownloadUrl = $GeckoDriverWindowsAsset.browser_download_url
 
-$DestFile = Join-Path $FireFoxDriverPath $DriversZipFile
-$FireFoxDriverDownloadUrl = $geckodriverWindowsAsset.browser_download_url
-try{
-    Invoke-WebRequest -Uri $FireFoxDriverDownloadUrl -OutFile $DestFile
-} catch {
-    Write-Error "[!] Failed to download $DriversZipFile"
-    exit 1
-}
+$GeckoDriverArchPath = Start-DownloadWithRetry -Url $GeckoDriverDownloadUrl -Name $GeckoDriverArchName
 
-Write-Host "FireFox driver install...."
-Expand-Archive -Path $DestFile -DestinationPath $FireFoxDriverPath -Force
-Remove-Item -Path $DestFile -Force
+Write-Host "Expand Gecko WebDriver archive..."
+Expand-Archive -Path $GeckoDriverArchPath -DestinationPath $GeckoDriverPath -Force
 
-
-Write-Host "Setting the environment variables"
-Add-MachinePathItem -PathItem $FireFoxDriverPath
-setx GeckoWebDriver "$FirefoxDriverPath" /M;
-
-exit 0
+Write-Host "Setting the environment variables..."
+Add-MachinePathItem -PathItem $GeckoDriverPath
+setx GeckoWebDriver "$GeckoDriverPath" /M


### PR DESCRIPTION
# Description

This PR improves Windows browsers provisioners (`Install-Edge`, `Install-Chrome`, `Install-Firefox`). 
Default `Install-Exe` functions in provisioners was changed to custom `Install-Binary`, `Invoke-WebRequest` methods was also changed to cusetom `Start-DownloadWithRetry` to avoid possible image-generation failures, caused by connectivity issues. PR also includes several minor improvements in provisioners syntax.

**How it was tested:**
Validation image was generated - [Windows2019](https://dev.azure.com/github/virtual-environments/_build/results?buildId=65239&view=results).

#### Related issue:
Issue: https://github.com/actions/virtual-environments-internal/issues/384

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated

