### PR TITLE
Suppress output from takeown during Windows's Finalize-VM.ps1

### DIFF
--- a/images/win/scripts/Installers/Finalize-VM.ps1
+++ b/images/win/scripts/Installers/Finalize-VM.ps1
@@ -19,7 +19,7 @@ Write-Host "Clean up various directories"
     if (Test-Path $_) {
         Write-Host "Removing $_"
         try {
-            Takeown /d Y /R /f $_
+            Takeown /d Y /R /f $_ | Out-Null
             Icacls $_ /GRANT:r administrators:F /T /c /q  2>&1 | Out-Null
             Remove-Item $_ -Recurse -Force | Out-Null
         }


### PR DESCRIPTION
# Description
New tool, Bug fixing, or Improvement?  Improvement!
Suppresses output from `takeown` during `Finalize-VM.ps1`, which reduces Packer overall log size by ~80% (8.87MB -> 1.80MB in a local run of mine).  I didn't observe any speed-up (still took a minute before and after), but I think the log size reduction still makes this worthwhile, and I hope you'll agree!

#### Related issue:
#1005 

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated