### PR TITLE
macOS 10.15 software updates week22

### DIFF
--- a/images/macos/macos-10.15-Readme.md
+++ b/images/macos/macos-10.15-Readme.md
@@ -2,7 +2,7 @@
 - System Version: macOS 10.15.4 (19E287)
 - Kernel Version: Darwin 19.4.0
 - System Integrity Protection: Enabled
-- Image Version: 20200507.1
+- Image Version: 20200518.2
 
 ## Installed Software
 ### Language and Runtime
@@ -21,13 +21,13 @@
 - Node.js v12.16.3
 - NVM 0.35.3
 - NVM - Cached node versions: v6.17.1 v8.17.0 v10.20.1 v12.16.3 v13.14.0 v14.2.0
-- PowerShell 7.0.0
+- PowerShell 7.0.1
 - Python 2.7.17
 - Python 3.7.7
 - Ruby 2.6.6p146
-- .NET SDK 2.0.0 3.0.100 3.0.101 3.0.102 3.0.103 3.1.100 3.1.101 3.1.200 3.1.201
-- Go 1.14.2
-- PHP 7.4.5
+- .NET SDK 2.0.0 3.0.100 3.0.101 3.0.102 3.0.103 3.1.100 3.1.101 3.1.200 3.1.201 3.1.202
+- Go 1.14.3
+- PHP 7.4.6
 - julia 1.4.1
 
 ### Package Management
@@ -36,7 +36,7 @@
 - Bundler version 2.1.4
 - Carthage 0.34.0
 - CocoaPods 1.9.1
-- Homebrew 2.2.15
+- Homebrew 2.2.17
 - NPM 6.14.4
 - Yarn 1.22.4
 - NuGet 5.5.0.6382
@@ -47,48 +47,51 @@
 
 ### Project Management
 - Apache Maven 3.6.3
-- Gradle 6.4
+- Gradle 6.4.1
 
 ### Utilities
 - Curl 7.70.0
 - Git: 2.26.2
-- Git LFS: 2.10.0
+- Git LFS: 2.11.0
+- GitHub CLI: 0.8.0
 - Hub CLI: 2.14.2
 - GNU Wget 1.20.3
 - Subversion (SVN) 1.13.0
 - Packer 1.5.6
 - GNU parallel 20200422
-- OpenSSL 1.0.2t  10 Sep 2019
+- OpenSSL 1.0.2t  10 Sep 2019 `(/usr/local/opt/openssl -> /usr/local/Cellar/openssl/1.0.2t)`
 - jq 1.6
 - gpg (GnuPG) 2.2.20
-- psql (PostgreSQL) 12.2
-- PostgreSQL 12.2
+- psql (PostgreSQL) 12.3
+- PostgreSQL 12.3
 - aria2 1.35.0
 - azcopy 10.4.3
 - zstd 1.4.4
 - bazel 3.1.0
 - bazelisk v1.4.0
-- helm v3.2.0+ge11b7ce
-- virtualbox 6.1.6r137129
-- Vagrant 2.2.8
+- helm v3.2.1+gfe51cd1
+- virtualbox 6.1.8r137981
+- mongo v4.2.6
+- mongod v4.2.6
+- Vagrant 2.2.9
 
 ### Tools
-- Fastlane 2.146.1
+- Fastlane 2.148.1
 - Cmake 3.17.2
-- App Center CLI 2.5.1
+- App Center CLI 2.5.2
 - Azure CLI 2.5.1
 - AWS CLI 2.0.10
-- AWS SAM CLI 0.48.0
-- Aliyun CLI 3.0.39
+- AWS SAM CLI 0.49.0
+- Aliyun CLI 3.0.42
 
 ### Browsers
 - Safari 13.1 (15609.1.20.111.8)
 - SafariDriver 13.1 (15609.1.20.111.8)
-- Google Chrome 81.0.4044.138
+- Google Chrome 81.0.4044.138 
 - ChromeDriver 81.0.4044.138
-- Microsoft Edge 81.0.416.68
-- MSEdgeDriver 81.0.416.68
-- Mozilla Firefox 76.0
+- Microsoft Edge 81.0.416.72 
+- MSEdgeDriver 81.0.416.72
+- Mozilla Firefox 76.0.1
 - geckodriver 0.26.0
 
 ### Toolcache
@@ -103,7 +106,7 @@
 - 3.5.9
 - 3.6.10
 - 3.7.7
