### PR TITLE
Add Business Central Generic

### DIFF
--- a/images/win/scripts/ImageHelpers/ImageHelpers.psm1
+++ b/images/win/scripts/ImageHelpers/ImageHelpers.psm1
@@ -26,6 +26,7 @@ Export-ModuleMember -Function @(
     'Install-VsixExtension'
     'Get-VSExtensionVersion'
     'Get-WinVersion'
+    'Get-WinVersionNo'
     'Test-IsWin19'
     'Test-IsWin16'
     'Choco-Install'

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -373,6 +373,11 @@ function Get-WinVersion
     (Get-CimInstance -ClassName Win32_OperatingSystem).Caption
 }
 
+function Get-WinVersionNo
+{
+    "$((Get-CimInstance Win32_OperatingSystem).Version).$((Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' -Name UBR).UBR)"
+}
+
 function Test-IsWin19
 {
     (Get-WinVersion) -match "2019"

--- a/images/win/scripts/Installers/Update-DockerImages.ps1
+++ b/images/win/scripts/Installers/Update-DockerImages.ps1
@@ -5,12 +5,12 @@
 ################################################################################
 
 function DockerPull {
-    Param ([string]$image)
+    Param ([string]$image, [switch]$ignoreErrors)
 
     Write-Host Installing $image ...
     docker pull $image
 
-    if (!$?) {
+    if (!$? -and !$ignoreErrors) {
       Write-Host "Docker pull failed with a non-zero exit code"
       exit 1
     }
@@ -31,3 +31,5 @@ if (Test-IsWin19) {
 }
 
 DockerPull microsoft/aspnetcore-build:1.0-2.0
+
+DockerPull "mcr.microsoft.com/dynamicsnav:$(Get-WindowsVersionNumber)-generic" -ignoreErrors


### PR DESCRIPTION
# Description
Add Business Central Generic Docker image for the current Windows Version

Microsoft Dynamics 365 Business Central uses Docker in Azure DevOps pipelines and Github Actions.
Today a lot of our App Developing partners are forced to use Self hosted agents because downloading the docker image takes too much time.
The image is built on top of the 4.8 dotnet framework image and contains all what is needed in order to run Dynamics NAV and Business Central docker containers.
The image is built and maintained by the Business Central R&D team out of MDCC (Microsoft Development Center Copenhagen)

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
