### PR TITLE
[Windows] Increase windows update restart timeout to 30 min

### DIFF
--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -896,7 +896,7 @@
         },
         {
             "type": "windows-restart",
-            "restart_timeout": "10m"
+            "restart_timeout": "30m"
         },
         {
             "type": "powershell",

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -901,7 +901,7 @@
         },
         {
             "type": "windows-restart",
-            "restart_timeout": "10m"
+            "restart_timeout": "30m"
         },
         {
             "type": "powershell",


### PR DESCRIPTION
# Description
Recently, Windows 2016 builds started to fail on reboot step after update installation: https://github.visualstudio.com/virtual-environments/_build/results?buildId=75637&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=486c0909-f67d-5748-80b3-bb1d531e7b43 due to ` vhd: Timeout waiting for machine to restart`.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/839
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
