### PR TITLE
Install Go to hostedtoolcache directory on Ubuntu image

### DIFF
--- a/images/linux/scripts/installers/go.sh
+++ b/images/linux/scripts/installers/go.sh
@@ -13,8 +13,8 @@ golangTags="/tmp/golang_tags.json"
 #   $2=IsDefaultVersion (true or false)
 function InstallGo () {
     version=$( getFullGoVersion $1 )
-    downloadVersion=$version.linux-amd64.tar.gz
-    goFolder="$AGENT_TOOLSDIRECTORY/go/$version/x64"
+    downloadVersion="go$version.linux-amd64.tar.gz"
+    goFolder="$AGENT_TOOLSDIRECTORY/Go/$version/x64"
 
     echo "Install Go $version"
     curl -sL https://dl.google.com/go/${downloadVersion} -o ${downloadVersion}
@@ -37,8 +37,8 @@ function getFullGoVersion () {
     local pattern="refs/tags/go$1([.0-9]{0,3})$"
     local query='[.[] | select( .ref | test($pattern))] | .[-1] | .ref'
     refValue=$(jq --arg pattern "$pattern" "$query" $golangTags)
-    version=$(echo "$refValue" | cut -d '/' -f 3)
-    version=$(echo "${version//\"}") # go1.12.17
+    version=$(echo "$refValue" | cut -d '/' -f 3 | awk -F 'go' '{print $2}')
+    version=$(echo "${version//\"}") # 1.12.17
     echo $version
 }
 

--- a/images/linux/scripts/installers/go.sh
+++ b/images/linux/scripts/installers/go.sh
@@ -14,7 +14,7 @@ golangTags="/tmp/golang_tags.json"
 function InstallGo () {
     version=$( getFullGoVersion $1 )
     downloadVersion=$version.linux-amd64.tar.gz
-    goFolder=/usr/local/go$1
+    goFolder="$AGENT_TOOLSDIRECTORY/go/$1/x64"
 
     echo "Install Go $version"
     curl -sL https://dl.google.com/go/${downloadVersion} -o ${downloadVersion}

--- a/images/linux/scripts/installers/go.sh
+++ b/images/linux/scripts/installers/go.sh
@@ -14,7 +14,7 @@ golangTags="/tmp/golang_tags.json"
 function InstallGo () {
     version=$( getFullGoVersion $1 )
     downloadVersion=$version.linux-amd64.tar.gz
-    goFolder="$AGENT_TOOLSDIRECTORY/go/$1/x64"
+    goFolder="$AGENT_TOOLSDIRECTORY/go/$version/x64"
 
     echo "Install Go $version"
     curl -sL https://dl.google.com/go/${downloadVersion} -o ${downloadVersion}
@@ -22,7 +22,7 @@ function InstallGo () {
     tar -C $goFolder -xzf $downloadVersion --strip-components=1 go
     rm $downloadVersion
     echo "GOROOT_${1//./_}_X64=$goFolder" | tee -a /etc/environment
-    DocumentInstalledItem "Go $1 ($($goFolder/bin/go version))"
+    DocumentInstalledItem "Go $version ($($goFolder/bin/go version))"
 
     # If this version of Go is to be the default version,
     # symlink it into the path and point GOROOT to it.

--- a/images/linux/scripts/installers/go.sh
+++ b/images/linux/scripts/installers/go.sh
@@ -14,7 +14,7 @@ golangTags="/tmp/golang_tags.json"
 function InstallGo () {
     version=$( getFullGoVersion $1 )
     downloadVersion="go$version.linux-amd64.tar.gz"
-    goFolder="$AGENT_TOOLSDIRECTORY/Go/$version/x64"
+    goFolder="$AGENT_TOOLSDIRECTORY/go/$version/x64"
 
     echo "Install Go $version"
     curl -sL https://dl.google.com/go/${downloadVersion} -o ${downloadVersion}

--- a/images/linux/scripts/installers/go.sh
+++ b/images/linux/scripts/installers/go.sh
@@ -24,6 +24,9 @@ function InstallGo () {
     echo "GOROOT_${1//./_}_X64=$goFolder" | tee -a /etc/environment
     DocumentInstalledItem "Go $version ($($goFolder/bin/go version))"
 
+    # Create symlink in old location /usr/local/go<version> to new location
+    ln -s $goFolder /usr/local/go$version
+
     # If this version of Go is to be the default version,
     # symlink it into the path and point GOROOT to it.
     if [ $2 = true ]

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -252,19 +252,6 @@
             "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {
-            "type": "shell",
-            "scripts": [
-                "{{template_dir}}/scripts/installers/go.sh"
-            ],
-            "environment_vars": [
-                "METADATA_FILE={{user `metadata_file`}}",
-                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
-                "GO_VERSIONS={{user `go_versions`}}",
-                "GO_DEFAULT={{user `go_default`}}"
-            ],
-            "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}"
-        },
-        {
             "type": "file",
             "source": "{{template_dir}}/toolcache-1604.json",
             "destination": "{{user `installer_script_folder`}}/toolcache.json"
@@ -291,6 +278,19 @@
                 "GITHUB_FEED_TOKEN={{user `github_feed_token`}}"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "scripts": [
+                "{{template_dir}}/scripts/installers/go.sh"
+            ],
+            "environment_vars": [
+                "METADATA_FILE={{user `metadata_file`}}",
+                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
+                "GO_VERSIONS={{user `go_versions`}}",
+                "GO_DEFAULT={{user `go_default`}}"
+            ],
+            "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}"
         },
         {
             "type": "shell",

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -273,18 +273,28 @@
                 "{{template_dir}}/scripts/helpers/containercache.sh",
                 "{{template_dir}}/scripts/installers/hosted-tool-cache.sh",
                 "{{template_dir}}/scripts/installers/python.sh",
-                "{{template_dir}}/scripts/installers/go.sh",
                 "{{template_dir}}/scripts/installers/test-toolcache.sh"
             ],
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",
                 "HELPER_SCRIPTS={{user `helper_script_folder`}}",
                 "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}",
-                "GITHUB_FEED_TOKEN={{user `github_feed_token`}}",
+                "GITHUB_FEED_TOKEN={{user `github_feed_token`}}"
+            ],
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "scripts": [
+                "{{template_dir}}/scripts/installers/go.sh"
+            ],
+            "environment_vars": [
+                "METADATA_FILE={{user `metadata_file`}}",
+                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
                 "GO_VERSIONS={{user `go_versions`}}",
                 "GO_DEFAULT={{user `go_default`}}"
             ],
-            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+            "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}"
         },
         {
             "type": "shell",

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -256,19 +256,6 @@
             "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {
-            "type": "shell",
-            "scripts": [
-                "{{template_dir}}/scripts/installers/go.sh"
-            ],
-            "environment_vars": [
-                "METADATA_FILE={{user `metadata_file`}}",
-                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
-                "GO_VERSIONS={{user `go_versions`}}",
-                "GO_DEFAULT={{user `go_default`}}"
-            ],
-            "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}"
-        },
-        {
             "type": "file",
             "source": "{{template_dir}}/toolcache-1804.json",
             "destination": "{{user `installer_script_folder`}}/toolcache.json"
@@ -286,13 +273,16 @@
                 "{{template_dir}}/scripts/helpers/containercache.sh",
                 "{{template_dir}}/scripts/installers/hosted-tool-cache.sh",
                 "{{template_dir}}/scripts/installers/python.sh",
+                "{{template_dir}}/scripts/installers/go.sh",
                 "{{template_dir}}/scripts/installers/test-toolcache.sh"
             ],
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",
                 "HELPER_SCRIPTS={{user `helper_script_folder`}}",
                 "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}",
-                "GITHUB_FEED_TOKEN={{user `github_feed_token`}}"
+                "GITHUB_FEED_TOKEN={{user `github_feed_token`}}",
+                "GO_VERSIONS={{user `go_versions`}}",
+                "GO_DEFAULT={{user `go_default`}}"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },


### PR DESCRIPTION
Internal issue: [#489](https://github.com/actions/virtual-environments-internal/issues/489)

Moved Go location from `/usr/local` to `/opt/hostedtoolcache/go` directory to work with `setup-go` action.

Example of path:
```
/opt/hostedtoolcache/go/1.14.2/x64
```
