### PR TITLE
add ninja build to Linux images

### DIFF
--- a/images/linux/scripts/installers/ninja.sh
+++ b/images/linux/scripts/installers/ninja.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+################################################################################
+##  File:  ninja.sh
+##  Desc:  Installs ninja
+################################################################################
+
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/document.sh
+source $HELPER_SCRIPTS/apt.sh
+
+set -e
+
+echo "Install ninja"
+apt-get install -y --no-install-recommends ninja-build
+
+# Run tests to determine that the software installed as expected
+echo "Testing to make sure that script performed as expected, and basic scenarios work"
+if ! command -v ninja ; then
+    echo "$cmd was not installed"
+    exit 1
+fi
+
+# Document what was added to the image
+echo "Lastly, documenting what we added to the metadata file"
+DocumentInstalledItem "ninja"

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -200,6 +200,7 @@
                 "{{template_dir}}/scripts/installers/miniconda.sh",
                 "{{template_dir}}/scripts/installers/mono.sh",
                 "{{template_dir}}/scripts/installers/mysql.sh",
+                "{{template_dir}}/scripts/installers/ninja.sh",
                 "{{template_dir}}/scripts/installers/nodejs.sh",
                 "{{template_dir}}/scripts/installers/bazel.sh",
                 "{{template_dir}}/scripts/installers/phantomjs.sh",

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -203,6 +203,7 @@
                 "{{template_dir}}/scripts/installers/miniconda.sh",
                 "{{template_dir}}/scripts/installers/mono.sh",
                 "{{template_dir}}/scripts/installers/mysql.sh",
+                "{{template_dir}}/scripts/installers/ninja.sh",
                 "{{template_dir}}/scripts/installers/nvm.sh",
                 "{{template_dir}}/scripts/installers/nodejs.sh",
                 "{{template_dir}}/scripts/installers/bazel.sh",


### PR DESCRIPTION
Add ninja-build to the Linux images.  It is already present on the
Windows builders and is very often used with CMake.

Issue: #741

# Description
New tool, Bug fixing, or Improvement?  
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.  
**For new tools, please provide total size and installation time.**

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
