### PR TITLE
Add retries to get PyPy version

### DIFF
--- a/images/linux/scripts/installers/pypy.sh
+++ b/images/linux/scripts/installers/pypy.sh
@@ -76,7 +76,7 @@ function getPyPyVersions
 
     while [ $i -gt 0 ]; do
         ((i--))
-        result="$(wget -q -4 -O - $uri | gunzip -c | grep 'linux64' | awk -v uri="$uri" -F'>|<' '{print uri$5}')"
+        result="$(curl -4 -s --compressed $uri | grep 'linux64' | awk -v uri="$uri" -F'>|<' '{print uri$5}')"
         if [ -z "$result" ]; then
             sleep 30
         else


### PR DESCRIPTION
# Description
The pypy.sh script failed due to unable to get PyPy version from downloads.python.org related to network issue.
```
==> azure-arm: Provisioning with shell script: C:\agent\_work\2\s\images\linux/scripts/installers/pypy.sh
==> azure-arm: gzip: stdin: not in gzip format
    azure-arm: Failed to get PyPy version '2.7'
```

Changes :
- Add curl parameter -4 to use IPv4 only
- Max attempts 20
#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
