### PR TITLE
Add C++ ATL for v141 build tools (x86 & x64)

### DIFF
--- a/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
@@ -66,6 +66,7 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.ATL.ARM.Spectre ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.ATL.ARM64.Spectre ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.ATL.Spectre ' + `
+              '--add Microsoft.VisualStudio.Component.VC.v141.MFC ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.MFC.ARM.Spectre ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.MFC.ARM64.Spectre ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.MFC.Spectre ' + `

--- a/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Windows2019/Install-VS2019.ps1
@@ -62,6 +62,7 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.x86.x64.Spectre ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.ARM.Spectre ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.ARM64.Spectre ' + `
+              '--add Microsoft.VisualStudio.Component.VC.v141.ATL ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.ATL.ARM.Spectre ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.ATL.ARM64.Spectre ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141.ATL.Spectre ' + `


### PR DESCRIPTION
# Description
New tool and fixing  

Microsoft.VisualStudio.Component.VC.v141.ATL is needed to build the VC++ projects which are not upgraded to 142 toolkit.

Installation size: **10mb**

#### Related issue: https://github.com/actions/virtual-environments/issues/1020

## Check list
- [x] Related issue / work item is attached
- [x] Changes are tested and related VM images are successfully generated
