### PR TITLE
Add SSDT Workload to Visual Studio 2019

### DIFF
--- a/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
@@ -33,6 +33,7 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.VisualStudio.Component.EntityFramework ' + `
               '--add Microsoft.VisualStudio.Component.FSharp.Desktop ' + `
               '--add Microsoft.VisualStudio.Component.LinqToSql ' + `
+              '--add Microsoft.VisualStudio.Component.SQL.SSDT ' + `
               '--add Microsoft.VisualStudio.Component.PortableLibrary ' + `
               '--add Microsoft.VisualStudio.Component.TeamOffice ' + `
               '--add Microsoft.VisualStudio.Component.TestTools.CodedUITest ' + `


### PR DESCRIPTION
# Description
Improvment
SSDT tools now should be installed as workload for Visual Studio 2019. More information can be obtained here: https://docs.microsoft.com/en-us/sql/ssdt/download-sql-server-data-tools-ssdt?view=sql-server-ver15#ssdt-for-vs-2017-standalone-installer
Size: 500 Mb

#### Related issue:
https://github.com/actions/virtual-environments/issues/702
## Check list
- [+] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
