### PR TITLE
Use full resource IDs and clean up output

### DIFF
--- a/helpers/CreateAzureVMFromPackerTemplate.ps1
+++ b/helpers/CreateAzureVMFromPackerTemplate.ps1
@@ -17,7 +17,7 @@ Function CreateAzureVMFromPackerTemplate {
 
         .PARAMETER VirtualMachineName
             The name of the virtual machine to be generated.
-        
+
         .PARAMETER AdminUserName
             The administrator username for the virtual machine to be created.
 
@@ -53,20 +53,21 @@ Function CreateAzureVMFromPackerTemplate {
     $nicName = $env:UserName + [System.GUID]::NewGuid().ToString().ToUpper()
     $publicIpName = $env:UserName + [System.GUID]::NewGuid().ToString().ToUpper()
 
-    Write-Host "Creating a Vnet and a Subnet"
-    az network vnet create -g $ResourceGroupName -l $AzureLocation --name $vnetName --address-prefix 10.0.0.0/16 --subscription $subscriptionId
-    az network vnet subnet create -g $ResourceGroupName --vnet-name $vnetName -n $subnetName --address-prefix 10.0.1.0/24  --subscription $subscriptionId
+    Write-Host "Creating a virtual network and subnet"
+    ($vnet = az network vnet create -g $ResourceGroupName -l $AzureLocation -n $vnetName --address-prefixes 10.0.0.0/16 --subnet-name $subnetName --subnet-prefixes 10.0.1.0/24 --subscription $subscriptionId)
+    $subnetId = ($vnet | ConvertFrom-Json).newVNet.subnets[0].id
 
-    Write-Host "Creating a network interface card (NIC)."
-    $nic = az network nic create -g $ResourceGroupName --vnet-name $vnetName --subnet $subnetName -n $nicName  --subscription $subscriptionId
+    Write-Host "`nCreating a network interface controller (NIC)"
+    ($nic = az network nic create -g $ResourceGroupName -l $AzureLocation -n $nicName --subnet $subnetId --subscription $subscriptionId)
     $networkId = ($nic | ConvertFrom-Json).NewNIC.id
 
-    Write-Host "create public IP."
-    az network public-ip create -g $ResourceGroupName -n $publicIpName --subscription $subscriptionId --allocation-method Static --location $AzureLocation --sku Standard --version IPv4 
+    Write-Host "`nCreating a public IP address"
+    ($publicIp = az network public-ip create -g $ResourceGroupName -l $AzureLocation -n $publicIpName --allocation-method Static --sku Standard --version IPv4 --subscription $subscriptionId)
+    $publicIpId = ($publicIp | ConvertFrom-Json).publicIp.id
 
-    Write-Host "Adding the public IP to the NIC."
-    az network nic ip-config update --name ipconfig1 --nic-name $nicName --resource-group $ResourceGroupName --subscription $subscriptionId --public-ip-address $publicIpName
+    Write-Host "`nAdding the public IP to the NIC"
+    az network nic ip-config update -g $ResourceGroupName -n ipconfig1 --nic-name $nicName --public-ip-address $publicIpId --subscription $subscriptionId
 
-    Write-Host "Creating the VM"
-    az group deployment create --resource-group $ResourceGroupName --subscription $subscriptionId --name $VirtualMachineName --template-file $templateFilePath --parameters vmSize=$vmSize vmName=$VirtualMachineName adminUserName=$AdminUsername adminPassword=$AdminPassword networkInterfaceId=$networkId
+    Write-Host "`nCreating the VM"
+    az group deployment create -g $ResourceGroupName -n $VirtualMachineName --subscription $subscriptionId --template-file $templateFilePath --parameters vmSize=$vmSize vmName=$VirtualMachineName adminUserName=$AdminUsername adminPassword=$AdminPassword networkInterfaceId=$networkId
 }


### PR DESCRIPTION
# Description
I ran into problems using CreateAzureVMFromPackerTemplate.ps1 because the subscription ID I passed in was not the default subscription in my account. Some of the Azure CLI commands failed even though the script passes in the `-r` and `--subscription` arguments. There might be a deeper problem in the Azure CLI, but I changed the script to pass in full resource IDs and the problem went away. I decided to submit a PR in case my changes are of value to anyone else.

I also cleaned up the output to make it more consistent. Each Azure CLI command now prints the JSON for the created/updated resource to the console (before, some commands did and others didn't).

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [X] Changes are tested and related VM images are successfully generated
