### PR TITLE
[Windows] rollback azure-cli hardcode and install the latest version

### DIFF
--- a/images/win/scripts/Installers/Install-AzureCli.ps1
+++ b/images/win/scripts/Installers/Install-AzureCli.ps1
@@ -3,8 +3,7 @@
 ##  Desc:  Install Azure CLI
 ################################################################################
 
-# Temporary hardcode 2.5.1 installation until version 2.7.0 with the fix for the issue is not released https://github.com/actions/virtual-environments/issues/948
-Choco-Install -PackageName azure-cli -ArgumentList "--version=2.5.1"
+Choco-Install -PackageName azure-cli
 
 $AzureCliExtensionPath = Join-Path $Env:CommonProgramFiles 'AzureCliExtensionDirectory'
 New-Item -ItemType "directory" -Path $AzureCliExtensionPath


### PR DESCRIPTION
# Description
Azure-cli 2.7.0 [has been released](https://github.com/Azure/azure-cli/releases/tag/azure-cli-2.7.0) and the bug with `azdevops login` is supposed to be fixed.

#### Related issue:
https://github.com/actions/virtual-environments/issues/948

## Check list
- [X] Related issue / work item is attached
- [N\A] Tests are written (if applicable)
- [N\A ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
