### PR TITLE
Fix setting Maven's environment variables

### DIFF
--- a/images/win/scripts/Installers/Install-JavaTools.ps1
+++ b/images/win/scripts/Installers/Install-JavaTools.ps1
@@ -66,8 +66,7 @@ Choco-Install -PackageName maven -ArgumentList "-i", "--version=3.6.3"
 Choco-Install -PackageName gradle
 
 # Move maven variables to Machine. They may not be in the environment for this script so we need to read them from the registry.
-$userSid = (Get-WmiObject win32_useraccount -Filter "name = '$env:USERNAME' AND domain = '$env:USERDOMAIN'").SID
-$userEnvironmentKey = 'Registry::HKEY_USERS\' + $userSid + '\Environment'
+$userEnvironmentKey = 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
 
 $m2_home = (Get-ItemProperty -Path $userEnvironmentKey -Name M2_HOME).M2_HOME
 $m2 = $m2_home + '\bin'


### PR DESCRIPTION
During setting maven's environment variables we have error, when we try to get `M2_HOME` value from registry:
```
$m2_home = (Get-ItemProperty -Path $userEnvironmentKey -Name M2_HOME) ...
Get-ItemProperty : Property M2_HOME does not exist at path
CategoryInfo          : InvalidArgument: (M2_HOME:String) [Get-ItemProperty], PSArgumentException
```
 and as a result of this we have incorrect value `M2` env variable: `M2=\bin` on Windows images.

 This can be fixed by replacing the registry key for getting value `M2_HOME` env variable from registry.

Test build: [Windows-2019](https://github.visualstudio.com/virtual-environments/_build/results?buildId=67169)
