### PR TITLE
Return back dotnent 3.1.102

### DIFF
--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -66,8 +66,8 @@ function InstallAllValidSdks()
         Invoke-WebRequest -Uri $dotnetChannel.'releases.json' -UseBasicParsing -OutFile "releases-$channelVersion.json"
         $currentReleases = Get-Content -Path "releases-$channelVersion.json" | ConvertFrom-Json
         # filtering out the preview/rc releases
-        # Remove version 3.1.102 from install list, .NET gave a heads-up that this might cause issues and they are working on a fix. https://github.com/dotnet/aspnetcore/issues/19133
-        $currentReleases = $currentReleases.'releases' | Where-Object { !$_.'release-version'.Contains('-') -and !$_.'release-version'.Contains('3.1.2') } | Sort-Object { [Version] $_.'release-version' }
+        $currentReleases = $currentReleases.'releases' | Where-Object { !$_.'release-version'.Contains('-') } | Sort-Object { [Version] $_.'release-version' }
+
         ForEach ($release in $currentReleases)
         {
             if ($release.'sdks'.Count -gt 0)


### PR DESCRIPTION
It is not most recent now and it not selected by defaultg

# Description
Improvement?  

[Buggy](https://github.com/dotnet/aspnetcore/issues/19133) Dotnet SDK 3.1.102 has been exclude for a while to avoid it became default. Since 3.1.201 release we can return it back to the images 

#### Related issue: https://github.com/actions/virtual-environments/issues/673

## Check list
- [x] Related issue / work item is attached
- [x] Changes are tested and related VM images are successfully generated
