### PR TITLE
Do not set `JAVA_TOOL_OPTIONS` on Linux

### DIFF
--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -46,7 +46,6 @@ if isUbuntu16 || isUbuntu18 ; then
 echo "JAVA_HOME_12_X64=/usr/lib/jvm/adoptopenjdk-12-hotspot-amd64" | tee -a /etc/environment
 fi
 echo "JAVA_HOME=/usr/lib/jvm/adoptopenjdk-${DEFAULT_JDK_VERSION}-hotspot-amd64" | tee -a /etc/environment
-echo "JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8" | tee -a /etc/environment
 
 # Install Ant
 apt-fast install -y --no-install-recommends ant ant-optional


### PR DESCRIPTION
# Description
This ensures that a) the `JAVA_TOOL_OPTIONS` environment variable is not set, which avoids additional output from some Java tools, and that b) the default Java file encoding is not changed.

#### Related issue: #1437
