### PR TITLE
Skip first time welcome message in .NET Core

### DIFF
--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -99,5 +99,6 @@ done
 # NuGetFallbackFolder at /usr/share/dotnet/sdk/NuGetFallbackFolder is warmed up by smoke test
 # Additional FTE will just copy to ~/.dotnet/NuGet which provides no benefit on a fungible machine
 setEtcEnvironmentVariable DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1
+setEtcEnvironmentVariable DOTNET_NOLOGO 1
 prependEtcEnvironmentPath /home/runner/.dotnet/tools
 echo 'export PATH="$PATH:$HOME/.dotnet/tools"' | tee -a /etc/skel/.bashrc


### PR DESCRIPTION
Since .NET Core 3.1.300, there is a new environment variable named `DOTNET_NOLOGO` that specifies whether .NET Core welcome and telemetry messages are displayed on first run.

Can read more about this flag here:
https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet
