### PR TITLE
[Ubuntu] Truncate log files at the end of the image generation

### DIFF
--- a/images/linux/scripts/installers/cleanup.sh
+++ b/images/linux/scripts/installers/cleanup.sh
@@ -8,6 +8,19 @@ before=$(df / -Pm | awk 'NR==2{print $4}')
 apt-get clean
 rm -rf /tmp/*
 
+# journalctl
+if command -v journalctl; then
+    journalctl --rotate
+    journalctl --vacuum-time=1s
+fi
+
+# delete all .gz and rotated file
+find /var/log -type f -regex ".*\.gz$" -delete
+find /var/log -type f -regex ".*\.[0-9]$" -delete
+
+# wipe log files
+find /var/log/ -type f -exec cp /dev/null {} \;
+
 # after cleanup
 after=$(df / -Pm | awk 'NR==2{print $4}')
 


### PR DESCRIPTION
# Description
Truncate log files in /var/log folder to save disk space and decrease content for debugging purpose.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/943
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
