### PR TITLE
Paragraphs (or stanzas) should cover 1 topic only.

### DIFF
--- a/images/linux/scripts/base/apt.sh
+++ b/images/linux/scripts/base/apt.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get -yqq update
+apt-get -yqq dist-upgrade
+systemctl disable apt-daily.service
+systemctl disable apt-daily.timer
+systemctl disable apt-daily-upgrade.timer
+systemctl disable apt-daily-upgrade.service

--- a/images/linux/scripts/base/limits.sh
+++ b/images/linux/scripts/base/limits.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e -u -o pipefail
 
 echo '* soft nofile 65536' >> /etc/security/limits.conf
 echo '* hard nofile 65536' >> /etc/security/limits.conf

--- a/images/linux/scripts/base/limits.sh
+++ b/images/linux/scripts/base/limits.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e -u -o pipefail
+
+echo '* soft nofile 65536' >> /etc/security/limits.conf
+echo '* hard nofile 65536' >> /etc/security/limits.conf
+echo 'session required pam_limits.so' >> /etc/pam.d/common-session
+echo 'session required pam_limits.so' >> /etc/pam.d/common-session-noninteractive
+echo 'DefaultLimitNOFILE=65536' >> /etc/systemd/system.conf

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -75,18 +75,12 @@
         },
         {
             "type": "shell",
-            "inline": [
-                "apt-get update",
-                "apt-get dist-upgrade -y",
-                "systemctl disable apt-daily.service",
-                "systemctl disable apt-daily.timer",
-                "systemctl disable apt-daily-upgrade.timer",
-                "systemctl disable apt-daily-upgrade.service",
-                "echo '* soft nofile 65536 \n* hard nofile 65536' >> /etc/security/limits.conf",
-                "echo 'session required pam_limits.so' >> /etc/pam.d/common-session",
-                "echo 'session required pam_limits.so' >> /etc/pam.d/common-session-noninteractive",
-                "echo 'DefaultLimitNOFILE=65536' >> /etc/systemd/system.conf"
-            ],
+            "script": "{{template_dir}}/scripts/base/apt.sh",
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "script": "{{template_dir}}/scripts/base/limits.sh",
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -78,18 +78,12 @@
         },
         {
             "type": "shell",
-            "inline": [
-                "apt-get update",
-                "apt-get dist-upgrade -y",
-                "systemctl disable apt-daily.service",
-                "systemctl disable apt-daily.timer",
-                "systemctl disable apt-daily-upgrade.timer",
-                "systemctl disable apt-daily-upgrade.service",
-                "echo '* soft nofile 65536 \n* hard nofile 65536' >> /etc/security/limits.conf",
-                "echo 'session required pam_limits.so' >> /etc/pam.d/common-session",
-                "echo 'session required pam_limits.so' >> /etc/pam.d/common-session-noninteractive",
-                "echo 'DefaultLimitNOFILE=65536' >> /etc/systemd/system.conf"
-            ],
+            "script": "{{template_dir}}/scripts/base/apt.sh",
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "script": "{{template_dir}}/scripts/base/limits.sh",
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -78,18 +78,12 @@
         },
         {
             "type": "shell",
-            "inline": [
-                "apt-get update",
-                "apt-get dist-upgrade -y",
-                "systemctl disable apt-daily.service",
-                "systemctl disable apt-daily.timer",
-                "systemctl disable apt-daily-upgrade.timer",
-                "systemctl disable apt-daily-upgrade.service",
-                "echo '* soft nofile 65536 \n* hard nofile 65536' >> /etc/security/limits.conf",
-                "echo 'session required pam_limits.so' >> /etc/pam.d/common-session",
-                "echo 'session required pam_limits.so' >> /etc/pam.d/common-session-noninteractive",
-                "echo 'DefaultLimitNOFILE=65536' >> /etc/systemd/system.conf"
-            ],
+            "script": "{{template_dir}}/scripts/base/apt.sh",
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "script": "{{template_dir}}/scripts/base/limits.sh",
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {


### PR DESCRIPTION
# Description

I propose a slight improvement: Each stanza, like a paragraph or a function, should cover one topic.  Move the apt commands and ulimit adjustments into separate scripts and invoke them separately.

See https://github.com/actions/virtual-environments/issues/1061