### PR TITLE
Add swig support

### DIFF
--- a/images/linux/scripts/installers/swig.sh
+++ b/images/linux/scripts/installers/swig.sh
@@ -8,7 +8,6 @@
 source $HELPER_SCRIPTS/document.sh
 
 # Install Swig
-apt-get update -y
 sudo apt-get install -y swig
 
 # Run tests to determine that the software installed as expected

--- a/images/linux/scripts/installers/swig.sh
+++ b/images/linux/scripts/installers/swig.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
-################################################################################
-##  File:  swig.sh
-##  Desc:  Installs Swig
-################################################################################
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/document.sh
@@ -19,4 +15,4 @@ fi
 
 # Document what was added to the image
 echo "Lastly, documenting what we added to the metadata file"
-DocumentInstalledItem "$(swig -version | sed -n 2p)"
+DocumentInstalledItem "Swig $(swig -version | sed -n 2p | cut -d ' ' -f 3)"

--- a/images/linux/scripts/installers/swig.sh
+++ b/images/linux/scripts/installers/swig.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+################################################################################
+##  File:  swig.sh
+##  Desc:  Installs Swig
+################################################################################
+
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/document.sh
+
+# Install Swig
+apt-get update -y
+sudo apt-get install -y swig
+
+# Run tests to determine that the software installed as expected
+echo "Testing to make sure that script performed as expected, and basic scenarios work"
+if ! command -v swig; then
+    echo "Swig was not installed"
+    exit 1
+fi
+
+# Document what was added to the image
+echo "Lastly, documenting what we added to the metadata file"
+DocumentInstalledItem "$(swig -version | sed -n 2p)"

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -196,7 +196,8 @@
                 "{{template_dir}}/scripts/installers/vercel.sh",
                 "{{template_dir}}/scripts/installers/dpkg-config.sh",
                 "{{template_dir}}/scripts/installers/mongodb.sh",
-                "{{template_dir}}/scripts/installers/rndgenerator.sh"
+                "{{template_dir}}/scripts/installers/rndgenerator.sh",
+                "{{template_dir}}/scripts/installers/swig.sh"
             ],
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -200,7 +200,8 @@
                 "{{template_dir}}/scripts/installers/vercel.sh",
                 "{{template_dir}}/scripts/installers/dpkg-config.sh",
                 "{{template_dir}}/scripts/installers/mongodb.sh",
-                "{{template_dir}}/scripts/installers/rndgenerator.sh"
+                "{{template_dir}}/scripts/installers/rndgenerator.sh",
+                "{{template_dir}}/scripts/installers/swig.sh"
             ],
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -201,7 +201,8 @@
                 "{{template_dir}}/scripts/installers/vcpkg.sh",
                 "{{template_dir}}/scripts/installers/vercel.sh",
                 "{{template_dir}}/scripts/installers/dpkg-config.sh",
-                "{{template_dir}}/scripts/installers/rndgenerator.sh"
+                "{{template_dir}}/scripts/installers/rndgenerator.sh",
+                "{{template_dir}}/scripts/installers/swig.sh"
             ],
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",


### PR DESCRIPTION
# Description
This PR adds on all Ubuntu images new tool - Swig. 
`apt-get` was used for installation.

#### Related issue:
#1203
## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Changes are tested and related VM images are successfully generated
