### PR TITLE
the Github CLI version fix for short version number

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -222,7 +222,9 @@ function Get-NewmanVersion {
 }
 
 function Get-GHVersion {
-    return "GitHub CLI $(gh --version)"
+    $(gh --version) -match "gh version (?<version>.+)" | Out-Null
+    $ghVersion = $Matches.Version
+    return "GitHub CLI $ghVersion"
 }
 
 function Get-VisualCPPComponents {

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -222,7 +222,7 @@ function Get-NewmanVersion {
 }
 
 function Get-GHVersion {
-    $(gh --version) -match "gh version (?<version>.+)" | Out-Null
+    ($(gh --version) | Select-String -Pattern "gh version") -match "gh version (?<version>\d+\.\d+\.\d+)" | Out-Null
     $ghVersion = $Matches.Version
     return "GitHub CLI $ghVersion"
 }


### PR DESCRIPTION
# Description
Current documentation displays Github CLI version as
GitHub CLI gh version 0.11.1 (2020-07-28) https://github.com/cli/cli/releases/tag/v0.11.1

but should display as
GitHub CLI 0.11.1

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