-- 3.8.2
+- 3.8.3
 
 #### PyPy
 - 2.7.17
@@ -145,18 +148,16 @@
 - NUnit 3.6.1
 
 ### Xcode
-| Version          | Build   | Path                              |
-| ---------------- | ------- | --------------------------------- |
-| 11.5 (beta)      | 11N605f | /Applications/Xcode_11.5_beta.app |
-| 11.4.1 (default) | 11E503a | /Applications/Xcode_11.4.1.app    |
-| 11.4             | 11E146  | /Applications/Xcode_11.4.app      |
-| 11.3.1           | 11C505  | /Applications/Xcode_11.3.1.app    |
-| 11.3             | 11C29   | /Applications/Xcode_11.3.app      |
-| 11.2.1           | 11B500  | /Applications/Xcode_11.2.1.app    |
-| 11.2             | 11B52   | /Applications/Xcode_11.2.app      |
-| 11.1             | 11A1027 | /Applications/Xcode_11.1.app      |
-| 11.0             | 11A420a | /Applications/Xcode_11.app        |
-| 10.3             | 10G8    | /Applications/Xcode_10.3.app      |
+| Version          | Build   | Path                           |
+| ---------------- | ------- | ------------------------------ |
+| 11.5             | 11E608c | /Applications/Xcode_11.5.app   |
+| 11.4.1 (default) | 11E503a | /Applications/Xcode_11.4.1.app |
+| 11.4             | 11E146  | /Applications/Xcode_11.4.app   |
+| 11.3.1           | 11C505  | /Applications/Xcode_11.3.1.app |
+| 11.2.1           | 11B500  | /Applications/Xcode_11.2.1.app |
+| 11.1             | 11A1027 | /Applications/Xcode_11.1.app   |
+| 11.0             | 11A420a | /Applications/Xcode_11.app     |
+| 10.3             | 10G8    | /Applications/Xcode_10.3.app   |
 
 #### Xcode Support Tools
 - Nomad CLI 3.1.3
@@ -166,59 +167,59 @@
 - xcversion 2.6.4
 
 #### Installed SDKs
