### PR TITLE
Use curl in download retry helper

### DIFF
--- a/images/linux/scripts/helpers/install.sh
+++ b/images/linux/scripts/helpers/install.sh
@@ -16,8 +16,7 @@ download_with_retries() {
     i=20
     while [ $i -gt 0 ]; do
         ((i--))
-        wget $URL   --output-document="$DEST/$NAME" \
-                    --no-verbose
+        curl $URL -4 -s -o "$DEST/$NAME"
         if [ $? != 0 ]; then
             sleep 30
         else


### PR DESCRIPTION
# Description
Use `curl` in download retry helper function instead `wget`, because wget can return gzip content.

#### Related issue:
#1066 

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
