### PR TITLE
[Ubuntu] Move homebrew to the end of the $PATH

### DIFF
--- a/images/linux/scripts/helpers/etc-environment.sh
+++ b/images/linux/scripts/helpers/etc-environment.sh
@@ -61,6 +61,11 @@ function prependEtcEnvironmentPath {
     prependEtcEnvironmentVariable PATH "${element}"
 }
 
+function appendEtcEnvironmentPath {
+    element="$1"
+    appendEtcEnvironmentVariable PATH "${element}"
+}
+
 # Process /etc/environment as if it were shell script with `export VAR=...` expressions
 #    The PATH variable is handled specially in order to do not override the existing PATH
 #    variable. The value of PATH variable read from /etc/environment is added to the end

--- a/images/linux/scripts/installers/homebrew.sh
+++ b/images/linux/scripts/installers/homebrew.sh
@@ -20,7 +20,7 @@ sudo chmod -R o+w $HOMEBREW_PREFIX
 brew shellenv|grep 'export HOMEBREW'|sed -E 's/^export (.*);$/\1/' | sudo tee -a /etc/environment
 # add brew executables locations to PATH
 brew_path=$(brew shellenv|grep  '^export PATH' |sed -E 's/^export PATH="([^$]+)\$.*/\1/')
-prependEtcEnvironmentPath "$brew_path"
+appendEtcEnvironmentPath "$brew_path"
 
 # Validate the installation ad hoc
 echo "Validate the installation reloading /etc/environment"


### PR DESCRIPTION
Homebrew for Linux contains internal python that overrides system python at the moment.

Changes:
- Add function that is able to add path at the end of the $PATH
- Change brew installation to use new function