### PR TITLE
[Windows] Remove WSL from software output on Windows 2016

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -22,10 +22,13 @@ $markdown += New-MDList -Style Unordered -Lines @(
     "Image Version: $env:ImageVersion"
 )
 
-$markdown += New-MDHeader "Enabled windows optional features" -Level 2
-$markdown += New-MDList -Style Unordered -Lines @(
-    "Windows Subsystem for Linux"
-)
+if ($OSName -match "Microsoft Windows Server 2019 Datacenter")
+{
+    $markdown += New-MDHeader "Enabled windows optional features" -Level 2
+    $markdown += New-MDList -Style Unordered -Lines @(
+        "Windows Subsystem for Linux"
+    )
+}
 
 $markdown += New-MDHeader "Installed Software" -Level 2
 $markdown += New-MDHeader "Language and Runtime" -Level 3

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -22,7 +22,7 @@ $markdown += New-MDList -Style Unordered -Lines @(
     "Image Version: $env:ImageVersion"
 )
 
-if ($OSName -match "Microsoft Windows Server 2019 Datacenter")
+if (Test-IsWin19)
 {
     $markdown += New-MDHeader "Enabled windows optional features" -Level 2
     $markdown += New-MDList -Style Unordered -Lines @(


### PR DESCRIPTION
# Description
WSL was added to Windows 2019 only in the scope of this PR, but it seems we forget to add a condition in the software report generator.

#### Related issue:
https://github.com/actions/virtual-environments/issues/50

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
