### PR TITLE
Use Install-Binary instead of Install-MSI

### DIFF
--- a/images/win/scripts/Installers/Install-AWS-SAM.ps1
+++ b/images/win/scripts/Installers/Install-AWS-SAM.ps1
@@ -4,4 +4,4 @@
 ##         https://aws.amazon.com/serverless/sam/
 ################################################################################
 
-Install-MSI -MsiUrl "https://github.com/awslabs/aws-sam-cli/releases/latest/download/AWS_SAM_CLI_64_PY3.msi" -MsiName "AWS_SAM_CLI_64_PY3.msi"
+Install-Binary -Url "https://github.com/awslabs/aws-sam-cli/releases/latest/download/AWS_SAM_CLI_64_PY3.msi" -Name "AWS_SAM_CLI_64_PY3.msi"


### PR DESCRIPTION
# Description
Bug fixing 

Catch up with the most recent master changes: Install-MSI replaced with Install-Binary

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/418

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
