### PR TITLE
Add libc++ and libc++abi for all Ubuntu images

### DIFF
--- a/images/linux/scripts/installers/basic.sh
+++ b/images/linux/scripts/installers/basic.sh
@@ -38,7 +38,9 @@ common_packages="dnsutils
                  gnupg2
                  lib32z1
                  texinfo
-                 libsqlite3-dev"
+                 libsqlite3-dev
+                 libc++-dev
+                 libc++abi-dev"
 
 cmd_packages="curl
               file
@@ -81,8 +83,6 @@ apt-get install -y --no-install-recommends $libcurelVer
 # install additional packages only for Ubuntu16.04
 if isUbuntu16; then
     common_packages="$common_packages
-            libc++-dev
-            libc++abi-dev
             libicu55"
 fi
 


### PR DESCRIPTION
# Description
Modifies the existing script to add libc++ and libc++abi to all Ubuntu images, rather than just 16.04.

#### Related issue: #1314 
