### PR TITLE
[Ubuntu 20] Add toolcache(Ruby,Python,PyPy,Node)

### DIFF
--- a/images/linux/toolcache-2004.json
+++ b/images/linux/toolcache-2004.json
@@ -1,0 +1,5 @@
+{
+    "@actions/toolcache-ruby-ubuntu-2004-x64": [
+        "2.5", "2.6", "2.7"
+    ]
+}

--- a/images/linux/toolset-2004.json
+++ b/images/linux/toolset-2004.json
@@ -1,0 +1,39 @@
+{
+    "toolcache": [
+        {
+            "name": "Python",
+            "url" : "https://raw.githubusercontent.com/actions/python-versions/master/versions-manifest.json",
+            "platform" : "linux",
+            "platform_version": "20.04",
+            "arch": "x64",
+            "versions": [
+                "2.7.*",
+                "3.5.*",
+                "3.6.*",
+                "3.7.*",
+                "3.8.*"
+            ]
+        },
+        {
+            "name": "PyPy",
+            "arch": "x64",
+            "platform" : "linux",
+            "versions": [
+                "2.7",
+                "3.6"
+            ]
+        },
+        {
+            "name": "node",
+            "url" : "https://raw.githubusercontent.com/actions/node-versions/master/versions-manifest.json",
+            "platform" : "linux",
+            "arch": "x64",
+            "versions": [
+                "8.*",
+                "10.*",
+                "12.*",
+                "14.*"
+            ]
+        }
+    ]
+}

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -257,12 +257,25 @@
             "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {
+            "type": "file",
+            "source": "{{template_dir}}/toolcache-2004.json",
+            "destination": "{{user `installer_script_folder`}}/toolcache.json"
+        },
+        {
+            "type": "file",
+            "source": "{{template_dir}}/toolset-2004.json",
+            "destination": "{{user `installer_script_folder`}}/toolset.json"
+        },
+        {
             "type": "shell",
             "scripts":[
                 "{{template_dir}}/scripts/installers/2004/android.sh",
                 "{{template_dir}}/scripts/installers/azpowershell.sh",
                 "{{template_dir}}/scripts/helpers/containercache.sh",
-                "{{template_dir}}/scripts/installers/python.sh"
+                "{{template_dir}}/scripts/installers/hosted-tool-cache.sh",
+                "{{template_dir}}/scripts/installers/pypy.sh",
+                "{{template_dir}}/scripts/installers/python.sh",
+                "{{template_dir}}/scripts/installers/test-toolcache.sh"
             ],
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",
@@ -284,6 +297,19 @@
                 "GO_DEFAULT={{user `go_default`}}"
             ],
             "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}"
+        },
+        {
+            "type": "shell",
+            "scripts":[
+                "{{template_dir}}/scripts/installers/Install-Toolset.ps1",
+                "{{template_dir}}/scripts/installers/Validate-Toolset.ps1"
+            ],
+            "environment_vars": [
+                "METADATA_FILE={{user `metadata_file`}}",
+                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
+                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
+            ],
+            "execute_command": "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
         },
         {
             "type": "shell",


### PR DESCRIPTION
# Description
Add toolcache:
- Ruby    [2.5, 2.6, 2.7]
- Python [2.7, 3.5, 3.6, 3.7, 3.8]
- Pypy     [2.7, 3.6]
- Node    [8, 10, 12, 14]

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/629
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
