### PR TITLE
Install Go to hostedtoolcache directory on Windows image

### DIFF
--- a/images/win/scripts/Installers/Install-Go.ps1
+++ b/images/win/scripts/Installers/Install-Go.ps1
@@ -29,7 +29,7 @@ function Install-GoVersion
 
     # Extract the zip archive.  It contains a single directory named "go".
     Write-Host "Extracting Go $latestVersion..."
-    $toolDirectory = Join-Path $env:AGENT_TOOLSDIRECTORY "Go\$latestVersion"
+    $toolDirectory = Join-Path $env:AGENT_TOOLSDIRECTORY "go\$latestVersion"
     7z.exe x $goArchPath -o"$toolDirectory" -y | Out-Null
 
     # Rename the extracted "go" directory to "x64" for full path "C:\hostedtoolcache\windows\Go\1.14.2\x64\..."

--- a/images/win/scripts/Installers/Install-Go.ps1
+++ b/images/win/scripts/Installers/Install-Go.ps1
@@ -29,36 +29,37 @@ function Install-GoVersion
 
     # Extract the zip archive.  It contains a single directory named "go".
     Write-Host "Extracting Go $latestVersion..."
-    Expand-Archive -Path $goArchPath -DestinationPath "C:\" -Force
+    $toolDirectory = Join-Path $env:AGENT_TOOLSDIRECTORY "Go\$latestVersion"
+    7z.exe x $goArchPath -o"$toolDirectory" -y | Out-Null
+
+    # Rename the extracted "go" directory to "x64" for full path "C:\hostedtoolcache\windows\Go\1.14.2\x64\..."
+    Rename-Item -path "$toolDirectory\go" -newName "x64"
+    $fullArchPath = "$toolDirectory\x64"
 
     # Delete unnecessary files to conserve space
     Write-Host "Cleaning directories of Go $latestVersion..."
-    if (Test-Path "C:\go\doc")
+    if (Test-Path "$fullArchPath\doc")
     {
-        Remove-Item -Recurse -Force "C:\go\doc"
+        Remove-Item -Recurse -Force "$fullArchPath\doc"
     }
-    if (Test-Path "C:\go\blog")
+    if (Test-Path "$fullArchPath\blog")
     {
-        Remove-Item -Recurse -Force "C:\go\blog"
+        Remove-Item -Recurse -Force "$fullArchPath\blog"
     }
-
-    # Rename the extracted "go" directory to include the Go version number (to support side-by-side versions of Go).
-    $newDirName = "Go$latestVersion"
-    Rename-Item -path "C:\go" -newName $newDirName
 
     # Make this the default version of Go?
     if ($addToDefaultPath)
     {
         Write-Host "Adding Go $latestVersion to the path..."
         # Add the Go binaries to the path.
-        Add-MachinePathItem "C:\$newDirName\bin" | Out-Null
+        Add-MachinePathItem "$fullArchPath\bin" | Out-Null
         # Set the GOROOT environment variable.
-        setx GOROOT "C:\$newDirName" /M | Out-Null
+        setx GOROOT "$fullArchPath" /M | Out-Null
     }
 
     # Done
     Write-Host "Done installing Go $latestVersion."
-    return "C:\$newDirName"
+    return $fullArchPath
 }
 
 # Install Go

--- a/images/win/scripts/Installers/Install-Go.ps1
+++ b/images/win/scripts/Installers/Install-Go.ps1
@@ -47,6 +47,9 @@ function Install-GoVersion
         Remove-Item -Recurse -Force "$fullArchPath\blog"
     }
 
+    # Create symlink in old location
+    New-Item -Path "C:\go$latestVersion" -ItemType SymbolicLink -Value $fullArchPath
+
     # Make this the default version of Go?
     if ($addToDefaultPath)
     {

--- a/images/win/scripts/Installers/Validate-Go.ps1
+++ b/images/win/scripts/Installers/Validate-Go.ps1
@@ -11,9 +11,9 @@ function Get-GoVersion
         [String]$goVersion
     )
     Write-Host "Check if $goVersion is presented in the system"
-    $DestinationPath = "$($env:SystemDrive)\"
-    $goDirectory = Get-ChildItem -Path $DestinationPath -Filter "Go$goVersion*" | Select-Object -First 1
-    $goPath = Join-Path $env:SystemDrive $goDirectory
+    $DestinationPath = "$($env:AGENT_TOOLSDIRECTORY)\Go"
+    $goDirectory = Get-ChildItem -Path $DestinationPath -Filter "$goVersion*" | Select-Object -First 1
+    $goPath = Join-Path $env:SystemDrive "$goDirectory\x64"
 
     $env:Path = "$goPath\bin;" + $env:Path
     $version = $(go version)

--- a/images/win/scripts/Installers/Validate-Go.ps1
+++ b/images/win/scripts/Installers/Validate-Go.ps1
@@ -11,9 +11,9 @@ function Get-GoVersion
         [String]$goVersion
     )
     Write-Host "Check if $goVersion is presented in the system"
-    $DestinationPath = "$($env:AGENT_TOOLSDIRECTORY)\Go"
-    $goDirectory = Get-ChildItem -Path $DestinationPath -Filter "$goVersion*" | Select-Object -First 1
-    $goPath = Join-Path $env:SystemDrive "$goDirectory\x64"
+    $destinationPath = "$($env:AGENT_TOOLSDIRECTORY)\Go"
+    $goDirectory = Get-ChildItem -Path $destinationPath -Filter "$goVersion*" | Select-Object -First 1
+    $goPath = Join-Path $destinationPath "$goDirectory\x64"
 
     $env:Path = "$goPath\bin;" + $env:Path
     $version = $(go version)

--- a/images/win/scripts/Installers/Validate-Go.ps1
+++ b/images/win/scripts/Installers/Validate-Go.ps1
@@ -11,7 +11,7 @@ function Get-GoVersion
         [String]$goVersion
     )
     Write-Host "Check if $goVersion is presented in the system"
-    $destinationPath = "$($env:AGENT_TOOLSDIRECTORY)\Go"
+    $destinationPath = "$($env:AGENT_TOOLSDIRECTORY)\go"
     $goDirectory = Get-ChildItem -Path $destinationPath -Filter "$goVersion*" | Select-Object -First 1
     $goPath = Join-Path $destinationPath "$goDirectory\x64"
 


### PR DESCRIPTION
Internal issue: [#488](https://github.com/actions/virtual-environments-internal/issues/488)

Moved Go location from `C:` to `C:\hostedtoolcache\go` directory to work with `setup-go` action.

Example of path:
```
C:\hostedtoolcache\go\1.14.2\x64
```

Also it uses `7z` tool instead `Expand-Archive` to decrease expand archive time (about 20 min with `Expand-Archive` and 3 min with `7z`).
