### PR TITLE
[Ubuntu] Fix incorrect parsing download url for geckodriver

### DIFF
--- a/images/linux/scripts/installers/firefox.sh
+++ b/images/linux/scripts/installers/firefox.sh
@@ -28,7 +28,7 @@ HOME=/root
 DocumentInstalledItem "Firefox ($(firefox --version))"
 
 # Download and unpack latest release of geckodriver
-URL=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r '.assets[].browser_download_url | select(contains("linux64.tar.gz"))')
+URL=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r '.assets[].browser_download_url | select(test("linux64.tar.gz$"))')
 echo "Downloading geckodriver $URL"
 wget "$URL" -O geckodriver.tar.gz
 tar -xzf geckodriver.tar.gz


### PR DESCRIPTION
# Description
Ubuntu image generation is broken due to incorrect download link for geckodriver.

```
   azure-arm: Downloading geckodriver https://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-linux64.tar.gz
    azure-arm: https://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-linux64.tar.gz.asc
==> azure-arm: --2020-07-30 01:44:44--  https://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-linux64.tar.gz%0Ahttps://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-linux64.tar.gz.asc
==> azure-arm: Resolving github.com (github.com)... 192.30.255.112
==> azure-arm: Connecting to github.com (github.com)|192.30.255.112|:443... connected.
==> azure-arm: HTTP request sent, awaiting response... 404 Not Found
==> azure-arm: 2020-07-30 01:44:44 ERROR 404: Not Found
```
#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/906

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
