### PR TITLE
Remove verbose flag from android helper

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -30,7 +30,7 @@ function Get-AndroidSDKManagerPath {
 
 function Get-AndroidInstalledPackages {
     $androidSDKManagerPath = Get-AndroidSDKManagerPath
-    $androidSDKManagerList = & $androidSDKManagerPath --list --include_obsolete --verbose
+    $androidSDKManagerList = & $androidSDKManagerPath --list --include_obsolete
     $androidInstalledPackages = @()
     foreach($packageInfo in $androidSDKManagerList) {
         if($packageInfo -Match "Available Packages:") {


### PR DESCRIPTION
# Description
Bug fixing: this flag has broken software report generation.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
