### PR TITLE
Temporary downgrade Azure-Cli to 2.5.1

### DIFF
--- a/images/linux/scripts/installers/azure-cli.sh
+++ b/images/linux/scripts/installers/azure-cli.sh
@@ -8,7 +8,9 @@
 source $HELPER_SCRIPTS/document.sh
 
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
-curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+#curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+# Temporary hardcode 2.5.1 installation until version 2.7.0 with the fix for the issue is not released https://github.com/actions/virtual-environments/issues/948
+apt-get install -y azure-cli 2.5.1
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"

--- a/images/linux/scripts/installers/azure-cli.sh
+++ b/images/linux/scripts/installers/azure-cli.sh
@@ -6,11 +6,16 @@
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/document.sh
+source $HELPER_SCRIPTS/os.sh
 
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
-#curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-# Temporary hardcode 2.5.1 installation until version 2.7.0 with the fix for the issue is not released https://github.com/actions/virtual-environments/issues/948
-apt-get install -y azure-cli 2.5.1
+curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+# Temporary downgrade to 2.5.1 installation until version 2.7.0 with the fix for the issue is not released https://github.com/actions/virtual-environments/issues/948
+# There is no 2.5.1 version for Ubuntu20
+if isUbuntu16 || isUbuntu18 ; then
+    label=$(getOSVersionLabel)
+    apt-get install -y --allow-downgrades azure-cli=2.5.1-1~$label
+fi
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"

--- a/images/win/scripts/Installers/Install-AzureCli.ps1
+++ b/images/win/scripts/Installers/Install-AzureCli.ps1
@@ -3,7 +3,8 @@
 ##  Desc:  Install Azure CLI
 ################################################################################
 
-Choco-Install -PackageName azure-cli
+# Temporary hardcode 2.5.1 installation until version 2.7.0 with the fix for the issue is not released https://github.com/actions/virtual-environments/issues/948
+Choco-Install -PackageName azure-cli -ArgumentList "--version=2.5.1"
 
 $AzureCliExtensionPath = Join-Path $Env:CommonProgramFiles 'AzureCliExtensionDirectory'
 New-Item -ItemType "directory" -Path $AzureCliExtensionPath


### PR DESCRIPTION
# Description
Azure-cli 2.6.0 has [a bug](https://github.com/Azure/azure-cli/issues/13706), which is supposed to be fixed in 2.7.0. 
Hardcode version 2.5.1 in the install scripts until then to unblock image rollout.

#### Related issue:
https://github.com/actions/virtual-environments/issues/948

## Checklist
- [X] Related issue / work item is attached
- [N\A] Tests are written (if applicable)
- [N\A] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
