### PR TITLE
Update IEDriverServer url

### DIFF
--- a/images/win/scripts/Installers/Install-IEWebDriver.ps1
+++ b/images/win/scripts/Installers/Install-IEWebDriver.ps1
@@ -3,12 +3,10 @@
 ##  Desc:  Install Selenium Web Drivers
 ################################################################################
 
-# https://www.selenium.dev/downloads/
-# 32 bit Windows IE (recommended)
 try {
     $latestReleaseUrl = "https://selenium-release.storage.googleapis.com/"
     $latestReleaseInfo = Invoke-RestMethod -Uri $latestReleaseUrl
-    $latestIEVersion = $latestReleaseInfo.ListBucketResult.Contents | Where-Object Key -match "IEDriverServer_Win32" | Sort-Object LastModified | Select-Object -ExpandProperty Key -Last 1
+    $latestIEVersion = $latestReleaseInfo.ListBucketResult.Contents | Where-Object Key -match "IEDriverServer_x64" | Sort-Object LastModified | Select-Object -ExpandProperty Key -Last 1
     $ieDriverUrl = -join ($latestReleaseUrl, $latestIEVersion)
 } catch {
     Write-Error "[!] Failed to get IEDriver version [$latestReleaseUrl]: $_"
@@ -32,6 +30,9 @@ if (-not (Test-Path -Path $ieDriverPath)) {
 
 Extract-7Zip -Path $driverZipFile -DestinationPath $ieDriverPath
 Remove-Item $driverZipFile
+
+Write-Host "Get the IEDriver version..."
+(Get-Item "$ieDriverPath\IEDriverServer.exe").VersionInfo.FileVersion | Out-File -FilePath "$ieDriverPath\versioninfo.txt"
 
 Write-Host "Setting the IEWebDriver environment variables"
 setx IEWebDriver $ieDriverPath /M

--- a/images/win/scripts/Installers/Install-IEWebDriver.ps1
+++ b/images/win/scripts/Installers/Install-IEWebDriver.ps1
@@ -6,33 +6,32 @@
 # https://www.selenium.dev/downloads/
 # 32 bit Windows IE (recommended)
 try {
-    $LatestReleaseUrl = "https://selenium-release.storage.googleapis.com/"
-    $LatestReleaseInfo = Invoke-RestMethod -Uri $latestReleaseUrl
-    $LatestIEVersion = $latestReleaseInfo.ListBucketResult.Contents | Where-Object Key -match "IEDriverServer_Win32" | Sort-Object LastModified | Select-Object -ExpandProperty Key -Last 1
-    $IEDriverUrl = -join ($LatestReleaseUrl, $LatestIEVersion)
+    $latestReleaseUrl = "https://selenium-release.storage.googleapis.com/"
+    $latestReleaseInfo = Invoke-RestMethod -Uri $latestReleaseUrl
+    $latestIEVersion = $latestReleaseInfo.ListBucketResult.Contents | Where-Object Key -match "IEDriverServer_Win32" | Sort-Object LastModified | Select-Object -ExpandProperty Key -Last 1
+    $ieDriverUrl = -join ($latestReleaseUrl, $latestIEVersion)
 } catch {
-    Write-Error "[!] Failed to get IEDriver version [$LatestReleaseUrl]: $_"
+    Write-Error "[!] Failed to get IEDriver version [$latestReleaseUrl]: $_"
     exit 1
 }
 
 # Download IE selenium driver
 try {
     Write-Host "Selenium IEDriverServer download and install..."
-    $DriversZipFile = Start-DownloadWithRetry -Url $IEDriverUrl -Name "SeleniumWebDrivers.zip"
+    $driverZipFile = Start-DownloadWithRetry -Url $ieDriverUrl -Name "SeleniumWebDrivers.zip"
 }
 catch {
-    Write-Error "[!] Failed to download $IEDriverUrl"
+    Write-Error "[!] Failed to download $ieDriverUrl"
     exit 1
 }
 
-$SeleniumWebDriverPath = Join-Path $env:SystemDrive "SeleniumWebDrivers"
-$IEDriverPath = Join-Path $SeleniumWebDriverPath "IEDriver"
-if (-not (Test-Path -Path $IEDriverPath)) {
-    $null = New-Item -Path $IEDriverPath -ItemType Directory -Force
+$ieDriverPath = "C:\SeleniumWebDrivers\IEDriver"
+if (-not (Test-Path -Path $ieDriverPath)) {
+    $null = New-Item -Path $ieDriverPath -ItemType Directory -Force
 }
 
-Extract-7Zip -Path $DriversZipFile -DestinationPath $IEDriverPath
-Remove-Item $DriversZipFile
+Extract-7Zip -Path $driverZipFile -DestinationPath $ieDriverPath
+Remove-Item $driverZipFile
 
 Write-Host "Setting the IEWebDriver environment variables"
-setx IEWebDriver "C:\SeleniumWebDrivers\IEDriver" /M
+setx IEWebDriver $ieDriverPath /M

--- a/images/win/scripts/Installers/Install-IEWebDriver.ps1
+++ b/images/win/scripts/Installers/Install-IEWebDriver.ps1
@@ -2,31 +2,37 @@
 ##  File:  Install-SeleniumWebDrivers.ps1
 ##  Desc:  Install Selenium Web Drivers
 ################################################################################
-$DestinationPath = "$($env:SystemDrive)\"
-$DriversZipFile = "SeleniumWebDrivers.zip"
-Write-Host "Destination path: [$DestinationPath]"
-Write-Host "Selenium drivers download and install..."
+
+# https://www.selenium.dev/downloads/
+# 32 bit Windows IE (recommended)
 try {
-    Invoke-WebRequest -UseBasicParsing -Uri "https://seleniumwebdrivers.blob.core.windows.net/seleniumwebdrivers/${DriversZipFile}" -OutFile $DriversZipFile
-}
-catch {
-    Write-Error "[!] Failed to download $DriversZipFile"
+    $LatestReleaseUrl = "https://selenium-release.storage.googleapis.com/"
+    $LatestReleaseInfo = Invoke-RestMethod -Uri $latestReleaseUrl
+    $LatestIEVersion = $latestReleaseInfo.ListBucketResult.Contents | Where-Object Key -match "IEDriverServer_Win32" | Sort-Object LastModified | Select-Object -ExpandProperty Key -Last 1
+    $IEDriverUrl = -join ($LatestReleaseUrl, $LatestIEVersion)
+} catch {
+    Write-Error "[!] Failed to get IEDriver version [$LatestReleaseUrl]: $_"
     exit 1
 }
 
-$TempSeleniumDir = Join-Path $Env:TEMP "SeleniumWebDrivers"
-Extract-7Zip -Path $DriversZipFile -DestinationPath $Env:TEMP
-Remove-Item $DriversZipFile
-
-$SeleniumWebDriverPath = Join-Path $DestinationPath "SeleniumWebDrivers"
-$IEDriverPathTemp = Join-Path $TempSeleniumDir 'IEDriver'
-
-if (-not (Test-Path -Path $SeleniumWebDriverPath)) {
-    New-Item -Path $SeleniumWebDriverPath -ItemType "directory"
+# Download IE selenium driver
+try {
+    Write-Host "Selenium IEDriverServer download and install..."
+    $DriversZipFile = Start-DownloadWithRetry -Url $IEDriverUrl -Name "SeleniumWebDrivers.zip"
+}
+catch {
+    Write-Error "[!] Failed to download $IEDriverUrl"
+    exit 1
 }
 
-Move-Item -Path "$IEDriverPathTemp" -Destination $SeleniumWebDriverPath
+$SeleniumWebDriverPath = Join-Path $env:SystemDrive "SeleniumWebDrivers"
+$IEDriverPath = Join-Path $SeleniumWebDriverPath "IEDriver"
+if (-not (Test-Path -Path $IEDriverPath)) {
+    $null = New-Item -Path $IEDriverPath -ItemType Directory -Force
+}
 
-Write-Host "Setting the environment variables"
+Extract-7Zip -Path $DriversZipFile -DestinationPath $IEDriverPath
+Remove-Item $DriversZipFile
 
+Write-Host "Setting the IEWebDriver environment variables"
 setx IEWebDriver "C:\SeleniumWebDrivers\IEDriver" /M


### PR DESCRIPTION
# Description
Windows images build fails due to unable to download Selenium Web Driver for IE:
`C:\Windows\Temp\script-5ecd16ad-74f7-86b7-1e84-501f9e9dfe1f.ps1 : [!] Failed to download SeleniumWebDrivers.zip`

Previous installation source is unavailable - https://seleniumwebdrivers.blob.core.windows.net/seleniumwebdrivers/SeleniumWebDrivers.zip .

#### Related issue:
https://github.com/actions/virtual-environments/issues/940
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
