### PR TITLE
Android SDK binaries insufficient permissions.

### DIFF
--- a/images/linux/scripts/installers/1604/android.sh
+++ b/images/linux/scripts/installers/1604/android.sh
@@ -38,7 +38,7 @@ else
 fi
 
 # Add required permissions
-sudo chmod -R 755 ${ANDROID_SDK_ROOT}
+chmod -R 755 ${ANDROID_SDK_ROOT}
 
 # Install the following SDKs and build tools, passing in "y" to accept licenses.
 echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager \

--- a/images/linux/scripts/installers/1604/android.sh
+++ b/images/linux/scripts/installers/1604/android.sh
@@ -38,7 +38,7 @@ else
 fi
 
 # Add required permissions
-chmod -R 755 ${ANDROID_SDK_ROOT}
+chmod -R a+X ${ANDROID_SDK_ROOT}
 
 # Install the following SDKs and build tools, passing in "y" to accept licenses.
 echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager \

--- a/images/linux/scripts/installers/1604/android.sh
+++ b/images/linux/scripts/installers/1604/android.sh
@@ -38,7 +38,7 @@ else
 fi
 
 # Add required permissions
-chmod -R 755 ${ANDROID_SDK_ROOT}
+sudo chmod -R 755 ${ANDROID_SDK_ROOT}
 
 # Install the following SDKs and build tools, passing in "y" to accept licenses.
 echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager \

--- a/images/linux/scripts/installers/1604/android.sh
+++ b/images/linux/scripts/installers/1604/android.sh
@@ -37,6 +37,8 @@ else
     exit 1
 fi
 
+# Add required permissions
+chmod -R 755 ${ANDROID_SDK_ROOT}
 
 # Install the following SDKs and build tools, passing in "y" to accept licenses.
 echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager \

--- a/images/linux/scripts/installers/1804/android.sh
+++ b/images/linux/scripts/installers/1804/android.sh
@@ -28,7 +28,7 @@ unzip android-sdk.zip -d ${ANDROID_SDK_ROOT}
 rm -f android-sdk.zip
 
 # Add required permissions
-chmod -R 755 ${ANDROID_SDK_ROOT}
+sudo chmod -R 755 ${ANDROID_SDK_ROOT}
 
 # Check sdk manager installation
 /usr/local/lib/android/sdk/tools/bin/sdkmanager --list 1>/dev/null

--- a/images/linux/scripts/installers/1804/android.sh
+++ b/images/linux/scripts/installers/1804/android.sh
@@ -27,6 +27,9 @@ wget -O android-sdk.zip https://dl.google.com/android/repository/sdk-tools-linux
 unzip android-sdk.zip -d ${ANDROID_SDK_ROOT}
 rm -f android-sdk.zip
 
+# Add required permissions
+chmod -R 755 ${ANDROID_SDK_ROOT}
+
 # Check sdk manager installation
 /usr/local/lib/android/sdk/tools/bin/sdkmanager --list 1>/dev/null
 if [ $? -eq 0 ]

--- a/images/linux/scripts/installers/1804/android.sh
+++ b/images/linux/scripts/installers/1804/android.sh
@@ -28,7 +28,7 @@ unzip android-sdk.zip -d ${ANDROID_SDK_ROOT}
 rm -f android-sdk.zip
 
 # Add required permissions
-sudo chmod -R 755 ${ANDROID_SDK_ROOT}
+chmod -R 755 ${ANDROID_SDK_ROOT}
 
 # Check sdk manager installation
 /usr/local/lib/android/sdk/tools/bin/sdkmanager --list 1>/dev/null

--- a/images/linux/scripts/installers/1804/android.sh
+++ b/images/linux/scripts/installers/1804/android.sh
@@ -28,7 +28,7 @@ unzip android-sdk.zip -d ${ANDROID_SDK_ROOT}
 rm -f android-sdk.zip
 
 # Add required permissions
-chmod -R 755 ${ANDROID_SDK_ROOT}
+chmod -R a+X ${ANDROID_SDK_ROOT}
 
 # Check sdk manager installation
 /usr/local/lib/android/sdk/tools/bin/sdkmanager --list 1>/dev/null


### PR DESCRIPTION
# Description
Bug fixing
Installed Android SDK binaries can be executed only by root, due to lack of permissions.

#### Related issue:
https://github.com/actions/virtual-environments/issues/738

## Check list
It seems it's really minor change, and nothing is changed in image build workflow.
