### PR TITLE
WebBuildTools extension for VS added

### DIFF
--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -225,7 +225,8 @@
             "Microsoft.VisualStudio.Component.VC.Runtimes.ARM.Spectre",
             "Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre",
             "Microsoft.VisualStudio.Component.Workflow",
-            "Microsoft.VisualStudio.Workload.Office"
+            "Microsoft.VisualStudio.Workload.Office",
+            "Microsoft.VisualStudio.Workload.WebBuildTools"
         ]
     }
 }

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -255,6 +255,7 @@
             "Microsoft.VisualStudio.Workload.Python",
             "Microsoft.VisualStudio.Workload.Universal",
             "Microsoft.VisualStudio.Workload.VisualStudioExtension",
+            "Microsoft.VisualStudio.Workload.WebBuildTools",
             "Component.MDD.Linux",
             "Component.MDD.Linux.GCC.arm"
         ]


### PR DESCRIPTION
# Description
Added WebBuildTools extension for Visual Studio for Windows 2016/2019 images

#### Related issue:
https://github.com/actions/virtual-environments/issues/1470

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
