### PR TITLE
Add NuGet.exe on Windows Server 2016/2019

### DIFF
--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -194,6 +194,12 @@
             "elevated_password": "{{user `install_password`}}"
         },
         {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-Nuget.ps1"
+            ]
+        },
+        {
             "type": "windows-restart",
             "restart_timeout": "30m"
         },

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -196,6 +196,12 @@
         {
             "type": "powershell",
             "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-Nuget.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-Wix.ps1"
             ]
         },

--- a/images/win/scripts/Installers/Install-Nuget.ps1
+++ b/images/win/scripts/Installers/Install-Nuget.ps1
@@ -5,7 +5,6 @@
 
 Choco-Install -PackageName NuGet.CommandLine
 
-$env:Path = $env:Path + ";$env:ChocolateyInstall\bin"
 if (Get-Command -Name 'nuget.exe')
 {
     Write-Host 'nuget on path'

--- a/images/win/scripts/Installers/Install-Nuget.ps1
+++ b/images/win/scripts/Installers/Install-Nuget.ps1
@@ -1,0 +1,17 @@
+################################################################################
+##  File:  Install-Nuget.ps1
+##  Desc:  Install NuGet.CommandLine
+################################################################################
+
+Choco-Install -PackageName NuGet.CommandLine
+
+$env:Path = $env:Path + ";$env:ChocolateyInstall\bin"
+if (Get-Command -Name 'nuget.exe')
+{
+    Write-Host 'nuget on path'
+}
+else
+{
+    Write-Host 'nuget is not on path'
+    exit 1
+}

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -127,6 +127,10 @@ function Get-ComposerVersion {
     return "Composer $composerVersion"
 }
 
+function Get-NugetVersion {
+    (nuget help) -match "NuGet Version" -replace "Version: "
+}
+
 function Get-AntVersion {
     ($(ant -version) | Out-String) -match "version (?<version>\d+\.\d+\.\d+)" | Out-Null
     $antVersion = $Matches.Version

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -48,7 +48,8 @@ $markdown += New-MDList -Style Unordered -Lines @(
     (Get-CondaVersion)
     (Get-RubyGemsVersion),
     (Get-HelmVersion),
-    (Get-ComposerVersion)
+    (Get-ComposerVersion),
+    (Get-NugetVersion)
 )
 
 $markdown += New-MDHeader "Project Management" -Level 3


### PR DESCRIPTION
# Description
The macOS 10.15 image includes nuget.exe (using Mono) but our Windows images doesn’t. This is unfortunate because publishing NuGet packages doesn’t work consistently with dotnet nuget. Users need to figure out a way to download nuget.exe manually if they want to use it,NuGet.exe is required to consistently install packages to GitHub Packages.

#### Related issue:
https://github.com/actions/virtual-environments/issues/1039

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
