### PR TITLE
Change minimum free space limit to 16000mb for Ubuntu 16.04/18.04

### DIFF
--- a/images/linux/scripts/installers/validate-disk-space.sh
+++ b/images/linux/scripts/installers/validate-disk-space.sh
@@ -5,7 +5,7 @@
 ################################################################################
 
 availableSpaceMB=$(df / -hm | sed 1d | awk '{ print $4}')
-minimumFreeSpaceMB=17800
+minimumFreeSpaceMB=16000
 
 echo "Available disk space: $availableSpaceMB MB"
 


### PR DESCRIPTION
# Description
Change minimum free space limit from 17800mb to 16000mb for Ubuntu 16.04/18.04

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
