### PR TITLE
[Ubuntu] Add /tmp cleanup

### DIFF
--- a/images/linux/scripts/installers/cleanup.sh
+++ b/images/linux/scripts/installers/cleanup.sh
@@ -6,6 +6,7 @@ before=$(df / -Pm | awk 'NR==2{print $4}')
 # clears out the local repository of retrieved package files
 # It removes everything but the lock file from /var/cache/apt/archives/ and /var/cache/apt/archives/partial
 apt-get clean
+rm -rf /tmp/*
 
 # after cleanup
 after=$(df / -Pm | awk 'NR==2{print $4}')

--- a/images/linux/scripts/installers/validate-disk-space.sh
+++ b/images/linux/scripts/installers/validate-disk-space.sh
@@ -5,7 +5,7 @@
 ################################################################################
 
 availableSpaceMB=$(df / -hm | sed 1d | awk '{ print $4}')
-minimumFreeSpaceMB=18000
+minimumFreeSpaceMB=17800
 
 echo "Available disk space: $availableSpaceMB MB"
 if [ $availableSpaceMB -le $minimumFreeSpaceMB ]; then


### PR DESCRIPTION
# Description
We check disk free space when some garbage files are in /tmp, yet these files do not exist on the final VM. Need to clean them up before the checking. The limit is also lowered because we have a bit more space after provisioning now.

#### Related issue:
https://github.com/actions/virtual-environments/issues/709

## Check list
- [x] Related issue / work item is attached
- [N\A] Tests are written (if applicable)
- [N\A] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
