### PR TITLE
Improve Windows Visual Studio provisioners

### DIFF
--- a/images/win/scripts/ImageHelpers/ImageHelpers.psm1
+++ b/images/win/scripts/ImageHelpers/ImageHelpers.psm1
@@ -14,7 +14,7 @@ Export-ModuleMember -Function @(
     'Get-SystemVariable'
     'Set-SystemVariable'
     'Install-Binary'
-    'Install-VS'
+    'Install-VisualStudio'
     'Get-ToolcachePackages'
     'Get-ToolsByName'
     'Add-ContentToMarkdown'

--- a/images/win/scripts/ImageHelpers/ImageHelpers.psm1
+++ b/images/win/scripts/ImageHelpers/ImageHelpers.psm1
@@ -14,6 +14,7 @@ Export-ModuleMember -Function @(
     'Get-SystemVariable'
     'Set-SystemVariable'
     'Install-Binary'
+    'Install-VS'
     'Get-ToolcachePackages'
     'Get-ToolsByName'
     'Add-ContentToMarkdown'

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -75,57 +75,54 @@ Function Install-VisualStudio
     .PARAMETER BootstrapperUrl
         The URL from which the bootstrapper will be downloaded. Required parameter.
 
-    .PARAMETER BootstrapperName
-        The Name with which bootstrapper will be downloaded. Required parameter.
-
     .PARAMETER WorkLoads
         The string that contain workloads that will be passed to the installer.
     #>
-  Param
-  (
-    [Parameter(Mandatory)]
-    [String] $BootstrapperName,
-    [Parameter(Mandatory)]
-    [String] $BootstrapperUrl,
-    [String] $WorkLoads
-  )
+    Param
+    (
+        [Parameter(Mandatory)]
+        [String] $BootstrapperUrl,
+        [String] $WorkLoads
+    )
 
-  Write-Host "Downloading Bootstrapper ..."
-  $bootstrapperFilePath = Start-DownloadWithRetry -Url $BootstrapperUrl -Name $BootstrapperName
+    $BootstrapperName = [IO.Path]::GetFileName($BootstrapperUrl)
 
-  try
-  {
-    Write-Host "Enable short name support on Windows needed for Xamarin Android AOT, defaults appear to have been changed in Azure VMs"
-    $shortNameEnableProcess = Start-Process -FilePath fsutil.exe -ArgumentList ('8dot3name', 'set', '0') -Wait -PassThru
+    Write-Host "Downloading Bootstrapper ..."
+    $bootstrapperFilePath = Start-DownloadWithRetry -Url $BootstrapperUrl -Name $BootstrapperName
 
-    $shortNameEnableExitCode = $shortNameEnableProcess.ExitCode
-    if ($shortNameEnableExitCode -ne 0)
+    try
     {
-      Write-Host "Enabling short name support on Windows failed. This needs to be enabled prior to VS 2017 install for Xamarin Andriod AOT to work."
-      exit $shortNameEnableExitCode
-    }
+        Write-Host "Enable short name support on Windows needed for Xamarin Android AOT, defaults appear to have been changed in Azure VMs"
+        $shortNameEnableProcess = Start-Process -FilePath fsutil.exe -ArgumentList ('8dot3name', 'set', '0') -Wait -PassThru
 
-    Write-Host "Starting Install ..."
-    $bootstrapperArgumentList = ('/c', $bootstrapperFilePath, $WorkLoads, '--quiet', '--norestart', '--wait', '--nocache' )
-    $process = Start-Process -FilePath cmd.exe -ArgumentList $bootstrapperArgumentList -Wait -PassThru
+        $shortNameEnableExitCode = $shortNameEnableProcess.ExitCode
+        if ($shortNameEnableExitCode -ne 0)
+        {
+            Write-Host "Enabling short name support on Windows failed. This needs to be enabled prior to VS 2017 install for Xamarin Andriod AOT to work."
+            exit $shortNameEnableExitCode
+        }
 
-    $exitCode = $process.ExitCode
-    if ($exitCode -eq 0 -or $exitCode -eq 3010)
-    {
-      Write-Host "Installation successful"
-      return $exitCode
+        Write-Host "Starting Install ..."
+        $bootstrapperArgumentList = ('/c', $bootstrapperFilePath, $WorkLoads, '--quiet', '--norestart', '--wait', '--nocache' )
+        $process = Start-Process -FilePath cmd.exe -ArgumentList $bootstrapperArgumentList -Wait -PassThru
+
+        $exitCode = $process.ExitCode
+        if ($exitCode -eq 0 -or $exitCode -eq 3010)
+        {
+            Write-Host "Installation successful"
+            return $exitCode
+        }
+        else
+        {
+            Write-Host "Non zero exit code returned by the installation process : $exitCode"
+            exit $exitCode
+        }
     }
-    else
+    catch
     {
-      Write-Host "Non zero exit code returned by the installation process : $exitCode"
-      exit $exitCode
+        Write-Host "Failed to install Visual Studio; $($_.Exception.Message)"
+        exit -1
     }
-  }
-  catch
-  {
-    Write-Host "Failed to install Visual Studio; $($_.Exception.Message)"
-    exit -1
-  }
 }
 
 function Stop-SvcWithErrHandling

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -63,7 +63,7 @@ function Install-Binary
     }
 }
 
