### PR TITLE
Add brotli to linux images

### DIFF
--- a/images/linux/scripts/installers/basic.sh
+++ b/images/linux/scripts/installers/basic.sh
@@ -61,6 +61,7 @@ cmd_packages="curl
               patchelf
               bzip2
               sqlite3
+              brotli
               yamllint"
 
 if isUbuntu20 ; then


### PR DESCRIPTION
# Description
Add brotli to linux images
Approximate size: 730.0 kB (Installed size in Ubuntu 20.04: https://packages.ubuntu.com/focal/brotli)

Tests should already be included: https://github.com/actions/virtual-environments/blob/main/images/linux/scripts/installers/basic.sh#L94-L101

#### Related issue: https://github.com/actions/virtual-environments/issues/1313

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
