### PR TITLE
[Ubuntu] Fix aws-sam-cli repository url

### DIFF
--- a/images/linux/scripts/installers/aws-sam-cli.sh
+++ b/images/linux/scripts/installers/aws-sam-cli.sh
@@ -9,7 +9,7 @@
 source $HELPER_SCRIPTS/document.sh
 
 # Download latest aws sam cli sources
-TarballUrl=$(curl -s https://api.github.com/repos/awslabs/aws-sam-cli/releases/latest | jq -r '.tarball_url')
+TarballUrl=$(curl -s https://api.github.com/repos/aws/aws-sam-cli/releases/latest | jq -r '.tarball_url')
 TarballPath="/tmp/aws-sam-cli.tar.gz"
 wget $TarballUrl -O $TarballPath
 tar -xzvf $TarballPath -C /tmp

--- a/images/linux/scripts/installers/aws-sam-cli.sh
+++ b/images/linux/scripts/installers/aws-sam-cli.sh
@@ -13,7 +13,7 @@ TarballUrl=$(curl -s https://api.github.com/repos/aws/aws-sam-cli/releases/lates
 TarballPath="/tmp/aws-sam-cli.tar.gz"
 wget $TarballUrl -O $TarballPath
 tar -xzvf $TarballPath -C /tmp
-cd /tmp/awslabs-aws-sam-cli*
+cd /tmp/aws-aws-sam-cli*
 
 mkdir /opt/python-aws-sam-cli
 cp -r /opt/hostedtoolcache/Python/3.7* /opt/python-aws-sam-cli


### PR DESCRIPTION
# Description
Aws-sam-cli url changed from https://github.com/awslabs/aws-sam-cli to https://github.com/aws/aws-sam-cli and that breaks image generation.

#### Related issue:
n\a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
