### PR TITLE
Install Git for Windows with symbolic links enabled

### DIFF
--- a/images/win/scripts/Installers/Install-Git.ps1
+++ b/images/win/scripts/Installers/Install-Git.ps1
@@ -30,6 +30,7 @@ Install-Binary  -Url $downloadUrl `
                     "/RESTARTAPPLICATIONS", `
                     "/o:PathOption=CmdTools", `
                     "/o:BashTerminalOption=ConHost", `
+                    "/o:EnableSymlinks=Enabled", `
                     "/COMPONENTS=gitlfs")
 
 Choco-Install -PackageName hub


### PR DESCRIPTION
# Description
Bug fix: enable symlink support of Git for Windows

@al-cheb reached out privately to ask whether it would be a good idea to enable Git's symbolic link support, and I think it makes sense.