### PR TITLE
Resolve possible conflicts in software update PR

### DIFF
--- a/.github/workflows/create_pull_request.yml
+++ b/.github/workflows/create_pull_request.yml
@@ -11,6 +11,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Clone release branch to create pull request
+      run: |
+        git checkout ${{ github.event.client_payload.ReleaseBranchName }}
+        git branch ${{ github.event.client_payload.ReleaseBranchName }}-pull-request
+        git push origin ${{ github.event.client_payload.ReleaseBranchName }}-pull-request
 
     - name: Create pull request for ${{ github.event.client_payload.ReleaseBranchName }}
       uses: actions/github-script@v2
@@ -21,7 +29,7 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             title: "${{ github.event.client_payload.PullRequestTitle }}",
-            head: "${{ github.event.client_payload.ReleaseBranchName }}",
+            head: "${{ github.event.client_payload.ReleaseBranchName }}-pull-request",
             base: "${{ github.event.client_payload.PullRequestBase }}",
             body: `${{ github.event.client_payload.PullRequestBody }}`
           });

--- a/.github/workflows/create_pull_request.yml
+++ b/.github/workflows/create_pull_request.yml
@@ -17,8 +17,8 @@ jobs:
     - name: Clone release branch to create pull request
       run: |
         git checkout ${{ github.event.client_payload.ReleaseBranchName }}
-        git branch ${{ github.event.client_payload.ReleaseBranchName }}-pull-request
-        git push origin ${{ github.event.client_payload.ReleaseBranchName }}-pull-request
+        git branch ${{ github.event.client_payload.ReleaseBranchName }}-docs
+        git push origin ${{ github.event.client_payload.ReleaseBranchName }}-docs
 
     - name: Create pull request for ${{ github.event.client_payload.ReleaseBranchName }}
       uses: actions/github-script@v2
@@ -29,7 +29,7 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             title: "${{ github.event.client_payload.PullRequestTitle }}",
-            head: "${{ github.event.client_payload.ReleaseBranchName }}-pull-request",
+            head: "${{ github.event.client_payload.ReleaseBranchName }}-docs",
             base: "${{ github.event.client_payload.PullRequestBase }}",
             body: `${{ github.event.client_payload.PullRequestBody }}`
           });

--- a/.github/workflows/merge_pull_request.yml
+++ b/.github/workflows/merge_pull_request.yml
@@ -18,9 +18,9 @@ jobs:
       run: |
         git config --global user.email "no-reply@github.com"
         git config --global user.name "Actions service account"
-        git checkout ${{ github.event.client_payload.ReleaseBranchName }}-pull-request
+        git checkout ${{ github.event.client_payload.ReleaseBranchName }}-docs
         git merge --no-edit --strategy-option=ours main
-        git push origin ${{ github.event.client_payload.ReleaseBranchName }}-pull-request
+        git push origin ${{ github.event.client_payload.ReleaseBranchName }}-docs
         sleep 30
 
     - name: Merge pull request for ${{ github.event.client_payload.ReleaseBranchName }}

--- a/.github/workflows/merge_pull_request.yml
+++ b/.github/workflows/merge_pull_request.yml
@@ -33,3 +33,14 @@ jobs:
             repo: context.repo.repo,
             pull_number: ${{ github.event.client_payload.PullRequestNumber }}
           })
+
+    - name: Delete docs branch ${{ github.event.client_payload.ReleaseBranchName }}-docs
+      uses: actions/github-script@v2
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.git.deleteRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: "heads/${{ github.event.client_payload.ReleaseBranchName }}-docs"
+          })

--- a/.github/workflows/merge_pull_request.yml
+++ b/.github/workflows/merge_pull_request.yml
@@ -18,9 +18,9 @@ jobs:
       run: |
         git config --global user.email "no-reply@github.com"
         git config --global user.name "Actions service account"
-        git checkout ${{ github.event.client_payload.ReleaseBranchName }}
+        git checkout ${{ github.event.client_payload.ReleaseBranchName }}-pull-request
         git merge --no-edit --strategy-option=ours main
-        git push origin ${{ github.event.client_payload.ReleaseBranchName }}
+        git push origin ${{ github.event.client_payload.ReleaseBranchName }}-pull-request
         git checkout main
 
     - name: Merge pull request for ${{ github.event.client_payload.ReleaseBranchName }}

--- a/.github/workflows/merge_pull_request.yml
+++ b/.github/workflows/merge_pull_request.yml
@@ -16,8 +16,8 @@ jobs:
 
     - name: Resolve possible conflicts ${{ github.event.client_payload.ReleaseBranchName }} with main
       run: |
-        git config --global user.email "no-reply@microsoft.com"
-        git config --global user.name "Image generation service account."
+        git config --global user.email "no-reply@github.com"
+        git config --global user.name "Actions service account"
         git checkout ${{ github.event.client_payload.ReleaseBranchName }}
         git merge --no-edit --strategy-option=ours main
         git push origin ${{ github.event.client_payload.ReleaseBranchName }}

--- a/.github/workflows/merge_pull_request.yml
+++ b/.github/workflows/merge_pull_request.yml
@@ -11,11 +11,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Resolve possible conflicts ${{ github.event.client_payload.ReleaseBranchName }} with main
       run: |
         git checkout ${{ github.event.client_payload.ReleaseBranchName }}
         git merge --no-edit --strategy-option=ours main
+        git push origin ${{ github.event.client_payload.ReleaseBranchName }}
         git checkout main
 
     - name: Merge pull request for ${{ github.event.client_payload.ReleaseBranchName }}

--- a/.github/workflows/merge_pull_request.yml
+++ b/.github/workflows/merge_pull_request.yml
@@ -16,6 +16,8 @@ jobs:
 
     - name: Resolve possible conflicts ${{ github.event.client_payload.ReleaseBranchName }} with main
       run: |
+        git config --global user.email "no-reply@microsoft.com"
+        git config --global user.name "Image generation service account."
         git checkout ${{ github.event.client_payload.ReleaseBranchName }}
         git merge --no-edit --strategy-option=ours main
         git push origin ${{ github.event.client_payload.ReleaseBranchName }}

--- a/.github/workflows/merge_pull_request.yml
+++ b/.github/workflows/merge_pull_request.yml
@@ -21,7 +21,7 @@ jobs:
         git checkout ${{ github.event.client_payload.ReleaseBranchName }}-pull-request
         git merge --no-edit --strategy-option=ours main
         git push origin ${{ github.event.client_payload.ReleaseBranchName }}-pull-request
-        git checkout main
+        sleep 30
 
     - name: Merge pull request for ${{ github.event.client_payload.ReleaseBranchName }}
       uses: actions/github-script@v2

--- a/.github/workflows/merge_pull_request.yml
+++ b/.github/workflows/merge_pull_request.yml
@@ -12,6 +12,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Resolve possible conflicts ${{ github.event.client_payload.ReleaseBranchName }} with main
+      run: |
+        git checkout ${{ github.event.client_payload.ReleaseBranchName }}
+        git merge --no-edit --strategy-option=ours main
+        git checkout main
+
     - name: Merge pull request for ${{ github.event.client_payload.ReleaseBranchName }}
       uses: actions/github-script@v2
       with:


### PR DESCRIPTION
# Description
Sometimes, merge-pull-request workflow fails because of conflicts in PR. It happens when current deployment was started earlier then previous one was finished.
 
Changes:
- Added step to create special branch for pull request
- Added step to resolve PR's conflicts in this branch before merging to main
- Added step to delete this additional branch

#### Related issue:
Internal issue: [#908](https://github.com/actions/virtual-environments-internal/issues/908)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
