### PR TITLE
[Windows] Add available disk space info to markdown

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -17,8 +17,8 @@ function Get-AvailableDiskSpace {
     {
         $availableDiskSpace = [math]::Round((Get-PSDrive -Name $driveLabel).Free / $sizeMultiplier)
         [PSCustomObject]@{
-            "Drive Label" = $driveLabel
-            "Available space ${sizeMultiplierLabel}" = $availableDiskSpace
+            "Drive Label" = "${driveLabel}:"
+            "Available space (${sizeMultiplierLabel})" = $availableDiskSpace
         }
     }
 }

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -9,17 +9,14 @@ function Get-OSVersion {
 }
 
 function Get-AvailableDiskSpace {
-    $drives = @("C", "D")
-    $sizeMultiplier = "1MB"
+    $rootDrive = "C"
+    $sizeMultiplier = "1GB"
     $sizeMultiplierLabel = $sizeMultiplier.substring($sizeMultiplier.Length - 2)
 
-    foreach ($driveLabel in $drives)
-    {
-        $availableDiskSpace = [math]::Round((Get-PSDrive -Name $driveLabel).Free / $sizeMultiplier)
-        [PSCustomObject]@{
-            "Drive Label" = "${driveLabel}:"
-            "Available space (${sizeMultiplierLabel})" = $availableDiskSpace
-        }
+    $availableDiskSpace = [math]::Round((Get-PSDrive -Name $rootDrive).Free / $sizeMultiplier)
+    [PSCustomObject]@{
+        "Drive Label" = "${rootDrive}:"
+        "Available space (${sizeMultiplierLabel})" = $availableDiskSpace
     }
 }
 

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -8,6 +8,21 @@ function Get-OSVersion {
     return "OS Version: $OSVersion Build $OSBuild"
 }
 
+function Get-AvailableDiskSpace {
+    $drives = @("C", "D")
+    $sizeMultiplier = "1MB"
+    $sizeMultiplierLabel = $sizeMultiplier.substring($sizeMultiplier.Length - 2)
+
+    foreach ($driveLabel in $drives)
+    {
+        $availableDiskSpace = [math]::Round((Get-PSDrive -Name $driveLabel).Free / $sizeMultiplier)
+        [PSCustomObject]@{
+            "Drive Label" = $driveLabel
+            "Available space ${sizeMultiplierLabel}" = $availableDiskSpace
+        }
+    }
+}
+
 function Get-JavaVersionsList {
     param(
         [string] $DefaultVersion

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -22,6 +22,10 @@ $markdown += New-MDList -Style Unordered -Lines @(
     "Image Version: $env:ImageVersion"
 )
 
+$markdown += New-MDHeader "Available disk space" -Level 3
+$markdown += Get-AvailableDiskSpace | New-MDTable
+$markdown += New-MDNewLine
+
 $markdown += New-MDHeader "Installed Software" -Level 2
 $markdown += New-MDHeader "Language and Runtime" -Level 3
 

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -24,6 +24,9 @@ $markdown += New-MDList -Style Unordered -Lines @(
 
 $markdown += New-MDHeader "Available disk space" -Level 3
 $markdown += Get-AvailableDiskSpace | New-MDTable
+$markdown += @'
+*Size of provided mounted SSD may vary, please check [documentation.](https://docs.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources)
+'@
 $markdown += New-MDNewLine
 
 $markdown += New-MDHeader "Installed Software" -Level 2


### PR DESCRIPTION
# Description
This PR add info about available disk space to generated markdown.

**Example:**
```
# Microsoft Windows Server 2019 Datacenter
- OS Version: 10.0.17763 Build 17763
- Image Version: 20200630.0

### Available disk space
| Drive Label | Available space (GB) |
| ----------- | -------------------- |
| C:          | 90                   |
*Size of provided mounted SSD may vary, please check [documentation.](https://docs.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources)

## Installed Software
### Language and Runtime
- Java 1.7.0_232 

```

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/759

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
