### PR TITLE
Systemd-resolve workaround for Ubuntu 18.

### DIFF
--- a/images/linux/scripts/installers/1804/basic.sh
+++ b/images/linux/scripts/installers/1804/basic.sh
@@ -139,6 +139,10 @@ for cmd in curl file ftp jq netcat ssh parallel rsync shellcheck sudo telnet tim
     fi
 done
 
+# Workaround for systemd-resolve, since sometimes stub resolver does not work properly. Details: https://github.com/actions/virtual-environments/issues/798
+echo "Create resolv.conf link."
+ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
+
 # Document what was added to the image
 echo "Lastly, documenting what we added to the metadata file"
 DocumentInstalledItem "Basic CLI:"


### PR DESCRIPTION
# Description
Bug fixing
Sometimes, stub DNS for systemd-resolve does not work properly, and it is not possible to determine what exactly is happening. It looks like a bug in systemd-resolve service.

#### Related issue:
https://github.com/actions/virtual-environments/issues/798

## Check list
- [+] Related issue / work item is attached
- [+] Changes are tested and related VM images are successfully generated