-Function Install-VS
+Function Install-VisualStudio
 {
     <#
     .SYNOPSIS

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -78,6 +78,7 @@ Function Install-VisualStudio
     .PARAMETER WorkLoads
         The string that contain workloads that will be passed to the installer.
     #>
+
     Param
     (
         [Parameter(Mandatory)]
@@ -85,9 +86,8 @@ Function Install-VisualStudio
         [String] $WorkLoads
     )
 
-    $BootstrapperName = [IO.Path]::GetFileName($BootstrapperUrl)
-
     Write-Host "Downloading Bootstrapper ..."
+    $BootstrapperName = [IO.Path]::GetFileName($BootstrapperUrl)
     $bootstrapperFilePath = Start-DownloadWithRetry -Url $BootstrapperUrl -Name $BootstrapperName
 
     try

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -20,7 +20,8 @@ function Install-Binary
         Install-Binary -Url "https://go.microsoft.com/fwlink/p/?linkid=2083338" -Name "winsdksetup.exe" -ArgumentList ("/features", "+", "/quiet")
     #>
 
-    Param (
+    Param
+    (
         [Parameter(Mandatory)]
         [String] $Url,
         [Parameter(Mandatory)]
@@ -62,6 +63,71 @@ function Install-Binary
     }
 }
 
+Function Install-VS
+{
+    <#
+    .SYNOPSIS
+        A helper function to install Visual Studio.
+
+    .DESCRIPTION
+        Prepare system environment, and install Visual Studio bootstrapper with selected workloads.
+
+    .PARAMETER BootstrapperUrl
+        The URL from which the bootstrapper will be downloaded. Required parameter.
+
+    .PARAMETER BootstrapperName
+        The Name with which bootstrapper will be downloaded. Required parameter.
+
+    .PARAMETER WorkLoads
+        The string that contain workloads that will be passed to the installer.
+    #>
+  Param
+  (
+    [Parameter(Mandatory)]
+    [String] $BootstrapperName,
+    [Parameter(Mandatory)]
+    [String] $BootstrapperUrl,
+    [String] $WorkLoads
+  )
+
+  Write-Host "Downloading Bootstrapper ..."
+  $bootstrapperFilePath = Start-DownloadWithRetry -Url $BootstrapperUrl -Name $BootstrapperName
+
+  try
+  {
+    Write-Host "Enable short name support on Windows needed for Xamarin Android AOT, defaults appear to have been changed in Azure VMs"
+    $shortNameEnableProcess = Start-Process -FilePath fsutil.exe -ArgumentList ('8dot3name', 'set', '0') -Wait -PassThru
+
+    $shortNameEnableExitCode = $shortNameEnableProcess.ExitCode
+    if ($shortNameEnableExitCode -ne 0)
+    {
+      Write-Host "Enabling short name support on Windows failed. This needs to be enabled prior to VS 2017 install for Xamarin Andriod AOT to work."
+      exit $shortNameEnableExitCode
+    }
+
+    Write-Host "Starting Install ..."
+    $bootstrapperArgumentList = ('/c', $bootstrapperFilePath, $WorkLoads, '--quiet', '--norestart', '--wait', '--nocache' )
+    $process = Start-Process -FilePath cmd.exe -ArgumentList $bootstrapperArgumentList -Wait -PassThru
+
+    $exitCode = $process.ExitCode
+    if ($exitCode -eq 0 -or $exitCode -eq 3010)
+    {
+      Write-Host "Installation successful"
+      return $exitCode
+    }
+    else
+    {
+      Write-Host"Non zero exit code returned by the installation process : $exitCode"
+      exit $exitCode
+    }
+  }
+  catch
+  {
+    Write-Host "Failed to install Visual Studio; $($_.Exception.Message)"
+    exit -1
+  }
+}
+
 function Stop-SvcWithErrHandling
 {
     <#
@@ -74,7 +140,8 @@ function Stop-SvcWithErrHandling
     .PARAMETER StopOnError
         Switch for stopping the script and exit from PowerShell if one service is absent
     #>
-    param (
+    param
+    (
         [Parameter(Mandatory, ValueFromPipeLine = $true)]
         [string] $ServiceName,
         [switch] $StopOnError
@@ -123,7 +190,8 @@ function Set-SvcWithErrHandling
         Hashtable for service arguments
     #>
 
-    param (
+    param
+    (
         [Parameter(Mandatory, ValueFromPipeLine = $true)]
         [string] $ServiceName,
         [Parameter(Mandatory)]
@@ -152,7 +220,8 @@ function Set-SvcWithErrHandling
 
 function Start-DownloadWithRetry
 {
-    param (
+    param
+    (
         [Parameter(Mandatory)]
         [string] $Url,
         [Parameter(Mandatory)]
@@ -253,7 +322,8 @@ function Install-VsixExtension
 
 function Get-VSExtensionVersion
 {
-    param (
+    Param
+    (
         [Parameter(Mandatory=$true)]
         [string] $packageName
     )
@@ -284,7 +354,8 @@ function Get-ToolcachePackages {
 }
 
 function Get-ToolsByName {
-    param (
+    Param
+    (
         [Parameter(Mandatory = $True)]
         [string]$SoftwareName
     )

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -117,7 +117,7 @@ Function Install-VS
     }
     else
     {
-      Write-Host"Non zero exit code returned by the installation process : $exitCode"
+      Write-Host "Non zero exit code returned by the installation process : $exitCode"
       exit $exitCode
     }
   }

--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -32,7 +32,10 @@ function InstallSDKVersion (
     }
 
     # Fix for issue 1276.  This will be fixed in 3.1.
-    Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dotnet/sdk/82bc30c99f1325dfaa7ad450be96857a4fca2845/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportPublishProfile.targets" -outfile "C:\Program Files\dotnet\sdk\$sdkVersion\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.ImportPublishProfile.targets"
+    $sdkTargetsName = "Microsoft.NET.Sdk.ImportPublishProfile.targets"
+    $sdkTargetsUrl = "https://raw.githubusercontent.com/dotnet/sdk/82bc30c99f1325dfaa7ad450be96857a4fca2845/src/Tasks/Microsoft.NET.Build.Tasks/targets/${sdkTargetsName}"
+    $sdkTargetsPath = "C:\Program Files\dotnet\sdk\$sdkVersion\Sdks\Microsoft.NET.Sdk\targets"
+    Start-DownloadWithRetry -Url $sdkTargetsUrl -DownloadPath $sdkTargetsPath -Name $sdkTargetsName
 
     # warm up dotnet for first time experience
     $templates | ForEach-Object {
@@ -49,8 +52,8 @@ function InstallSDKVersion (
 
 function InstallAllValidSdks()
 {
-    Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases-index.json' -UseBasicParsing -OutFile 'releases-index.json'
-    $dotnetChannels = Get-Content -Path 'releases-index.json' | ConvertFrom-Json
+    $releasesIndexPath = Start-DownloadWithRetry -Url 'https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases-index.json' -Name 'releases-index.json'
+    $dotnetChannels = Get-Content -Path $releasesIndexPath | ConvertFrom-Json
 
     # Consider all channels except preview/eol channels.
     # Sort the channels in ascending order
@@ -58,13 +61,15 @@ function InstallAllValidSdks()
     $dotnetChannels = $dotnetChannels.'releases-index' | Where-Object { (!$_."support-phase".Equals('preview') -and !$_."support-phase".Equals('eol')) -or ($_."channel-version" -eq "2.2") } | Sort-Object { [Version] $_."channel-version" }
 
     # Download installation script.
-    Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -UseBasicParsing -OutFile 'dotnet-install.ps1'
+    $installationName = "dotnet-install.ps1"
+    $installationUrl = "https://dot.net/v1/${installationName}"
+    Start-DownloadWithRetry -Url $installationUrl -Name $installationName -DownloadPath ".\"
 
     ForEach ($dotnetChannel in $dotnetChannels)
     {
         $channelVersion = $dotnetChannel.'channel-version';
-        Invoke-WebRequest -Uri $dotnetChannel.'releases.json' -UseBasicParsing -OutFile "releases-$channelVersion.json"
-        $currentReleases = Get-Content -Path "releases-$channelVersion.json" | ConvertFrom-Json
+        $releasesJsonPath = Start-DownloadWithRetry -Url $dotnetChannel.'releases.json' -Name "releases-$channelVersion.json"
+        $currentReleases = Get-Content -Path $releasesJsonPath | ConvertFrom-Json
         # filtering out the preview/rc releases
         # Remove version 3.1.102 from install list, .NET gave a heads-up that this might cause issues and they are working on a fix. https://github.com/dotnet/aspnetcore/issues/19133
         $currentReleases = $currentReleases.'releases' | Where-Object { !$_.'release-version'.Contains('-') -and !$_.'release-version'.Contains('3.1.2') } | Sort-Object { [Version] $_.'release-version' }
@@ -73,7 +78,6 @@ function InstallAllValidSdks()
             if ($release.'sdks'.Count -gt 0)
             {
                 Write-Host 'Found sdks property in release: ' + $release.'release-version' + 'with sdks count: ' + $release.'sdks'.Count
-
 
                 # Remove duplicate entries & preview/rc version from download list
                 # Sort the sdks on version

--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -52,7 +52,9 @@ function InstallSDKVersion (
 
 function InstallAllValidSdks()
 {
-    $releasesIndexPath = Start-DownloadWithRetry -Url 'https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases-index.json' -Name 'releases-index.json'
+    $releaseIndexName = "releases-index.json"
+    $releaseIndexUrl = "https://raw.githubusercontent.com/dotnet/core/master/release-notes/${releaseIndexName}"
+    $releasesIndexPath = Start-DownloadWithRetry -Url $releaseIndexUrl -Name $releaseIndexName
     $dotnetChannels = Get-Content -Path $releasesIndexPath | ConvertFrom-Json
 
     # Consider all channels except preview/eol channels.

--- a/images/win/scripts/Installers/Windows2016/Install-VS2017.ps1
+++ b/images/win/scripts/Installers/Windows2016/Install-VS2017.ps1
@@ -78,11 +78,10 @@ $WorkLoads =    '--allWorkloads --includeRecommended ' + `
                 '--add Microsoft.VisualStudio.Workload.OfficeBuildTools '
 
 $ReleaseInPath = "Enterprise"
-$BootstrapperName = "vs_${ReleaseInPath}.exe"
-$BootstrapperUrl = "https://aka.ms/vs/15/release/${BootstrapperName}"
+$BootstrapperUrl = "https://aka.ms/vs/15/release/vs_${ReleaseInPath}.exe"
 
 # Install VS
-Install-VisualStudio -BootstrapperName $BootstrapperName -BootstrapperUrl $BootstrapperUrl -WorkLoads $WorkLoads
+Install-VisualStudio -BootstrapperUrl $BootstrapperUrl -WorkLoads $WorkLoads
 
 # Find the version of VS installed for this instance
 # Only supports a single instance

--- a/images/win/scripts/Installers/Windows2016/Install-VS2017.ps1
+++ b/images/win/scripts/Installers/Windows2016/Install-VS2017.ps1
@@ -3,63 +3,11 @@
 ##  Desc:  Install Visual Studio 2017
 ################################################################################
 
-Function InstallVS
-{
-  Param
-  (
-    [String]$WorkLoads,
-    [String]$Sku,
-    [String] $VSBootstrapperURL
-  )
+$ErrorActionPreference = "Stop"
 
-  $exitCode = -1
+Import-Module -Name ImageHelpers -Force
 
-  try
-  {
-    Write-Host "Enable short name support on Windows needed for Xamarin Android AOT, defaults appear to have been changed in Azure VMs"
-    $shortNameEnableProcess = Start-Process -FilePath fsutil.exe -ArgumentList ('8dot3name', 'set', '0') -Wait -PassThru
-    $shortNameEnableExitCode = $shortNameEnableProcess.ExitCode
-
-    if ($shortNameEnableExitCode -ne 0)
-    {
-      Write-Host -Object 'Enabling short name support on Windows failed. This needs to be enabled prior to VS 2017 install for Xamarin Andriod AOT to work.'
-      exit $shortNameEnableExitCode
-    }
-
-    Write-Host "Downloading Bootstrapper ..."
-    Invoke-WebRequest -Uri $VSBootstrapperURL -OutFile "${env:Temp}\vs_$Sku.exe"
-
-    $FilePath = "${env:Temp}\vs_$Sku.exe"
-    $Arguments = ('/c', $FilePath, $WorkLoads, '--quiet', '--norestart', '--wait', '--nocache' )
-
-    Write-Host "Starting Install ..."
-    $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru
-    $exitCode = $process.ExitCode
-
-    if ($exitCode -eq 0 -or $exitCode -eq 3010)
-    {
-      Write-Host -Object 'Installation successful'
-      return $exitCode
-    }
-    else
-    {
-      Write-Host -Object "Non zero exit code returned by the installation process : $exitCode."
-
-      # this wont work because of log size limitation in extension manager
-      # Get-Content $customLogFilePath | Write-Host
-
-      exit $exitCode
-    }
-  }
-  catch
-  {
-    Write-Host -Object "Failed to install Visual Studio. Check the logs for details in $customLogFilePath"
-    Write-Host -Object $_.Exception.Message
-    exit -1
-  }
-}
-
-$WorkLoads = '--allWorkloads --includeRecommended ' + `
+$WorkLoads =    '--allWorkloads --includeRecommended ' + `
                 '--add Microsoft.Net.Component.4.6.2.SDK ' + `
                 '--add Microsoft.Net.Component.4.6.2.TargetingPack ' + `
                 '--add Microsoft.Net.ComponentGroup.4.6.2.DeveloperTools ' + `
@@ -129,20 +77,19 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
                 '--add Microsoft.VisualStudio.Workload.Office ' + `
                 '--add Microsoft.VisualStudio.Workload.OfficeBuildTools '
 
-$Sku = 'Enterprise'
-$VSBootstrapperURL = 'https://aka.ms/vs/15/release/vs_enterprise.exe'
-
-$ErrorActionPreference = 'Stop'
+$ReleaseInPath = "Enterprise"
+$BootstrapperName = "vs_${ReleaseInPath}.exe"
+$BootstrapperUrl = "https://aka.ms/vs/15/release/${BootstrapperName}"
 
 # Install VS
-$exitCode = InstallVS -WorkLoads $WorkLoads -Sku $Sku -VSBootstrapperURL $VSBootstrapperURL
+Install-VS -BootstrapperName $BootstrapperName -BootstrapperUrl $BootstrapperUrl -WorkLoads $WorkLoads
 
 # Find the version of VS installed for this instance
 # Only supports a single instance
 $vsProgramData = Get-Item -Path "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances"
 $instanceFolders = Get-ChildItem -Path $vsProgramData.FullName
 
-if($instanceFolders -is [array])
+if ($instanceFolders -is [array])
 {
     Write-Host "More than one instance installed"
     exit 1
@@ -151,20 +98,19 @@ if($instanceFolders -is [array])
 $catalogContent = Get-Content -Path ($instanceFolders.FullName + '\catalog.json')
 $catalog = $catalogContent | ConvertFrom-Json
 $version = $catalog.info.id
-$VSInstallRoot = "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise"
+$VSInstallRoot = "C:\Program Files (x86)\Microsoft Visual Studio\2017\$ReleaseInPath"
 Write-Host "Visual Studio version" $version "installed"
 
 # Initialize Visual Studio Experimental Instance for integration testing
-&"$VSInstallRoot\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings /Command File.Exit | Wait-Process
+& "$VSInstallRoot\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings /Command File.Exit | Wait-Process
 
 # Updating content of MachineState.json file to disable autoupdate of VSIX extensions
 $newContent = '{"Extensions":[{"Key":"1e906ff5-9da8-4091-a299-5c253c55fdc9","Value":{"ShouldAutoUpdate":false}},{"Key":"Microsoft.VisualStudio.Web.AzureFunctions","Value":{"ShouldAutoUpdate":false}}],"ShouldAutoUpdate":false,"ShouldCheckForUpdates":false}'
 Set-Content -Path "$VSInstallRoot\Common7\IDE\Extensions\MachineState.json" -Value $newContent
 
-
 # Adding description of the software to Markdown
 
-$SoftwareName = "Visual Studio 2017 Enterprise"
+$SoftwareName = "Visual Studio 2017 $ReleaseInPath"
 
 $Description = @"
 _Version:_ $version<br/>
@@ -199,7 +145,3 @@ Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $
 
 # Adding explicitly added Workloads details to markdown by parsing $Workloads
 Add-ContentToMarkdown -Content $($WorkLoads.Split('--') | % { if( ($_.Split(" "))[0] -like "add") { "* " +($_.Split(" "))[1] }  } )
-
-
-
-exit $exitCode

--- a/images/win/scripts/Installers/Windows2016/Install-VS2017.ps1
+++ b/images/win/scripts/Installers/Windows2016/Install-VS2017.ps1
@@ -82,7 +82,7 @@ $BootstrapperName = "vs_${ReleaseInPath}.exe"
 $BootstrapperUrl = "https://aka.ms/vs/15/release/${BootstrapperName}"
 
 # Install VS
-Install-VS -BootstrapperName $BootstrapperName -BootstrapperUrl $BootstrapperUrl -WorkLoads $WorkLoads
+Install-VisualStudio -BootstrapperName $BootstrapperName -BootstrapperUrl $BootstrapperUrl -WorkLoads $WorkLoads
 
 # Find the version of VS installed for this instance
 # Only supports a single instance

--- a/images/win/scripts/Installers/Windows2016/Install-VS2017.ps1
+++ b/images/win/scripts/Installers/Windows2016/Install-VS2017.ps1
@@ -99,7 +99,7 @@ $catalogContent = Get-Content -Path ($instanceFolders.FullName + '\catalog.json'
 $catalog = $catalogContent | ConvertFrom-Json
 $version = $catalog.info.id
 $VSInstallRoot = "C:\Program Files (x86)\Microsoft Visual Studio\2017\$ReleaseInPath"
-Write-Host "Visual Studio version" $version "installed"
+Write-Host "Visual Studio version ${version} installed"
 
 # Initialize Visual Studio Experimental Instance for integration testing
 & "$VSInstallRoot\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings /Command File.Exit | Wait-Process

--- a/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
@@ -102,7 +102,7 @@ $BootstrapperName = "vs_${ReleaseInPath}.exe"
 $BootstrapperUrl = "https://aka.ms/vs/16/release/${BootstrapperName}"
 
 # Install VS
-Install-VS -WorkLoads $WorkLoads -BootstrapperName $BootstrapperName -BootstrapperUrl $BootstrapperUrl
+Install-VS -BootstrapperName $BootstrapperName -BootstrapperUrl $BootstrapperUrl -WorkLoads $WorkLoads
 
 # Find the version of VS installed for this instance
 # Only supports a single instance

--- a/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
@@ -118,14 +118,15 @@ if ($instanceFolders -is [array])
 $catalogContent = Get-Content -Path ($instanceFolders.FullName + '\catalog.json')
 $catalog = $catalogContent | ConvertFrom-Json
 $version = $catalog.info.id
-Write-Host "Visual Studio version" $version "installed"
+$VSInstallRoot = "C:\Program Files (x86)\Microsoft Visual Studio\2019\$ReleaseInPath"
+Write-Host "Visual Studio version ${version} installed"
 
 # Initialize Visual Studio Experimental Instance
-& "C:\Program Files (x86)\Microsoft Visual Studio\2019\$ReleaseInPath\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings /Command File.Exit
+& "$VSInstallRoot\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings /Command File.Exit
 
 # Updating content of MachineState.json file to disable autoupdate of VSIX extensions
 $newContent = '{"Extensions":[{"Key":"1e906ff5-9da8-4091-a299-5c253c55fdc9","Value":{"ShouldAutoUpdate":false}},{"Key":"Microsoft.VisualStudio.Web.AzureFunctions","Value":{"ShouldAutoUpdate":false}}],"ShouldAutoUpdate":false,"ShouldCheckForUpdates":false}'
-Set-Content -Path "C:\Program Files (x86)\Microsoft Visual Studio\2019\$ReleaseInPath\Common7\IDE\Extensions\MachineState.json" -Value $newContent
+Set-Content -Path "$VSInstallRoot\Common7\IDE\Extensions\MachineState.json" -Value $newContent
 
 
 # Adding description of the software to Markdown
@@ -134,7 +135,7 @@ $SoftwareName = "Visual Studio 2019 Enterprise"
 
 $Description = @"
 _Version:_ $version<br/>
-_Location:_ C:\Program Files (x86)\Microsoft Visual Studio\2019\$ReleaseInPath
+_Location:_ $VSInstallRoot
 
 The following workloads and components are installed with Visual Studio 2019:
 "@
@@ -143,6 +144,3 @@ Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $
 
 # Adding explicitly added Workloads details to markdown by parsing $Workloads
 Add-ContentToMarkdown -Content $($WorkLoads.Split('--') | % { if( ($_.Split(" "))[0] -like "add") { "* " +($_.Split(" "))[1] }  } )
-
-
-exit $exitCode

--- a/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
@@ -96,13 +96,11 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.VisualStudio.Workload.Universal ' + `
               '--add Microsoft.VisualStudio.Workload.VisualStudioExtension'
 
-
 $ReleaseInPath = "Enterprise"
-$BootstrapperName = "vs_${ReleaseInPath}.exe"
-$BootstrapperUrl = "https://aka.ms/vs/16/release/${BootstrapperName}"
+$BootstrapperUrl = "https://aka.ms/vs/16/release/vs_${ReleaseInPath}.exe"
 
 # Install VS
-Install-VisualStudio -BootstrapperName $BootstrapperName -BootstrapperUrl $BootstrapperUrl -WorkLoads $WorkLoads
+Install-VisualStudio -BootstrapperUrl $BootstrapperUrl -WorkLoads $WorkLoads
 
 # Find the version of VS installed for this instance
 # Only supports a single instance

--- a/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
@@ -102,7 +102,7 @@ $BootstrapperName = "vs_${ReleaseInPath}.exe"
 $BootstrapperUrl = "https://aka.ms/vs/16/release/${BootstrapperName}"
 
 # Install VS
-Install-VS -BootstrapperName $BootstrapperName -BootstrapperUrl $BootstrapperUrl -WorkLoads $WorkLoads
+Install-VisualStudio -BootstrapperName $BootstrapperName -BootstrapperUrl $BootstrapperUrl -WorkLoads $WorkLoads
 
 # Find the version of VS installed for this instance
 # Only supports a single instance

--- a/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
@@ -4,61 +4,7 @@
 ################################################################################
 $ErrorActionPreference = "Stop"
 
-Function InstallVS
-{
-  Param
-  (
-    [String]$WorkLoads,
-    [String]$Sku,
-    [String] $VSBootstrapperURL
-  )
-
-  $exitCode = -1
-
-  try
-  {
-    Write-Host "Enable short name support on Windows needed for Xamarin Android AOT, defaults appear to have been changed in Azure VMs"
-    $shortNameEnableProcess = Start-Process -FilePath fsutil.exe -ArgumentList ('8dot3name', 'set', '0') -Wait -PassThru
-    $shortNameEnableExitCode = $shortNameEnableProcess.ExitCode
-
-    if ($shortNameEnableExitCode -ne 0)
-    {
-      Write-Host -Object 'Enabling short name support on Windows failed. This needs to be enabled prior to VS 2017 install for Xamarin Andriod AOT to work.'
-      exit $shortNameEnableExitCode
-    }
-
-    Write-Host "Downloading Bootstrapper ..."
-    Invoke-WebRequest -Uri $VSBootstrapperURL -OutFile "${env:Temp}\vs_$Sku.exe"
-
-    $FilePath = "${env:Temp}\vs_$Sku.exe"
-    $Arguments = ('/c', $FilePath, $WorkLoads, '--quiet', '--norestart', '--wait', '--nocache' )
-
-    Write-Host "Starting Install ..."
-    $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru
-    $exitCode = $process.ExitCode
-
-    if ($exitCode -eq 0 -or $exitCode -eq 3010)
-    {
-      Write-Host -Object 'Installation successful'
-      return $exitCode
-    }
-    else
-    {
-      Write-Host -Object "Non zero exit code returned by the installation process : $exitCode."
-
-      # this wont work because of log size limitation in extension manager
-      # Get-Content $customLogFilePath | Write-Host
-
-      exit $exitCode
-    }
-  }
-  catch
-  {
-    Write-Host -Object "Failed to install Visual Studio. Check the logs for details in $customLogFilePath"
-    Write-Host -Object $_.Exception.Message
-    exit -1
-  }
-}
+Import-Module -Name ImageHelpers -Force
 
 $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Component.Dotfuscator ' + `
@@ -151,21 +97,19 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.VisualStudio.Workload.VisualStudioExtension'
 
 
-$ReleaseInPath = 'Enterprise'
-$Sku = 'Enterprise'
-$VSBootstrapperURL = 'https://aka.ms/vs/16/release/vs_Enterprise.exe'
-
-$ErrorActionPreference = 'Stop'
+$ReleaseInPath = "Enterprise"
+$BootstrapperName = "vs_${ReleaseInPath}.exe"
+$BootstrapperUrl = "https://aka.ms/vs/16/release/${BootstrapperName}"
 
 # Install VS
-$exitCode = InstallVS -WorkLoads $WorkLoads -Sku $Sku -VSBootstrapperURL $VSBootstrapperURL
+Install-VS -WorkLoads $WorkLoads -BootstrapperName $BootstrapperName -BootstrapperUrl $BootstrapperUrl
 
 # Find the version of VS installed for this instance
 # Only supports a single instance
 $vsProgramData = Get-Item -Path "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances"
 $instanceFolders = Get-ChildItem -Path $vsProgramData.FullName
 
-if($instanceFolders -is [array])
+if ($instanceFolders -is [array])
 {
     Write-Host "More than one instance installed"
     exit 1
@@ -177,7 +121,7 @@ $version = $catalog.info.id
 Write-Host "Visual Studio version" $version "installed"
 
 # Initialize Visual Studio Experimental Instance
-&"C:\Program Files (x86)\Microsoft Visual Studio\2019\$ReleaseInPath\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings /Command File.Exit
+& "C:\Program Files (x86)\Microsoft Visual Studio\2019\$ReleaseInPath\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings /Command File.Exit
 
 # Updating content of MachineState.json file to disable autoupdate of VSIX extensions
 $newContent = '{"Extensions":[{"Key":"1e906ff5-9da8-4091-a299-5c253c55fdc9","Value":{"ShouldAutoUpdate":false}},{"Key":"Microsoft.VisualStudio.Web.AzureFunctions","Value":{"ShouldAutoUpdate":false}}],"ShouldAutoUpdate":false,"ShouldCheckForUpdates":false}'


### PR DESCRIPTION
# Description
This PR improves stability for following Windows provisioners:
1. Install-DotnetSDK
1. Install-VS2017
1. Install-VS2019

Most of default `Invoke-WebRequest` occurrences was replace with custom `Start-DownloadWithRetry` function that support retries logic. Also several improvements in syntax was made.

**How it was tested:**
Windows 2016 - https://github.visualstudio.com/virtual-environments/_build/results?buildId=65825&view=results
Windows 2019 - https://github.visualstudio.com/virtual-environments/_build/results?buildId=65826&view=results

#### Related issue:
Issue: https://github.com/actions/virtual-environments-internal/issues/384

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
