### PR TITLE
[Windows] Fix Wix Toolset version numbers in documentation

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
@@ -35,8 +35,8 @@ function Get-WDKVersion {
 function Get-VisualStudioExtensions {
     # Wix
     $vs = (Get-VisualStudioVersion).Name.Split()[-1]
-    $wixPackageVersion = (Get-VisualStudioPackages | Where-Object {$_.id -match 'WixToolset.VisualStudioExtension.Dev' -and $_.type -eq 'vsix'}).Version
-    $wixExtensionVersion = Get-WixVersion
+    $wixPackageVersion = Get-WixVersion
+    $wixExtensionVersion = (Get-VisualStudioPackages | Where-Object {$_.id -match 'WixToolset.VisualStudioExtension.Dev' -and $_.type -eq 'vsix'}).Version
 
     # WDK
     $wdkPackageVersion = Get-VSExtensionVersion -packageName 'Microsoft.Windows.DriverKit'


### PR DESCRIPTION
# Description
Version numbers for the Wix Toolset and Wix Visual Studio Extension in documentation are flipped. In scope of this PR we are fixing it.

#### Related issue:
https://github.com/actions/virtual-environments/issues/1299

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
