### PR TITLE
[Windows] .NET Framework  Performance Issue

### DIFF
--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -773,6 +773,12 @@
         },
         {
             "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Run-NGen.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
             "inline": [
                 "if( Test-Path $Env:SystemRoot\\System32\\Sysprep\\unattend.xml ){ rm $Env:SystemRoot\\System32\\Sysprep\\unattend.xml -Force}",
                 "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /quiet /quit",

--- a/images/win/scripts/Installers/Run-NGen.ps1
+++ b/images/win/scripts/Installers/Run-NGen.ps1
@@ -1,6 +1,6 @@
 Write-Host "NGen: Microsoft.PowerShell.Utility.Activities"
-& $env:SystemRoot\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+$null = & $env:SystemRoot\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
 Write-Host "NGen: Framework64"
-& $env:SystemRoot\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update
+$null = & $env:SystemRoot\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update
 Write-Host "NGen: Framework"
-& $env:SystemRoot\Microsoft.NET\Framework\v4.0.30319\ngen.exe update
+$null = & $env:SystemRoot\Microsoft.NET\Framework\v4.0.30319\ngen.exe update

--- a/images/win/scripts/Installers/Run-NGen.ps1
+++ b/images/win/scripts/Installers/Run-NGen.ps1
@@ -1,0 +1,6 @@
+Write-Host "NGen: Microsoft.PowerShell.Utility.Activities"
+& $env:SystemRoot\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+Write-Host "NGen: Framework64"
+& $env:SystemRoot\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update
+Write-Host "NGen: Framework"
+& $env:SystemRoot\Microsoft.NET\Framework\v4.0.30319\ngen.exe update


### PR DESCRIPTION
# Description
https://support.microsoft.com/en-us/help/2570538/installing-updates-for-the-microsoft-net-framework-4-can-take-longer-t - When you install an update for the Microsoft .NET Framework 4, the Native Image Generator (NGen.exe) uses a high percentage of the CPU cycles on the computer for a long time. This time varies with how many Native Images are installed on the computer.

#### Related issue:
https://github.com/actions/virtual-environments/issues/1269

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
