### PR TITLE
[Ubuntu] Update mongodb 4.2 -> 4.4 lts

### DIFF
--- a/images/linux/scripts/installers/mongodb.sh
+++ b/images/linux/scripts/installers/mongodb.sh
@@ -9,9 +9,9 @@ source $HELPER_SCRIPTS/os.sh
 source $HELPER_SCRIPTS/document.sh
 
 #  Install Mongo DB
-wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -
+wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | sudo apt-key add -
 version=$(getOSVersionLabel)
-echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu $version/mongodb-org/4.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list
+echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu $version/mongodb-org/4.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.4.list
 sudo apt-get update
 sudo apt-get install -y mongodb-org
 
@@ -24,4 +24,4 @@ fi
 
 # Document the installed version
 echo "Document the installed version"
-DocumentInstalledItem "MongoDB on Linux ($(mongod -v|grep -i version 2>&1))"
+DocumentInstalledItem "MongoDB on Linux $(mongod --version | awk 'NR==1{print $3}')"

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -204,6 +204,7 @@
                 "{{template_dir}}/scripts/installers/vcpkg.sh",
                 "{{template_dir}}/scripts/installers/vercel.sh",
                 "{{template_dir}}/scripts/installers/dpkg-config.sh",
+                "{{template_dir}}/scripts/installers/mongodb.sh",
                 "{{template_dir}}/scripts/installers/rndgenerator.sh",
                 "{{template_dir}}/scripts/installers/swig.sh",
                 "{{template_dir}}/scripts/installers/netlify.sh"


### PR DESCRIPTION
# Description
Mongodb 4.2 doesn't support Ubuntu 20.04, that's why we decided to update mongodb from v4.2 to v4.4 version that supports Ubuntu 20.04. In that case we will use the same mongodb v4.4 version for all Ubuntu 16.04/18.04/20.04 images and thus avoiding to support separate branches 4.2/4.4.  

https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/#platform-support
```
MongoDB 4.4 Community Edition supports the following 64-bit Ubuntu LTS (long-term support) releases on x86_64 architecture:
20.04 LTS (“Focal”)
18.04 LTS (“Bionic”)
16.04 LTS (“Xenial”)
```

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/947

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
