### PR TITLE
Create .composer folder to preserve permissions

### DIFF
--- a/images/linux/scripts/installers/1604/php.sh
+++ b/images/linux/scripts/installers/1604/php.sh
@@ -283,6 +283,9 @@ prependEtcEnvironmentPath /home/runner/.config/composer/vendor/bin
 # Add composer bin folder to path
 echo 'export PATH="$PATH:$HOME/.config/composer/vendor/bin"' >> /etc/skel/.bashrc
 
+#Create composer folder for user to preserve folder permissions
+mkdir -p /etc/skel/.composer
+
 # Install phpunit (for PHP)
 wget -q -O phpunit https://phar.phpunit.de/phpunit-7.phar
 chmod +x phpunit

--- a/images/linux/scripts/installers/1804/php.sh
+++ b/images/linux/scripts/installers/1804/php.sh
@@ -200,6 +200,9 @@ prependEtcEnvironmentPath /home/runner/.config/composer/vendor/bin
 # Add composer bin folder to path
 echo 'export PATH="$PATH:$HOME/.config/composer/vendor/bin"' >> /etc/skel/.bashrc
 
+#Create composer folder for user to preserve folder permissions
+mkdir -p /etc/skel/.composer
+
 # Install phpunit (for PHP)
 wget -q -O phpunit https://phar.phpunit.de/phpunit-7.phar
 chmod +x phpunit


### PR DESCRIPTION
# Description
Bug fixing
Php composer set permission for `.composer` folder like for `/usr/bin/composer` which causes lack of permissions issue in attempt to use compose in agents.

#### Related issue:
https://github.com/actions/virtual-environments/issues/824

## Check list
- [+] Related issue / work item is attached
- [+] Changes are tested and related VM images are successfully generated
