### PR TITLE
WIndows - update Install-Msys2.ps1

### DIFF
--- a/images/win/scripts/Installers/Install-Msys2.ps1
+++ b/images/win/scripts/Installers/Install-Msys2.ps1
@@ -10,8 +10,11 @@
 $origPath = $env:PATH
 $gitPath  = "$env:ProgramFiles\Git"
 
-# get info from https://sourceforge.net/projects/msys2/files/Base/x86_64/
-$msys2Uri  = "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20190524.tar.xz"
+$msys2_release = "https://api.github.com/repos/msys2/msys2-installer/releases/latest"
+
+$msys2Uri = ((Invoke-RestMethod $msys2_release).assets | Where-Object {
+  $_.name -match "x86_64" -and $_.name.EndsWith("tar.xz") }).browser_download_url
+
 $msys2File = "$env:TEMP\msys2.tar.xz"
 
 # Download the latest msys2 x86_64
@@ -19,13 +22,17 @@ Write-Host "Starting msys2 download"
 (New-Object System.Net.WebClient).DownloadFile($msys2Uri, $msys2File)
 Write-Host "Finished download"
 
-$msys2FileU = "/$msys2File".replace(':', '')
+# nix style path for tar
+$msys2FileU = "/$msys2File".replace(':', '').replace('\', '/')
+
+# Git tar needs exe's from mingw64\bin
+$env:PATH = "$gitPath\usr\bin;$gitPath\mingw64\bin;$origPath"
 
 $tar = "$gitPath\usr\bin\tar.exe"
 
 # extract tar.xz to C:\
-Write-Host "Starting msys2 extraction"
-&$tar -Jxf $msys2FileU -C /c/
+Write-Host "Starting msys2 extraction from $msys2FileU"
+&$tar -xJf $msys2FileU -C /c/
 Remove-Item $msys2File
 Write-Host "Finished extraction"
 


### PR DESCRIPTION
# Description

1. Use 20200517 release from GitHub (https) instead of older 20190524 release (http)
2. Git tar  - change paths to full nix style
3. Git tar - requires exe's from Git/mingw64/bin, set ENV

2 & 3 may not be needed, but if anything changes...

Script will run locally assuming one has Git for Windows installed.  Since the base install is much newer, it requires fewer updates to be installed.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated