### PR TITLE
Revert systemd-resolve workaround.

### DIFF
--- a/images/linux/scripts/installers/basic.sh
+++ b/images/linux/scripts/installers/basic.sh
@@ -159,13 +159,6 @@ for cmd in curl file ftp jq netcat ssh parallel rsync shellcheck sudo telnet tim
     fi
 done
 
-# Workaround for systemd-resolve, since sometimes stub resolver does not work properly. Details: https://github.com/actions/virtual-environments/issues/798
-echo "Create resolv.conf link."
-if [[ -f /run/systemd/resolve/resolv.conf ]]; then
-    echo "Create resolv.conf link."
-    ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
-fi
-
 # Document what was added to the image
 echo "Lastly, documenting what we added to the metadata file"
 DocumentInstalledItem "Basic CLI:"


### PR DESCRIPTION
# Description
Bug fixing.
Due to issues after systemd-resolve fix, described in[ github issue 929](https://github.com/actions/virtual-environments/issues/929#issuecomment-634148495), it is required to revert it back.
#### Related issue:
https://github.com/actions/virtual-environments/issues/929#issuecomment-634148495
## Check list
- [+] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
