### PR TITLE
Fix error in Install-Toolset.ps1 and added cleanup

### DIFF
--- a/images/linux/scripts/installers/Install-Toolset.ps1
+++ b/images/linux/scripts/installers/Install-Toolset.ps1
@@ -14,7 +14,7 @@ Function Install-Asset {
     wget $ReleaseAsset.download_url -nv --retry-connrefused --tries=10
 
     Write-Host "Extract $($ReleaseAsset.filename) content..."
-    $assetFolderPath = Join-Path $env:INSTALLER_SCRIPT_FOLDER $($ReleaseAsset.filename)
+    $assetFolderPath = (Join-Path $env:INSTALLER_SCRIPT_FOLDER $($ReleaseAsset.filename)) + "_tmp"
     New-Item -ItemType Directory -Path $assetFolderPath
     tar -xzf $ReleaseAsset.filename -C $assetFolderPath
 
@@ -22,6 +22,7 @@ Function Install-Asset {
     Push-Location -Path $assetFolderPath
     Invoke-Expression "bash ./setup.sh"
     Pop-Location
+    rm -rf $assetFolderPath
 }
 
 $ErrorActionPreference = "Stop"


### PR DESCRIPTION
# Description
Bug fixing & Improvement

At line 17 the assetFolderPath is equal to the name of the file that was just downloaded.
This causes line 18 to fail since we try to create a directory that has the exact same name as the file downloaded.
So i added a _tmp to the end of the path so that it can create the folder.
Also added at line 25 a cleanup so we remove these install folders once the work is finished

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
