### PR TITLE
Install AWS SAM CLI on Windows images

### DIFF
--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -461,6 +461,12 @@
         {
             "type": "powershell",
             "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-AWS-SAM.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-DACFx.ps1"
             ]
         },
@@ -617,6 +623,12 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-AzureCli.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-AWS-SAM.ps1"
             ]
         },
         {

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -436,6 +436,12 @@
         {
             "type": "powershell",
             "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-AWS-SAM.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-DACFx.ps1"
             ]
         },
@@ -610,6 +616,12 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-AzureCli.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-AWS-SAM.ps1"
             ]
         },
         {

--- a/images/win/scripts/Installers/Install-AWS-SAM.ps1
+++ b/images/win/scripts/Installers/Install-AWS-SAM.ps1
@@ -1,0 +1,7 @@
+################################################################################
+##  File:  Install-AWS-SAM.ps1
+##  Desc:  Install aws sam cli
+##         https://aws.amazon.com/serverless/sam/
+################################################################################
+
+Install-MSI -MsiUrl "https://github.com/awslabs/aws-sam-cli/releases/latest/download/AWS_SAM_CLI_64_PY3.msi" -MsiName "AWS_SAM_CLI_64_PY3.msi"

--- a/images/win/scripts/Installers/Validate-AWS-SAM.ps1
+++ b/images/win/scripts/Installers/Validate-AWS-SAM.ps1
@@ -1,0 +1,27 @@
+################################################################################
+##  File:  Validate-AWS-SAM.ps1
+##  Desc:  Validate aws sam cli
+################################################################################
+
+$command = Get-Command -Name 'sam'
+
+if ($command)
+{
+    Write-Host "aws sam cli on path"
+}
+else
+{
+    Write-Host 'aws sam cli is not on path'
+    exit 1
+}
+
+# Adding description of the software to Markdown
+$SoftwareName = "AWS SAM CLI"
+
+$version = (sam --version).Split(" ")[3]
+
+$Description = @"
+_Version:_ $version<br/>
+"@
+
+Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description

--- a/images/win/scripts/Installers/Validate-AWS-SAM.ps1
+++ b/images/win/scripts/Installers/Validate-AWS-SAM.ps1
@@ -7,11 +7,11 @@ $command = Get-Command -Name 'sam'
 
 if ($command)
 {
-    Write-Host "aws sam cli on path"
+    Write-Host "AWS SAM CLI on path"
 }
 else
 {
-    Write-Host 'aws sam cli is not on path'
+    Write-Host 'AWS SAM CLI is not on path'
     exit 1
 }
 


### PR DESCRIPTION
# Description
New tool
Install AWS SAM CLI according to the instruction https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install-windows.html
There's no official choco package so MSI installation used. It is confirmed the Machine Environment is updated by MSI installer.

**Total size:** 132Mb
**Installation time.** 1min

#### Related issue: https://github.com/actions/virtual-environments/issues/94

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