-| SDK                     | SDK Name             | Xcode Version                                              |
-| ----------------------- | -------------------- | ---------------------------------------------------------- |
-| macOS 10.14             | macosx10.14          | 10.3                                                       |
-| macOS 10.15             | macosx10.15          | 11.0, 11.1, 11.2, 11.2.1, 11.3, 11.3.1, 11.4, 11.4.1, 11.5 |
-| iOS 12.4                | iphoneos12.4         | 10.3                                                       |
-| iOS 13.0                | iphoneos13.0         | 11.0                                                       |
-| iOS 13.1                | iphoneos13.1         | 11.1                                                       |
-| iOS 13.2                | iphoneos13.2         | 11.2, 11.2.1, 11.3, 11.3.1                                 |
-| iOS 13.4                | iphoneos13.4         | 11.4, 11.4.1                                               |
-| iOS 13.5                | iphoneos13.5         | 11.5                                                       |
-| Simulator - iOS 12.4    | iphonesimulator12.4  | 10.3                                                       |
-| Simulator - iOS 13.0    | iphonesimulator13.0  | 11.0                                                       |
-| Simulator - iOS 13.1    | iphonesimulator13.1  | 11.1                                                       |
-| Simulator - iOS 13.2    | iphonesimulator13.2  | 11.2, 11.2.1, 11.3, 11.3.1                                 |
-| Simulator - iOS 13.4    | iphonesimulator13.4  | 11.4, 11.4.1                                               |
-| Simulator - iOS 13.5    | iphonesimulator13.5  | 11.5                                                       |
-| tvOS 12.4               | appletvos12.4        | 10.3                                                       |
-| tvOS 13.0               | appletvos13.0        | 11.0, 11.1                                                 |
-| tvOS 13.2               | appletvos13.2        | 11.2, 11.2.1, 11.3, 11.3.1                                 |
-| tvOS 13.4               | appletvos13.4        | 11.4, 11.4.1, 11.5                                         |
-| Simulator - tvOS 12.4   | appletvsimulator12.4 | 10.3                                                       |
-| Simulator - tvOS 13.0   | appletvsimulator13.0 | 11.0, 11.1                                                 |
-| Simulator - tvOS 13.2   | appletvsimulator13.2 | 11.2, 11.2.1, 11.3, 11.3.1                                 |
-| Simulator - tvOS 13.4   | appletvsimulator13.4 | 11.4, 11.4.1, 11.5                                         |
-| watchOS 5.3             | watchos5.3           | 10.3                                                       |
-| watchOS 6.0             | watchos6.0           | 11.0, 11.1                                                 |
-| watchOS 6.1             | watchos6.1           | 11.2, 11.2.1, 11.3, 11.3.1                                 |
-| watchOS 6.2             | watchos6.2           | 11.4, 11.4.1, 11.5                                         |
-| Simulator - watchOS 5.3 | watchsimulator5.3    | 10.3                                                       |
-| Simulator - watchOS 6.0 | watchsimulator6.0    | 11.0, 11.1                                                 |
-| Simulator - watchOS 6.1 | watchsimulator6.1    | 11.2, 11.2.1, 11.3, 11.3.1                                 |
-| Simulator - watchOS 6.2 | watchsimulator6.2    | 11.4, 11.4.1, 11.5                                         |
-| DriverKit 19.0          | driverkit.macosx19.0 | 11.0, 11.1, 11.2, 11.2.1, 11.3, 11.3.1, 11.4, 11.4.1, 11.5 |
+| SDK                     | SDK Name             | Xcode Version                                  |
+| ----------------------- | -------------------- | ---------------------------------------------- |
+| macOS 10.14             | macosx10.14          | 10.3                                           |
+| macOS 10.15             | macosx10.15          | 11.0, 11.1, 11.2.1, 11.3.1, 11.4, 11.4.1, 11.5 |
+| iOS 12.4                | iphoneos12.4         | 10.3                                           |
+| iOS 13.0                | iphoneos13.0         | 11.0                                           |
+| iOS 13.1                | iphoneos13.1         | 11.1                                           |
+| iOS 13.2                | iphoneos13.2         | 11.2.1, 11.3.1                                 |
+| iOS 13.4                | iphoneos13.4         | 11.4, 11.4.1                                   |
+| iOS 13.5                | iphoneos13.5         | 11.5                                           |
+| Simulator - iOS 12.4    | iphonesimulator12.4  | 10.3                                           |
+| Simulator - iOS 13.0    | iphonesimulator13.0  | 11.0                                           |
+| Simulator - iOS 13.1    | iphonesimulator13.1  | 11.1                                           |
+| Simulator - iOS 13.2    | iphonesimulator13.2  | 11.2.1, 11.3.1                                 |
+| Simulator - iOS 13.4    | iphonesimulator13.4  | 11.4, 11.4.1                                   |
+| Simulator - iOS 13.5    | iphonesimulator13.5  | 11.5                                           |
+| tvOS 12.4               | appletvos12.4        | 10.3                                           |
+| tvOS 13.0               | appletvos13.0        | 11.0, 11.1                                     |
+| tvOS 13.2               | appletvos13.2        | 11.2.1, 11.3.1                                 |
+| tvOS 13.4               | appletvos13.4        | 11.4, 11.4.1, 11.5                             |
+| Simulator - tvOS 12.4   | appletvsimulator12.4 | 10.3                                           |
+| Simulator - tvOS 13.0   | appletvsimulator13.0 | 11.0, 11.1                                     |
+| Simulator - tvOS 13.2   | appletvsimulator13.2 | 11.2.1, 11.3.1                                 |
+| Simulator - tvOS 13.4   | appletvsimulator13.4 | 11.4, 11.4.1, 11.5                             |
+| watchOS 5.3             | watchos5.3           | 10.3                                           |
+| watchOS 6.0             | watchos6.0           | 11.0, 11.1                                     |
+| watchOS 6.1             | watchos6.1           | 11.2.1, 11.3.1                                 |
+| watchOS 6.2             | watchos6.2           | 11.4, 11.4.1, 11.5                             |
+| Simulator - watchOS 5.3 | watchsimulator5.3    | 10.3                                           |
+| Simulator - watchOS 6.0 | watchsimulator6.0    | 11.0, 11.1                                     |
+| Simulator - watchOS 6.1 | watchsimulator6.1    | 11.2.1, 11.3.1                                 |
+| Simulator - watchOS 6.2 | watchsimulator6.2    | 11.4, 11.4.1, 11.5                             |
+| DriverKit 19.0          | driverkit.macosx19.0 | 11.0, 11.1, 11.2.1, 11.3.1, 11.4, 11.4.1, 11.5 |
 
 #### Installed Simulators
