### PR TITLE
Remove mention of Boost in PATH from Windows image docs

### DIFF
--- a/images/win/Windows2016-Readme.md
+++ b/images/win/Windows2016-Readme.md
@@ -478,7 +478,6 @@ _Environment:_
 #### 1.69.0 [msvc-14.1]
 
 _Environment:_
-* PATH: contains the location of Boost version 1.69.0
 * BOOST_ROOT_1_69_0: root directory of the Boost version 1.69.0 installation
 #### 1.72.0 [msvc-14.1]
 

--- a/images/win/Windows2019-Readme.md
+++ b/images/win/Windows2019-Readme.md
@@ -483,7 +483,6 @@ _Environment:_
 #### 1.72.0 [msvc-14.2]
 
 _Environment:_
-* PATH: contains the location of Boost version 1.72.0
 * BOOST_ROOT_1_72_0: root directory of the Boost version 1.72.0 installation
 
 #### _Notes:_


### PR DESCRIPTION
# Description
Fixes mismatch between the documentation saying Boost is part of `PATH` on Windows, and the actual Windows images not having the location of Boost in `PATH`.

#### Related issue: doc fix related to removal of Boost from `PATH` that happened in PR #569

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
