### PR TITLE
Don't create backup sed file

### DIFF
--- a/images/linux/scripts/helpers/etc-environment.sh
+++ b/images/linux/scripts/helpers/etc-environment.sh
@@ -26,7 +26,7 @@ function replaceEtcEnvironmentVariable {
     variable_value="$2"
 
     # modify /etc/environemnt in place by replacing a string that begins with variable_name
-    sudo sed -ie "s%^${variable_name}=.*$%${variable_name}=\"${variable_value}\"%" /etc/environment
+    sudo sed -i -e "s%^${variable_name}=.*$%${variable_name}=\"${variable_value}\"%" /etc/environment
 }
 
 function setEtcEnvironmentVariable {


### PR DESCRIPTION
# Description
Improvement

Don't leave the backup file after `sed` execution

#### Related issue: https://github.com/actions/virtual-environments/issues/790

## Check list
- [x] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
