### PR TITLE
Do not let Git for Windows' internal tools bleed into the PATH

### DIFF
--- a/images/win/scripts/Installers/Install-Git.ps1
+++ b/images/win/scripts/Installers/Install-Git.ps1
@@ -28,7 +28,7 @@ Install-Binary  -Url $downloadUrl `
                     "/SP-", `
                     "/CLOSEAPPLICATIONS", `
                     "/RESTARTAPPLICATIONS", `
-                    "/o:PathOption=CmdTools", `
+                    "/o:PathOption=Cmd", `
                     "/o:BashTerminalOption=ConHost", `
                     "/o:EnableSymlinks=Enabled", `
                     "/COMPONENTS=gitlfs")


### PR DESCRIPTION
This recently bit me, and I have no idea why it did not start biting me with bd3709460b286ffade35dd83b2be9a76d5e99d4c.

In any case, we should fix this. Git's internal tools are _internal_. If anybody _really_ wants to use them, they have to use a hack: execute a Git alias to get the benefit of those internal tools.