### PR TITLE
[Ubuntu] Provide documentation about installed openssl and libssl-dev package versions

### DIFF
--- a/images/linux/scripts/installers/php.sh
+++ b/images/linux/scripts/installers/php.sh
@@ -148,3 +148,5 @@ fi
 
 DocumentInstalledItem "Composer  ($(composer --version))"
 DocumentInstalledItem "PHPUnit ($(phpunit --version))"
+DocumentInstalledItem "$(openssl version)"
+DocumentInstalledItem "Libssl $(dpkg -l libssl-dev | grep '^ii' | awk '{print $3}')"


### PR DESCRIPTION
# Description
Provide documentation about installed openssl and libssl-dev package versions for Ubuntu images.

ubuntu 16.04:
```
- OpenSSL 1.1.0h  27 Mar 2018 (Library: OpenSSL 1.1.1g  21 Apr 2020)
- Libssl 1.1.1g-1+ubuntu16.04.1+deb.sury.org+1
```

ubuntu 18.04:
```
- OpenSSL 1.1.1g  21 Apr 2020
- Libssl 1.1.1g-1+ubuntu18.04.1+deb.sury.org+1
```

ubuntu 20.04:
```
- OpenSSL 1.1.1f  31 Mar 2020
- Libssl 1.1.1f-1ubuntu2
```
#### Related issue:
https://github.com/actions/virtual-environments/issues/1307

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
