### PR TITLE
[Ubuntu] Prepend brew directories to the PATH

### DIFF
--- a/images/linux/scripts/installers/aws-sam-cli.sh
+++ b/images/linux/scripts/installers/aws-sam-cli.sh
@@ -16,7 +16,7 @@ tar -xzvf $TarballPath -C /tmp
 cd /tmp/awslabs-aws-sam-cli*
 
 # Use python 3.7 from toolcache to install aws sam, setuptools package required for the installation
-Python3Dir=$(echo ${AGENT_TOOLSDIRECTORY}/Python/3.7*/x64)
+Python3Dir=$(echo /opt/hostedtoolcache/Python/3.7*/x64)
 Python3BinDir="${Python3Dir}/bin"
 export PATH="$Python3Dir:$Python3BinDir:$PATH"
 python3 -m pip install setuptools

--- a/images/linux/scripts/installers/homebrew-validate.sh
+++ b/images/linux/scripts/installers/homebrew-validate.sh
@@ -8,7 +8,7 @@
 echo "Validate the Homebrew can run after reboot"
 
 if ! command -v brew; then
-    echo "brew cat not run after reboot"
+    echo "brew executable not found after reboot"
     exit 1
 fi
 

--- a/images/linux/scripts/installers/homebrew.sh
+++ b/images/linux/scripts/installers/homebrew.sh
@@ -2,6 +2,7 @@
 ################################################################################
 ##  File:  homebrew.sh
 ##  Desc:  Installs the Homebrew on Linux
+##  Caveat: Brew MUST NOT be used to install any tool during the image build to avoid dependencies, which may come along with the tool
 ################################################################################
 
 # Source the helpers

--- a/images/linux/scripts/installers/homebrew.sh
+++ b/images/linux/scripts/installers/homebrew.sh
@@ -20,7 +20,7 @@ sudo chmod -R o+w $HOMEBREW_PREFIX
 brew shellenv|grep 'export HOMEBREW'|sed -E 's/^export (.*);$/\1/' | sudo tee -a /etc/environment
 # add brew executables locations to PATH
 brew_path=$(brew shellenv|grep  '^export PATH' |sed -E 's/^export PATH="([^$]+)\$.*/\1/')
