### PR TITLE
Add Google Cloud SDK for Windows

### DIFF
--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -1007,6 +1007,12 @@
         {
             "type": "powershell",
             "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-GoogleCloudSDK.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-DiskSpace.ps1"
             ]
         },

--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -683,6 +683,12 @@
             ]
         },
         {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-GoogleCloudSDK.ps1"
+            ]
+        },
+        {
             "type": "windows-restart",
             "restart_timeout": "30m"
         },

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -998,6 +998,12 @@
         {
             "type": "powershell",
             "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-GoogleCloudSDK.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-DiskSpace.ps1"
             ]
         },

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -668,6 +668,12 @@
             ]
         },
         {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-GoogleCloudSDK.ps1"
+            ]
+        },
+        {
             "type": "windows-restart",
             "restart_timeout": "10m"
         },

--- a/images/win/scripts/Installers/Install-GoogleCloudSDK.ps1
+++ b/images/win/scripts/Installers/Install-GoogleCloudSDK.ps1
@@ -7,19 +7,3 @@
 $googleCloudSDKInstaller = "https://dl.google.com/dl/cloudsdk/channels/rapid/GoogleCloudSDKInstaller.exe"
 $argumentList = @("/S", "/allusers", "/noreporting")
 Install-Binary -Url $googleCloudSDKInstaller -Name "GoogleCloudSDKInstaller.exe" -ArgumentList $argumentList
-
-# Simple validation gcloud, gsutil, and bq command line tools
-$env:Path += ";${env:ProgramFiles(x86)}\Google\Cloud SDK\google-cloud-sdk\bin"
-$validateTools = @("bq", "gcloud", "gsutil")
-foreach($tool in $validateTools)
-{
-    if (Get-Command -Name $tool)
-    {
-        Write-Host "$tool on path"
-    }
-    else
-    {
-        Write-Host "$tool is not on path"
-        exit 1
-    }
-}

--- a/images/win/scripts/Installers/Install-GoogleCloudSDK.ps1
+++ b/images/win/scripts/Installers/Install-GoogleCloudSDK.ps1
@@ -1,0 +1,25 @@
+################################################################################
+##  File:  Install-GoogleCloudSDK.ps1
+##  Desc:  Install Google Cloud SDK
+################################################################################
+
+# https://cloud.google.com/sdk/docs/downloads-interactive
+$googleCloudSDKInstaller = "https://dl.google.com/dl/cloudsdk/channels/rapid/GoogleCloudSDKInstaller.exe"
+$argumentList = @("/S", "/allusers", "/noreporting")
+Install-Binary -Url $googleCloudSDKInstaller -Name "GoogleCloudSDKInstaller.exe" -ArgumentList $argumentList
+
+# Simple validation gcloud, gsutil, and bq command line tools
+$env:Path += ";${env:ProgramFiles(x86)}\Google\Cloud SDK\google-cloud-sdk\bin"
+$validateTools = @("bq", "gcloud", "gsutil")
+foreach($tool in $validateTools)
+{
+    if (Get-Command -Name $tool)
+    {
+        Write-Host "$tool on path"
+    }
+    else
+    {
+        Write-Host "$tool is not on path"
+        exit 1
+    }
+}

--- a/images/win/scripts/Installers/Validate-GoogleCloudSDK.ps1
+++ b/images/win/scripts/Installers/Validate-GoogleCloudSDK.ps1
@@ -1,0 +1,19 @@
+################################################################################
+##  File:  Validate-GoogleCloudSDK.ps1
+##  Desc:  Validate Install Google Cloud SDK for Windows
+################################################################################
+
+# Simple validation gcloud, gsutil, and bq command line tools
+$validateTools = @("bq", "gcloud", "gsutil")
+foreach($tool in $validateTools)
+{
+    if (Get-Command -Name $tool)
+    {
+        Write-Host "$tool on path"
+    }
+    else
+    {
+        Write-Host "$tool is not on path"
+        exit 1
+    }
+}

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -101,7 +101,8 @@ $markdown += New-MDList -Style Unordered -Lines @(
     (Get-AWSSAMVersion),
     (Get-AlibabaCLIVersion),
     (Get-CloudFoundryVersion),
-    (Get-HubVersion)
+    (Get-HubVersion),
+    (Get-GoogleCloudSDKVersion)
 )
 
 $markdown += New-MDHeader "Browsers and webdrivers" -Level 3

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -203,3 +203,7 @@ function Get-StackVersion {
     $stackVersion = $Matches.Version
     return "Stack $stackVersion"
 }
+
+function Get-GoogleCloudSDKVersion {
+    (gcloud --version) -match "Google Cloud SDK"
+}


### PR DESCRIPTION
# Description
Google Cloud SDK is a set of tools that you can use to manage resources and applications hosted on Google Cloud Platform. These include the gcloud, gsutil, and bq command line tools. Google Cloud SDK is already available on the Mac and Ubuntu environments.

Google Cloud SDK:
- Size ~800mb
- Installation time ~ 3 -5 minutes

#### Related issue:
https://github.com/actions/virtual-environments/issues/206
## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
