### PR TITLE
Fixes for Install-WindowsUpdates.ps1 to install updates correctly

### DIFF
--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -556,12 +556,6 @@
             ]
         },
         {
-            "type": "powershell",
-            "scripts":[
-                "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1"
-            ]
-        },
-        {
             "type": "windows-shell",
             "inline": ["wmic product where \"name like '%%microsoft azure powershell%%'\" call uninstall /nointeractive"]
         },
@@ -1022,6 +1016,18 @@
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-DiskSpace.ps1"
             ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1"
+            ],
+            "elevated_user": "{{user `install_user`}}",
+            "elevated_password": "{{user `install_password`}}"
+        },
+        {
+            "type": "windows-restart",
+            "restart_timeout": "10m"
         },
         {
             "type": "powershell",

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -517,12 +517,6 @@
             ]
         },
         {
-            "type": "powershell",
-            "scripts":[
-                "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1"
-            ]
-        },
-        {
             "type": "windows-shell",
             "inline": ["wmic product where \"name like '%%microsoft azure powershell%%'\" call uninstall /nointeractive"]
         },
@@ -1013,6 +1007,18 @@
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-DiskSpace.ps1"
             ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1"
+            ],
+            "elevated_user": "{{user `install_user`}}",
+            "elevated_password": "{{user `install_password`}}"
+        },
+        {
+            "type": "windows-restart",
+            "restart_timeout": "10m"
         },
         {
             "type": "powershell",

--- a/images/win/scripts/Installers/Install-WindowsUpdates.ps1
+++ b/images/win/scripts/Installers/Install-WindowsUpdates.ps1
@@ -1,10 +1,9 @@
 ################################################################################
 ##  File:  Install-WindowsUpdates.ps1
 ##  Desc:  Install Windows Updates.
-##         Should be run at end just before Antivirus.
+##         Should be run at end, just before SoftwareReport and Finalize-VM.ps1.
 ################################################################################
 
 Write-Host "Run windows updates"
 Install-Module -Name PSWindowsUpdate -Force -AllowClobber
-Get-WUInstall -WindowsUpdate -AcceptAll -Install -UpdateType Software -IgnoreReboot
 Get-WUInstall -MicrosoftUpdate -AcceptAll -Install -IgnoreUserInput -IgnoreReboot

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -3,9 +3,8 @@ function Get-OSName {
 }
 
 function Get-OSVersion {
-    $systemInfo = Get-CimInstance -ClassName Win32_OperatingSystem
-    $OSVersion = $systemInfo.Version
-    $OSBuild = $systemInfo.BuildNumber
+    $OSVersion = (Get-CimInstance -ClassName Win32_OperatingSystem).Version
+    $OSBuild = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion' UBR).UBR
     return "OS Version: $OSVersion Build $OSBuild"
 }
 


### PR DESCRIPTION
# Description
This addresses the issues raised in #1070, with Windows Updates not being applied to the machine.  To address the two main issues as called out in the bug:
1. I've added `elevated_user`/`elevated_password` properties to the `Install-WindowsUpdates.ps1` PowerShell provisioner, so that updates can actually be properly installed.
2. I've relocated the provisioner to be right before the SoftwareReport is generated.  We want WU to be run as late as possible (even `Install-WindowsUpdates.ps1` included comments about this 😇), so this is a better location for it.  I've also added a reboot task, so that the updates can be properly applied.

Additionally, I've removed one of the `Get-WUInstall` calls to speed up a bit; there shouldn't be a need to run `-WindowsUpdate` prior to `-MicrosoftUpdate`, and in some cases I saw both calls run up to ~5 minutes longer than when we only ran the single `-MicrosoftUpdate` (even though the same packages were installed in the end).

Lastly, I updated the SoftwareReport to report the patch/QFE version of Windows, instead of outputting the build number twice.  Old format:
```markdown
# Microsoft Windows Server 2019 Datacenter
- OS Version: 10.0.17763 Build 17763
- Image Version: dev
```
New format:
```markdown
# Microsoft Windows Server 2019 Datacenter
- OS Version: 10.0.17763 Build 1282
- Image Version: dev
```

Have tested this locally, but it'd be good to get testing on your official pipelines too. :smile:

#### Related issue:
Fixes #1070

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
