### PR TITLE
Update MongoDB and PostgreSQL documentation

### DIFF
--- a/images/win/scripts/Installers/Install-MongoDB.ps1
+++ b/images/win/scripts/Installers/Install-MongoDB.ps1
@@ -3,6 +3,7 @@
 ##  Desc:  Install MongoDB
 ####################################################################################
 
-choco install mongodb
-
-Add-MachinePathItem "$($env:SystemDrive)\Program Files\MongoDB\Server\4.2\bin"
+Choco-Install -PackageName mongodb
+$mongoPath = (Get-CimInstance Win32_Service -Filter "Name LIKE 'mongodb'").PathName
+$mongoBin = Split-Path -Path $mongoPath.split('"')[1]
+Add-MachinePathItem "$mongoBin"

--- a/images/win/scripts/Installers/Install-PostgreSQL.ps1
+++ b/images/win/scripts/Installers/Install-PostgreSQL.ps1
@@ -1,22 +1,19 @@
 $ErrorActionPreference = "Stop"
 
-Import-Module -Name ImageHelpers
-
 #Define user and password for PostgreSQL database
-$postgresusr="postgres"
-$postgrespwd="root"
+$pgUser = "postgres"
+$pgPwd = "root"
 
 #Prepare environment variable for validation
-Set-SystemVariable -SystemVariable PGUSER -Value $postgresusr
-Set-SystemVariable -SystemVariable PGPASSWORD -Value $postgrespwd
-#Install latest PostgreSQL
+Set-SystemVariable -SystemVariable PGUSER -Value $pgUser
+Set-SystemVariable -SystemVariable PGPASSWORD -Value $pgPwd
 
-cinst postgresql --params "/Password:$postgrespwd" --params-global --debug --verbose
+#Install latest PostgreSQL
+Choco-Install -PackageName postgresql -ArgumentList "--params", "/Password:$pgPwd", "--params-global", "--debug", "--verbose"
 
 #Get Path to pg_ctl.exe
-$paths = (Get-CimInstance Win32_Service -Filter "Name LIKE 'postgresql-%'").PathName
+$pgPath = (Get-CimInstance Win32_Service -Filter "Name LIKE 'postgresql-%'").PathName
 #Parse output of command above to obtain pure path
-$pgbin = $paths.split('"')[1].replace("\pg_ctl.exe", "")
-#Added PostgreSQL bin path into PATH variable.
-Add-MachinePathItem $pgbin
-
+$pgBin = Split-Path -Path $pgPath.split('"')[1]
+#Added PostgreSQL bin path into PATH variable
+Add-MachinePathItem $pgBin

--- a/images/win/scripts/Installers/Validate-MongoDB.ps1
+++ b/images/win/scripts/Installers/Validate-MongoDB.ps1
@@ -3,10 +3,9 @@
 ##  Desc:  Validate MongoDB
 ################################################################################
 
-$command = Get-Command -Name 'mongod'
-if($command)
+if (Get-Command -Name 'mongod')
 {
-    Write-Host "mongod is on path"
+    Write-Host 'mongod is on path'
 }
 else
 {
@@ -14,25 +13,12 @@ else
     exit 1
 }
 
-$command = Get-Command -Name 'mongo'
-if($command)
+if (Get-Command -Name 'mongo')
 {
-    Write-Host "mongo is on path"
+    Write-Host 'mongo is on path'
 }
 else
 {
     Write-Host 'mongo not on path'
     exit 1
 }
-
-# Adding description of the software to Markdown
-$SoftwareName = "MongoDB"
-$version = $command.Version.ToString();
-
-$Description = @"
-_Version:_ $version<br/>
-_Environment:_
-* PATH: contains location of mongo.exe and mongod.exe
-"@
-
-Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description

