### PR TITLE
[Ubuntu] Start and enable docker.service if not running or enabled

### DIFF
--- a/images/linux/scripts/installers/docker-moby.sh
+++ b/images/linux/scripts/installers/docker-moby.sh
@@ -27,6 +27,10 @@ else
     echo "Docker ($docker_package) is already installed"
 fi
 
+# Enable docker.service
+systemctl is-active --quiet docker.service || systemctl start docker.service
+systemctl is-enabled --quiet docker.service || systemctl enable docker.service
+
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
 echo "Checking the docker-moby and moby-buildx"


### PR DESCRIPTION
# Description
After the new version of Docker-Moby was released for Ubuntu 16.04 the image generation process is failing with the error:
```
    azure-arm: Server:
    azure-arm: ERROR: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
    azure-arm: Provisioning step had errors: Running the cleanup provisioner, if present...
```


#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/748

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