-appendEtcEnvironmentPath "$brew_path"
+prependEtcEnvironmentPath "$brew_path"
 
 # Validate the installation ad hoc
 echo "Validate the installation reloading /etc/environment"

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -138,36 +138,6 @@
         {
             "type": "shell",
             "scripts": [
-                "{{template_dir}}/scripts/installers/homebrew.sh"
-            ],
-            "environment_vars": [
-                "METADATA_FILE={{user `metadata_file`}}",
-                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
-                "DEBIAN_FRONTEND=noninteractive"
-            ],
-            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
-            "type": "shell",
-            "expect_disconnect": true,
-            "scripts": [
-                "{{template_dir}}/scripts/base/reboot.sh"
-            ],
-            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
-            "type": "shell",
-            "pause_before": "30s",
-            "timeout": "10m",
-            "start_retry_timeout": "10s",
-            "scripts": [
-                "{{template_dir}}/scripts/installers/homebrew-validate.sh"
-            ],
-            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
-            "type": "shell",
-            "scripts": [
                 "{{template_dir}}/scripts/installers/7-zip.sh",
                 "{{template_dir}}/scripts/installers/ansible.sh",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
@@ -284,6 +254,36 @@
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",
                 "HELPER_SCRIPTS={{user `helper_script_folder`}}"
+            ],
+            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "scripts": [
+                "{{template_dir}}/scripts/installers/homebrew.sh"
+            ],
+            "environment_vars": [
+                "METADATA_FILE={{user `metadata_file`}}",
+                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
+                "DEBIAN_FRONTEND=noninteractive"
+            ],
+            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "expect_disconnect": true,
+            "scripts": [
+                "{{template_dir}}/scripts/base/reboot.sh"
+            ],
+            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "pause_before": "30s",
+            "timeout": "10m",
+            "start_retry_timeout": "10s",
+            "scripts": [
+                "{{template_dir}}/scripts/installers/homebrew-validate.sh"
             ],
             "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
         },

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -141,36 +141,6 @@
         {
             "type": "shell",
             "scripts": [
-                "{{template_dir}}/scripts/installers/homebrew.sh"
-            ],
-            "environment_vars": [
-                "METADATA_FILE={{user `metadata_file`}}",
-                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
-                "DEBIAN_FRONTEND=noninteractive"
-            ],
-            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
-            "type": "shell",
-            "expect_disconnect": true,
-            "scripts": [
-                "{{template_dir}}/scripts/base/reboot.sh"
-            ],
-            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
-            "type": "shell",
-            "pause_before": "30s",
-            "timeout": "10m",
-            "start_retry_timeout": "10s",
-            "scripts": [
-                "{{template_dir}}/scripts/installers/homebrew-validate.sh"
-            ],
-            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
-            "type": "shell",
-            "scripts": [
                 "{{template_dir}}/scripts/installers/7-zip.sh",
                 "{{template_dir}}/scripts/installers/ansible.sh",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
@@ -288,6 +258,36 @@
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",
                 "HELPER_SCRIPTS={{user `helper_script_folder`}}"
+            ],
+            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "scripts": [
+                "{{template_dir}}/scripts/installers/homebrew.sh"
+            ],
+            "environment_vars": [
+                "METADATA_FILE={{user `metadata_file`}}",
+                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
+                "DEBIAN_FRONTEND=noninteractive"
+            ],
+            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "expect_disconnect": true,
+            "scripts": [
+                "{{template_dir}}/scripts/base/reboot.sh"
+            ],
+            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "pause_before": "30s",
+            "timeout": "10m",
+            "start_retry_timeout": "10s",
+            "scripts": [
+                "{{template_dir}}/scripts/installers/homebrew-validate.sh"
             ],
             "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
         },

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -143,36 +143,6 @@
         {
             "type": "shell",
             "scripts": [
-                "{{template_dir}}/scripts/installers/homebrew.sh"
-            ],
-            "environment_vars": [
-                "METADATA_FILE={{user `metadata_file`}}",
-                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
-                "DEBIAN_FRONTEND=noninteractive"
-            ],
-            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
-            "type": "shell",
-            "expect_disconnect": true,
-            "scripts": [
-                "{{template_dir}}/scripts/base/reboot.sh"
-            ],
-            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
-            "type": "shell",
-            "pause_before": "30s",
-            "timeout": "10m",
-            "start_retry_timeout": "10s",
-            "scripts": [
-                "{{template_dir}}/scripts/installers/homebrew-validate.sh"
-            ],
-            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
-            "type": "shell",
-            "scripts": [
                 "{{template_dir}}/scripts/installers/7-zip.sh",
                 "{{template_dir}}/scripts/installers/ansible.sh",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
@@ -289,6 +259,36 @@
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",
                 "HELPER_SCRIPTS={{user `helper_script_folder`}}"
+            ],
+            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "scripts": [
+                "{{template_dir}}/scripts/installers/homebrew.sh"
+            ],
+            "environment_vars": [
+                "METADATA_FILE={{user `metadata_file`}}",
+                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
+                "DEBIAN_FRONTEND=noninteractive"
+            ],
+            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "expect_disconnect": true,
+            "scripts": [
+                "{{template_dir}}/scripts/base/reboot.sh"
+            ],
+            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "pause_before": "30s",
+            "timeout": "10m",
+            "start_retry_timeout": "10s",
+            "scripts": [
+                "{{template_dir}}/scripts/installers/homebrew-validate.sh"
             ],
             "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
         },


### PR DESCRIPTION
# Description
This is the second PR to resolve the initial issue. We don't use brew to install tools anymore after https://github.com/actions/virtual-environments/pull/1160 so brew executables can be safely placed at the beginning of the `PATH` in order to install tools via brew **in runtime** correctly
`/usr/share/rust/.cargo/bin:/home/runner/.config/composer/vendor/bin:/home/runner/.dotnet/tools:/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin` -> `/usr/share/rust/.cargo/bin:/home/runner/.config/composer/vendor/bin:/home/runner/.dotnet/tools:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games`
As a note: clean brew installation doesn't contain any packages thus it's supposed to be safe to install brew at any time of the image build.

#### Related issue:
https://github.com/actions/virtual-environments/issues/1136

## Check list
- [x] Related issue / work item is attached
- [-] Tests are written (if applicable)
- [-] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
