### PR TITLE
Fix android permissions

### DIFF
--- a/images/linux/scripts/installers/android.sh
+++ b/images/linux/scripts/installers/android.sh
@@ -27,9 +27,6 @@ wget -O android-sdk.zip https://dl.google.com/android/repository/sdk-tools-linux
 unzip android-sdk.zip -d ${ANDROID_SDK_ROOT}
 rm -f android-sdk.zip
 
-# Add required permissions
-chmod -R a+rwx ${ANDROID_SDK_ROOT}
-
 if isUbuntu20 ; then
     # Sdk manager doesn't work with Java > 8, set version 8 explicitly
     sed -i "2i export JAVA_HOME=${JAVA_HOME_8_X64}" /usr/local/lib/android/sdk/tools/bin/sdkmanager
@@ -62,6 +59,9 @@ constraint_layout_versions_list=$(echo "$extras"|awk -F';' '/constraint-layout;/
 constraint_layout_solver_versions_list=$(echo "$extras"|awk -F';' '/constraint-layout-solver;/  {print $8}')
 platform_versions_list=$(echo "$platforms"|awk -F- '{print $2}')
 buildtools_versions_list=$(echo "$buildtools"|awk -F';' '{print $2}')
+
+# Add required permissions
+chmod -R a+rwx ${ANDROID_SDK_ROOT}
 
 echo "Lastly, document what was added to the metadata file"
 DocumentInstalledItem "Google Repository $(cat ${ANDROID_SDK_ROOT}/extras/google/m2repository/source.properties 2>&1 | grep Pkg.Revision | cut -d '=' -f 2)"


### PR DESCRIPTION
# Description
FIx the issue with android permissions. The following command `/usr/local/lib/android/sdk/tools/bin/sdkmanager "add-ons;addon-google_apis-google-19"` threw an error if it run without sudo permissions. It was fixed by adding permissions after creation all directories.

#### Related issue: https://github.com/actions/virtual-environments/issues/1337
#### Build: https://github.visualstudio.com/virtual-environments/_build/results?buildId=79809&view=results
#### Test result
![image](https://user-images.githubusercontent.com/28229110/91696378-248c5180-eb78-11ea-8120-4e351225877b.png)

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
