### PR TITLE
[Ubuntu20] Add azure-cli and azure-devops extension

### DIFF
--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -182,6 +182,8 @@
                 "{{template_dir}}/scripts/installers/7-zip.sh",
                 "{{template_dir}}/scripts/installers/ansible.sh",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
+                "{{template_dir}}/scripts/installers/azure-cli.sh",
+                "{{template_dir}}/scripts/installers/azure-devops-cli.sh",
                 "{{template_dir}}/scripts/installers/basic.sh",
                 "{{template_dir}}/scripts/installers/aliyun-cli.sh",
                 "{{template_dir}}/scripts/installers/aws.sh",


### PR DESCRIPTION
# Description
Azure-cli package for Ubuntu20 has been released recently
https://github.com/Azure/azure-cli/issues/13081

#### Related issue:
N\A

## Checklist
- [N\A] Related issue / work item is attached
- [N\A] Tests are written (if applicable)
- [N\A] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
