### PR TITLE
Fix regression with PHP installation

### DIFF
--- a/images/linux/scripts/installers/php.sh
+++ b/images/linux/scripts/installers/php.sh
@@ -7,6 +7,7 @@
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/etc-environment.sh
 source $HELPER_SCRIPTS/document.sh
+source $HELPER_SCRIPTS/os.sh
 
 set -e
 
@@ -131,7 +132,7 @@ echo "Lastly, documenting what we added to the metadata file"
 
 for version in $php_versions; do
     DocumentInstalledItem "PHP $version ($(php$version --version | head -n 1))"
-done;
+done
 
 DocumentInstalledItem "Composer  ($(composer --version))"
 DocumentInstalledItem "PHPUnit ($(phpunit --version))"

--- a/images/linux/scripts/installers/php.sh
+++ b/images/linux/scripts/installers/php.sh
@@ -51,20 +51,20 @@ for version in $php_versions; do
         php$version-ldap \
         php$version-mbstring \
         php$version-mysql \
-        php$version-odbc \
-        php$version-opcache \
+        php$version-odbc \
+        php$version-opcache \
         php$version-pgsql \
-        php$version-phpdbg \
-        php$version-pspell \
-        php$version-readline \
-        php$version-snmp \
-        php$version-soap \
+        php$version-phpdbg \
+        php$version-pspell \
+        php$version-readline \
+        php$version-snmp \
+        php$version-soap \
         php$version-sqlite3 \
-        php$version-sybase \
-        php$version-tidy \
-        php$version-xml \
-        php$version-xmlrpc \
-        php$version-xsl \
+        php$version-sybase \
+        php$version-tidy \
+        php$version-xml \
+        php$version-xmlrpc \
+        php$version-xsl \
         php$version-zip
 
     if [[ $version == "5.6" || $version == "7.0" || $version == "7.1" ]]; then


### PR DESCRIPTION
# Description
PHP is missing  from Ubuntu 16.04/18.04/20.04 images.

#### Related issue:
https://github.com/actions/virtual-environments/issues/981
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
