### PR TITLE
Install hub without snap

### DIFF
--- a/images/linux/scripts/helpers/install.sh
+++ b/images/linux/scripts/helpers/install.sh
@@ -13,7 +13,7 @@ download_with_retries() {
     local NAME="${3:-${URL##*/}}"
     local COMPRESSED="$4"
 
-    if [ $COMPRESSED == "compressed" ]; then
+    if [[ $COMPRESSED == "compressed" ]]; then
         COMMAND="curl $URL -4 -sL --compressed -o '$DEST/$NAME'"
     else
         COMMAND="curl $URL -4 -sL -o '$DEST/$NAME'"

--- a/images/linux/scripts/installers/git.sh
+++ b/images/linux/scripts/installers/git.sh
@@ -52,7 +52,7 @@ tmp_hub="/tmp/hub"
 mkdir -p "$tmp_hub"
 url=$(curl -s https://api.github.com/repos/github/hub/releases/latest | jq -r '.assets[].browser_download_url | select(contains("hub-linux-amd64"))')
 download_with_retries "$url" "$tmp_hub"
-tar xzvf /tmp/hub-linux-amd64-*.tgz --strip-components 1 -C "$tmp_hub"
+tar xzvf "$tmp_hub"/hub-linux-amd64-*.tgz --strip-components 1 -C "$tmp_hub"
 mv "$tmp_hub"/bin/hub /usr/local/bin
 
 if command -v hub; then

--- a/images/linux/scripts/installers/git.sh
+++ b/images/linux/scripts/installers/git.sh
@@ -5,7 +5,7 @@
 ################################################################################
 
 # Source the helpers for use with the script
-source $HELPER_SCRIPTS/document.sh
+source "$HELPER_SCRIPTS"/document.sh
 
 ## Install git
 add-apt-repository ppa:git-core/ppa -y
@@ -46,7 +46,15 @@ DocumentInstalledItem "Git Large File Storage (LFS) ($(git-lfs --version 2>&1 | 
 DocumentInstalledItem "Git-ftp ($(git-ftp --version | cut -d ' ' -f 3))"
 
 #Install hub
-snap install hub --classic
+TEMP_HUB=$(mktemp -d -t)
+pushd "$TEMP_HUB" || exit
+URL=$(curl -s https://api.github.com/repos/github/hub/releases/latest | jq -r '.assets[].browser_download_url | select(contains("hub-linux-amd64"))')
+wget -P "$TEMP_HUB" "$URL"
+tar xzvf "$TEMP_HUB"/hub-linux-amd64-*.tgz --strip-components 1
+mv bin/hub /usr/local/bin
+rm -rf "$TEMP_HUB"
+popd || exit
+
 if command -v hub; then
     echo "hub CLI was installed successfully"
     DocumentInstalledItem "Hub CLI ($(hub --version | grep "hub version" | cut -d ' ' -f 3))"

--- a/images/linux/scripts/installers/git.sh
+++ b/images/linux/scripts/installers/git.sh
@@ -3,9 +3,11 @@
 ##  File:  git.sh
 ##  Desc:  Installs Git
 ################################################################################
+set -e
 
 # Source the helpers for use with the script
 source "$HELPER_SCRIPTS"/document.sh
+source "$HELPER_SCRIPTS"/install.sh
 
 ## Install git
 add-apt-repository ppa:git-core/ppa -y
@@ -46,14 +48,12 @@ DocumentInstalledItem "Git Large File Storage (LFS) ($(git-lfs --version 2>&1 | 
 DocumentInstalledItem "Git-ftp ($(git-ftp --version | cut -d ' ' -f 3))"
 
 #Install hub
-TEMP_HUB=$(mktemp -d -t)
-pushd "$TEMP_HUB" || exit
-URL=$(curl -s https://api.github.com/repos/github/hub/releases/latest | jq -r '.assets[].browser_download_url | select(contains("hub-linux-amd64"))')
-wget -P "$TEMP_HUB" "$URL"
-tar xzvf "$TEMP_HUB"/hub-linux-amd64-*.tgz --strip-components 1
-mv bin/hub /usr/local/bin
-rm -rf "$TEMP_HUB"
-popd || exit
+tmp_hub="/tmp/hub"
+mkdir -p "$tmp_hub"
+url=$(curl -s https://api.github.com/repos/github/hub/releases/latest | jq -r '.assets[].browser_download_url | select(contains("hub-linux-amd64"))')
+download_with_retries "$url" "$tmp_hub"
+tar xzvf /tmp/hub-linux-amd64-*.tgz --strip-components 1 -C "$tmp_hub"
+mv "$tmp_hub"/bin/hub /usr/local/bin
 
 if command -v hub; then
     echo "hub CLI was installed successfully"


### PR DESCRIPTION
# Description

New tool, Bug fixing, or Improvement?  Improvement

Snap is no more the recommended way to install `hub`, as stated on the [official project](https://github.com/github/hub#installation).

#### Related issue:

## Check list
- [x] https://github.com/actions/virtual-environments/issues/1514
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
