### PR TITLE
Fix gem update for system default Ruby

### DIFF
--- a/images/win/scripts/Installers/Download-ToolCache.ps1
+++ b/images/win/scripts/Installers/Download-ToolCache.ps1
@@ -71,8 +71,10 @@ Function Set-DefaultRubyVersion {
     Write-Host "Use Ruby ${Version} as a system Ruby"
     Add-MachinePathItem -PathItem $rubyDir.FullName
 
+    $env:Path = Get-MachinePath
+
     # Update ruby gem to latest version
-    gem update --system
+    Invoke-Expression "gem update --system"
 }
 
 Import-Module -Name ImageHelpers -Force


### PR DESCRIPTION
# Description
This PR fix issue with gem update of system default ruby in `Download-Toolcache.ps1`.

Previously, `gem update --system` was executed before changes in system path were applied.
```
    vhd: Use Ruby 2.5 as a system Ruby
...
==> vhd: gem : The term 'gem' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the
==> vhd: spelling of the name, or if a path was included, verify that the path is correct and try again.
==> vhd: At C:\Windows\Temp\script-5e981db6-c29e-5a7e-58ae-d3139d037aec.ps1:75 char:5
==> vhd: +     gem update --system
==> vhd: +     ~~~
==> vhd:     + CategoryInfo          : ObjectNotFound: (gem:String) [], CommandNotFoundException
==> vhd:     + FullyQualifiedErrorId : CommandNotFoundException
```
This fix update environment before get update.

**How it was tested:**
Windows2019 - https://dev.azure.com/github/virtual-environments/_build/results?buildId=65415&view=results
