### PR TITLE
[Ubuntu] Increase vm.max_map_count=262144

### DIFF
--- a/images/linux/scripts/installers/configure-environment.sh
+++ b/images/linux/scripts/installers/configure-environment.sh
@@ -19,3 +19,7 @@ AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
 mkdir $AGENT_TOOLSDIRECTORY
 echo "AGENT_TOOLSDIRECTORY=$AGENT_TOOLSDIRECTORY" | tee -a /etc/environment
 chmod -R 777 $AGENT_TOOLSDIRECTORY
+
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
+# https://www.suse.com/support/kb/doc/?id=000016692
+echo 'vm.max_map_count=262144' | tee -a /etc/sysctl.conf


### PR DESCRIPTION
# Description
https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html - Elasticsearch uses a mmapfs directory by default to store its indices. The default operating system limits on mmap counts is likely to be too low, which may result in out of memory exceptions.The vm.max_map_count kernel setting must be set to at least 262144 for production use.

#### Related issue:
https://github.com/actions/virtual-environments/issues/1457

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
