### PR TITLE
[Windows] Set the dynamic port range to start at port 49152 and to end at the 65536 (16384 ports)

### DIFF
--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -326,7 +326,8 @@
         {
             "type": "powershell",
             "scripts":[
-                "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1"
+                "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1",
+                "{{ template_dir }}/scripts/Installers/Configure-DynamicPort.ps1"
             ],
             "elevated_user": "{{user `install_user`}}",
             "elevated_password": "{{user `install_password`}}"

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -325,7 +325,8 @@
         {
             "type": "powershell",
             "scripts":[
-                "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1"
+                "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1",
+                "{{ template_dir }}/scripts/Installers/Configure-DynamicPort.ps1"
             ],
             "elevated_user": "{{user `install_user`}}",
             "elevated_password": "{{user `install_password`}}"

--- a/images/win/scripts/Installers/Configure-DynamicPort.ps1
+++ b/images/win/scripts/Installers/Configure-DynamicPort.ps1
@@ -1,0 +1,9 @@
+# https://support.microsoft.com/en-us/help/929851/the-default-dynamic-port-range-for-tcp-ip-has-changed-in-windows-vista
+# The new default start port is 49152, and the new default end port is 65535.
+Write-Host "Set the dynamic port range to start at port 49152 and to end at the 65536 (16384 ports)"
+$null = netsh int ipv4 set dynamicport tcp start=49152 num=16384
+$null = netsh int ipv4 set dynamicport udp start=49152 num=16384
+$null = netsh int ipv6 set dynamicport tcp start=49152 num=16384
+$null = netsh int ipv6 set dynamicport udp start=49152 num=16384
+
+Invoke-PesterTests -TestFile "WindowsFeatures" -TestName "DynamicPorts"

--- a/images/win/scripts/Installers/Configure-DynamicPort.ps1
+++ b/images/win/scripts/Installers/Configure-DynamicPort.ps1
@@ -1,5 +1,10 @@
 # https://support.microsoft.com/en-us/help/929851/the-default-dynamic-port-range-for-tcp-ip-has-changed-in-windows-vista
 # The new default start port is 49152, and the new default end port is 65535.
+# Default port configuration was changed during image generation by Visual Studio Enterprise Installer to:
+#   Protocol tcp Dynamic Port Range
+#   ---------------------------------
+#   Start Port      : 1024
+#   Number of Ports : 64511
 Write-Host "Set the dynamic port range to start at port 49152 and to end at the 65536 (16384 ports)"
 $null = netsh int ipv4 set dynamicport tcp start=49152 num=16384
 $null = netsh int ipv4 set dynamicport udp start=49152 num=16384

--- a/images/win/scripts/Tests/WindowsFeatures.Tests.ps1
+++ b/images/win/scripts/Tests/WindowsFeatures.Tests.ps1
@@ -42,8 +42,8 @@ Describe "DiskSpace" {
 
 Describe "DynamicPorts" {
     It "Set dynamicport start=49152 num=16384" {
-        $tcpPorts = Get-NetTCPSetting | Where-Object {
-            ($_.DynamicPortRangeStartPort -and $_.DynamicPortRangeNumberOfPorts) -and ($_.DynamicPortRangeStartPort -ne 49152 -or $_.DynamicPortRangeNumberOfPorts -ne 16384)
+        $tcpPorts = Get-NetTCPSetting | Where-Object {$_.SettingName -ne "Automatic"} | Where-Object {
+            $_.DynamicPortRangeStartPort -ne 49152 -or $_.DynamicPortRangeNumberOfPorts -ne 16384
         }
 
         $udpPorts = Get-NetUDPSetting | Where-Object {

--- a/images/win/scripts/Tests/WindowsFeatures.Tests.ps1
+++ b/images/win/scripts/Tests/WindowsFeatures.Tests.ps1
@@ -32,10 +32,25 @@ Describe "ContainersFeature" {
 }
 
 Describe "DiskSpace" {
-    it "The image has enough disk space"{
+    It "The image has enough disk space"{
         $availableSpaceMB =  [math]::Round((Get-PSDrive -Name C).Free / 1MB)
         $minimumFreeSpaceMB = 18 * 1024
 
         $availableSpaceMB | Should -BeGreaterThan $minimumFreeSpaceMB
+    }
+}
+
+Describe "DynamicPorts" {
+    It "Set dynamicport start=49152 num=16384" {
+        $tcpPorts = Get-NetTCPSetting | Where-Object {
+            ($_.DynamicPortRangeStartPort -and $_.DynamicPortRangeNumberOfPorts) -and ($_.DynamicPortRangeStartPort -ne 49152 -or $_.DynamicPortRangeNumberOfPorts -ne 16384)
+        }
+
+        $udpPorts = Get-NetUDPSetting | Where-Object {
+            $_.DynamicPortRangeStartPort -ne 49152 -or $_.DynamicPortRangeNumberOfPorts -ne 16384
+        }
+
+        $tcpPorts | Should -BeNullOrEmpty
+        $udpPorts | Should -BeNullOrEmpty
     }
 }

--- a/images/win/scripts/Tests/WindowsFeatures.Tests.ps1
+++ b/images/win/scripts/Tests/WindowsFeatures.Tests.ps1
@@ -41,13 +41,13 @@ Describe "DiskSpace" {
 }
 
 Describe "DynamicPorts" {
-    It "Set dynamicport start=49152 num=16384" {
+    It "Test dynamicport start=49152 num=16384" {
         $tcpPorts = Get-NetTCPSetting | Where-Object {$_.SettingName -ne "Automatic"} | Where-Object {
-            $_.DynamicPortRangeStartPort -ne 49152 -or $_.DynamicPortRangeNumberOfPorts -ne 16384
+            $_.DynamicPortRangeStartPort -eq 49152 -and $_.DynamicPortRangeNumberOfPorts -eq 16384
         }
 
         $udpPorts = Get-NetUDPSetting | Where-Object {
-            $_.DynamicPortRangeStartPort -ne 49152 -or $_.DynamicPortRangeNumberOfPorts -ne 16384
+            $_.DynamicPortRangeStartPort -eq 49152 -and $_.DynamicPortRangeNumberOfPorts -eq 16384
         }
 
         $tcpPorts | Should -BeNullOrEmpty

--- a/images/win/scripts/Tests/WindowsFeatures.Tests.ps1
+++ b/images/win/scripts/Tests/WindowsFeatures.Tests.ps1
@@ -41,16 +41,19 @@ Describe "DiskSpace" {
 }
 
 Describe "DynamicPorts" {
-    It "Test dynamicport start=49152 num=16384" {
+    It "Test TCP dynamicport start=49152 num=16384" {
         $tcpPorts = Get-NetTCPSetting | Where-Object {$_.SettingName -ne "Automatic"} | Where-Object {
-            $_.DynamicPortRangeStartPort -eq 49152 -and $_.DynamicPortRangeNumberOfPorts -eq 16384
-        }
-
-        $udpPorts = Get-NetUDPSetting | Where-Object {
-            $_.DynamicPortRangeStartPort -eq 49152 -and $_.DynamicPortRangeNumberOfPorts -eq 16384
+            $_.DynamicPortRangeStartPort -ne 49152 -or $_.DynamicPortRangeNumberOfPorts -ne 16384
         }
 
         $tcpPorts | Should -BeNullOrEmpty
+    }
+
+    It "Test UDP dynamicport start=49152 num=16384" {
+        $udpPorts = Get-NetUDPSetting | Where-Object {
+            $_.DynamicPortRangeStartPort -ne 49152 -or $_.DynamicPortRangeNumberOfPorts -ne 16384
+        }
+
         $udpPorts | Should -BeNullOrEmpty
     }
 }


### PR DESCRIPTION
# Description
After installing VS via script https://github.com/actions/virtual-environments/blob/main/images/win/scripts/Installers/Install-VS.ps1 the dynamic port range is changed to:

```
Protocol tcp Dynamic Port Range
    vhd: ---------------------------------
    vhd: Start Port      : 1024
    vhd: Number of Ports : 64511
```
Example https://github.visualstudio.com/virtual-environments/_build/results?buildId=78654&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=486c0909-f67d-5748-80b3-bb1d531e7b43 : 

Before Visual Studio installation [703]:
```
==> vhd: Provisioning with powershell script: C:\agent\_work\9\s\images\win/scripts/Installers/Install-VS.ps1
    vhd: Display ports
    vhd:
    vhd: Protocol tcp Dynamic Port Range
    vhd: ---------------------------------
    vhd: Start Port      : 49152
    vhd: Number of Ports : 16384
```
After [825]:

```
    vhd: Display ports
    vhd:
    vhd: Protocol tcp Dynamic Port Range
    vhd: ---------------------------------
    vhd: Start Port      : 1024
    vhd: Number of Ports : 64511
    vhd:
```

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/996

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
