### PR TITLE
Update Windows2019 image to use 2004 SDK & WDK

### DIFF
--- a/images/win/scripts/Installers/Install-WDK.ps1
+++ b/images/win/scripts/Installers/Install-WDK.ps1
@@ -9,8 +9,8 @@ Import-Module -Name ImageHelpers -Force
 
 if (Test-IsWin19)
 {
-    $winSdkUrl = "https://go.microsoft.com/fwlink/p/?linkid=2083338"
-    $wdkUrl = "https://go.microsoft.com/fwlink/?linkid=2085767"
+    $winSdkUrl = "https://go.microsoft.com/fwlink/p/?linkid=2120843"
+    $wdkUrl = "https://go.microsoft.com/fwlink/?linkid=2128854"
     $FilePath = "C:\Program Files (x86)\Windows Kits\10\Vsix\VS2019\WDK.vsix"
     $VSver = "2019"
 }

--- a/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
@@ -72,6 +72,7 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.VisualStudio.Component.Windows10SDK.17134 ' + `
               '--add Microsoft.VisualStudio.Component.Windows10SDK.17763 ' + `
               '--add Microsoft.VisualStudio.Component.Windows10SDK.18362 ' + `
+              '--add Microsoft.VisualStudio.Component.Windows10SDK.19041 ' + `
               '--add Microsoft.VisualStudio.Component.WinXP ' + `
               '--add Microsoft.VisualStudio.ComponentGroup.Azure.CloudServices ' + `
               '--add Microsoft.VisualStudio.ComponentGroup.Azure.ResourceManager.Tools ' + `


### PR DESCRIPTION
# Description
Need newer Windows SDK to compile against GraphicsCaptureSession.IsCursorCaptureEnabled property. I personally don't care about WDK, but it seems like they need to be updated as a set.

Verified correct version of SDK, WDK, and WDK VS extension were all installed to generated VM. My application compiles successfully.

Didn't touch Windows2019-Readme.md because it looks auto-generated.

#### Related issue:
Should I create an issue?

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated