### PR TITLE
Toolset support for Semver notation

### DIFF
--- a/images/win/scripts/Installers/Install-Toolset.ps1
+++ b/images/win/scripts/Installers/Install-Toolset.ps1
@@ -45,7 +45,6 @@ foreach ($tool in $tools) {
     # Get github release asset for each version
     foreach ($toolVersion in $tool.versions) {
         $asset = $assets | Where-Object version -like $toolVersion `
-                         | Sort-Object -Property {[version]$_.version} -Descending `
                          | Select-Object -ExpandProperty files `
                          | Where-Object { ($_.platform -eq $tool.platform) -and ($_.arch -eq $tool.arch) -and ($_.toolset -eq $tool.toolset) } `
                          | Select-Object -First 1


### PR DESCRIPTION
# Description
Since, we are working on adding support for unstable versions of Python, `versions-manifest.json` will include versions in format `3.9.0-beta.2` and etc.
`[System.Version]` type doesn't support such format and will fail even we don't cache such versions on image. Just on parsing of `versions-manifest.json`.
This PR removes sorting of versions because it is redundant. `versions-manifest.json` is sorted by default and we don't need to sort it one more time 

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
