### PR TITLE
[Windows] Change Alibaba Cloud CLI installation to direct download

### DIFF
--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -299,13 +299,13 @@
         {
             "type": "powershell",
             "scripts":[
-                "{{ template_dir }}/scripts/Installers/Install-AliyunCli.ps1"
+                "{{ template_dir }}/scripts/Installers/Install-7zip.ps1"
             ]
         },
         {
             "type": "powershell",
             "scripts":[
-                "{{ template_dir }}/scripts/Installers/Install-7zip.ps1"
+                "{{ template_dir }}/scripts/Installers/Install-AliyunCli.ps1"
             ]
         },
         {

--- a/images/win/scripts/Installers/Install-AliyunCli.ps1
+++ b/images/win/scripts/Installers/Install-AliyunCli.ps1
@@ -3,6 +3,15 @@
 ##  Desc:  Install Alibaba Cloud CLI
 ################################################################################
 
-Choco-Install -PackageName aliyun-cli
+Write-Host "Download Latest aliyun-cli archive"
+$url = 'https://api.github.com/repos/aliyun/aliyun-cli/releases/latest'
+# Explicitly set type to string since match returns array by default
+[System.String] $aliyunLatest = (Invoke-RestMethod -Uri $url).assets.browser_download_url -match "aliyun-cli-windows"
+$aliyunArchivePath = Start-DownloadWithRetry -Url $aliyunLatest -Name "aliyin-cli.zip"
+
+Write-Host "Expand aliyun-cli archive"
+# Expand aliyun.exe to System32 directory
+$DestinationPath = [System.Environment]::SystemDirectory
+Extract-7Zip -Path $aliyunArchivePath -DestinationPath $DestinationPath
 
 Invoke-PesterTests -TestFile "Tools" -TestName "AliyunCli"

--- a/images/win/scripts/Installers/Install-AliyunCli.ps1
+++ b/images/win/scripts/Installers/Install-AliyunCli.ps1
@@ -10,8 +10,11 @@ $url = 'https://api.github.com/repos/aliyun/aliyun-cli/releases/latest'
 $aliyunArchivePath = Start-DownloadWithRetry -Url $aliyunLatest -Name "aliyin-cli.zip"
 
 Write-Host "Expand aliyun-cli archive"
-# Expand aliyun.exe to System32 directory
-$DestinationPath = [System.Environment]::SystemDirectory
-Extract-7Zip -Path $aliyunArchivePath -DestinationPath $DestinationPath
+$aliyunPath = "C:\aliyun-cli"
+New-Item -Path $aliyunPath -ItemType Directory -Force
+Extract-7Zip -Path $aliyunArchivePath -DestinationPath $aliyunPath
+
+# Add aliyun-cli to path
+Add-MachinePathItem $aliyunPath
 
 Invoke-PesterTests -TestFile "Tools" -TestName "AliyunCli"

--- a/images/win/scripts/Installers/Install-AliyunCli.ps1
+++ b/images/win/scripts/Installers/Install-AliyunCli.ps1
@@ -7,7 +7,7 @@ Write-Host "Download Latest aliyun-cli archive"
 $url = 'https://api.github.com/repos/aliyun/aliyun-cli/releases/latest'
 # Explicitly set type to string since match returns array by default
 [System.String] $aliyunLatest = (Invoke-RestMethod -Uri $url).assets.browser_download_url -match "aliyun-cli-windows"
-$aliyunArchivePath = Start-DownloadWithRetry -Url $aliyunLatest -Name "aliyin-cli.zip"
+$aliyunArchivePath = Start-DownloadWithRetry -Url $aliyunLatest -Name "aliyun-cli.zip"
 
 Write-Host "Expand aliyun-cli archive"
 $aliyunPath = "C:\aliyun-cli"


### PR DESCRIPTION
# Description
Alibaba-cli chocolatey package is outdated, it was updated in 2019 last time
https://chocolatey.org/packages/aliyun-cli
Switch to download the latest release from GitHub since the installation is pretty simple — the archive contains only 1 exe file.

#### Related issue:
https://github.com/actions/virtual-environments/issues/1350

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
