### PR TITLE
[Ubuntu] Provide documentation about installed openssl and libssl-dev package versions

### DIFF
--- a/images/linux/scripts/installers/php.sh
+++ b/images/linux/scripts/installers/php.sh
@@ -148,5 +148,3 @@ fi
 
 DocumentInstalledItem "Composer  ($(composer --version))"
 DocumentInstalledItem "PHPUnit ($(phpunit --version))"
-DocumentInstalledItem "$(openssl version)"
-DocumentInstalledItem "Libssl $(dpkg -l libssl-dev | grep '^ii' | awk '{print $3}')"

--- a/images/linux/scripts/installers/ruby.sh
+++ b/images/linux/scripts/installers/ruby.sh
@@ -15,3 +15,5 @@ apt-get install -y libz-dev openssl libssl-dev
 
 DocumentInstalledItem "ruby ($(ruby --version 2>&1 | cut -d ' ' -f 2))"
 DocumentInstalledItem "gem ($(gem -v 2>&1 | tail -n 1))"
+DocumentInstalledItem "$(openssl version)"
+DocumentInstalledItem "Libssl $(dpkg -l libssl-dev | grep '^ii' | awk '{print $3}')"


### PR DESCRIPTION
# Description
Previous https://github.com/actions/virtual-environments/pull/1312 PR contains mismatch position where openssl and libssl-dev installation occurs as a result we provide the old version in the documentation file.

![image](https://user-images.githubusercontent.com/47745270/89888675-01a1f980-dbd9-11ea-82c8-982502750895.png)

#### Related issue:
https://github.com/actions/virtual-environments/issues/1307

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
