### PR TITLE
Add a note about MSYS2 installation

### DIFF
--- a/images/win/scripts/Installers/Validate-Msys2.ps1
+++ b/images/win/scripts/Installers/Validate-Msys2.ps1
@@ -62,6 +62,8 @@ $gccVersion = Get-ToolVersion -ToolPath "$msys2mingwDir/gcc" -VersionLineNumber 
 $tarVersion = Get-ToolVersion -ToolPath "$msys2BinDir/tar" -VersionLineNumber 0
 
 $Description = @"
+> _Note:_ MSYS2 is pre-installed on image but not added to PATH.
+
 _Tool versions_
 _pacman:_ $pacmanVersion<br/>
 _bash:_ $bashVersion<br/>


### PR DESCRIPTION
# Description
Added a note that MSYS2 is pre-installed but not added to PATH.

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/576

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
