### PR TITLE
Add Android SDK 29.0.1 and NDK 21

### DIFF
--- a/images/win/scripts/Installers/Update-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Update-AndroidSDK.ps1
@@ -36,9 +36,6 @@ Expand-Archive -Path .\android-sdk-licenses.zip -DestinationPath 'C:\Program Fil
 
 $sdk_root = "C:\Program Files (x86)\Android\android-sdk"
 
-# NDK version to be installed.
-$ndk_version = '21.1.6352462'
-
 Push-Location -Path $sdk.FullName
 
 & '.\tools\bin\sdkmanager.bat' --sdk_root=$sdk_root `
@@ -98,10 +95,10 @@ Push-Location -Path $sdk.FullName
     "cmake;3.6.4111459" `
     "cmake;3.10.2.4988404" `
     "patcher;v4" `
-    "ndk;$ndk_version"
+    "ndk-bundle"
 
     # Android NDK root path.
-    $ndk_root = "C:\Program Files (x86)\Android\android-sdk\ndk\$ndk_version"
+    $ndk_root = "C:\Program Files (x86)\Android\android-sdk\ndk-bundle"
 
     if(Test-Path $ndk_root){
     

--- a/images/win/scripts/Installers/Update-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Update-AndroidSDK.ps1
@@ -102,12 +102,9 @@ Push-Location -Path $sdk.FullName
 
     if(Test-Path $ndk_root){
     
-        $androidNDKs = Get-ChildItem -Path $ndk_root | Sort-Object -Property Name -Descending | Select-Object -First 1
-        $latestAndroidNDK = $androidNDKs.FullName;
-    
         setx ANDROID_HOME $sdk_root /M
-        setx ANDROID_NDK_HOME $latestAndroidNDK /M
-        setx ANDROID_NDK_PATH $latestAndroidNDK /M
+        setx ANDROID_NDK_HOME $ndk_root /M
+        setx ANDROID_NDK_PATH $ndk_root /M
     }
     else {
         Write-Host "NDK is not installed at path $ndk_root"

--- a/images/win/scripts/Installers/Update-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Update-AndroidSDK.ps1
@@ -36,23 +36,8 @@ Expand-Archive -Path .\android-sdk-licenses.zip -DestinationPath 'C:\Program Fil
 
 $sdk_root = "C:\Program Files (x86)\Android\android-sdk"
 
-# The NDK is installed by Visual Studio at this location:
-$ndk_root = "C:\Microsoft\AndroidNDK64\"
-
-if(Test-Path $ndk_root){
-
-    $androidNDKs = Get-ChildItem -Path $ndk_root | Sort-Object -Property Name -Descending | Select-Object -First 1
-    $latestAndroidNDK = $androidNDKs.FullName;
-
-    setx ANDROID_HOME $sdk_root /M
-    setx ANDROID_NDK_HOME $latestAndroidNDK /M
-    setx ANDROID_NDK_PATH $latestAndroidNDK /M
-}
-else {
-    Write-Host "NDK is not installed at path $ndk_root"
-    exit 1
-}
-
+# NDK version to be installed.
+$ndk_version = '21.1.6352462'
 
 Push-Location -Path $sdk.FullName
 
@@ -70,6 +55,7 @@ Push-Location -Path $sdk.FullName
     "platforms;android-19" `
     "build-tools;29.0.3" `
     "build-tools;29.0.2" `
+    "build-tools;29.0.1" `
     "build-tools;29.0.0" `
     "build-tools;28.0.3" `
     "build-tools;28.0.2" `
@@ -111,7 +97,25 @@ Push-Location -Path $sdk.FullName
     "add-ons;addon-google_apis-google-21" `
     "cmake;3.6.4111459" `
     "cmake;3.10.2.4988404" `
-    "patcher;v4"
+    "patcher;v4" `
+    "ndk;$ndk_version"
+
+    # Android NDK root path.
+    $ndk_root = "C:\Program Files (x86)\Android\android-sdk\ndk\$ndk_version"
+
+    if(Test-Path $ndk_root){
+    
+        $androidNDKs = Get-ChildItem -Path $ndk_root | Sort-Object -Property Name -Descending | Select-Object -First 1
+        $latestAndroidNDK = $androidNDKs.FullName;
+    
+        setx ANDROID_HOME $sdk_root /M
+        setx ANDROID_NDK_HOME $latestAndroidNDK /M
+        setx ANDROID_NDK_PATH $latestAndroidNDK /M
+    }
+    else {
+        Write-Host "NDK is not installed at path $ndk_root"
+        exit 1
+    }
 
 Pop-Location
 

--- a/images/win/scripts/Installers/Update-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Update-AndroidSDK.ps1
@@ -100,19 +100,16 @@ Push-Location -Path $sdk.FullName
     # Android NDK root path.
     $ndk_root = "C:\Program Files (x86)\Android\android-sdk\ndk-bundle"
 
-    if(Test-Path $ndk_root){
-    
+    if (Test-Path $ndk_root){    
         setx ANDROID_HOME $sdk_root /M
         setx ANDROID_NDK_HOME $ndk_root /M
         setx ANDROID_NDK_PATH $ndk_root /M
-    }
-    else {
+    } else {
         Write-Host "NDK is not installed at path $ndk_root"
         exit 1
     }
 
 Pop-Location
-
 
 # Adding description of the software to Markdown
 $Header = @"


### PR DESCRIPTION
# Description
Improvement
We have only Android NDK installed with Visual Studio, but version is too old(16.1.4479499). Need to install the latest one.
Also, by unknown reason we missed Android SDK 29.0.1 in our installation steps. So, added it.
NDK installation time is about 4-5 minutes.

#### Related issue:
https://github.com/actions/virtual-environments/issues/344
## Check list
- [+] Related issue / work item is attached
- [+] Changes are tested and related VM images are successfully generated
