### PR TITLE
Set javac version 1.8 on Ubuntu 16.04

### DIFF
--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -38,12 +38,12 @@ apt-get -y install adoptopenjdk-8-hotspot=\*
 apt-get -y install adoptopenjdk-11-hotspot=\*
 
 # Set Default Java version.
-update-java-alternatives -s /usr/lib/jvm/adoptopenjdk-${DEFAULT_JDK_VERSION}-hotspot-amd64
 if isUbuntu16; then
     # issue: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=825987
     # stackoverflow: https://askubuntu.com/questions/1187136/update-java-alternatives-only-java-but-not-javac-is-changed
     sudo sed -i 's/(hl|jre|jdk|plugin|DUMMY) /(hl|jre|jdk|jdkhl|plugin|DUMMY) /g' /usr/sbin/update-java-alternatives
 fi
+update-java-alternatives -s /usr/lib/jvm/adoptopenjdk-${DEFAULT_JDK_VERSION}-hotspot-amd64
 
 echo "JAVA_HOME_8_X64=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64" | tee -a /etc/environment
 echo "JAVA_HOME_11_X64=/usr/lib/jvm/adoptopenjdk-11-hotspot-amd64" | tee -a /etc/environment
@@ -98,7 +98,7 @@ else
     exit 1
 fi
 
-javacVersion=`javac -version | sed 's/javac //g'`
+javacVersion=`javac -version 2>&1 | sed 's/javac //g'`
 if [[ "$javacVersion" =~ ([1]{0,1}.)?$DEFAULT_JDK_VERSION.* ]]; then
     echo "Javac is equal to default"
 else

--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -40,7 +40,7 @@ apt-get -y install adoptopenjdk-11-hotspot=\*
 # Set Default Java version.
 update-java-alternatives -s /usr/lib/jvm/adoptopenjdk-${DEFAULT_JDK_VERSION}-hotspot-amd64
 if isUbuntu16; then
-    sudo update-alternatives --set javac /usr/lib/jvm/adoptopenjdk-${DEFAULT_JDK_VERSION}-hotspot-amd64/bin/javac
+    sudo sed -i 's/(hl|jre|jdk|plugin|DUMMY) /(hl|jre|jdk|jdkhl|plugin|DUMMY) /g' /usr/sbin/update-java-alternatives
 fi
 
 echo "JAVA_HOME_8_X64=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64" | tee -a /etc/environment

--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -39,6 +39,9 @@ apt-get -y install adoptopenjdk-11-hotspot=\*
 
 # Set Default Java version.
 update-java-alternatives -s /usr/lib/jvm/adoptopenjdk-${DEFAULT_JDK_VERSION}-hotspot-amd64
+if isUbuntu16; then
+    sudo update-alternatives --set javac /usr/lib/jvm/adoptopenjdk-${DEFAULT_JDK_VERSION}-hotspot-amd64/bin/javac
+fi
 
 echo "JAVA_HOME_8_X64=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64" | tee -a /etc/environment
 echo "JAVA_HOME_11_X64=/usr/lib/jvm/adoptopenjdk-11-hotspot-amd64" | tee -a /etc/environment

--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -91,11 +91,18 @@ for cmd in gradle java javac mvn ant; do
 done
 
 javaVersion=`java -version 2>&1 | head -n 1 | cut -d\" -f 2`
-javacVersion=`javac -version | sed 's/javac //g'`
-if [[ "$javaVersion" == "$javacVersion" ]]; then
-    echo "Java and javac versions are the same"
+if [[ "$javaVersion" =~ ([1]{0,1}.)?$DEFAULT_JDK_VERSION.* ]]; then
+    echo "Java is equal to defaul"
 else
-    echo "Java and Javac are not the same"
+    echo "Java is not equal to default"
+    exit 1
+fi
+
+javacVersion=`javac -version | sed 's/javac //g'`
+if [[ "$javacVersion" =~ ([1]{0,1}.)?$DEFAULT_JDK_VERSION.* ]]; then
+    echo "Javac is equal to default"
+else
+    echo "Javac is not equal to default"
     exit 1
 fi
 

--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -40,6 +40,8 @@ apt-get -y install adoptopenjdk-11-hotspot=\*
 # Set Default Java version.
 update-java-alternatives -s /usr/lib/jvm/adoptopenjdk-${DEFAULT_JDK_VERSION}-hotspot-amd64
 if isUbuntu16; then
+    # issue: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=825987
+    # stackoverflow: https://askubuntu.com/questions/1187136/update-java-alternatives-only-java-but-not-javac-is-changed
     sudo sed -i 's/(hl|jre|jdk|plugin|DUMMY) /(hl|jre|jdk|jdkhl|plugin|DUMMY) /g' /usr/sbin/update-java-alternatives
 fi
 
@@ -87,6 +89,15 @@ for cmd in gradle java javac mvn ant; do
         exit 1
     fi
 done
+
+javaVersion=`java -version 2>&1 | head -n 1 | cut -d\" -f 2`
+javacVersion=`javac -version | sed 's/javac //g'`
+if [[ "$javaVersion" == "$javacVersion" ]]; then
+    echo "Java and javac versions are the same"
+else
+    echo "Java and Javac are not the same"
+    exit 1
+fi
 
 # Document what was added to the image
 echo "Lastly, documenting what we added to the metadata file"


### PR DESCRIPTION
# Description
24 June 2020 we merged our pull request with migration from Java Zulu to AdopOpenJdk. We got an issue that on ubuntu16 java and javac versions are different. On all other images they have same java and javac versions. With this pull request we want to manually setup javac version for ubuntu 16.04.
Ubuntu 16.04:
 - java -version: 
```
openjdk version "1.8.0_265"
OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_265-b01)
OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.265-b01, mixed mode)
```
 - javac -version: 
```
javac 1.7.0_272
```
Java config for Ubuntu 16.04:
```
  Selection    Path                                                  Priority   Status
------------------------------------------------------------
* 0            /usr/lib/jvm/zulu-7-azure-amd64/bin/javac              1704006   auto mode
  1            /usr/lib/jvm/adoptopenjdk-11-hotspot-amd64/bin/javac   1111      manual mode
  2            /usr/lib/jvm/adoptopenjdk-12-hotspot-amd64/bin/javac   1121      manual mode
  3            /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/bin/javac    1081      manual mode
  4            /usr/lib/jvm/zulu-7-azure-amd64/bin/javac              1704006   manual mode

```
Java config for Ubuntu 18.04:
```
  Selection    Path                                                  Priority   Status
------------------------------------------------------------
  0            /usr/lib/jvm/zulu-7-azure-amd64/bin/javac              1704006   auto mode
  1            /usr/lib/jvm/adoptopenjdk-11-hotspot-amd64/bin/javac   1111      manual mode
  2            /usr/lib/jvm/adoptopenjdk-12-hotspot-amd64/bin/javac   1121      manual mode
* 3            /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/bin/javac    1081      manual mode
  4            /usr/lib/jvm/zulu-7-azure-amd64/bin/javac              1704006   manual mode
```

The root cause of the issue is the bug of debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=825987. update-java-alternatives difference between ubuntu16 and ubuntu18.
![image](https://user-images.githubusercontent.com/28229110/91179790-a4856800-e6ef-11ea-9cb4-afa1f9dfe218.png)

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
