### PR TITLE
[Ubuntu] Add Azcopy10

### DIFF
--- a/images/linux/scripts/installers/azcopy.sh
+++ b/images/linux/scripts/installers/azcopy.sh
@@ -34,5 +34,5 @@ fi
 azcopy7Version=$(azcopy --version | awk '{print $2}' | cut -d '-' -f 1)
 azcopy10Version=$(azcopy10 --version | awk '{print $3}')
 echo "Lastly, documenting what we added to the metadata file"
-DocumentInstalledItem "AzCopy7(available by azcopy alias) $azcopy7Version"
-DocumentInstalledItem "AzCopy10(available by azcopy10 alias) $azcopy10Version"
+DocumentInstalledItem "AzCopy7 (available by azcopy alias) $azcopy7Version"
+DocumentInstalledItem "AzCopy10 (available by azcopy10 alias) $azcopy10Version"

--- a/images/linux/scripts/installers/azcopy.sh
+++ b/images/linux/scripts/installers/azcopy.sh
@@ -7,19 +7,32 @@
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/document.sh
 
-# Install AzCopy
+# Install AzCopy7
 wget -O azcopy.tar.gz https://aka.ms/downloadazcopylinux64
 tar -xf azcopy.tar.gz
 rm azcopy.tar.gz
 ./install.sh
 
+# Install AzCopy10
+wget -O /tmp/azcopy.tar.gz https://aka.ms/downloadazcopy-v10-linux
+tar zxvf /tmp/azcopy.tar.gz --strip-components=1 -C /tmp
+mv /tmp/azcopy /usr/local/bin/azcopy10
+
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
 if ! command -v azcopy; then
-    echo "azcopy was not installed"
+    echo "azcopy7 was not installed"
+    exit 1
+fi
+
+if ! command -v azcopy10; then
+    echo "azcopy10 was not installed"
     exit 1
 fi
 
 # Document what was added to the image
+azcopy7Version=$(azcopy --version | awk '{print $2}' | cut -d '-' -f 1)
+azcopy10Version=$(azcopy10 --version | awk '{print $3}')
 echo "Lastly, documenting what we added to the metadata file"
-DocumentInstalledItem "AzCopy ($(azcopy --version))"
+DocumentInstalledItem "AzCopy7(available by azcopy alias) $azcopy7Version"
+DocumentInstalledItem "AzCopy10(available by azcopy10 alias) $azcopy10Version"


### PR DESCRIPTION
# Description
Add Azcopy10 to the image and preserve Azcopy 7 because the functionality between these versions differs(AzCopy 7 uses Shared Keys while version 10 uses SAS)

Azcopy10 size ~20Mb

#### Related issue:
https://github.com/actions/virtual-environments/issues/868
## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
