### PR TITLE
Remove  ppa:ondrej/php from the list of apt repositories

### DIFF
--- a/images/linux/scripts/helpers/document.sh
+++ b/images/linux/scripts/helpers/document.sh
@@ -28,3 +28,15 @@ function DocumentInstalledItem {
 function DocumentInstalledItemIndent {
     WriteItem "  - $1"
 }
+
+function AddBlockquote {
+    WriteItem "> $1"
+}
+
+function StartCode {
+    WriteItem "``````"
+}
+
+function EndCode {
+    WriteItem "``````"
+}

--- a/images/linux/scripts/installers/php.sh
+++ b/images/linux/scripts/installers/php.sh
@@ -93,6 +93,10 @@ apt-get remove --purge -yq php7.2-dev
 
 apt-fast install -y --no-install-recommends snmp
 
+if isUbuntu20 ; then
+    php_versions="7.4"
+fi
+
 # Install composer
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 php -r "if (hash_file('sha384', 'composer-setup.php') === file_get_contents('https://composer.github.io/installer.sig')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
@@ -133,6 +137,12 @@ echo "Lastly, documenting what we added to the metadata file"
 for version in $php_versions; do
     DocumentInstalledItem "PHP $version ($(php$version --version | head -n 1))"
 done
+
+# ubuntu 20.04 libzip-dev is libzip5 based and is not compatible libzip-dev of ppa:ondrej/php
+if isUbuntu20 ; then
+  rm /etc/apt/sources.list.d/ondrej-ubuntu-php-focal.list
+  apt-get update
+fi
 
 DocumentInstalledItem "Composer  ($(composer --version))"
 DocumentInstalledItem "PHPUnit ($(phpunit --version))"

--- a/images/linux/scripts/installers/php.sh
+++ b/images/linux/scripts/installers/php.sh
@@ -93,10 +93,6 @@ apt-get remove --purge -yq php7.2-dev
 
 apt-fast install -y --no-install-recommends snmp
 
-if isUbuntu20 ; then
-    php_versions="7.4"
-fi
-
 # Install composer
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 php -r "if (hash_file('sha384', 'composer-setup.php') === file_get_contents('https://composer.github.io/installer.sig')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
@@ -139,6 +135,7 @@ for version in $php_versions; do
 done
 
 # ubuntu 20.04 libzip-dev is libzip5 based and is not compatible libzip-dev of ppa:ondrej/php
+# see https://github.com/actions/virtual-environments/issues/1084
 if isUbuntu20 ; then
   rm /etc/apt/sources.list.d/ondrej-ubuntu-php-focal.list
   apt-get update
@@ -146,3 +143,9 @@ fi
 
 DocumentInstalledItem "Composer  ($(composer --version))"
 DocumentInstalledItem "PHPUnit ($(phpunit --version))"
+
+if isUbuntu20 ; then
+  AddBlockquote "To use ppa:ondrej/php APT repository On Ubuntu 20.04 it is necessary to add it to the APT sources"
+apt-add-repository ppa:ondrej/php -y
+apt-get update
+fi

--- a/images/linux/scripts/installers/php.sh
+++ b/images/linux/scripts/installers/php.sh
@@ -139,13 +139,12 @@ done
 if isUbuntu20 ; then
   rm /etc/apt/sources.list.d/ondrej-ubuntu-php-focal.list
   apt-get update
+  AddBlockquote "To use ppa:ondrej/php APT repository On Ubuntu 20.04 it is necessary to add it to the APT sources"
+  StartCode
+  WriteItem apt-add-repository ppa:ondrej/php -y
+  WriteItem apt-get update
+  EndCode
 fi
 
 DocumentInstalledItem "Composer  ($(composer --version))"
 DocumentInstalledItem "PHPUnit ($(phpunit --version))"
-
-if isUbuntu20 ; then
-  AddBlockquote "To use ppa:ondrej/php APT repository On Ubuntu 20.04 it is necessary to add it to the APT sources"
-apt-add-repository ppa:ondrej/php -y
-apt-get update
-fi


### PR DESCRIPTION
# Description
Bug fixing.

ppa:ondrej/php repository is used to install PHP and the modules. Currently it contains libzip-dev package corresponding to libzip4 shared libraries. Ubuntu 20.04 does not contain libzip4 so, instead it has libzip5 libraries. As a result the binaries built with pipelines are linked against to libzip4 and crash on the real life Ubuntu 20.04 

As a solution in this PR i removed the ppa:ondrej/php right after PHP has been installed. 

#### Related issue: https://github.com/actions/virtual-environments/issues/1084

## Check list
- [x] Related issue / work item is attached
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