-| OS          | Xcode Version                    | Simulators                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| ----------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| iOS 12.4    | 10.3                             | iPhone 5s<br>iPhone 6 Plus<br>iPhone 6<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone SE<br>iPhone 7<br>iPhone 7 Plus<br>iPhone 8<br>iPhone 8 Plus<br>iPhone X<br>iPhone Xs<br>iPhone Xs Max<br>iPhone Xʀ<br>iPad Air<br>iPad Air 2<br>iPad Pro (9.7-inch)<br>iPad Pro (12.9-inch)<br>iPad (5th generation)<br>iPad Pro (12.9-inch) (2nd generation)<br>iPad Pro (10.5-inch)<br>iPad (6th generation)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation) |
-| iOS 13.0    | 11.0                             | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                                                                                                                                                                                                                                                                                             |
-| iOS 13.1    | 11.1                             | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                                                                                                                                                                                                                                                                                             |
-| iOS 13.2    | 11.2<br>11.2.1                   | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                                                                                                                                                                                                                                                                                             |
-| iOS 13.3    | 11.3<br>11.3.1                   | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                                                                                                                                                                                                                                                                                             |
-| iOS 13.4    | 11.4<br>11.4.1                   | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPhone SE (2nd generation)<br>iPad Pro (9.7-inch)<br>iPad (7th generation)<br>iPad Pro (11-inch) (2nd generation)<br>iPad Pro (12.9-inch) (4th generation)<br>iPad Air (3rd generation)                                                                                                                                                                                                                     |
-| iOS 13.5    | 11.5                             | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPhone SE (2nd generation)<br>iPad Pro (9.7-inch)<br>iPad (7th generation)<br>iPad Pro (11-inch) (2nd generation)<br>iPad Pro (12.9-inch) (4th generation)<br>iPad Air (3rd generation)                                                                                                                                                                                                                     |
-| tvOS 12.4   | 10.3                             | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| tvOS 13.0   | 11.0<br>11.1                     | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| tvOS 13.2   | 11.2<br>11.2.1                   | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| tvOS 13.3   | 11.3<br>11.3.1                   | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| tvOS 13.4   | 11.4<br>11.4.1<br>11.5           | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| watchOS 5.3 | 10.3                             | Apple Watch Series 2 - 38mm<br>Apple Watch Series 2 - 42mm<br>Apple Watch Series 3 - 38mm<br>Apple Watch Series 3 - 42mm<br>Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm                                                                                                                                                                                                                                                                                                      |
-| watchOS 6.0 | 11.0<br>11.1                     | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                                                                                                                                                                                                                                                                                    |
-| watchOS 6.1 | 11.2<br>11.2.1<br>11.3<br>11.3.1 | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                                                                                                                                                                                                                                                                                    |
-| watchOS 6.2 | 11.4<br>11.4.1<br>11.5           | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                                                                                                                                                                                                                                                                                    |
+| OS          | Xcode Version          | Simulators                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| ----------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| iOS 12.4    | 10.3                   | iPhone 5s<br>iPhone 6 Plus<br>iPhone 6<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone SE<br>iPhone 7<br>iPhone 7 Plus<br>iPhone 8<br>iPhone 8 Plus<br>iPhone X<br>iPhone Xs<br>iPhone Xs Max<br>iPhone Xʀ<br>iPad Air<br>iPad Air 2<br>iPad Pro (9.7-inch)<br>iPad Pro (12.9-inch)<br>iPad (5th generation)<br>iPad Pro (12.9-inch) (2nd generation)<br>iPad Pro (10.5-inch)<br>iPad (6th generation)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation) |
+| iOS 13.0    | 11.0                   | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                                                                                                                                                                                                                                                                                             |
+| iOS 13.1    | 11.1                   | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                                                                                                                                                                                                                                                                                             |
+| iOS 13.2    | 11.2.1                 | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                                                                                                                                                                                                                                                                                             |
+| iOS 13.3    | 11.3.1                 | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                                                                                                                                                                                                                                                                                             |
+| iOS 13.4    | 11.4<br>11.4.1         | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad (7th generation)<br>iPad Pro (11-inch) (2nd generation)<br>iPad Pro (12.9-inch) (4th generation)<br>iPad Air (3rd generation)<br>iPhone SE (2nd generation)                                                                                                                                                                                                                     |
+| iOS 13.5    | 11.5                   | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPhone SE (2nd generation)<br>iPad Pro (9.7-inch)<br>iPad (7th generation)<br>iPad Pro (11-inch) (2nd generation)<br>iPad Pro (12.9-inch) (4th generation)<br>iPad Air (3rd generation)                                                                                                                                                                                                                     |
+| tvOS 12.4   | 10.3                   | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| tvOS 13.0   | 11.0<br>11.1           | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| tvOS 13.2   | 11.2.1                 | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| tvOS 13.3   | 11.3.1                 | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| tvOS 13.4   | 11.4<br>11.4.1<br>11.5 | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| watchOS 5.3 | 10.3                   | Apple Watch Series 2 - 38mm<br>Apple Watch Series 2 - 42mm<br>Apple Watch Series 3 - 38mm<br>Apple Watch Series 3 - 42mm<br>Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm                                                                                                                                                                                                                                                                                                      |
+| watchOS 6.0 | 11.0<br>11.1           | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                                                                                                                                                                                                                                                                                    |
+| watchOS 6.1 | 11.2.1<br>11.3.1       | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                                                                                                                                                                                                                                                                                    |
+| watchOS 6.2 | 11.4<br>11.4.1<br>11.5 | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                                                                                                                                                                                                                                                                                    |
 
 ### Android
 #### Android SDK Tools
