### PR TITLE
Update pacman package to install msys2

### DIFF
--- a/images/win/scripts/Installers/Install-Msys2.ps1
+++ b/images/win/scripts/Installers/Install-Msys2.ps1
@@ -38,6 +38,13 @@ bash.exe -c "pacman-key --init 2>&1"
 Write-Host "bash pacman-key --populate msys2"
 bash.exe -c "pacman-key --populate msys2 2>&1"
 
+Write-Host "pacman --noconfirm -Sy pacman"
+pacman --noconfirm -Sy pacman
+pacman --noconfirm -Su
+
+# Force stop gpg-agent to continue installation
+Get-Process gpg-agent -ErrorAction SilentlyContinue | Stop-Process -Force
+
 Write-Host "pacman --noconfirm -Syyuu"
 pacman.exe -Syyuu --noconfirm
 pacman.exe -Syuu --noconfirm


### PR DESCRIPTION
# Description
Packer fails while building the MSYS2  due to missing  ZST archives. 

#### Related issue:
https://github.com/actions/virtual-environments/issues/898
https://github.com/msys2/MSYS2-packages/issues/1960

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
