### PR TITLE
Fix unicode char c=1089 to c=99 in TestsHelpers.ps1

### DIFF
--- a/images/win/scripts/ImageHelpers/TestsHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/TestsHelpers.ps1
@@ -80,8 +80,8 @@ function ShouldReturnZeroExitCode {
 
     if (-not $succeeded)
     {
-        $сommandOutputIndent = " " * 4
-        $commandOutput = ($result.Output | ForEach-Object { "${сommandOutputIndent}${_}" }) -join "`n"
+        $commandOutputIndent = " " * 4
+        $commandOutput = ($result.Output | ForEach-Object { "${commandOutputIndent}${_}" }) -join "`n"
         $failureMessage = "Command '${ActualValue}' has finished with exit code ${actualExitCode}`n${commandOutput}"
     }
 


### PR DESCRIPTION
Issue:
PowerShell Desktop can't import ImageHelpers module with unicode char:
```
PS > Import-Module C:\Users\testAdm2\Desktop\virtual-environments\images\win\scripts\ImageHelpers\ImageHelpers.psm1
At .\virtual-environments\images\win\scripts\ImageHelpers\TestsHelpers.ps1:83 char:11
+         $ÑommandOutputIndent = " " * 4
+           ~~~~~~~~~~~~~~~~~~~
Unexpected token 'ommandOutputIndent' in expression or statement.
    + CategoryInfo          : ParserError: (:) [], ParseException
    + FullyQualifiedErrorId : UnexpectedToken

```