@@ -270,12 +271,18 @@
 | build-tools-29.0.3     | Android SDK Build-Tools, Revision 29.0.3     |
 | build-tools-30.0.0-rc4 | Android SDK Build-Tools, Revision 30.0.0 rc4 |
 
+#### Android NDKs
+| Version      | Path                                       |
+| ------------ | ------------------------------------------ |
+| 15.2.4203891 | $HOME/Library/Android/sdk/android-ndk-r15c |
+| 18.1.5063045 | $HOME/Library/Android/sdk/ndk/18.1.5063045 |
+| 21.1.6352462 | $HOME/Library/Android/sdk/ndk-bundle       |
+
 #### Android Utils
-| Package Name     | Version      |
-| ---------------- | ------------ |
-| cmake            | 3.6.4111459  |
-| ndk-bundle       | 21.1.6352462 |
-| Android Emulator | 30.0.5       |
+| Package Name     | Version     |
+| ---------------- | ----------- |
+| cmake            | 3.6.4111459 |
+| Android Emulator | 30.0.12     |
 
 #### Android Google APIs
 | Package Name                | Description             |


### PR DESCRIPTION
## Installed Software
### Language and Runtime
- PowerShell 7.0.1  
- .NET SDK 3.1.202
- Go 1.14.3
- PHP 7.4.6
### Package Management
- Homebrew 2.2.17  
### Project Management
- Gradle 6.4.1  
### Utilities
- Git LFS: 2.11.0
- GitHub CLI: 0.8.0
- psql (PostgreSQL) 12.3  
- PostgreSQL 12.3  
- helm v3.2.1+gfe51cd1
- virtualbox 6.1.8r137981
- mongo v4.2.6
- mongod v4.2.6
- Vagrant 2.2.9 
### Tools
- Fastlane 2.148.1
- App Center CLI 2.5.2
- AWS SAM CLI 0.49.0
- Aliyun CLI 3.0.42 
### Browsers
- Google Chrome 81.0.4044.138 
- Microsoft Edge 81.0.416.72 
- MSEdgeDriver 81.0.416.72
- Mozilla Firefox 76.0.1
### ToolCache
#### Python
- 3.8.3
### Xcode
| Version          | Build   | Path                           |
| ---------------- | ------- | ------------------------------ |
 | 11.5             | 11E608c | /Applications/Xcode_11.5.app   |  

#### Android NDKs
| Version      | Path                                       |
| ------------ | ------------------------------------------ |
| 15.2.4203891 | $HOME/Library/Android/sdk/android-ndk-r15c |
| 18.1.5063045 | $HOME/Library/Android/sdk/ndk/18.1.5063045 |
| 21.1.6352462 | $HOME/Library/Android/sdk/ndk-bundle       |

#### Android Utils
| Package Name     | Version     |
| ---------------- | ----------- |
| Android Emulator | 30.0.12     |
