### PR TITLE
Add Canary test requirement to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,9 @@ Please include a summary of the change and which issue is fixed. Also include re
 
 #### Related issue:
 
+**For new tools, please provide a link to the PR in the azure-pipelines-canary repo with Canary test for this new tool.**
+#### Link to Canary tests PR: 
+
 ## Check list
 - [ ] Related issue / work item is attached
 - [ ] Tests are written (if applicable)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,5 +11,6 @@ Please include a summary of the change and which issue is fixed. Also include re
 ## Check list
 - [ ] Related issue / work item is attached
 - [ ] Tests are written (if applicable)
+- [ ] Canary tests are written (if applicable)
 - [ ] Documentation is updated (if applicable)
 - [ ] Changes are tested and related VM images are successfully generated

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ Please include a summary of the change and which issue is fixed. Also include re
 #### Related issue:
 
 **For new tools, please provide a link to the PR in the azure-pipelines-canary repo with Canary test for this new tool.**
-#### Link to Canary tests PR: 
+#### Canary tests PR: 
 
 ## Check list
 - [ ] Related issue / work item is attached


### PR DESCRIPTION
# Description
From now on we should include the link to the PR in Canary tests repo for each newly added tool. I am adding a reminder about it to the PR template. 

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/840

## Check list
- [X] Related issue / work item is attached
- [N\A] Tests are written (if applicable)
- [N\A] Documentation is updated (if applicable)
- [N\A] Changes are tested and related VM images are successfully generated
