### PR TITLE
AddVisualStudio BuildTools

### DIFF
--- a/images/win/scripts/Installers/Windows2016/Install-VS2017.ps1
+++ b/images/win/scripts/Installers/Windows2016/Install-VS2017.ps1
@@ -65,6 +65,7 @@ $WorkLoads =    '--allWorkloads --includeRecommended ' + `
                 '--add Microsoft.VisualStudio.ComponentGroup.ArchitectureTools.Managed ' + `
                 '--add Microsoft.Component.Blend.SDK.WPF ' + `
                 '--add Microsoft.Component.VC.Runtime.UCRTSDK ' + `
+                '--add Microsoft.VisualStudio.Component.Sharepoint.BuildTools ' + `
                 '--add Microsoft.VisualStudio.Component.TeamOffice.BuildTools ' + `
                 '--add Microsoft.VisualStudio.Component.VC.ATL.Spectre ' + `
                 '--add Microsoft.VisualStudio.Component.VC.ATL.ARM.Spectre ' + `
@@ -75,6 +76,7 @@ $WorkLoads =    '--allWorkloads --includeRecommended ' + `
                 '--add Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre '+ `
                 '--add Microsoft.VisualStudio.Component.VC.Runtimes.ARM.Spectre ' + `
                 '--add Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre ' + `
+                '--add Microsoft.VisualStudio.Component.Workflow.BuildTools ' + `
                 '--add Microsoft.VisualStudio.Workload.Office ' + `
                 '--add Microsoft.VisualStudio.Workload.OfficeBuildTools '
 

--- a/images/win/scripts/Installers/Windows2016/Install-VS2017.ps1
+++ b/images/win/scripts/Installers/Windows2016/Install-VS2017.ps1
@@ -65,6 +65,7 @@ $WorkLoads =    '--allWorkloads --includeRecommended ' + `
                 '--add Microsoft.VisualStudio.ComponentGroup.ArchitectureTools.Managed ' + `
                 '--add Microsoft.Component.Blend.SDK.WPF ' + `
                 '--add Microsoft.Component.VC.Runtime.UCRTSDK ' + `
+                '--add Microsoft.VisualStudio.Component.TeamOffice.BuildTools ' + `
                 '--add Microsoft.VisualStudio.Component.VC.ATL.Spectre ' + `
                 '--add Microsoft.VisualStudio.Component.VC.ATL.ARM.Spectre ' + `
                 '--add Microsoft.VisualStudio.Component.VC.ATL.ARM64.Spectre ' + `

--- a/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
@@ -36,6 +36,7 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.VisualStudio.Component.SQL.SSDT ' + `
               '--add Microsoft.VisualStudio.Component.PortableLibrary ' + `
               '--add Microsoft.VisualStudio.Component.TeamOffice ' + `
+              '--add Microsoft.VisualStudio.Component.TeamOffice.BuildTools ' + `
               '--add Microsoft.VisualStudio.Component.TestTools.CodedUITest ' + `
               '--add Microsoft.VisualStudio.Component.TestTools.WebLoadTest ' + `
               '--add Microsoft.VisualStudio.Component.UWP.VC.ARM64 ' + `

--- a/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
@@ -35,6 +35,7 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.VisualStudio.Component.LinqToSql ' + `
               '--add Microsoft.VisualStudio.Component.SQL.SSDT ' + `
               '--add Microsoft.VisualStudio.Component.PortableLibrary ' + `
+              '--add Microsoft.VisualStudio.Component.Sharepoint.BuildTools ' + `
               '--add Microsoft.VisualStudio.Component.TeamOffice ' + `
               '--add Microsoft.VisualStudio.Component.TeamOffice.BuildTools ' + `
               '--add Microsoft.VisualStudio.Component.TestTools.CodedUITest ' + `
@@ -75,6 +76,7 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.VisualStudio.Component.Windows10SDK.18362 ' + `
               '--add Microsoft.VisualStudio.Component.Windows10SDK.19041 ' + `
               '--add Microsoft.VisualStudio.Component.WinXP ' + `
+              '--add Microsoft.VisualStudio.Component.Workflow.BuildTools ' + `
               '--add Microsoft.VisualStudio.ComponentGroup.Azure.CloudServices ' + `
               '--add Microsoft.VisualStudio.ComponentGroup.Azure.ResourceManager.Tools ' + `
               '--add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang ' + `


### PR DESCRIPTION
# Description
Add new Visual Studio workloads:
Visual Studio Tools for Office (VSTO) build tools
Office/SharePoint development build tools
Windows Workflow Foundation Build Tools

The installed workloads contain components for the development of Office, SharePoint and Workflow foundation application with Visual Studio

**total size.**
  200Mb

**installation time**
 less than 30sec

#### Related issue: https://github.com/actions/virtual-environments/issues/541

## Check list
- [x] Related issue / work item is attached
- [x] Changes are tested and related VM images are successfully generated
