### PR TITLE
[Ubuntu] Fix Cleanup Cargo registry data folders

### DIFF
--- a/images/linux/scripts/installers/rust.sh
+++ b/images/linux/scripts/installers/rust.sh
@@ -35,7 +35,7 @@ for cmd in rustup rustc rustdoc cargo rustfmt cargo-clippy bindgen cbindgen 'car
 done
 
 # Cleanup Cargo cache
-rm -rf "${CARGO_HOME}/registry/*"
+rm -rf ${CARGO_HOME}/registry/*
 
 # Update /etc/environemnt
 prependEtcEnvironmentPath "${CARGO_HOME}/bin"


### PR DESCRIPTION
# Description
`rm -rf` with quotes doesn't do the job

#### Related issue:
https://github.com/actions/virtual-environments/issues/895

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
