### PR TITLE
Return back dotnent 3.1.102 on Ubuntu images

### DIFF
--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -60,8 +60,7 @@ for release_url in ${release_urls[@]}; do
     sdks=("${sdks[@]}" $(echo "${releases}" | jq '.releases[]' | jq '.sdks[]?' | jq '.version'))
 done
 
-#temporary avoid 3.1.102 installation due to https://github.com/dotnet/aspnetcore/issues/19133
-sortedSdks=$(echo ${sdks[@]} | tr ' ' '\n' | grep -v 3.1.102 | grep -v preview | grep -v rc | grep -v display | cut -d\" -f2 | sort -u -r)
+sortedSdks=$(echo ${sdks[@]} | tr ' ' '\n' | grep -v preview | grep -v rc | grep -v display | cut -d\" -f2 | sort -u -r)
 
 for sdk in $sortedSdks; do
     url="https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$sdk/dotnet-sdk-$sdk-linux-x64.tar.gz"


### PR DESCRIPTION
It is not most recent now and it not selected by defaultg

# Description
Improvement

[Buggy](https://github.com/dotnet/aspnetcore/issues/19133) Dotnet SDK 3.1.102 has been exclude for a while to avoid it became default. Since 3.1.201 release we can return it back to the images 

#### Related issue: https://github.com/actions/virtual-environments/issues/673

## Check list
- [x] Related issue / work item is attached
- [x] Changes are tested and related VM images are successfully generated
