### PR TITLE
Disable auto triage rules for type of issue

### DIFF
--- a/triage-rules.yml
+++ b/triage-rules.yml
@@ -133,17 +133,6 @@ rules:
   contains: 'Xamarin'
   addLabels: ['Area: Xamarin']
 
-# Types
-- valueFor: '**Question, Bug, or Feature?**'
-  contains: Feature
-  addLabels: ['enhancement']
-- valueFor: '**Question, Bug, or Feature?**'
-  contains: Bug
-  addLabels: ['bug']
-- valueFor: '**Question, Bug, or Feature?**'
-  contains: Question
-  addLabels: ['question']
-
 # runs if first set had no matches
 # add likely teams to look at based on text searches
 nomatches:

--- a/triage-rules.yml
+++ b/triage-rules.yml
@@ -133,6 +133,17 @@ rules:
   contains: 'Xamarin'
   addLabels: ['Area: Xamarin']
 
+# Types
+- valueFor: '**Question, Bug, or Feature?**'
+  contains: Feature
+  addLabels: ['feature request']
+- valueFor: '**Question, Bug, or Feature?**'
+  contains: Bug
+  addLabels: ['investigate']
+- valueFor: '**Question, Bug, or Feature?**'
+  contains: Question
+  addLabels: ['question']
+
 # runs if first set had no matches
 # add likely teams to look at based on text searches
 nomatches:


### PR DESCRIPTION
# Description
We don't want to mark issues as bugs before investigation and confirmation that it is a real bug
