### PR TITLE
Add Pulumi to Windows images

### DIFF
--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -217,6 +217,7 @@
                 "{{ template_dir }}/scripts/Installers/Install-AliyunCli.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-PostgreSQL.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Packer.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-Pulumi.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-JavaTools.ps1"
             ]
         },

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -206,6 +206,7 @@
                 "{{ template_dir }}/scripts/Installers/Install-NodeLts.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-7zip.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Packer.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-Pulumi.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-JavaTools.ps1"
             ]
         },

--- a/images/win/scripts/Installers/Install-Pulumi.ps1
+++ b/images/win/scripts/Installers/Install-Pulumi.ps1
@@ -3,6 +3,6 @@
 ##  Desc:  Install Pulumi
 ################################################################################
 
-Choco-Install -PackageName pulumi.install
+Choco-Install -PackageName pulumi
 
 Invoke-PesterTests -TestFile "Tools" -TestName "Pulumi"

--- a/images/win/scripts/Installers/Install-Pulumi.ps1
+++ b/images/win/scripts/Installers/Install-Pulumi.ps1
@@ -1,0 +1,8 @@
+################################################################################
+##  File:  Install-Pulumi.ps1
+##  Desc:  Install Pulumi
+################################################################################
+
+Choco-Install -PackageName pulumi.install
+
+Invoke-PesterTests -TestFile "Tools" -TestName "Pulumi"

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -94,6 +94,7 @@ $markdown += New-MDList -Style Unordered -Lines @(
     (Get-NewmanVersion),
     (Get-OpenSSLVersion),
     (Get-PackerVersion),
+    (Get-PulumiVersion),
     (Get-SQLPSVersion),
     (Get-SQLServerPSVersion),
     (Get-SVNVersion),

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -107,6 +107,10 @@ function Get-PackerVersion {
     return "Packer $(packer --version)"
 }
 
+function Get-PulumiVersion {
+    return "Pulumi $(pulumi version)"
+}
+
 function Get-SQLPSVersion {
     $module = Get-Module -Name SQLPS -ListAvailable
     $version = $module.Version

--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -187,6 +187,12 @@ Describe "PowerShell Core" {
     }
 }
 
+Describe "Pulumi" {
+    It "pulumi" {
+       "pulumi version" | Should -ReturnZeroExitCode
+    }
+}
+
 Describe "Sbt" {
     It "sbt" {
         "sbt --version" | Should -ReturnZeroExitCode


### PR DESCRIPTION
# Description
This installs Pulumi on Windows images, the latest available version will be installed.
The total size of the package is 57MB and it takes approximately 10 seconds to install.

#### Related issue:https://github.com/actions/virtual-environments/issues/1242

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
