### PR TITLE
[Ubuntu] Add libgbm to resolve puppeteer issue

### DIFF
--- a/images/linux/scripts/installers/1604/basic.sh
+++ b/images/linux/scripts/installers/1604/basic.sh
@@ -49,6 +49,7 @@ apt-fast install -y --no-install-recommends \
     libgconf-2-4 \
     dbus \
     xvfb \
+    libgbm-dev \
     libgtk-3-0 \
     tk \
     fakeroot \
@@ -80,6 +81,7 @@ DocumentInstalledItemIndent "jq"
 DocumentInstalledItemIndent "libc++-dev"
 DocumentInstalledItemIndent "libc++abi-dev"
 DocumentInstalledItemIndent "libcurl3"
+DocumentInstalledItemIndent "libgbm-dev"
 DocumentInstalledItemIndent "libicu55"
 DocumentInstalledItemIndent "libunwind8"
 DocumentInstalledItemIndent "locales"

--- a/images/linux/scripts/installers/1804/basic.sh
+++ b/images/linux/scripts/installers/1804/basic.sh
@@ -97,6 +97,9 @@ apt-get install -y --no-install-recommends dbus
 echo "Install xvfb"
 apt-get install -y --no-install-recommends xvfb
 
+echo "Install libgbm-dev"
+apt-get install -y --no-install-recommends libgbm-dev
+
 echo "Install libgtk"
 apt-get install -y --no-install-recommends libgtk-3-0
 
@@ -147,6 +150,7 @@ DocumentInstalledItemIndent "iproute2"
 DocumentInstalledItemIndent "iputils-ping"
 DocumentInstalledItemIndent "jq"
 DocumentInstalledItemIndent "libcurl3"
+DocumentInstalledItemIndent "libgbm-dev"
 DocumentInstalledItemIndent "libicu55"
 DocumentInstalledItemIndent "libunwind8"
 DocumentInstalledItemIndent "locales"


### PR DESCRIPTION
# Description
The new version of puppeteer(Node library which provides a high-level API to control Chrome or Chromium) requires libgbm library, which is not installed on the images.
Related issues: 
https://github.com/actions/virtual-environments/issues/732
https://github.com/puppeteer/puppeteer/issues/5661

**Library size:** 100 Kb
**Installation time:** less that a minute

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
