### PR TITLE
[Ubuntu] rollback azure-cli hardcode and install the latest version

### DIFF
--- a/images/linux/scripts/installers/azure-cli.sh
+++ b/images/linux/scripts/installers/azure-cli.sh
@@ -6,7 +6,6 @@
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/document.sh
-source $HELPER_SCRIPTS/os.sh
 
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash

--- a/images/linux/scripts/installers/azure-cli.sh
+++ b/images/linux/scripts/installers/azure-cli.sh
@@ -10,12 +10,6 @@ source $HELPER_SCRIPTS/os.sh
 
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-# Temporary downgrade to 2.5.1 installation until version 2.7.0 with the fix for the issue is not released https://github.com/actions/virtual-environments/issues/948
-# There is no 2.5.1 version for Ubuntu20
-if isUbuntu16 || isUbuntu18 ; then
-    label=$(getOSVersionLabel)
-    apt-get install -y --allow-downgrades azure-cli=2.5.1-1~$label
-fi
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"


### PR DESCRIPTION
# Description
Azure-cli 2.7.0 [has been released](https://github.com/Azure/azure-cli/releases/tag/azure-cli-2.7.0) and the bug with `azdevops login` is supposed to be fixed.

#### Related issue:
https://github.com/actions/virtual-environments/issues/948

## Check list
- [X] Related issue / work item is attached
- [N\A] Tests are written (if applicable)
- [N\A ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
