### PR TITLE
PostgreSQL: Remove from PATH/Add environment variables.

### DIFF
--- a/images/win/scripts/Installers/Install-PostgreSQL.ps1
+++ b/images/win/scripts/Installers/Install-PostgreSQL.ps1
@@ -13,7 +13,13 @@ Choco-Install -PackageName postgresql -ArgumentList "--params", "/Password:$pgPw
 
 #Get Path to pg_ctl.exe
 $pgPath = (Get-CimInstance Win32_Service -Filter "Name LIKE 'postgresql-%'").PathName
+
 #Parse output of command above to obtain pure path
 $pgBin = Split-Path -Path $pgPath.split('"')[1]
-#Added PostgreSQL bin path into PATH variable
+$pgRoot = Split-Path -Path $pgPath.split('"')[5]
+$pgData = Join-Path $pgRoot "data"
+
+#Added PostgreSQL environment variable
 Set-SystemVariable -SystemVariable PGBIN -Value $pgBin
+Set-SystemVariable -SystemVariable PGROOT -Value $pgRoot
+Set-SystemVariable -SystemVariable PGDATA -Value $pgData

--- a/images/win/scripts/Installers/Install-PostgreSQL.ps1
+++ b/images/win/scripts/Installers/Install-PostgreSQL.ps1
@@ -9,11 +9,11 @@ Set-SystemVariable -SystemVariable PGUSER -Value $pgUser
 Set-SystemVariable -SystemVariable PGPASSWORD -Value $pgPwd
 
 #Install latest PostgreSQL
-Choco-Install -PackageName postgresql -ArgumentList "--params", "/Password:$pgPwd", "--params-global", "--debug", "--verbose"
+Choco-Install -PackageName postgresql -ArgumentList "--params", "/Password:$pgPwd", "/NoPath", "--params-global", "--debug", "--verbose"
 
 #Get Path to pg_ctl.exe
 $pgPath = (Get-CimInstance Win32_Service -Filter "Name LIKE 'postgresql-%'").PathName
 #Parse output of command above to obtain pure path
 $pgBin = Split-Path -Path $pgPath.split('"')[1]
 #Added PostgreSQL bin path into PATH variable
-Add-MachinePathItem $pgBin
+Set-SystemVariable -SystemVariable PGBIN -Value $pgBin

--- a/images/win/scripts/Installers/Validate-PostgreSQL.ps1
+++ b/images/win/scripts/Installers/Validate-PostgreSQL.ps1
@@ -1,4 +1,5 @@
-$pgReady = Start-Process -FilePath pg_isready -Wait -PassThru
+$pgReadyPath = Join-Path $PGBIN "pg_isready.exe"
+$pgReady = Start-Process -FilePath $pgReadyPath -Wait -PassThru
 $exitCode = $pgReady.ExitCode
 
 if ($exitCode -eq 0)

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Databases.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Databases.psm1
@@ -9,7 +9,7 @@ function Get-PostgreSQLMarkdown
         Version = $pgVersion
         UserName = $env:PGUSER
         Password = $env:PGPASSWORD
-        EnvironmentVariables = @{PGBIN=$env:PGROOT; PGDATA=$env:PGDATA; PGROOT=$env:PGBIN}
+        EnvironmentVariables = "PGBIN=$env:PGROOT; <br> PGDATA=$env:PGDATA; <br> PGROOT=$env:PGBIN"
         Path = $pgRoot
         ServiceName = $pgService.Name
         ServiceStatus = $pgService.State

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Databases.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Databases.psm1
@@ -9,6 +9,7 @@ function Get-PostgreSQLMarkdown
         Version = $pgVersion
         UserName = $env:PGUSER
         Password = $env:PGPASSWORD
+        EnvironmentVariables = @{PGBIN=$env:PGROOT; PGDATA=$env:PGDATA; PGROOT=$env:PGBIN}
         Path = $pgRoot
         ServiceName = $pgService.Name
         ServiceStatus = $pgService.State

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Databases.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Databases.psm1
@@ -9,7 +9,7 @@ function Get-PostgreSQLMarkdown
         Version = $pgVersion
         UserName = $env:PGUSER
         Password = $env:PGPASSWORD
-        EnvironmentVariables = "PGBIN=$env:PGROOT; <br> PGDATA=$env:PGDATA; <br> PGROOT=$env:PGBIN"
+        EnvironmentVariables = "PGBIN=$env:PGBIN; <br> PGDATA=$env:PGDATA; <br> PGROOT=$env:PGROOT"
         Path = $pgRoot
         ServiceName = $pgService.Name
         ServiceStatus = $pgService.State


### PR DESCRIPTION
# Description
Bug fixing.
When compiling C++ code using the MinGW install already on the machine, #include <pthread.h> finds a header located in Postgress's install directory

I have verified that the fix works as expected.

#### Related issue:
https://github.com/actions/virtual-environments/issues/1089

## Check list
- [+] Related issue / work item is attached
- [-] Changes are tested and related VM images are successfully generated
