### PR TITLE
[Ubuntu] Add localhost alias ::1 IPv6

### DIFF
--- a/images/linux/scripts/installers/configure-environment.sh
+++ b/images/linux/scripts/installers/configure-environment.sh
@@ -11,6 +11,9 @@ sed -i 's/ResourceDisk.Format=n/ResourceDisk.Format=y/g' /etc/waagent.conf
 sed -i 's/ResourceDisk.EnableSwap=n/ResourceDisk.EnableSwap=y/g' /etc/waagent.conf
 sed -i 's/ResourceDisk.SwapSizeMB=0/ResourceDisk.SwapSizeMB=4096/g' /etc/waagent.conf
 
+# Add localhost alias to ::1 IPv6
+sed -i 's/::1 ip6-localhost ip6-loopback/::1     localhost ip6-localhost ip6-loopback/g' /etc/hosts
+
 # Prepare directory and env variable for toolcache
 AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
 mkdir $AGENT_TOOLSDIRECTORY


### PR DESCRIPTION
# Description
Cannot resolve localhost to an IPv6 address on ubuntu-latest due to missing localhost alias ::1.

Current behavior:
```
ubuntu:~$ java -classpath . Test localhost
localhost/127.0.0.1
```
Expected:
```
ubuntu:~$ java -classpath . Test localhost
localhost/127.0.0.1
localhost/0:0:0:0:0:0:0:1
```

#### Related issue:
https://github.com/actions/virtual-environments/issues/929

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
