### PR TITLE
Revert "Pre-install Android NDK 20 on Ubuntu"

### DIFF
--- a/images/linux/scripts/installers/1604/android.sh
+++ b/images/linux/scripts/installers/1604/android.sh
@@ -43,7 +43,6 @@ chmod -R a+X ${ANDROID_SDK_ROOT}
 # Install the following SDKs and build tools, passing in "y" to accept licenses.
 echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager \
     "ndk-bundle" \
-    "ndk;20.0.5594570" \
     "platform-tools" \
     "platforms;android-29" \
     "platforms;android-28" \
@@ -163,6 +162,5 @@ DocumentInstalledItem "Android SDK Build-Tools 20.0.0"
 DocumentInstalledItem "Android SDK Build-Tools 19.1.0"
 DocumentInstalledItem "Android SDK Build-Tools 17.0.0"
 DocumentInstalledItem "Android NDK $(cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | cut -d ' ' -f 3)"
-DocumentInstalledItem "Android NDK 20.0.5594570"
 DocumentInstalledItem "Android ConstraintLayout 1.0.2"
 DocumentInstalledItem "Android ConstraintLayout 1.0.1"

--- a/images/linux/scripts/installers/1804/android.sh
+++ b/images/linux/scripts/installers/1804/android.sh
@@ -43,7 +43,6 @@ fi
 # Install the following SDKs and build tools, passing in "y" to accept licenses.
 echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager \
     "ndk-bundle" \
-    "ndk;20.0.5594570" \
     "platform-tools" \
     "platforms;android-29" \
     "platforms;android-28" \
@@ -153,4 +152,3 @@ DocumentInstalledItem "Android SDK Build-Tools 20.0.0"
 DocumentInstalledItem "Android SDK Build-Tools 19.1.0"
 DocumentInstalledItem "Android SDK Build-Tools 17.0.0"
 DocumentInstalledItem "Android NDK $(cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | cut -d ' ' -f 3)"
-DocumentInstalledItem "Android NDK 20.0.5594570"


### PR DESCRIPTION
Reverts actions/virtual-environments#711
This PR will help us to get ~3.8 gb disk space back to resolve
https://github.com/actions/virtual-environments/issues/709