### PR TITLE
Clean up apt package cache

### DIFF
--- a/images/linux/scripts/installers/cleanup.sh
+++ b/images/linux/scripts/installers/cleanup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# before cleanup
+before=$(df / -Pm | awk 'NR==2{print $4}')
+
+# clears out the local repository of retrieved package files
+# It removes everything but the lock file from /var/cache/apt/archives/ and /var/cache/apt/archives/partial
+apt-get clean
+
+# after cleanup
+after=$(df / -Pm | awk 'NR==2{print $4}')
+
+# display size
+ echo "Before: $before MB"
+ echo "After : $after MB"
+ echo "Delta : $(($after-$before)) MB"

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -290,6 +290,13 @@
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {
+            "type": "shell",
+            "scripts":[
+                "{{template_dir}}/scripts/installers/cleanup.sh"
+            ],
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
             "type": "file",
             "source": "{{user `metadata_file`}}",
             "destination": "{{template_dir}}/Ubuntu1604-README.md",

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -294,6 +294,13 @@
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {
+            "type": "shell",
+            "scripts":[
+                "{{template_dir}}/scripts/installers/cleanup.sh"
+            ],
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
             "type": "file",
             "source": "{{user `metadata_file`}}",
             "destination": "{{template_dir}}/Ubuntu1804-README.md",


### PR DESCRIPTION
# Description
At the end of image generation we should cleanup the apt package cache (apt-get clean). There's no use for it on deployed images. Doing this would free up multiple GB of disk space.

#### Related issue:
https://github.com/actions/virtual-environments/issues/751

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