--- a/images/win/scripts/Installers/Validate-PostgreSQL.ps1
+++ b/images/win/scripts/Installers/Validate-PostgreSQL.ps1
@@ -1,35 +1,17 @@
-$PGUSER="postgres"
-function Validate-PostgreSQL {
-    $pgready = Start-Process -FilePath pg_isready -Wait -PassThru
-    $exitCode = $pgready.ExitCode
-    if ($exitCode -eq 0)
-    {
-        Write-Host -Object "PostgreSQL has been successfully installed."
-    }
-    else
-    {
-        Write-Host -Object "PostgreSQL is not ready. Exitcode: $exitCode"
-        exit $exitCode
-    }
+$pgReady = Start-Process -FilePath pg_isready -Wait -PassThru
+$exitCode = $pgReady.ExitCode
+
+if ($exitCode -eq 0)
+{
+    Write-Host -Object "PostgreSQL has been successfully installed."
+}
+else
+{
+    Write-Host -Object "PostgreSQL is not ready. Exitcode: $exitCode"
+    exit $exitCode
 }
 
-$paths = (Get-CimInstance Win32_Service -Filter "Name LIKE 'postgresql-%'").PathName
-$pgservice = (Get-CimInstance Win32_Service -Filter "Name LIKE 'postgresql-%'").Name
-$pgroot = $paths.split('"')[1].replace("\bin\pg_ctl.exe", "")
-$psqlVersion = pg_config --version | Out-String
-Validate-PostgreSQL
-
-# Adding description of the software to Markdown
-$SoftwareName = "PostgreSQL"
-$Description = @"
-_Version:_ $psqlVersion<br/>
-_Default Path:_ $pgroot<br/>
-_User:_ $env:PGUSER<br/>
-_Password:_ $env:PGPASSWORD
-"@
-
-Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description
-
 #Stop and disable PostgreSQL service
-Stop-Service -Name $pgservice
-Set-Service $pgservice -StartupType Disabled
+$pgService = Get-Service -Name postgresql*
+Stop-Service -InputObject $pgService
+Set-Service -InputObject $pgService -StartupType Disabled

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Databases.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Databases.psm1
@@ -1,8 +1,8 @@
 function Get-PostgreSQLMarkdown
 {
     $name = "PostgreSQL"
-    $pgService = Get-Service -Name postgresql*
-    $pgPath = (Get-CimInstance Win32_Service -Filter "Name LIKE 'postgresql-%'").PathName
+    $pgService = Get-CimInstance Win32_Service -Filter "Name LIKE 'postgresql-%'"
+    $pgPath = $pgService.PathName
     $pgRoot = $pgPath.split('"')[1].replace("\bin\pg_ctl.exe", "")
     $pgVersion = (pg_config --version).split()[1].Trim()
     $content = [PSCustomObject]@{
@@ -11,8 +11,8 @@ function Get-PostgreSQLMarkdown
         Password = $env:PGPASSWORD
         Path = $pgRoot
         ServiceName = $pgService.Name
-        ServiceStatus = $pgService.Status
-        ServiceStartType = $pgService.StartType
+        ServiceStatus = $pgService.State
+        ServiceStartType = $pgService.StartMode
     } | New-MDTable
 
     Build-MarkdownElement -Head $name -Content $content

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Databases.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Databases.psm1
@@ -1,0 +1,41 @@
+function Get-PostgreSQLMarkdown
+{
+    $name = "PostgreSQL"
+    $pgService = Get-Service -Name postgresql*
+    $pgPath = (Get-CimInstance Win32_Service -Filter "Name LIKE 'postgresql-%'").PathName
+    $pgRoot = $pgPath.split('"')[1].replace("\bin\pg_ctl.exe", "")
+    $pgVersion = (pg_config --version).split()[1].Trim()
+    $content = [PSCustomObject]@{
+        Version = $pgVersion
+        UserName = $env:PGUSER
+        Password = $env:PGPASSWORD
+        Path = $pgRoot
+        ServiceName = $pgService.Name
+        ServiceStatus = $pgService.Status
+        ServiceStartType = $pgService.StartType
+    } | New-MDTable
+
+    Build-MarkdownElement -Head $name -Content $content
+}
+
+function Get-MongoDBMarkdown
+{
+    $name = "MongoDB"
+    $mongoService = Get-Service -Name $name
+    $mongoVersion = (Get-Command -Name 'mongo').Version.ToString()
+    $content = [PSCustomObject]@{
+        Version = $mongoVersion
+        ServiceName = $name
+        ServiceStatus = $mongoService.Status
+        ServiceStartType = $mongoService.StartType
+    } | New-MDTable
+    Build-MarkdownElement -Head $name -Content $content
+}
+
+function Build-DatabasesMarkdown
+{
+    $markdown = ""
+    $markdown += Get-PostgreSQLMarkdown
+    $markdown += Get-MongoDBMarkdown
+    $markdown
+}

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -2,13 +2,14 @@
 Install-Module MarkdownPS -Force -Scope AllUsers
 
 Import-Module MarkdownPS
-Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Helpers.psm1") -DisableNameChecking
-Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Common.psm1") -DisableNameChecking
-Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Tools.psm1") -DisableNameChecking
+Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Android.psm1") -DisableNameChecking
 Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Browsers.psm1") -DisableNameChecking
 Import-Module (Join-Path $PSScriptRoot "SoftwareReport.CachedTools.psm1") -DisableNameChecking
+Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Common.psm1") -DisableNameChecking
+Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Databases.psm1") -DisableNameChecking
+Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Helpers.psm1") -DisableNameChecking
+Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Tools.psm1") -DisableNameChecking
 Import-Module (Join-Path $PSScriptRoot "SoftwareReport.VisualStudio.psm1") -DisableNameChecking
-Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Android.psm1") -DisableNameChecking
 
 $markdown = ""
 
@@ -125,6 +126,10 @@ $markdown += New-MDNewLine
 
 $markdown += New-MDHeader "Cached Tools" -Level 3
 $markdown += (Build-CachedToolsMarkdown)
+$markdown += New-MDNewLine
+
+$markdown += New-MDHeader "Databases" -Level 3
+$markdown += Build-DatabasesMarkdown
 $markdown += New-MDNewLine
 
 $vs = Get-VisualStudioVersion


### PR DESCRIPTION
# Description
We have merged PRs for [PostgreSQL](https://github.com/actions/virtual-environments/pull/636) and [MongoDB](https://github.com/actions/virtual-environments/pull/680) on Windows, but they use the old way of docs generation. We should update it in the scope of this ticket.

 ### Databases
 #### PostgreSQL
 | Version | UserName | Password | Path                           | ServiceName       | ServiceStatus | ServiceStartType |
 | ------- | -------- | -------- | ------------------------------ | ----------------- | ------------- | ---------------- |
 | 12.3    | postgres | root     | C:\Program Files\PostgreSQL\12 | postgresql-x64-12 | Stopped       | Disabled         |
 
 
 #### MongoDB
 | Version | ServiceName | ServiceStatus | ServiceStartType |
 | ------- | ----------- | ------------- | ---------------- |
 | 4.2.7.0 | MongoDB     | Running       | Automatic        |

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/614
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
