### PR TITLE
[Ubuntu] Install aws-sam-cli without brew

### DIFF
--- a/images/linux/scripts/installers/aws-sam-cli.sh
+++ b/images/linux/scripts/installers/aws-sam-cli.sh
@@ -2,7 +2,7 @@
 ################################################################################
 ##  File:  aws-sam-cli.sh
 ##  Desc:  Installs AWS SAM CLI
-##         Requires Pyton >=3.6, must be run as non-root user after toolset installation
+##         Requires Python >=3.6, must be run as non-root user after toolset installation
 ################################################################################
 
 # Source the helpers for use with the script

--- a/images/linux/scripts/installers/aws-sam-cli.sh
+++ b/images/linux/scripts/installers/aws-sam-cli.sh
@@ -13,20 +13,19 @@ TarballUrl=$(curl -s https://api.github.com/repos/awslabs/aws-sam-cli/releases/l
 TarballPath="/tmp/aws-sam-cli.tar.gz"
 wget $TarballUrl -O $TarballPath
 tar -xzvf $TarballPath -C /tmp
-SourcesDir=$(echo /tmp/awslabs-aws-sam-cli*)
+cd /tmp/awslabs-aws-sam-cli*
 
 # Use python 3.7 from toolcache to install aws sam, setuptools package required for the installation
 Python3Dir=$(echo ${AGENT_TOOLSDIRECTORY}/Python/3.7*/x64)
 Python3BinDir="${Python3Dir}/bin"
 export PATH="$Python3Dir:$Python3BinDir:$PATH"
 python3 -m pip install setuptools
-cd $SourcesDir
 python3 setup.py install
 sudo ln -sf ${Python3BinDir}/sam /usr/local/bin/sam
 
 # Cleanup downloaded files
 rm -rf $TarballPath
-rm -rf $SourcesDir
+rm -rf /tmp/awslabs-aws-sam-cli*
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"

--- a/images/linux/scripts/installers/aws-sam-cli.sh
+++ b/images/linux/scripts/installers/aws-sam-cli.sh
@@ -23,10 +23,6 @@ python3 -m pip install setuptools
 python3 setup.py install
 sudo ln -sf ${Python3BinDir}/sam /usr/local/bin/sam
 
-# Cleanup downloaded files
-rm -rf $TarballPath
-rm -rf /tmp/awslabs-aws-sam-cli*
-
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
 if ! sam --version; then

--- a/images/linux/scripts/installers/aws-sam-cli.sh
+++ b/images/linux/scripts/installers/aws-sam-cli.sh
@@ -17,7 +17,7 @@ SourcesDir=$(echo /tmp/awslabs-aws-sam-cli*)
 
 # Use python 3.7 from toolcache to install aws sam, setuptools package required for the installation
 Python3Dir=$(echo ${AGENT_TOOLSDIRECTORY}/Python/3.7*/x64)
-Python3BinDir=$(echo ${Python3Dir}/bin)
+Python3BinDir="${Python3Dir}/bin"
 export PATH="$Python3Dir:$Python3BinDir:$PATH"
 python3 -m pip install setuptools
 cd $SourcesDir

--- a/images/linux/scripts/installers/aws-sam-cli.sh
+++ b/images/linux/scripts/installers/aws-sam-cli.sh
@@ -2,29 +2,31 @@
 ################################################################################
 ##  File:  aws-sam-cli.sh
 ##  Desc:  Installs AWS SAM CLI
-##         Must be run after toolset installation
+##         Requires Pyton >=3.6, must be run after toolset installation
 ################################################################################
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/document.sh
 
-# Install aws sam cli
+# Download latest aws sam cli sources
 TarballUrl=$(curl -s https://api.github.com/repos/awslabs/aws-sam-cli/releases/latest | jq -r '.tarball_url')
 TarballPath="/tmp/aws-sam-cli.tar.gz"
 wget $TarballUrl -O $TarballPath
 tar -xzvf $TarballPath -C /tmp
-cd /tmp/awslabs-aws-sam-cli*
+SourcesDir=$(echo /tmp/awslabs-aws-sam-cli*)
+
 # Use python 3.7 from toolcache to install aws sam, setuptools module required for the installation
 Python3Dir=$(echo ${AGENT_TOOLSDIRECTORY}/Python/3.7*/x64)
 Python3BinDir=$(echo ${Python3Dir}/bin)
 export PATH="$Python3Dir:$Python3BinDir:$PATH"
 python3 -m pip install setuptools
+cd $SourcesDir
 python3 setup.py install
 sudo ln -sf ${Python3BinDir}/sam /usr/local/bin/sam
 
 # Cleanup downloaded files
 rm -rf $TarballPath
-rm -rf /tmp/awslabs-aws-sam-cli*
+rm -rf $SourcesDir
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"

--- a/images/linux/scripts/installers/aws-sam-cli.sh
+++ b/images/linux/scripts/installers/aws-sam-cli.sh
@@ -2,7 +2,7 @@
 ################################################################################
 ##  File:  aws-sam-cli.sh
 ##  Desc:  Installs AWS SAM CLI
-##         Requires Pyton >=3.6, must be run after toolset installation
+##         Requires Pyton >=3.6, must be run as non-root user after toolset installation
 ################################################################################
 
 # Source the helpers for use with the script
@@ -15,7 +15,7 @@ wget $TarballUrl -O $TarballPath
 tar -xzvf $TarballPath -C /tmp
 SourcesDir=$(echo /tmp/awslabs-aws-sam-cli*)
 
-# Use python 3.7 from toolcache to install aws sam, setuptools module required for the installation
+# Use python 3.7 from toolcache to install aws sam, setuptools package required for the installation
 Python3Dir=$(echo ${AGENT_TOOLSDIRECTORY}/Python/3.7*/x64)
 Python3BinDir=$(echo ${Python3Dir}/bin)
 export PATH="$Python3Dir:$Python3BinDir:$PATH"

--- a/images/linux/scripts/installers/aws-sam-cli.sh
+++ b/images/linux/scripts/installers/aws-sam-cli.sh
@@ -2,15 +2,29 @@
 ################################################################################
 ##  File:  aws-sam-cli.sh
 ##  Desc:  Installs AWS SAM CLI
-##         Must be run as non-root user after homebrew and clang
+##         Must be run after toolset installation
 ################################################################################
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/document.sh
 
 # Install aws sam cli
-brew tap aws/tap
-brew install aws-sam-cli
+TarballUrl=$(curl -s https://api.github.com/repos/awslabs/aws-sam-cli/releases/latest | jq -r '.tarball_url')
+TarballPath="/tmp/aws-sam-cli.tar.gz"
+wget $TarballUrl -O $TarballPath
+tar -xzvf $TarballPath -C /tmp
+cd /tmp/awslabs-aws-sam-cli*
+# Use python 3.7 from toolcache to install aws sam, setuptools module required for the installation
+Python3Dir=$(echo ${AGENT_TOOLSDIRECTORY}/Python/3.7*/x64)
+Python3BinDir=$(echo ${Python3Dir}/bin)
+export PATH="$Python3Dir:$Python3BinDir:$PATH"
+python3 -m pip install setuptools
+python3 setup.py install
+sudo ln -sf ${Python3BinDir}/sam /usr/local/bin/sam
+
+# Cleanup downloaded files
+rm -rf $TarballPath
+rm -rf /tmp/awslabs-aws-sam-cli*
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -283,8 +283,7 @@
             ],
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",
-                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
-                "DEBIAN_FRONTEND=noninteractive"
+                "HELPER_SCRIPTS={{user `helper_script_folder`}}"
             ],
             "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
         },

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -234,18 +234,6 @@
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {
-            "type": "shell",
-            "scripts": [
-                "{{template_dir}}/scripts/installers/aws-sam-cli.sh"
-            ],
-            "environment_vars": [
-                "METADATA_FILE={{user `metadata_file`}}",
-                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
-                "DEBIAN_FRONTEND=noninteractive"
-            ],
-            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
             "type": "file",
             "source": "{{template_dir}}/toolsets/toolcache-1604.json",
             "destination": "{{user `installer_script_folder`}}/toolcache.json"
@@ -287,6 +275,18 @@
                 "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "scripts": [
+                "{{template_dir}}/scripts/installers/aws-sam-cli.sh"
+            ],
+            "environment_vars": [
+                "METADATA_FILE={{user `metadata_file`}}",
+                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
+                "DEBIAN_FRONTEND=noninteractive"
+            ],
+            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {
             "type": "shell",

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -238,18 +238,6 @@
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {
-            "type": "shell",
-            "scripts": [
-                "{{template_dir}}/scripts/installers/aws-sam-cli.sh"
-            ],
-            "environment_vars": [
-                "METADATA_FILE={{user `metadata_file`}}",
-                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
-                "DEBIAN_FRONTEND=noninteractive"
-            ],
-            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
             "type": "file",
             "source": "{{template_dir}}/toolsets/toolcache-1804.json",
             "destination": "{{user `installer_script_folder`}}/toolcache.json"
@@ -291,6 +279,17 @@
                 "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "scripts": [
+                "{{template_dir}}/scripts/installers/aws-sam-cli.sh"
+            ],
+            "environment_vars": [
+                "METADATA_FILE={{user `metadata_file`}}",
+                "HELPER_SCRIPTS={{user `helper_script_folder`}}"
+            ],
+            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {
             "type": "shell",

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -239,18 +239,6 @@
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {
-            "type": "shell",
-            "scripts": [
-                "{{template_dir}}/scripts/installers/aws-sam-cli.sh"
-            ],
-            "environment_vars": [
-                "METADATA_FILE={{user `metadata_file`}}",
-                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
-                "DEBIAN_FRONTEND=noninteractive"
-            ],
-            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
             "type": "file",
             "source": "{{template_dir}}/toolsets/toolcache-2004.json",
             "destination": "{{user `installer_script_folder`}}/toolcache.json"
@@ -292,6 +280,18 @@
                 "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "scripts": [
+                "{{template_dir}}/scripts/installers/aws-sam-cli.sh"
+            ],
+            "environment_vars": [
+                "METADATA_FILE={{user `metadata_file`}}",
+                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
+                "DEBIAN_FRONTEND=noninteractive"
+            ],
+            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {
             "type": "shell",

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -288,8 +288,7 @@
             ],
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",
-                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
-                "DEBIAN_FRONTEND=noninteractive"
+                "HELPER_SCRIPTS={{user `helper_script_folder`}}"
             ],
             "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
         },


### PR DESCRIPTION
# Description
Aws-sam-cli is supposed to be installed via homebrew yet that approach leads to install separate python3, which overrides system one and causes issues for some customers. The workaround was implemented here https://github.com/actions/virtual-environments/pull/789 but it turned out that brew functionality is partly broken after the changes.
The solution is to get-rid of brew aws-sam cli installation and use `setup.py` script that comes along with aws-sam sources. After these changes, another PR will be made to move homebrew to the beginning of the PATH as it was initially.

Changes:
- Aws-sam-cli installation switched to build from sources via setup.py script
- Installation script moved to the end of the template in order to run after toolset installation

#### Related issue:
https://github.com/actions/virtual-environments/issues/1136

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
