### PR TITLE
Fix the cleanup script.

### DIFF
--- a/images.CI/azure-pipelines/image-generation.yml
+++ b/images.CI/azure-pipelines/image-generation.yml
@@ -8,6 +8,7 @@ jobs:
 - job:
   pool: ci-agent-pool
   timeoutInMinutes: 600
+  cancelTimeoutInMinutes: 30
   variables:
   - group: Image Generation Variables
 

--- a/images.CI/cleanup.ps1
+++ b/images.CI/cleanup.ps1
@@ -11,7 +11,7 @@ az login --service-principal --username $ClientId --password $ClientSecret --ten
 
 $TempResourceGroupName = "${ResourcesNamePrefix}_${Image}"
 
-$groupExist = az group exists --name $TempResourceGroupName --subscription $SubscriptionId | Out-Null
+$groupExist = az group exists --name $TempResourceGroupName --subscription $SubscriptionId
 if ($groupExist -eq "true") {
     Write-Host "Found a match, deleting temporary files"
     az group delete --name $TempResourceGroupName --subscription $SubscriptionId --yes | Out-Null


### PR DESCRIPTION
The result is not returned to the variable because of the output redirect

# Description
Bug fixing  
The cleanup script does not work anymore.It does not get the result in the variable $groupExists due to output redirect.



