### PR TITLE
[Windows 2019] Fix missing msvcr100.dll

### DIFF
--- a/images/win/scripts/Installers/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/Initialize-VM.ps1
@@ -119,6 +119,11 @@ if (Test-IsWin16) {
     Choco-Install -PackageName vcredist140
 }
 
+if (Test-IsWin19) {
+    # Install vcredist2010
+    Choco-Install -PackageName vcredist2010
+}
+
 # Expand disk size of OS drive
 New-Item -Path d:\ -Name cmds.txt -ItemType File -Force
 Add-Content -Path d:\cmds.txt "SELECT VOLUME=C`r`nEXTEND"

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -173,6 +173,11 @@ $markdown += New-MDNewLine
 $markdown += ((Get-VisualStudioComponents) + (Get-VisualStudioExtensions)) | New-MDTable
 $markdown += New-MDNewLine
 
+$markdown += New-MDHeader "Microsoft Visual C++:" -Level 4
+$markdown += New-MDNewLine
+$markdown += Get-VisualCPPComponents | New-MDTable
+$markdown += New-MDNewLine
+
 $markdown += New-MDHeader ".NET Core SDK" -Level 3
 $sdk = Get-DotnetSdks
 $markdown += "``Location $($sdk.Path)``"

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -224,3 +224,20 @@ function Get-NewmanVersion {
 function Get-GHVersion {
     return "GitHub CLI $(gh --version)"
 }
+
+function Get-VisualCPPComponents {
+    $vcpp = Get-CimInstance -ClassName Win32_Product -Filter "Name LIKE 'Microsoft Visual C++%'"
+    $vcpp | Sort-Object Name, Version | ForEach-Object {
+        $isMatch = $_.Name -match "^(?<Name>Microsoft Visual C\+\+ \d{4})\s+(?<Arch>\w{3})\s+(?<Ext>.+)\s+-"
+        if ($isMatch) {
+            $name = '{0} {1}' -f $matches["Name"], $matches["Ext"]
+            $arch = $matches["Arch"].ToLower()
+            $version = $_.Version
+            [PSCustomObject]@{
+                Name = $name
+                Architecture = $arch
+                Version = $version
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description
msvcr100.dll - is missing for Windows Server 2019. We should install `Microsoft Visual C++ 2010 Redistributable Package` to fix missing dll for Windows Server 2019. 
![image](https://user-images.githubusercontent.com/47745270/90514551-fd8e5280-e169-11ea-9291-70dbbe531ca3.png)

Example output:
#### Microsoft Visual C++:

| Name                                         | Architecture | Version     |
| -------------------------------------------- | ------------ | ----------- |
| Microsoft Visual C++ 2010 Redistributable    | x64          | 10.0.30319  |
| Microsoft Visual C++ 2010 Redistributable    | x86          | 10.0.40219  |
| Microsoft Visual C++ 2012 Additional Runtime | x64          | 11.0.61030  |
| Microsoft Visual C++ 2012 Minimum Runtime    | x64          | 11.0.61030  |
| Microsoft Visual C++ 2013 Additional Runtime | x64          | 12.0.40660  |
| Microsoft Visual C++ 2013 Minimum Runtime    | x64          | 12.0.40660  |
| Microsoft Visual C++ 2013 Additional Runtime | x86          | 12.0.21005  |
| Microsoft Visual C++ 2013 Minimum Runtime    | x86          | 12.0.21005  |
| Microsoft Visual C++ 2017 Debug Runtime      | x64          | 14.16.27033 |
| Microsoft Visual C++ 2017 Debug Runtime      | x86          | 14.16.27033 |
| Microsoft Visual C++ 2019 Additional Runtime | x64          | 14.26.28720 |
| Microsoft Visual C++ 2019 Minimum Runtime    | x64          | 14.26.28720 |
| Microsoft Visual C++ 2019 Additional Runtime | x86          | 14.26.28720 |
| Microsoft Visual C++ 2019 Minimum Runtime    | x86          | 14.26.28720 |


#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/994

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
