### PR TITLE
Updated README with new rules of tool installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ In general, these are the guidelines we consider when deciding what to pre-insta
 - Tools and versions will typically be removed 6 months after they are deprecated or have reached end-of-life.
 - If a tool can be installed during the build, we will evaluate how much time is saved
  and how much space is used by having the tool pre-installed.
-- If tool license is not MIT, Apache or GNU, we will have to check it with legal.
-- If tool takes much space we will evaluate space usage and provide a decision if this tool can be pre-installed.
+- If a tool license is not MIT, Apache or GNU, we will have to check it with legal.
+- If a tool takes much space we will evaluate space usage and provide a decision if this tool can be pre-installed.
 - If a tool requires the support of more than one version, we will consider the cost of this maintenance, how often new versions bring dangerous updates.
 
 **Note:** For new tools, please, create an issue and get an approval from us to add this tool to the image before creating the pull request.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In general, these are the guidelines we consider when deciding what to pre-insta
 - If a tool can be installed during the build, we will evaluate how much time is saved
  and how much space is used by having the tool pre-installed.
 - If tool license is not MIT, Apache or GNU, we will have to check it with legal.
-- Big tools can be pre-installed after our evaluation of the image space usage.
+- If tool takes much space we will evaluate space usage and provide a decision if this tool can be pre-installed.
 - If a tool requires the support of more than one version, we will consider the cost of this maintenance, how often new versions bring dangerous updates.
 
 **Note:** For new tools, please, create an issue and get an approval from us to add this tool to the image before creating the pull request.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In general, these are the guidelines we consider when deciding what to pre-insta
 - Tools and versions will typically be removed 6 months after they are deprecated or have reached end-of-life.
 - If a tool can be installed during the build, we will evaluate how much time is saved
  and how much space is used by having the tool pre-installed.
-- If tool license is not MIT, Apach or GNU, the tool cannot be installed on image.
+- If tool license is not MIT, Apache or GNU, the tool cannot be installed on image.
 - Big tools can be pre-installed after our evaluation of the image space usage.
 - If a tool requires the support of more than one version, we will consider the cost of this maintenance, how often new versions bring dangerous updates.
 - Please, before creating a PR with tool installation, wait for confirmation that this tool can be installed on image.

--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ In general, these are the guidelines we consider when deciding what to pre-insta
 - Tools and versions will typically be removed 6 months after they are deprecated or have reached end-of-life.
 - If a tool can be installed during the build, we will evaluate how much time is saved
  and how much space is used by having the tool pre-installed.
-- If tool license is not MIT, Apache or GNU, the tool cannot be installed on image.
+- If tool license is not MIT, Apache or GNU, we will have to check it with legal.
 - Big tools can be pre-installed after our evaluation of the image space usage.
 - If a tool requires the support of more than one version, we will consider the cost of this maintenance, how often new versions bring dangerous updates.
-- Please, before creating a PR with tool installation, wait for confirmation that this tool can be installed on image.
+
+**Note:** For new tools, please, create an issue and get an approval from us to add this tool to the image before creating the pull request.
 
 ## Updates to virtual environments
 *Cadence*

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In general, these are the guidelines we consider when deciding what to pre-insta
 - Tools and versions will typically be removed 6 months after they are deprecated or have reached end-of-life.
 - If a tool can be installed during the build, we will evaluate how much time is saved
  and how much space is used by having the tool pre-installed.
-- If a tool license is not MIT, Apache or GNU, we will have to check it with legal.
+- MIT, Apache, and GNU licenses are ok, anything else we'll have to check with lawyers.
 - If a tool takes much space we will evaluate space usage and provide a decision if this tool can be pre-installed.
 - If a tool requires the support of more than one version, we will consider the cost of this maintenance, how often new versions bring dangerous updates.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ In general, these are the guidelines we consider when deciding what to pre-insta
 - Tools and versions will typically be removed 6 months after they are deprecated or have reached end-of-life.
 - If a tool can be installed during the build, we will evaluate how much time is saved
  and how much space is used by having the tool pre-installed.
+- If tool license is not MIT, Apach or GNU, the tool cannot be installed on image.
+- Big tools can be pre-installed after our evaluation of the image space usage.
+- If a tool requires the support of more than one version, we will consider the cost of this maintenance, how often new versions bring dangerous updates.
+- Please, before creating a PR with tool installation, wait for confirmation that this tool can be installed on image.
 
 ## Updates to virtual environments
 *Cadence*


### PR DESCRIPTION
I adde few new items to tool installation guide:

- If tool license is not MIT, Apache or GNU, the tool cannot be installed on image.
- Big tools can be pre-installed after our evaluation of the image space usage.
- If a tool requires the support of more than one version, we will consider the cost of this maintenance, how often new versions bring dangerous updates.
- Please, before creating a PR with tool installation, wait for confirmation that this tool can be installed on image.
