### PR TITLE
[Ubuntu 18] systemd-resolve workaround

### DIFF
--- a/images/linux/scripts/installers/1804/basic.sh
+++ b/images/linux/scripts/installers/1804/basic.sh
@@ -142,6 +142,13 @@ for cmd in curl file ftp jq netcat ssh parallel rsync shellcheck sudo telnet tim
     fi
 done
 
+# Workaround for systemd-resolve, since sometimes stub resolver does not work properly. Details: https://github.com/actions/virtual-environments/issues/798
+echo "Create resolv.conf link."
+if [[ -f /run/systemd/resolve/resolv.conf ]]; then
+    echo "Create resolv.conf link."
+    ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
+fi
+
 # Document what was added to the image
 echo "Lastly, documenting what we added to the metadata file"
 DocumentInstalledItem "Basic CLI:"


### PR DESCRIPTION
# Description
Bug fixing
- [This is Github issue](https://github.com/systemd/systemd/issues/10298), with exactly the same problem, which was not fixed, only workaround was provided as solution.
- Root cause is unclear.
- I'm not sure that we can remove systemd-resolve without effects. but we can disable it by default. However, in this case, it is required to add manually nameserver record to `/etc/resolv.conf `file.
- In the [official documentation](https://wiki.archlinux.org/index.php/Systemd-resolved), I didn't find misconfigurations.

So, the workaround helps us to resolve the issue with default systemd-resolve.

However, during the last try, we faced the issue with docker agents. I have verified that current workaround works as expected.

$ docker exec -it ubuntu:18 /bin/bash

**Reproduced:**
```
/# ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
ln: failed to create symbolic link '/etc/resolv.conf': Device or resource busy
```
**Current fix** 
```
/# if [[ -f /run/systemd/resolve/resolv.conf ]]; then
>     echo "Create resolv.conf link."
>     ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
> fi
```
works fine.

#### Related issue:
https://github.com/actions/virtual-environments/pull/819
## Check list
- [+] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
