### PR TITLE
Fix getting version of aliyun cli.

### DIFF
--- a/images/linux/scripts/installers/aliyun-cli.sh
+++ b/images/linux/scripts/installers/aliyun-cli.sh
@@ -22,6 +22,6 @@ if ! command -v aliyun ; then
 fi
 
 # Document what was added to the image
-aliyun_version="$(aliyun --version | grep "Alibaba Cloud Command Line Interface Version" | cut -d " " -f 7)"
+aliyun_version="$(aliyun version)"
 echo "Lastly, documenting what we added to the metadata file"
 DocumentInstalledItem "Alibaba Cloud CLI ($aliyun_version)"

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -164,7 +164,7 @@ function Get-AWSSAMVersion {
 
 function Get-AlibabaCLIVersion {
     $alicliVersion = $(aliyun version)
-    return "Alibaba CLI $alicliVersion"
+    return "Alibaba Cloud CLI $alicliVersion"
 }
 
 function Get-CloudFoundryVersion {

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -163,8 +163,7 @@ function Get-AWSSAMVersion {
 }
 
 function Get-AlibabaCLIVersion {
-    $(aliyun --version | Select-String "Alibaba Cloud Command Line Interface") -match "(?<version>\d+\.\d+\.\d+)" | Out-Null
-    $alicliVersion = $Matches.Version
+    $alicliVersion = $(aliyun version)
     return "Alibaba CLI $alicliVersion"
 }
 


### PR DESCRIPTION
It has a version sub command, and --version is used to specify product api version,
not to get version of aliyun-cli.

# Description
Improvement of getting version of aliyun-cli.
#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
