### PR TITLE
[Ubuntu] Fix workaround for vcpkg

### DIFF
--- a/images/linux/scripts/installers/vcpkg.sh
+++ b/images/linux/scripts/installers/vcpkg.sh
@@ -14,6 +14,7 @@ echo "VCPKG_INSTALLATION_ROOT=${VCPKG_INSTALLATION_ROOT}" | tee -a /etc/environm
 # Install vcpkg
 git clone https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT
 # Workaround to avoid issues caused by this PR https://github.com/microsoft/vcpkg/pull/10834
+cd $VCPKG_INSTALLATION_ROOT
 git checkout 1e19af09e53e5f306ed89c2033817a21e5ee0bcf
 
 $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh


### PR DESCRIPTION
Fix for pr https://github.com/actions/virtual-environments/pull/724
`git checkout` is supposed to be invoked from the downloaded repo directory