### PR TITLE
Adding Android 11 (android-30) into SDK installation

### DIFF
--- a/images/linux/scripts/installers/1604/android.sh
+++ b/images/linux/scripts/installers/1604/android.sh
@@ -44,6 +44,7 @@ chmod -R a+X ${ANDROID_SDK_ROOT}
 echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager \
     "ndk-bundle" \
     "platform-tools" \
+    "platforms;android-30" \
     "platforms;android-29" \
     "platforms;android-28" \
     "platforms;android-27" \
@@ -57,6 +58,7 @@ echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager \
     "platforms;android-17" \
     "platforms;android-15" \
     "platforms;android-10" \
+    "build-tools;30.0.0" \
     "build-tools;29.0.3" \
     "build-tools;29.0.2" \
     "build-tools;29.0.0" \
@@ -116,6 +118,7 @@ DocumentInstalledItem "Android Support Repository 47.0.0"
 DocumentInstalledItem "Android Solver for ConstraintLayout 1.0.2"
 DocumentInstalledItem "Android Solver for ConstraintLayout 1.0.1"
 DocumentInstalledItem "Android SDK Platform-Tools $(cat ${ANDROID_SDK_ROOT}/platform-tools/source.properties 2>&1 | grep Pkg.Revision | cut -d '=' -f 2)"
+DocumentInstalledItem "Android SDK Platform 30"
 DocumentInstalledItem "Android SDK Platform 29"
 DocumentInstalledItem "Android SDK Platform 28"
 DocumentInstalledItem "Android SDK Platform 27"
@@ -130,6 +133,7 @@ DocumentInstalledItem "Android SDK Platform 17"
 DocumentInstalledItem "Android SDK Platform 15"
 DocumentInstalledItem "Android SDK Platform 10"
 DocumentInstalledItem "Android SDK Patch Applier v4"
+DocumentInstalledItem "Android SDK Build-Tools 30.0.0"
 DocumentInstalledItem "Android SDK Build-Tools 29.0.3"
 DocumentInstalledItem "Android SDK Build-Tools 29.0.2"
 DocumentInstalledItem "Android SDK Build-Tools 29.0.0"

--- a/images/linux/scripts/installers/1804/android.sh
+++ b/images/linux/scripts/installers/1804/android.sh
@@ -44,6 +44,7 @@ fi
 echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager \
     "ndk-bundle" \
     "platform-tools" \
+    "platforms;android-30" \
     "platforms;android-29" \
     "platforms;android-28" \
     "platforms;android-27" \
@@ -55,6 +56,7 @@ echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager \
     "platforms;android-21" \
     "platforms;android-19" \
     "platforms;android-17" \
+    "build-tools;30.0.0" \
     "build-tools;29.0.3" \
     "build-tools;29.0.2" \
     "build-tools;29.0.0" \
@@ -108,6 +110,7 @@ DocumentInstalledItem "Google APIs 21"
 DocumentInstalledItem "CMake $(ls ${ANDROID_SDK_ROOT}/cmake 2>&1)"
 DocumentInstalledItem "Android Support Repository 47.0.0"
 DocumentInstalledItem "Android SDK Platform-Tools $(cat ${ANDROID_SDK_ROOT}/platform-tools/source.properties 2>&1 | grep Pkg.Revision | cut -d '=' -f 2)"
+DocumentInstalledItem "Android SDK Platform 30"
 DocumentInstalledItem "Android SDK Platform 29"
 DocumentInstalledItem "Android SDK Platform 28"
 DocumentInstalledItem "Android SDK Platform 27"
@@ -120,6 +123,7 @@ DocumentInstalledItem "Android SDK Platform 21"
 DocumentInstalledItem "Android SDK Platform 19"
 DocumentInstalledItem "Android SDK Platform 17"
 DocumentInstalledItem "Android SDK Patch Applier v4"
+DocumentInstalledItem "Android SDK Build-Tools 30.0.0"
 DocumentInstalledItem "Android SDK Build-Tools 29.0.3"
 DocumentInstalledItem "Android SDK Build-Tools 29.0.2"
 DocumentInstalledItem "Android SDK Build-Tools 29.0.0"

--- a/images/linux/scripts/installers/2004/android.sh
+++ b/images/linux/scripts/installers/2004/android.sh
@@ -49,9 +49,11 @@ fi
 echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager \
     "ndk-bundle" \
     "platform-tools" \
+    "platforms;android-30" \
     "platforms;android-29" \
     "platforms;android-28" \
     "platforms;android-27" \
+    "build-tools;30.0.0" \
     "build-tools;29.0.3" \
     "build-tools;29.0.2" \
     "build-tools;29.0.0" \
@@ -76,10 +78,12 @@ DocumentInstalledItem "Google Play services $(cat ${ANDROID_SDK_ROOT}/extras/goo
 DocumentInstalledItem "CMake $(ls ${ANDROID_SDK_ROOT}/cmake 2>&1)"
 DocumentInstalledItem "Android Support Repository 47.0.0"
 DocumentInstalledItem "Android SDK Platform-Tools $(cat ${ANDROID_SDK_ROOT}/platform-tools/source.properties 2>&1 | grep Pkg.Revision | cut -d '=' -f 2)"
+DocumentInstalledItem "Android SDK Platform 30"
 DocumentInstalledItem "Android SDK Platform 29"
 DocumentInstalledItem "Android SDK Platform 28"
 DocumentInstalledItem "Android SDK Platform 27"
 DocumentInstalledItem "Android SDK Patch Applier v4"
+DocumentInstalledItem "Android SDK Build-Tools 30.0.0"
 DocumentInstalledItem "Android SDK Build-Tools 29.0.3"
 DocumentInstalledItem "Android SDK Build-Tools 29.0.2"
 DocumentInstalledItem "Android SDK Build-Tools 29.0.0"

--- a/images/win/scripts/Installers/Update-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Update-AndroidSDK.ps1
@@ -40,6 +40,7 @@ Push-Location -Path $sdk.FullName
 
 & '.\tools\bin\sdkmanager.bat' --sdk_root=$sdk_root `
     "platform-tools" `
+    "platforms;android-30" `
     "platforms;android-29" `
     "platforms;android-28" `
     "platforms;android-27" `
@@ -50,6 +51,7 @@ Push-Location -Path $sdk.FullName
     "platforms;android-22" `
     "platforms;android-21" `
     "platforms;android-19" `
+    "build-tools;30.0.0" `
     "build-tools;29.0.3" `
     "build-tools;29.0.2" `
     "build-tools;29.0.1" `


### PR DESCRIPTION
# Description
Based on https://github.com/actions/virtual-environments/pull/1030
This PR add Android 11 platform and build-tools to SDK on linux and windows.

#### Related issue: https://github.com/actions/virtual-environments/issues/1015

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
