### PR TITLE
Update documented Xcode 12 path

### DIFF
--- a/images/macos/macos-10.15-Readme.md
+++ b/images/macos/macos-10.15-Readme.md
@@ -171,7 +171,7 @@
 ### Xcode
 | Version        | Build   | Path                              |
 | -------------- | ------- | --------------------------------- |
-| 12.0 (beta)    | 12A6159 | /Applications/Xcode_12_beta.app   |
+| 12.0 (beta)    | 12A6159 | /Applications/Xcode_12.app   |
 | 11.6 (beta)    | 11N700h | /Applications/Xcode_11.6_beta.app |
 | 11.5 (default) | 11E608c | /Applications/Xcode_11.5.app      |
 | 11.4.1         | 11E503a | /Applications/Xcode_11.4.1.app    |


### PR DESCRIPTION
# Description
It appears the install path of Xcode 12 (or rather the name of the application) has been updated. This changes the documentation in the readme to reflect that.

#### Related issue:
https://github.com/actions/virtual-environments/issues/1133