### PR TITLE
Setup default NVM Node version properly

### DIFF
--- a/images/linux/scripts/installers/nvm.sh
+++ b/images/linux/scripts/installers/nvm.sh
@@ -19,4 +19,7 @@ if ! command -v nvm; then
     exit 1
 fi
 
+# set system node.js as default one
+nvm alias default system
+
 DocumentInstalledItem "nvm ($(nvm --version))"


### PR DESCRIPTION
# Description
Bug fixing

Default Node.JS version is not set for NVM. It causes unexpected behavior of NVM.
Repro steps:
1) `echo "10.20.1" > .nvmrc`
2) `source $HOME/.bash_profile`
3) Fails with non-zero exit code and error that Node.js 10.20.1 is not installed yet.

#### Related issue: #1082 

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
