### PR TITLE
[Ubuntu] Remove workaround for vcpkg

### DIFF
--- a/images/linux/scripts/installers/vcpkg.sh
+++ b/images/linux/scripts/installers/vcpkg.sh
@@ -17,7 +17,7 @@ git clone --depth=1 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT
 
 # vcpkg requires g++ version 7+, yet Ubuntu 16 default is 5.4. Set version 7 as default temporarily
 if isUbuntu16; then
-    sudo ln -sf g++-7 /usr/bin/g++
+    ln -sf g++-7 /usr/bin/g++
 fi
 
 $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh
@@ -27,7 +27,7 @@ ln -sf $VCPKG_INSTALLATION_ROOT/vcpkg /usr/local/bin
 
 # set back g++ 5.4 as default
 if isUbuntu16; then
-    sudo ln -sf g++-5 /usr/bin/g++
+    ln -sf g++-5 /usr/bin/g++
 fi
 
 # Run tests to determine that the software installed as expected

--- a/images/linux/scripts/installers/vcpkg.sh
+++ b/images/linux/scripts/installers/vcpkg.sh
@@ -12,11 +12,7 @@ VCPKG_INSTALLATION_ROOT=/usr/local/share/vcpkg
 echo "VCPKG_INSTALLATION_ROOT=${VCPKG_INSTALLATION_ROOT}" | tee -a /etc/environment
 
 # Install vcpkg
-git clone https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT
-# Workaround to avoid issues caused by this PR https://github.com/microsoft/vcpkg/pull/10834
-cd $VCPKG_INSTALLATION_ROOT
-git checkout 1e19af09e53e5f306ed89c2033817a21e5ee0bcf
-
+git clone --depth=1 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT
 $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh
 $VCPKG_INSTALLATION_ROOT/vcpkg integrate install
 chmod 0777 -R $VCPKG_INSTALLATION_ROOT

--- a/images/linux/scripts/installers/vcpkg.sh
+++ b/images/linux/scripts/installers/vcpkg.sh
@@ -40,7 +40,3 @@ fi
 # Document what was added to the image
 echo "Lastly, documenting what we added to the metadata file"
 DocumentInstalledItem "Vcpkg $(vcpkg version | head -n 1 | cut -d ' ' -f 6)"
-
-
-
-

--- a/images/linux/scripts/installers/vcpkg.sh
+++ b/images/linux/scripts/installers/vcpkg.sh
@@ -25,7 +25,7 @@ $VCPKG_INSTALLATION_ROOT/vcpkg integrate install
 chmod 0777 -R $VCPKG_INSTALLATION_ROOT
 ln -sf $VCPKG_INSTALLATION_ROOT/vcpkg /usr/local/bin
 
-# set back g++ 5.4 as default
+# Set back g++ 5.4 as default
 if isUbuntu16; then
     ln -sf g++-5 /usr/bin/g++
 fi

--- a/images/linux/scripts/installers/vcpkg.sh
+++ b/images/linux/scripts/installers/vcpkg.sh
@@ -6,6 +6,7 @@
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/document.sh
+source $HELPER_SCRIPTS/os.sh
 
 # Set env variable for vcpkg
 VCPKG_INSTALLATION_ROOT=/usr/local/share/vcpkg
@@ -13,10 +14,21 @@ echo "VCPKG_INSTALLATION_ROOT=${VCPKG_INSTALLATION_ROOT}" | tee -a /etc/environm
 
 # Install vcpkg
 git clone --depth=1 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT
+
+# vcpkg requires g++ version 7+, yet Ubuntu 16 default is 5.4. Set version 7 as default temporarily
+if isUbuntu16; then
+    sudo ln -sf g++-7 /usr/bin/g++
+fi
+
 $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh
 $VCPKG_INSTALLATION_ROOT/vcpkg integrate install
 chmod 0777 -R $VCPKG_INSTALLATION_ROOT
 ln -sf $VCPKG_INSTALLATION_ROOT/vcpkg /usr/local/bin
+
+# set back g++ 5.4 as default
+if isUbuntu16; then
+    sudo ln -sf g++-5 /usr/bin/g++
+fi
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
@@ -28,3 +40,7 @@ fi
 # Document what was added to the image
 echo "Lastly, documenting what we added to the metadata file"
 DocumentInstalledItem "Vcpkg $(vcpkg version | head -n 1 | cut -d ' ' -f 6)"
+
+
+
+


### PR DESCRIPTION
Don't need this workaround anymore – issue fixed in https://github.com/microsoft/vcpkg/pull/10846