### PR TITLE
Add DOTNET_MULTILEVEL_LOOKUP variable.

### DIFF
--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -100,5 +100,6 @@ done
 # Additional FTE will just copy to ~/.dotnet/NuGet which provides no benefit on a fungible machine
 setEtcEnvironmentVariable DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1
 setEtcEnvironmentVariable DOTNET_NOLOGO 1
+setEtcEnvironmentVariable DOTNET_MULTILEVEL_LOOKUP 0
 prependEtcEnvironmentPath /home/runner/.dotnet/tools
 echo 'export PATH="$PATH:$HOME/.dotnet/tools"' | tee -a /etc/skel/.bashrc

--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -7,6 +7,9 @@
 # ensure temp
 New-Item -Path C:\Temp -Force -ItemType Directory
 
+# Set environment variables
+Set-SystemVariable -SystemVariable DOTNET_MULTILEVEL_LOOKUP -Value "0"
+
 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor "Tls12"
 
 $templates = @(


### PR DESCRIPTION
# Description
Improvement
Looks like DOTNET_MULTILEVEL_LOOKUP that is enabled by default causes big delays in customers' builds that use DOTNET. We got request from .NET Core team to set environment variable DOTNET_MULTILEVEL_LOOKUP=0 for all runners (macOS, Ubuntu, Windows) images.
#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/944
## Check list
- [+] Related issue / work item is attached
- [ -] Changes are tested and related VM images are successfully generated
