### PR TITLE
[Ubuntu] Install 3 latest Haskell version and latest Cabal version

### DIFF
--- a/images/linux/scripts/installers/haskell.sh
+++ b/images/linux/scripts/installers/haskell.sh
@@ -38,8 +38,8 @@ for version in $ghcVersions; do
 done
 
 # Check cabal version
-if ! command -v /opt/cabal/$version/bin/cabal; then
-    echo "cabal $version was not installed"
+if ! command -v /opt/cabal/$cabalVersion/bin/cabal; then
+    echo "cabal $cabalVersion was not installed"
     exit 1
 fi
 

--- a/images/linux/scripts/installers/haskell.sh
+++ b/images/linux/scripts/installers/haskell.sh
@@ -13,7 +13,7 @@ apt-get install -y software-properties-common
 add-apt-repository -y ppa:hvr/ghc
 apt-get update
 
-# Get 3 latest Haskell version and latest Cabal version
+# Get 3 latest Haskell versions and latest Cabal version
 ghcVersions=$(apt-cache search "^ghc-" | grep -Po '(\d*\.){2}\d*' | awk 'BEGIN {FS=OFS=SUBSEP="."}{if (arr[$1,$2] < $3) arr[$1,$2] = $3} END {for (i in arr) print i,arr[i]}' | sort --version-sort | tail -3)
 cabalVersion=$(apt-cache search cabal-install-[0-9] | grep -Po '\d*\.\d*' | sort --unique --version-sort | tail -1)
 
@@ -36,7 +36,7 @@ for version in $ghcVersions; do
     fi
 done
 
-# Check cabal version
+# Check cabal
 if ! command -v /opt/cabal/$cabalVersion/bin/cabal; then
     echo "cabal $cabalVersion was not installed"
     exit 1

--- a/images/linux/scripts/installers/haskell.sh
+++ b/images/linux/scripts/installers/haskell.sh
@@ -15,16 +15,8 @@ add-apt-repository -y ppa:hvr/ghc
 apt-get update
 
 # Install various versions of ghc and cabal
-if isUbuntu20 ; then
-    ghcVersions="8.6.5 8.8.3 8.10.1"
-    cabalVersions="3.2"
-fi
-
-if isUbuntu16 || isUbuntu18 ; then
-    # Install various versions of ghc and cabal
-    ghcVersions="8.0.2 8.2.2 8.4.4 8.6.2 8.6.3 8.6.4 8.6.5 8.8.1 8.8.2 8.8.3 8.10.1"
-    cabalVersions="2.0 2.2 2.4 3.0 3.2"
-fi
+ghcVersions="8.6.5 8.8.3 8.10.1"
+cabalVersions="3.2"
 
 for version in $ghcVersions; do
     apt-get install -y ghc-$version

--- a/images/linux/scripts/installers/haskell.sh
+++ b/images/linux/scripts/installers/haskell.sh
@@ -6,7 +6,6 @@
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/document.sh
-source $HELPER_SCRIPTS/os.sh
 
 # Install Herbert V. Riedel's PPA for managing multiple version of ghc on ubuntu.
 # https://launchpad.net/~hvr/+archive/ubuntu/ghc
@@ -14,8 +13,8 @@ apt-get install -y software-properties-common
 add-apt-repository -y ppa:hvr/ghc
 apt-get update
 
-# Get 3 latest minor Haskell version and latest exact Cabal version
-ghcVersions=$(apt-cache search "^ghc-" | grep -Po '\d{1,}\.\d{1,}' | sort --unique --version-sort | tail -3)
+# Get 3 latest Haskell version and latest Cabal version
+ghcVersions=$(apt-cache search "^ghc-" | grep -Po '(\d*\.){2}\d*' | awk 'BEGIN {FS=OFS=SUBSEP="."}{if (arr[$1,$2] < $3) arr[$1,$2] = $3} END {for (i in arr) print i,arr[i]}' | sort --version-sort | tail -3)
 cabalVersion=$(apt-cache search cabal-install-[0-9] | grep -Po '\d*\.\d*' | sort --unique --version-sort | tail -1)
 
 for version in $ghcVersions; do
@@ -31,7 +30,7 @@ curl -sSL https://get.haskellstack.org/ | sh
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
 # Check all ghc versions
 for version in $ghcVersions; do
-    if ! command -v /opt/ghc/${version}.*/bin/ghc; then
+    if ! command -v /opt/ghc/$version/bin/ghc; then
         echo "ghc $version was not installed"
         exit 1
     fi
@@ -52,6 +51,6 @@ fi
 echo "Lastly, documenting what we added to the metadata file"
 DocumentInstalledItem "Haskell Cabal ($(/opt/cabal/$cabalVersion/bin/cabal --version))"
 for version in $ghcVersions; do
-    DocumentInstalledItem "GHC ($(/opt/ghc/${version}.*/bin/ghc --version))"
+    DocumentInstalledItem "GHC ($(/opt/ghc/$version/bin/ghc --version))"
 done
 DocumentInstalledItem "Haskell Stack ($(stack --version))"

--- a/images/linux/scripts/installers/haskell.sh
+++ b/images/linux/scripts/installers/haskell.sh
@@ -14,9 +14,9 @@ apt-get install -y software-properties-common
 add-apt-repository -y ppa:hvr/ghc
 apt-get update
 
-# Install various versions of ghc and cabal
-ghcVersions="8.6.5 8.8.3 8.10.1"
-cabalVersions="3.2"
+# Get 3 latest Haskell version and latest Cabal version
+ghcVersions=$(apt-cache search "^ghc-" | grep -Po '(\d*\.){2}\d*' | sort --unique --version-sort | tail -3)
+cabalVersion=$(apt-cache search cabal-install-[0-9] | grep -Po '\d*\.\d*' | sort --unique --version-sort | tail -1)
 
 for version in $ghcVersions; do
     apt-get install -y ghc-$version


### PR DESCRIPTION
# Description
Recently, [actions/setup-haskell v.1.1](https://github.com/actions/setup-haskell/releases/tag/v1.1.0) was released. This version started to support the installation of Haskel, Cabal, Stack on-demand. Considering this fact, we are planning to deprecate old versions of ghc and cabal from the image to release free space for new software.

In the future, we are planning to pre-cache 3 latest ghc releases (currently, 8.10.1, 8.8.3, 8.6.5) and 1 latest cabal release (currently, 3.2) on the image. Any other versions can be installed in runtime using [actions/setup-haskell](https://github.com/actions/setup-haskell) action.

#### Related issue:
https://github.com/actions/virtual-environments/issues/852

## Checklist
- [X] Related issue / work item is attached
- [X] Tests are written (if applicable)
- [X] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
