### PR TITLE
Improve Windows provisioners stability

### DIFF
--- a/images/win/scripts/Installers/Install-CloudFoundryCli.ps1
+++ b/images/win/scripts/Installers/Install-CloudFoundryCli.ps1
@@ -6,19 +6,18 @@
 Import-Module -Name ImageHelpers
 
 # Download the latest cf cli exe
-Invoke-WebRequest -UseBasicParsing -Uri "https://packages.cloudfoundry.org/stable?release=windows64-exe&source=github" -OutFile cf-cli.zip
+$CloudFoundryCliName = "cf-cli.zip"
+$CloudFoundryCliUrl = "https://packages.cloudfoundry.org/stable?release=windows64-exe&source=github"
+
+$CloudFoundryArchPath = Start-DownloadWithRetry -Url $CloudFoundryCliUrl -Name $CloudFoundryCliName
 
 # Create directory for cf cli
-$cf_cli_path = "C:\cf-cli"
-New-Item -Path $cf_cli_path -ItemType Directory -Force
+$CloudFoundryCliPath = "C:\cf-cli"
+New-Item -Path $CloudFoundryCliPath -ItemType Directory -Force
 
 # Extract the zip archive
 Write-Host "Extracting cf cli..."
-Expand-Archive -Path cf-cli.zip -DestinationPath $cf_cli_path -Force
+Expand-Archive -Path $CloudFoundryArchPath -DestinationPath $CloudFoundryCliPath -Force
 
 # Add cf to path
-Add-MachinePathItem $cf_cli_path
-
-# Delete the cfl-cli zip archive
-Write-Host "Deleting downloaded archive of cf cli"
-Remove-Item cf-cli.zip
+Add-MachinePathItem $CloudFoundryCliPath

--- a/images/win/scripts/Installers/Install-Kind.ps1
+++ b/images/win/scripts/Installers/Install-Kind.ps1
@@ -6,25 +6,24 @@
 $stableKindTag = "v0.7.0"
 $tagToUse = $stableKindTag;
 $destFilePath = "C:\ProgramData\kind"
-$outFilePath = "C:\ProgramData\kind\kind.exe"
 
 try
 {
-    $getkindUri =  "https://github.com/kubernetes-sigs/kind/releases/download/$tagToUse/kind-windows-amd64"
+    $kindUrl =  "https://github.com/kubernetes-sigs/kind/releases/download/$tagToUse/kind-windows-amd64"
+
     Write-Host "Downloading kind.exe..."
     New-Item -Path $destFilePath -ItemType Directory -Force
 
-    Invoke-WebRequest -Uri $getkindUri -OutFile $outFilePath
+    $kindInstallerPath = Start-DownloadWithRetry -Url $kindUrl -Name "kind.exe" -DownloadPath $destFilePath
 
     Write-Host "Starting Install kind.exe..."
-    $process = Start-Process -FilePath $outFilePath -Wait -PassThru
+    $process = Start-Process -FilePath $kindInstallerPath -Wait -PassThru
     $exitCode = $process.ExitCode
 
     if ($exitCode -eq 0 -or $exitCode -eq 3010)
     {
         Write-Host -Object 'Installation successful'
         Add-MachinePathItem $destFilePath
-        exit $exitCode
     }
     else
     {

--- a/images/win/scripts/Installers/Install-MysqlCli.ps1
+++ b/images/win/scripts/Installers/Install-MysqlCli.ps1
@@ -3,37 +3,26 @@
 ##  Desc:  Install Mysql CLI
 ################################################################################
 
-
 ## Downloading mysql jar
-$uri = 'https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-5.7.21-winx64.zip'
-$mysqlPath = 'C:\mysql-5.7.21-winx64\bin'
+$MysqlVersionName = "mysql-5.7.21-winx64"
+$MysqlVersionUrl = "https://dev.mysql.com/get/Downloads/MySQL-5.7/${MysqlVersionName}.zip"
+$MysqlPath = "C:\$MysqlVersionName\bin"
 
 # Installing visual c++ redistibutable package.
-$InstallerURI = 'https://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x64.exe'
-$InstallerName = 'vcredist_x64.exe'
-$ArgumentList = ('/install', '/quiet', '/norestart' )
+$InstallerName = "vcredist_x64.exe"
+$InstallerURI = "https://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/${InstallerName}"
+$ArgumentList = ("/install", "/quiet", "/norestart")
 
-$exitCode = Install-EXE -Url $InstallerURI -Name $InstallerName -ArgumentList $ArgumentList
-if ($exitCode -eq 0 -or $exitCode -eq 3010)
-{
-    # MySQL disabled TLS 1.0 support on or about Jul-14-2018.  Need to make sure TLS 1.2 is enabled.
-    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor "Tls12"
+Install-Binary -Url $InstallerURI -Name $InstallerName -ArgumentList $ArgumentList
 
-    # Get the latest mysql command line tools .
-    Invoke-WebRequest -UseBasicParsing -Uri $uri -OutFile mysql.zip
+# MySQL disabled TLS 1.0 support on or about Jul-14-2018.  Need to make sure TLS 1.2 is enabled.
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor "Tls12"
 
-    # Expand the zip
-    Expand-Archive -Path mysql.zip -DestinationPath "C:\" -Force
+# Get the latest mysql command line tools .
+$mysqlArchPath = Start-DownloadWithRetry -Url $MysqlVersionUrl -Name "mysql.zip"
 
-    # Deleting zip folder
-    Remove-Item -Recurse -Force mysql.zip
+# Expand the zip
+Expand-Archive -Path $mysqlArchPath -DestinationPath "C:\" -Force
 
-    # Adding mysql in system environment path
-    Add-MachinePathItem $mysqlPath
-
-    return 0;
-}
-else
-{
-    return $exitCode;
-}
+# Adding mysql in system environment path
+Add-MachinePathItem $mysqlPath

--- a/images/win/scripts/Installers/Install-MysqlCli.ps1
+++ b/images/win/scripts/Installers/Install-MysqlCli.ps1
@@ -19,20 +19,10 @@ Install-Binary -Url $InstallerURI -Name $InstallerName -ArgumentList $ArgumentLi
 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor "Tls12"
 
 # Get the latest mysql command line tools .
-<<<<<<< HEAD
 $mysqlArchPath = Start-DownloadWithRetry -Url $MysqlVersionUrl -Name "mysql.zip"
 
 # Expand the zip
 Expand-Archive -Path $mysqlArchPath -DestinationPath "C:\" -Force
-=======
-Invoke-WebRequest -UseBasicParsing -Uri $uri -OutFile mysql.zip
-
-# Expand the zip
-Expand-Archive -Path mysql.zip -DestinationPath "C:\" -Force
-
-# Deleting zip folder
-Remove-Item -Recurse -Force mysql.zip
->>>>>>> master
 
 # Adding mysql in system environment path
 Add-MachinePathItem $mysqlPath

--- a/images/win/scripts/Installers/Install-Rust.ps1
+++ b/images/win/scripts/Installers/Install-Rust.ps1
@@ -11,13 +11,10 @@ $env:CARGO_HOME="C:\Rust\.cargo"
 
 # Download the latest rustup-init.exe for Windows x64
 # See https://rustup.rs/#
-Invoke-WebRequest -UseBasicParsing -Uri "https://win.rustup.rs/x86_64" -OutFile rustup-init.exe
+$rustupPath = Start-DownloadWithRetry -Url "https://win.rustup.rs/x86_64" -Name "rustup-init.exe"
 
 # Install Rust by running rustup-init.exe (disabling the confirmation prompt with -y)
-.\rustup-init.exe -y --default-toolchain=stable --profile=minimal
-
-# Delete rustup-init.exe when it's no longer needed
-Remove-Item -Path .\rustup-init.exe
+& $rustupPath -y --default-toolchain=stable --profile=minimal
 
 # Add Rust binaries to the path
 Add-MachinePathItem "$env:CARGO_HOME\bin"

--- a/images/win/scripts/Installers/Install-SQLPowerShellTools.ps1
+++ b/images/win/scripts/Installers/Install-SQLPowerShellTools.ps1
@@ -5,57 +5,21 @@
 
 Import-Module -Name ImageHelpers -Force
 
-Function InstallMSI
-{
-    Param
-    (
-        [String]$MsiUrl,
-        [String]$MsiName
-    )
-
-    $exitCode = -1
-
-    try
-    {
-        Write-Host "Downloading $MsiName..."
-        $FilePath = "${env:Temp}\$MsiName"
-
-        Invoke-WebRequest -Uri $MsiUrl -OutFile $FilePath
-
-        $Arguments = ('/i', $FilePath, '/QN', '/norestart' )
-
-        Write-Host "Starting Install $MsiName..."
-        $process = Start-Process -FilePath msiexec.exe -ArgumentList $Arguments -Wait -PassThru
-        $exitCode = $process.ExitCode
-
-        if ($exitCode -eq 0 -or $exitCode -eq 3010)
-        {
-            Write-Host -Object 'Installation successful'
-            return $exitCode
-        }
-        else
-        {
-            Write-Host -Object "Non zero exit code returned by the installation process : $exitCode."
-            exit $exitCode
-        }
-    }
-    catch
-    {
-        Write-Host -Object "Failed to install the MSI $MsiName"
-        Write-Host -Object $_.Exception.Message
-        exit -1
-    }
-}
+$BaseUrl = "https://download.microsoft.com/download/8/7/2/872BCECA-C849-4B40-8EBE-21D48CDF1456/ENU/x64"
 
 # install required MSIs
-$SQLSysClrTypesExitCode = InstallMSI -MsiUrl "https://download.microsoft.com/download/8/7/2/872BCECA-C849-4B40-8EBE-21D48CDF1456/ENU/x64/SQLSysClrTypes.msi" -MsiName "SQLSysClrTypes.msi"
+$SQLSysClrTypesName = "SQLSysClrTypes.msi"
+$SQLSysClrTypesUrl = "${BaseUrl}/${SQLSysClrTypesName}"
+Install-Binary -Url $SQLSysClrTypesUrl -Name $SQLSysClrTypesName
 
-$SharedManagementObjectsExitCode = InstallMSI -MsiUrl "https://download.microsoft.com/download/8/7/2/872BCECA-C849-4B40-8EBE-21D48CDF1456/ENU/x64/SharedManagementObjects.msi" -MsiName "SharedManagementObjects.msi"
+$SharedManagementObjectsName = "SharedManagementObjects.msi"
+$SharedManagementObjectsUrl = "${BaseUrl}/${SharedManagementObjectsName}"
+Install-Binary -Url $SharedManagementObjectsUrl -Name $SharedManagementObjectsName
 
-$PowerShellToolsExitCode = InstallMSI -MsiUrl "https://download.microsoft.com/download/8/7/2/872BCECA-C849-4B40-8EBE-21D48CDF1456/ENU/x64/PowerShellTools.msi" -MsiName "PowerShellTools.msi"
+$PowerShellToolsName = "PowerShellTools.msi"
+$PowerShellToolsUrl = "${BaseUrl}/${PowerShellToolsName}"
+Install-Binary -Url $PowerShellToolsUrl -Name $PowerShellToolsName
 
 # install sqlserver PS module
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 Install-Module -Name SqlServer -AllowClobber
-
-exit $PowerShellToolsExitCode

--- a/images/win/scripts/Installers/Update-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Update-AndroidSDK.ps1
@@ -5,10 +5,10 @@
 
 # Download the latest command line tools so that we can accept all of the licenses.
 # See https://developer.android.com/studio/#command-tools
-Invoke-WebRequest -UseBasicParsing -Uri "https://dl.google.com/android/repository/sdk-tools-windows-4333796.zip" -OutFile android-sdk-tools.zip
+$sdkArchPath = Start-DownloadWithRetry -Url "https://dl.google.com/android/repository/sdk-tools-windows-4333796.zip" -Name "android-sdk-tools.zip"
 
 # Don't replace the one that VS installs as it seems to break things.
-Expand-Archive -Path android-sdk-tools.zip -DestinationPath android-sdk -Force
+Expand-Archive -Path $sdkArchPath -DestinationPath android-sdk -Force
 
 $sdk = Get-Item -Path .\android-sdk
 


### PR DESCRIPTION
# Description

This PR improves stability for following Windows provisioners:
1. Install-CloudFoundryCli.ps1
1. Install-Go.ps1
1. Install-Kind.ps1
1. Install-MysqlCli.ps1
1. Install-Rust.ps1
1. Install-SQLPowerShellTools.ps1
1. Update-AndroidSDK.ps1

Most of default `Invoke-WebRequest` occurrences was replace with custom `Start-DownloadWithRetry` function that support retries logic. Also several improvements in syntax was made.

**How it was tested:**
Validation image was generated - [Windows2019](https://dev.azure.com/github/virtual-environments/_build/results?buildId=65363&view=results).

#### Related issue:
Issue: https://github.com/actions/virtual-environments-internal/issues/384

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated

