### PR TITLE
Update AWS CLI V1 to V2 on Ubuntu 20.04 Image

### DIFF
--- a/images/linux/scripts/installers/aws.sh
+++ b/images/linux/scripts/installers/aws.sh
@@ -15,7 +15,9 @@ if isUbuntu20 ; then
     ./aws/install -i /usr/local/aws-cli -b /usr/local/bin
     rm awscliv2.zip
     rm -rf aws
-else
+fi
+
+if isUbuntu16 || isUbuntu18 ; then
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
     unzip awscli-bundle.zip
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws

--- a/images/linux/scripts/installers/aws.sh
+++ b/images/linux/scripts/installers/aws.sh
@@ -6,6 +6,7 @@
 
 # Source the helpers
 source $HELPER_SCRIPTS/document.sh
+source $HELPER_SCRIPTS/os.sh
 
 # Install the AWS CLI v1 on Ubuntu16 and Ubuntu18, and AWS CLI v2 on Ubuntu20
 if isUbuntu20 ; then

--- a/images/linux/scripts/installers/aws.sh
+++ b/images/linux/scripts/installers/aws.sh
@@ -7,12 +7,20 @@
 # Source the helpers
 source $HELPER_SCRIPTS/document.sh
 
-# Install the AWS CLI
-curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
-unzip awscli-bundle.zip
-./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
-rm awscli-bundle.zip
-rm -rf awscli-bundle
+# Install the AWS CLI v1 on Ubuntu16 and Ubuntu18, and AWS CLI v2 on Ubuntu20
+if isUbuntu20 ; then
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+    unzip awscliv2.zip
+    ./aws/install -i /usr/local/aws-cli -b /usr/local/bin
+    rm awscliv2.zip
+    rm -rf aws
+else
+    curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
+    unzip awscli-bundle.zip
+    ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+    rm awscli-bundle.zip
+    rm -rf awscli-bundle
+fi
 
 # Validate the installation
 echo "Validate the installation"


### PR DESCRIPTION
# Description
Bug fixing  
In scope of this PR we are updating AWS CLI V1 to V2 on Ubuntu 20.04 image to fix issue that occurs with AWS CLI V1 ('ascii' codec can't decode byte 0xc3 in position 66: ordinal not in range(128)). 
We are planning to merge this PR on 7/6/2020. Related announcement: [**#1108**](https://github.com/actions/virtual-environments/issues/1108) 

#### Related issue: [#1041](https://github.com/actions/virtual-environments/issues/1041)

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
