### PR TITLE
Install NSIS from Source Forge

### DIFF
--- a/images/win/scripts/Installers/Install-NSIS.ps1
+++ b/images/win/scripts/Installers/Install-NSIS.ps1
@@ -3,9 +3,7 @@
 ##  Desc:  Install NSIS
 ################################################################################
 
-# Choco-Install -PackageName nsis
-
-Install-Binary -Url https://jztkft.dl.sourceforge.net/project/nsis/NSIS%203/3.05/nsis-3.05-setup.exe -Name nsis-3.05-setup.exe  -ArgumentList ('/S')
+Install-Binary -Url 'https://downloads.sourceforge.net/project/nsis/NSIS%203/3.06.1/nsis-3.06.1-setup.exe' -Name  nsis-3.06.1-setup.exe -ArgumentList ('/S')
 
 $NsisPath = "${env:ProgramFiles(x86)}\NSIS\"
 Add-MachinePathItem $NsisPath

--- a/images/win/scripts/Installers/Install-NSIS.ps1
+++ b/images/win/scripts/Installers/Install-NSIS.ps1
@@ -3,7 +3,9 @@
 ##  Desc:  Install NSIS
 ################################################################################
 
-Choco-Install -PackageName nsis
+# Choco-Install -PackageName nsis
+
+Install-Binary -Url https://jztkft.dl.sourceforge.net/project/nsis/NSIS%203/3.05/nsis-3.05-setup.exe -Name nsis-3.05-setup.exe  -ArgumentList ('/S')
 
 $NsisPath = "${env:ProgramFiles(x86)}\NSIS\"
 Add-MachinePathItem $NsisPath

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -93,8 +93,7 @@ function Get-MercurialVersion {
 }
 
 function Get-NSISVersion {
-    $(choco list --local-only nsis | Out-String) -match "nsis (?<version>\d+\.\d+\.?\d*\.?\d*)" | Out-Null
-    $nsisVersion = $Matches.Version
+    $nsisVersion =  &"c:\Program Files (x86)\NSIS\makensis.exe" "/Version"
     return "NSIS $nsisVersion"
 }
 


### PR DESCRIPTION
# Description
Bug fixing

It is temporary workaround to fix the issued with non-working NSIS download link https://astuteinternet.dl.sourceforge.net/project/nsis/NSIS%203/3.05/nsis-3.05-setup.exe used by choco 

Use https://jztkft.dl.sourceforge.net/project/nsis/NSIS%203/3.05/nsis-3.05-setup.exe -Name nsis-3.05-setup.exe instead

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/942

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x ] Changes are tested and related VM images are successfully generated
