### PR TITLE
Add vswhere app on  Windows Server 2016

### DIFF
--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -457,6 +457,12 @@
         {
             "type": "powershell",
             "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-VSWhere.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-WinAppDriver.ps1"
             ]
         },
@@ -952,6 +958,12 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-Vcpkg.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-VSWhere.ps1"
             ]
         },
         {


### PR DESCRIPTION
# Description
vswhere is designed to be a redistributable, single-file executable that can be used in build or deployment scripts to find where Visual Studio - or other products in the Visual Studio family - is located. vswhere simplifies process of the generation markdown documentation related with Visual Studio. We already have the same util on Windows Server 2019.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
