### PR TITLE
[Windows] Hard-coded MongoDB v4.2.8

### DIFF
--- a/images/win/scripts/Installers/Install-MongoDB.ps1
+++ b/images/win/scripts/Installers/Install-MongoDB.ps1
@@ -3,7 +3,7 @@
 ##  Desc:  Install MongoDB
 ####################################################################################
 
-Choco-Install -PackageName mongodb
+Choco-Install -PackageName mongodb -ArgumentList @("--version","4.2.8")
 $mongoPath = (Get-CimInstance Win32_Service -Filter "Name LIKE 'mongodb'").PathName
 $mongoBin = Split-Path -Path $mongoPath.split('"')[1]
 Add-MachinePathItem "$mongoBin"


### PR DESCRIPTION
# Description
The MongoDB v4.4.0 package in chocolatey repository is currently broken. The root cause is a msi package doesn't contain components what previous version has:
` ["C:\windows\System32\msiexec.exe" /i "C:\Users\packer\AppData\Local\Temp\chocolatey\mongodb.install\4.4.0\mongodb-windows-x86_64-4.4.0-signed.msi" ADDLOCAL="Server,ServerService,Router,Client,MonitoringTools,ImportExportTools,MiscellaneousTools" /qn /norestart MONGO_DATA_PATH="C:\ProgramData\MongoDB\data\db"  MONGO_LOG_PATH="C:\ProgramData\MongoDB\log"  ] .`

As a temporary fix is to hard-coded previous MongoDB v4.2.8 version.

v4.4.0:
`ADDLOCAL=ServerService,Server,ProductFeature,Client,Router,MiscellaneousTools`
![image](https://user-images.githubusercontent.com/47745270/90139949-b6771a80-dd81-11ea-82fa-34c3ff5699c9.png)

v4.2.8:
`ADDLOCAL="Server,ServerService,Router,Client,MonitoringTools,ImportExportTools,MiscellaneousTools"`
![image](https://user-images.githubusercontent.com/47745270/90140067-e1616e80-dd81-11ea-8f25-eace479e6be6.png)

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/954
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
