### PR TITLE
[Windows] Remove .NET Core 2.2

### DIFF
--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -59,8 +59,7 @@ function InstallAllValidSdks()
 
     # Consider all channels except preview/eol channels.
     # Sort the channels in ascending order
-    # HACK: Explicitly adding eol channel 2.2 for a grace period as this channel is wierdly marked as eol with no higher 2.x channel
-    $dotnetChannels = $dotnetChannels.'releases-index' | Where-Object { (!$_."support-phase".Equals('preview') -and !$_."support-phase".Equals('eol')) -or ($_."channel-version" -eq "2.2") } | Sort-Object { [Version] $_."channel-version" }
+    $dotnetChannels = $dotnetChannels.'releases-index' | Where-Object { (!$_."support-phase".Equals('preview') -and !$_."support-phase".Equals('eol')) } | Sort-Object { [Version] $_."channel-version" }
 
     # Download installation script.
     $installationName = "dotnet-install.ps1"


### PR DESCRIPTION
# Description
We are going to remove .NET Core 2.2 on 19 June due to this version has reached end of life.

#### Related issue:
https://github.com/actions/virtual-environments/issues/975

## Check list
- [x] Related issue / work item is attached
- [n\a] Tests are written (if applicable)
- [n\a] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
