### PR TITLE
[Ubuntu20] Permission issues - using snap - Ubuntu 20.04

### DIFF
--- a/images/linux/scripts/installers/powershellcore.sh
+++ b/images/linux/scripts/installers/powershellcore.sh
@@ -12,7 +12,7 @@ source $HELPER_SCRIPTS/os.sh
 if isUbuntu20 ; then
     snap install powershell --classic --channel=edge/useedge
     # add perm to allow creating user-specific non-essential runtime files and other file objects
-    chmod +R 777 /run/user
+    chmod -R 777 /run/user
 fi
 
 if isUbuntu16 || isUbuntu18 ; then

--- a/images/linux/scripts/installers/powershellcore.sh
+++ b/images/linux/scripts/installers/powershellcore.sh
@@ -11,6 +11,8 @@ source $HELPER_SCRIPTS/os.sh
 # Install Powershell
 if isUbuntu20 ; then
     snap install powershell --classic --channel=edge/useedge
+    # add perm to allow creating user-specific non-essential runtime files and other file objects
+    chmod +R 777 /run/user
 fi
 
 if isUbuntu16 || isUbuntu18 ; then


### PR DESCRIPTION
# Description
PowerShell is not currently supported on Ubuntu 20.04 as a temporary solution we use snap to install powershell. While executing a powershell script, it raises an error : "mkrdir: cannot create directory /run/user/1001 : Permission denied",because this directory is created by the session manager.

#### Related issue:
https://github.com/actions/virtual-environments/issues/1378
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
