### PR TITLE
Install Windows 10 SDK (10.0.14393.795) via standalone installer

### DIFF
--- a/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
@@ -151,8 +151,9 @@ Add-ContentToMarkdown -Content $($WorkLoads.Split('--') | % { if( ($_.Split(" ")
 
 # Adding additional SDKs to markdown
 $SDKDescription = @"
-Additional Windows 10 SDKs
--- Windows 10 SDK version 10.0.14393.795
+
+Additional Windows 10 SDKs:
+* Windows 10 SDK version 10.0.14393.795
 "@
 
 Add-ContentToMarkdown -Content $SDKDescription

--- a/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
@@ -68,7 +68,6 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.MFC.ARM.Spectre ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.MFC.ARM64.Spectre ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.MFC.Spectre ' + `
-              '--add Microsoft.VisualStudio.Component.Windows10SDK.14393 ' + `
               '--add Microsoft.VisualStudio.Component.Windows10SDK.16299 ' + `
               '--add Microsoft.VisualStudio.Component.Windows10SDK.17134 ' + `
               '--add Microsoft.VisualStudio.Component.Windows10SDK.17763 ' + `
@@ -127,6 +126,12 @@ Write-Host "Visual Studio version ${version} installed"
 $newContent = '{"Extensions":[{"Key":"1e906ff5-9da8-4091-a299-5c253c55fdc9","Value":{"ShouldAutoUpdate":false}},{"Key":"Microsoft.VisualStudio.Web.AzureFunctions","Value":{"ShouldAutoUpdate":false}}],"ShouldAutoUpdate":false,"ShouldCheckForUpdates":false}'
 Set-Content -Path "$VSInstallRoot\Common7\IDE\Extensions\MachineState.json" -Value $newContent
 
+# Install Windows 10 SDK version 10.0.14393.795
+$sdkUrl = "https://go.microsoft.com/fwlink/p/?LinkId=838916"
+$sdkFileName = "sdksetup14393.exe"
+$argumentList = ("/q", "/norestart", "/ceip off", "/features OptionId.WindowsSoftwareDevelopmentKit")
+
+Install-Binary -Url $sdkUrl -Name $sdkFileName -ArgumentList $argumentList
 
 # Adding description of the software to Markdown
 
@@ -143,3 +148,11 @@ Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $
 
 # Adding explicitly added Workloads details to markdown by parsing $Workloads
 Add-ContentToMarkdown -Content $($WorkLoads.Split('--') | % { if( ($_.Split(" "))[0] -like "add") { "* " +($_.Split(" "))[1] }  } )
+
+# Adding additional SDKs to markdown
+$SDKDescription = @"
+Additional Windows 10 SDKs
+-- Windows 10 SDK version 10.0.14393.795
+"@
+
+Add-ContentToMarkdown -Content $SDKDescription


### PR DESCRIPTION
# Description
Windows 10 SDK (10.0.14393.795) VS19 workload was deprecated quite a long time ago https://github.com/MicrosoftDocs/visualstudio-docs/commit/37e6886087e40f8576eaa82dfd5e87e524c2319f#diff-757fef660bf40737850ce059881acf40L387 so we have to use a standalone installer.

#### Related issue:
https://github.com/actions/virtual-environments/issues/858

## Check list
- [x] Related issue / work item is attached
- [N/a] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
