### PR TITLE
Add VS build tools installation

### DIFF
--- a/images/win/scripts/ImageHelpers/ImageHelpers.psm1
+++ b/images/win/scripts/ImageHelpers/ImageHelpers.psm1
@@ -36,6 +36,6 @@ Export-ModuleMember -Function @(
     'Invoke-PesterTests'
     'Get-VsCatalogJsonPath'
     'Install-AndroidSDKPackages'
-    'Get-VisualStudioInstallation'
+    'Get-VisualStudioProduct'
     'Get-VisualStudioComponents'
 )

--- a/images/win/scripts/ImageHelpers/ImageHelpers.psm1
+++ b/images/win/scripts/ImageHelpers/ImageHelpers.psm1
@@ -35,8 +35,7 @@ Export-ModuleMember -Function @(
     'Get-EnvironmentVariable'
     'Invoke-PesterTests'
     'Get-VsCatalogJsonPath'
-    'Get-VisualStudioPath'
     'Install-AndroidSDKPackages'
-    'Get-VisualStudioPackages'
+    'Get-VisualStudioInstallation'
     'Get-VisualStudioComponents'
 )

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -267,8 +267,7 @@ function Get-VSExtensionVersion
     )
 
     $instanceFolders = "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances\" + (Get-VisualStudioInstallation -VSInstallType "VS").InstanceId
-    $stateContent = Get-Content -Path (Join-Path $instanceFolders '\state.packages.json')
-    $state = $stateContent | ConvertFrom-Json
+    $state = Get-Content -Path (Join-Path $instanceFolders '\state.packages.json') | ConvertFrom-Json
     $packageVersion = ($state.packages | Where-Object { $_.id -eq $packageName }).version
 
     if (-not $packageVersion)

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -266,14 +266,8 @@ function Get-VSExtensionVersion
         [string] $packageName
     )
 
-    $instanceFolders = Get-ChildItem -Path "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances"
-    if ($instanceFolders -is [array])
-    {
-        Write-Host "More than one instance installed"
-        exit 1
-    }
-
-    $stateContent = Get-Content -Path (Join-Path $instanceFolders.FullName '\state.packages.json')
+    $instanceFolders = "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances\" + (Get-VisualStudioInstallation -VSInstallType "VS").InstanceId
+    $stateContent = Get-Content -Path (Join-Path $instanceFolders '\state.packages.json')
     $state = $stateContent | ConvertFrom-Json
     $packageVersion = ($state.packages | Where-Object { $_.id -eq $packageName }).version
 

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -258,27 +258,6 @@ function Install-VsixExtension
         }
 }
 
-function Get-VSExtensionVersion
-{
-    Param
-    (
-        [Parameter(Mandatory=$true)]
-        [string] $packageName
-    )
-
-    $instanceFolders = "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances\" + (Get-VisualStudioInstallation -VSInstallType "VS").InstanceId
-    $state = Get-Content -Path (Join-Path $instanceFolders '\state.packages.json') | ConvertFrom-Json
-    $packageVersion = ($state.packages | Where-Object { $_.id -eq $packageName }).version
-
-    if (-not $packageVersion)
-    {
-        Write-Host "installed package $packageName for Visual Studio 2019 was not found"
-        exit 1
-    }
-
-    return $packageVersion
-}
-
 function Get-ToolcachePackages
 {
     $toolcachePath = Join-Path $env:ROOT_FOLDER "toolcache.json"

--- a/images/win/scripts/ImageHelpers/VisualStudioHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/VisualStudioHelpers.ps1
@@ -69,6 +69,7 @@ function Get-VisualStudioInstallation {
     Param
     (
         [Parameter(Mandatory)]
+        [ValidateSet('VS','BuildTools')]
         [String] $VSInstallType
     )
 
@@ -92,6 +93,7 @@ function Get-VisualStudioComponents {
     Param
     (
         [Parameter(Mandatory)]
+        [ValidateSet('VS','BuildTools')]
         [String] $VSInstallType
     )
     (Get-VisualStudioInstallation -VSInstallType $VSInstallType).Packages | Where-Object type -in 'Component', 'Workload' |

--- a/images/win/scripts/ImageHelpers/VisualStudioHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/VisualStudioHelpers.ps1
@@ -60,9 +60,12 @@ Function Install-VisualStudio
     }
 }
 
+function Get-VisualStudioInstancePath {
+    return "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances\" + (Get-VisualStudioProduct -ProductType "VisualStudio").InstanceId
+}
+
 function Get-VsCatalogJsonPath {
-    $instanceFolder = "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances\" + (Get-VisualStudioProduct -ProductType "VisualStudio").InstanceId
-    return Join-Path $instanceFolder "catalog.json"
+    return Join-Path (Get-VisualStudioInstancePath) "catalog.json"
 }
 
 function Get-VisualStudioProduct {
@@ -81,7 +84,7 @@ function Get-VisualStudioProduct {
     {
         $VSSelectionType = "*Build*"
     }
-    return Get-VSSetupInstance | Select-VSSetupInstance -Product * | Where-Object -Property DisplayName -like $VSSelectionType
+    return Get-VSSetupInstance | Where-Object -Property DisplayName -like $VSSelectionType
 }
 
 function Get-VisualStudioComponents {
@@ -103,8 +106,7 @@ function Get-VSExtensionVersion
         [string] $packageName
     )
 
-    $instanceFolders = "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances\" + (Get-VisualStudioProduct -ProductType "VisualStudio").InstanceId
-    $state = Get-Content -Path (Join-Path $instanceFolders '\state.packages.json') | ConvertFrom-Json
+    $state = Get-Content -Path (Join-Path (Get-VisualStudioInstancePath) '\state.packages.json') | ConvertFrom-Json
     $packageVersion = ($state.packages | Where-Object { $_.id -eq $packageName }).version
 
     if (-not $packageVersion)

--- a/images/win/scripts/ImageHelpers/VisualStudioHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/VisualStudioHelpers.ps1
@@ -103,15 +103,15 @@ function Get-VSExtensionVersion
     Param
     (
         [Parameter(Mandatory=$true)]
-        [string] $packageName
+        [string] $PackageName
     )
 
     $state = Get-Content -Path (Join-Path (Get-VisualStudioInstancePath) '\state.packages.json') | ConvertFrom-Json
-    $packageVersion = ($state.packages | Where-Object { $_.id -eq $packageName }).version
+    $packageVersion = ($state.packages | Where-Object { $_.id -eq $PackageName }).version
 
     if (-not $packageVersion)
     {
-        Write-Host "installed package $packageName for Visual Studio 2019 was not found"
+        Write-Host "installed package $PackageName for Visual Studio 2019 was not found"
         exit 1
     }
 

--- a/images/win/scripts/Installers/Install-VS.ps1
+++ b/images/win/scripts/Installers/Install-VS.ps1
@@ -29,7 +29,7 @@ $buildbootstrapperUrl = "https://aka.ms/vs/${subVersion}/release/vs_buildtools.e
 Install-VisualStudio -BootstrapperUrl $bootstrapperUrl -WorkLoads $workLoadsArgument
 Install-VisualStudio -BootstrapperUrl $buildbootstrapperUrl -WorkLoads $buildWorkLoadsArgument
 
-$vsInstallRoot = (Get-VisualStudioInstallation -VStype "VS").InstallationPath
+$vsInstallRoot = (Get-VisualStudioInstallation -VSInstallType "VS").InstallationPath
 
 # Initialize Visual Studio Experimental Instance
 & "$vsInstallRoot\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings /Command File.Exit

--- a/images/win/scripts/Installers/Install-VS.ps1
+++ b/images/win/scripts/Installers/Install-VS.ps1
@@ -7,18 +7,18 @@ $ErrorActionPreference = "Stop"
 
 $toolset = Get-ToolsetContent
 $requiredComponents = $toolset.visualStudio.workloads | ForEach-Object { "--add $_" }
-$buildRequiredComponents = $toolset.visualStudio.build_workloads | ForEach-Object { "--add $_" }
+$buildToolsRequiredComponents = $toolset.visualStudio.buildtools_workloads | ForEach-Object { "--add $_" }
 $workLoads = @(
 	"--allWorkloads --includeRecommended"
 	$requiredComponents
 	"--remove Component.CPython3.x64"
 )
 $workLoadsArgument = [String]::Join(" ", $workLoads)
-$buildWorkLoads = @(
+$buildToolsWorkloads= @(
 	"--includeRecommended"
-	$buildRequiredComponents
+	$buildToolsRequiredComponents
 )
-$buildWorkLoadsArgument = [String]::Join(" ", $buildWorkLoads)
+$buildWorkLoadsArgument = [String]::Join(" ", $buildToolsWorkloads)
 
 $releaseInPath = $toolset.visualStudio.edition
 $subVersion = $toolset.visualStudio.subversion
@@ -29,7 +29,7 @@ $buildbootstrapperUrl = "https://aka.ms/vs/${subVersion}/release/vs_buildtools.e
 Install-VisualStudio -BootstrapperUrl $bootstrapperUrl -WorkLoads $workLoadsArgument
 Install-VisualStudio -BootstrapperUrl $buildbootstrapperUrl -WorkLoads $buildWorkLoadsArgument
 
-$vsInstallRoot = (Get-VisualStudioInstallation -VSInstallType "VS").InstallationPath
+$vsInstallRoot = (Get-VisualStudioProduct -ProductType "VisualStudio").InstallationPath
 
 # Initialize Visual Studio Experimental Instance
 & "$vsInstallRoot\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings /Command File.Exit

--- a/images/win/scripts/Installers/Install-VS.ps1
+++ b/images/win/scripts/Installers/Install-VS.ps1
@@ -1,38 +1,35 @@
 ################################################################################
 ##  File:  Install-VS.ps1
-##  Desc:  Install Visual Studio
+##  Desc:  Install Visual Studio and build tools
 ################################################################################
 
 $ErrorActionPreference = "Stop"
 
 $toolset = Get-ToolsetContent
 $requiredComponents = $toolset.visualStudio.workloads | ForEach-Object { "--add $_" }
+$buildRequiredComponents = $toolset.visualStudio.build_workloads | ForEach-Object { "--add $_" }
 $workLoads = @(
 	"--allWorkloads --includeRecommended"
 	$requiredComponents
 	"--remove Component.CPython3.x64"
 )
 $workLoadsArgument = [String]::Join(" ", $workLoads)
+$buildWorkLoads = @(
+	"--includeRecommended"
+	$buildRequiredComponents
+)
+$buildWorkLoadsArgument = [String]::Join(" ", $buildWorkLoads)
 
 $releaseInPath = $toolset.visualStudio.edition
 $subVersion = $toolset.visualStudio.subversion
 $bootstrapperUrl = "https://aka.ms/vs/${subVersion}/release/vs_${releaseInPath}.exe"
+$buildbootstrapperUrl = "https://aka.ms/vs/${subVersion}/release/vs_buildtools.exe"
 
-# Install VS
+# Install VS and VS Build tools
 Install-VisualStudio -BootstrapperUrl $bootstrapperUrl -WorkLoads $workLoadsArgument
+Install-VisualStudio -BootstrapperUrl $buildbootstrapperUrl -WorkLoads $buildWorkLoadsArgument
 
-# Find the version of VS installed for this instance
-# Only supports a single instance
-$vsProgramData = Get-Item -Path "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances"
-$instanceFolders = Get-ChildItem -Path $vsProgramData.FullName
-
-if ($instanceFolders -is [array])
-{
-    Write-Host "More than one instance installed"
-    exit 1
-}
-
-$vsInstallRoot = Get-VisualStudioPath
+$vsInstallRoot = (Get-VisualStudioInstallation -VStype "VS").InstallationPath
 
 # Initialize Visual Studio Experimental Instance
 & "$vsInstallRoot\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings /Command File.Exit

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -171,12 +171,12 @@ $markdown += New-MDNewLine
 
 $markdown += New-MDHeader "Workloads, components and extensions:" -Level 4
 $markdown += New-MDNewLine
-$markdown += ((Get-VisualStudioComponents -VSInstallType "VS") + (Get-VisualStudioExtensions)) | New-MDTable
+$markdown += ((Get-VisualStudioComponents -ProductType "VisualStudio") + (Get-VisualStudioExtensions)) | New-MDTable
 $markdown += New-MDNewLine
 
-$markdown += New-MDHeader "Build Workloads and components:" -Level 4
+$markdown += New-MDHeader "Build Tools Workloads:" -Level 4
 $markdown += New-MDNewLine
-$markdown += (Get-VisualStudioComponents -VSInstallType "BuildTools") | New-MDTable
+$markdown += (Get-VisualStudioComponents -ProductType "BuildTools") | New-MDTable
 $markdown += New-MDNewLine
 
 $markdown += New-MDHeader "Microsoft Visual C++:" -Level 4

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -171,7 +171,12 @@ $markdown += New-MDNewLine
 
 $markdown += New-MDHeader "Workloads, components and extensions:" -Level 4
 $markdown += New-MDNewLine
-$markdown += ((Get-VisualStudioComponents) + (Get-VisualStudioExtensions)) | New-MDTable
+$markdown += ((Get-VisualStudioComponents -VSInstallType "VS") + (Get-VisualStudioExtensions)) | New-MDTable
+$markdown += New-MDNewLine
+
+$markdown += New-MDHeader "Build Workloads and components:" -Level 4
+$markdown += New-MDNewLine
+$markdown += (Get-VisualStudioComponents -VSInstallType "BuildTools") | New-MDTable
 $markdown += New-MDNewLine
 
 $markdown += New-MDHeader "Microsoft Visual C++:" -Level 4

--- a/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
@@ -23,7 +23,7 @@ function Get-VisualStudioExtensions {
     # Wix
     $vs = (Get-VisualStudioVersion).Name.Split()[-1]
     $wixPackageVersion = Get-WixVersion
-    $wixExtensionVersion = (Get-VisualStudioPackages | Where-Object {$_.Id -match 'WixToolset.VisualStudioExtension.Dev' -and $_.type -eq 'vsix'}).Version
+    $wixExtensionVersion = ((Get-VisualStudioInstallation -VSInstallType "VS").Packages  | Where-Object {$_.Id -match 'WixToolset.VisualStudioExtension.Dev' -and $_.type -eq 'vsix'}).Version
 
     # WDK
     $wdkPackageVersion = Get-VSExtensionVersion -packageName 'Microsoft.Windows.DriverKit'

--- a/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
@@ -23,7 +23,7 @@ function Get-VisualStudioExtensions {
     # Wix
     $vs = (Get-VisualStudioVersion).Name.Split()[-1]
     $wixPackageVersion = Get-WixVersion
-    $wixExtensionVersion = ((Get-VisualStudioInstallation -VSInstallType "VS").Packages  | Where-Object {$_.Id -match 'WixToolset.VisualStudioExtension.Dev' -and $_.type -eq 'vsix'}).Version
+    $wixExtensionVersion = ((Get-VisualStudioProduct -ProductType "VisualStudio").Packages  | Where-Object {$_.Id -match 'WixToolset.VisualStudioExtension.Dev' -and $_.type -eq 'vsix'}).Version
 
     # WDK
     $wdkPackageVersion = Get-VSExtensionVersion -packageName 'Microsoft.Windows.DriverKit'

--- a/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
@@ -26,15 +26,15 @@ function Get-VisualStudioExtensions {
     $wixExtensionVersion = ((Get-VisualStudioProduct -ProductType "VisualStudio").Packages  | Where-Object {$_.Id -match 'WixToolset.VisualStudioExtension.Dev' -and $_.type -eq 'vsix'}).Version
 
     # WDK
-    $wdkPackageVersion = Get-VSExtensionVersion -packageName 'Microsoft.Windows.DriverKit'
+    $wdkPackageVersion = Get-VSExtensionVersion -PackageName 'Microsoft.Windows.DriverKit'
     $wdkExtensionVersion = Get-WDKVersion
 
     # SSDT
-    $analysisPackageVersion = Get-VSExtensionVersion -packageName '04a86fc2-dbd5-4222-848e-911638e487fe'
-    $reportingPackageVersion = Get-VSExtensionVersion -packageName '717ad572-c4b7-435c-c166-c2969777f718'
+    $analysisPackageVersion = Get-VSExtensionVersion -PackageName '04a86fc2-dbd5-4222-848e-911638e487fe'
+    $reportingPackageVersion = Get-VSExtensionVersion -PackageName '717ad572-c4b7-435c-c166-c2969777f718'
 
     $integrationPackageName = ($vs -match "2019") ? '851E7A09-7B2B-4F06-A15D-BABFCB26B970' : 'D1B09713-C12E-43CC-9EF4-6562298285AB'
-    $integrationPackageVersion = Get-VSExtensionVersion -packageName $integrationPackageName
+    $integrationPackageVersion = Get-VSExtensionVersion -PackageName $integrationPackageName
 
     $extensions = @(
         @{Package = 'SSDT Microsoft Analysis Services Projects'; Version = $analysisPackageVersion}

--- a/images/win/scripts/Tests/SSDTExtensions.Tests.ps1
+++ b/images/win/scripts/Tests/SSDTExtensions.Tests.ps1
@@ -9,12 +9,12 @@ Describe "SSDTExtensions" {
       )
 
       It "Extensions id=<id>" -TestCases $testExtenions {
-        $version = Get-VSExtensionVersion -packageName "${id}"
+        $version = Get-VSExtensionVersion -PackageName "${id}"
         $version | Should -Not -BeNullOrEmpty
       }
     } else {
       It "Extension SSDT" {
-        $version = Get-VSExtensionVersion -packageName "SSDT"
+        $version = Get-VSExtensionVersion -PackageName "SSDT"
         $version | Should -Not -BeNullOrEmpty
       }
     }

--- a/images/win/scripts/Tests/VisualStudio.Tests.ps1
+++ b/images/win/scripts/Tests/VisualStudio.Tests.ps1
@@ -12,8 +12,7 @@ Describe "Visual Studio" {
     }
 
     Context "Visual Studio components" {
-        $expectedComponents = Get-ToolsetContent | Select-Object -ExpandProperty visualStudio | Select-Object -ExpandProperty workloads
-        $testCases = $expectedComponents | ForEach-Object { @{ComponentName = $_} }
+        $testCases = (Get-ToolsetContent).visualStudio.workloads | ForEach-Object { @{ComponentName = $_} }
         BeforeAll {
             $installedComponents = Get-VisualStudioComponents -ProductType "VisualStudio" | Select-Object -ExpandProperty Package
         }
@@ -24,8 +23,7 @@ Describe "Visual Studio" {
     }
 
     Context "Visual Studio Build Tools components" {
-        $expectedComponents = Get-ToolsetContent | Select-Object -ExpandProperty visualStudio | Select-Object -ExpandProperty buildtools_workloads
-        $testCases = $expectedComponents | ForEach-Object { @{ComponentName = $_} }
+        $testCases = (Get-ToolsetContent).visualStudio.buildtools_workloads | ForEach-Object { @{ComponentName = $_} }
         BeforeAll {
             $installedComponents = Get-VisualStudioComponents -ProductType "BuildTools" | Select-Object -ExpandProperty Package
         }

--- a/images/win/scripts/Tests/VisualStudio.Tests.ps1
+++ b/images/win/scripts/Tests/VisualStudio.Tests.ps1
@@ -27,7 +27,7 @@ Describe "Visual Studio" {
         $expectedComponents = Get-ToolsetContent | Select-Object -ExpandProperty visualStudio | Select-Object -ExpandProperty buildtools_workloads
         $testCases = $expectedComponents | ForEach-Object { @{ComponentName = $_} }
         BeforeAll {
-            $installedComponents = Get-VisualStudioComponents -ProductType "Build" | Select-Object -ExpandProperty Package
+            $installedComponents = Get-VisualStudioComponents -ProductType "BuildTools" | Select-Object -ExpandProperty Package
         }
 
         It "<ComponentName>" -TestCases $testCases {

--- a/images/win/scripts/Tests/VisualStudio.Tests.ps1
+++ b/images/win/scripts/Tests/VisualStudio.Tests.ps1
@@ -5,7 +5,7 @@ Describe "Visual Studio" {
         }
 
         It "Devenv.exe" {
-            $vsInstallRoot = Get-VisualStudioPath
+            $vsInstallRoot = (Get-VisualStudioInstallation -VStype "VS").InstallationPath
             $devenvexePath = "${vsInstallRoot}\Common7\IDE\devenv.exe"
             $devenvexePath | Should -Exist
         }
@@ -15,7 +15,19 @@ Describe "Visual Studio" {
         $expectedComponents = Get-ToolsetContent | Select-Object -ExpandProperty visualStudio | Select-Object -ExpandProperty workloads
         $testCases = $expectedComponents | ForEach-Object { @{ComponentName = $_} }
         BeforeAll {
-            $installedComponents = Get-VisualStudioComponents | Select-Object -ExpandProperty Package
+            $installedComponents = Get-VisualStudioComponents -VSInstallType "VS" | Select-Object -ExpandProperty Package
+        }
+
+        It "<ComponentName>" -TestCases $testCases {
+            $installedComponents | Should -Contain $ComponentName
+        }
+    }
+
+    Context "Visual Studio build components" {
+        $expectedComponents = Get-ToolsetContent | Select-Object -ExpandProperty visualStudio | Select-Object -ExpandProperty build_workloads
+        $testCases = $expectedComponents | ForEach-Object { @{ComponentName = $_} }
+        BeforeAll {
+            $installedComponents = Get-VisualStudioComponents -VSInstallType "Build" | Select-Object -ExpandProperty Package
         }
 
         It "<ComponentName>" -TestCases $testCases {

--- a/images/win/scripts/Tests/VisualStudio.Tests.ps1
+++ b/images/win/scripts/Tests/VisualStudio.Tests.ps1
@@ -5,7 +5,7 @@ Describe "Visual Studio" {
         }
 
         It "Devenv.exe" {
-            $vsInstallRoot = (Get-VisualStudioInstallation -VStype "VS").InstallationPath
+            $vsInstallRoot = (Get-VisualStudioInstallation -VSInstallType "VS").InstallationPath
             $devenvexePath = "${vsInstallRoot}\Common7\IDE\devenv.exe"
             $devenvexePath | Should -Exist
         }

--- a/images/win/scripts/Tests/VisualStudio.Tests.ps1
+++ b/images/win/scripts/Tests/VisualStudio.Tests.ps1
@@ -5,7 +5,7 @@ Describe "Visual Studio" {
         }
 
         It "Devenv.exe" {
-            $vsInstallRoot = (Get-VisualStudioInstallation -VSInstallType "VS").InstallationPath
+            $vsInstallRoot = (Get-VisualStudioProduct -ProductType "VisualStudio").InstallationPath
             $devenvexePath = "${vsInstallRoot}\Common7\IDE\devenv.exe"
             $devenvexePath | Should -Exist
         }
@@ -15,7 +15,7 @@ Describe "Visual Studio" {
         $expectedComponents = Get-ToolsetContent | Select-Object -ExpandProperty visualStudio | Select-Object -ExpandProperty workloads
         $testCases = $expectedComponents | ForEach-Object { @{ComponentName = $_} }
         BeforeAll {
-            $installedComponents = Get-VisualStudioComponents -VSInstallType "VS" | Select-Object -ExpandProperty Package
+            $installedComponents = Get-VisualStudioComponents -ProductType "VisualStudio" | Select-Object -ExpandProperty Package
         }
 
         It "<ComponentName>" -TestCases $testCases {
@@ -23,11 +23,11 @@ Describe "Visual Studio" {
         }
     }
 
-    Context "Visual Studio build components" {
-        $expectedComponents = Get-ToolsetContent | Select-Object -ExpandProperty visualStudio | Select-Object -ExpandProperty build_workloads
+    Context "Visual Studio Build Tools components" {
+        $expectedComponents = Get-ToolsetContent | Select-Object -ExpandProperty visualStudio | Select-Object -ExpandProperty buildtools_workloads
         $testCases = $expectedComponents | ForEach-Object { @{ComponentName = $_} }
         BeforeAll {
-            $installedComponents = Get-VisualStudioComponents -VSInstallType "Build" | Select-Object -ExpandProperty Package
+            $installedComponents = Get-VisualStudioComponents -ProductType "Build" | Select-Object -ExpandProperty Package
         }
 
         It "<ComponentName>" -TestCases $testCases {

--- a/images/win/scripts/Tests/WDK.Tests.ps1
+++ b/images/win/scripts/Tests/WDK.Tests.ps1
@@ -5,7 +5,7 @@ Describe "WDK" {
     }
 
     It "WDK version from system" {
-      $version = Get-VSExtensionVersion -packageName "Microsoft.Windows.DriverKit"
+      $version = Get-VSExtensionVersion -PackageName "Microsoft.Windows.DriverKit"
       $version | Should -Not -BeNullOrEmpty
     }
 }

--- a/images/win/scripts/Tests/Wix.Tests.ps1
+++ b/images/win/scripts/Tests/Wix.Tests.ps1
@@ -12,11 +12,11 @@ Describe "Wix" {
     It "Wix Toolset version from system" {
       if (Test-IsWin19)
       {
-        $exVersion = Get-VSExtensionVersion -packageName "WixToolset.VisualStudioExtension.Dev16"
+        $exVersion = Get-VSExtensionVersion -PackageName "WixToolset.VisualStudioExtension.Dev16"
       }
       else
       {
-        $exVersion = Get-VSExtensionVersion -packageName "WixToolset.VisualStudioExtension.Dev15"
+        $exVersion = Get-VSExtensionVersion -PackageName "WixToolset.VisualStudioExtension.Dev15"
       }
       $exVersion | Should -Not -BeNullOrEmpty
     }

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -227,7 +227,7 @@
             "Microsoft.VisualStudio.Component.Workflow",
             "Microsoft.VisualStudio.Workload.Office"
         ],
-        "build_workloads": [
+        "buildtools_workloads": [
             "Microsoft.VisualStudio.Workload.WebBuildTools"
         ]
     }

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -226,6 +226,9 @@
             "Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre",
             "Microsoft.VisualStudio.Component.Workflow",
             "Microsoft.VisualStudio.Workload.Office"
+        ],
+        "build_workloads": [
+            "Microsoft.VisualStudio.Workload.WebBuildTools"
         ]
     }
 }

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -258,7 +258,7 @@
             "Component.MDD.Linux",
             "Component.MDD.Linux.GCC.arm"
         ],
-        "build_workloads": [
+        "buildtools_workloads": [
             "Microsoft.VisualStudio.Workload.WebBuildTools"
         ]
     }

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -257,6 +257,9 @@
             "Microsoft.VisualStudio.Workload.VisualStudioExtension",
             "Component.MDD.Linux",
             "Component.MDD.Linux.GCC.arm"
+        ],
+        "build_workloads": [
+            "Microsoft.VisualStudio.Workload.WebBuildTools"
         ]
     }
 }


### PR DESCRIPTION
# Description
Added Visual Studio build tools installation for Windows 2016/2019 images with vs_buildtools.exe installer. Minor changes for current VS installation, testing and documentation.

This functionality creates an opportunity to install workloads corresponding to Visual Studio build tools.

Seems that vs_enterprise.exe can't install properly the Microsoft.VisualStudio.Workload.WebBuildTools workload, the installation process ends without errors, but the workload components are not installed. The vs_buildtools.exe looks like the proper way of installation for build tools workloads (as said in documentation, [Microsoft docs link](https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2019)), Microsoft.VisualStudio.Workload.WebBuildTools in this case.

After the installation there will be 2 "instances" of VS - one is VS itself and another one is build tools instance:
```
PS C:\WINDOWS\system32> Get-VSSetupInstance  | Select-Object DisplayName,InstanceId

DisplayName                    InstanceId
-----------                    ----------
Visual Studio Build Tools 2019 c97bc318
Visual Studio Enterprise 2019  fd5d5002

```
with different subset of components installed:
```
PS C:\WINDOWS\system32> Get-VisualStudioComponents -VSInstallType VS

Package                                     Version
-------                                     -------
Microsoft.VisualStudio.Component.CoreEditor 16.1.28811.260
Microsoft.VisualStudio.Workload.CoreEditor  16.0.28315.86
```
```
PS C:\WINDOWS\system32> Get-VisualStudioComponents -VSInstallType BuildTools

Package                                               Version
-------                                               -------
Microsoft.Component.MSBuild                           16.5.29515.121
Microsoft.Net.Component.4.7.2.TargetingPack           16.7.30310.162
Microsoft.Net.Component.4.8.SDK                       16.4.29313.120
Microsoft.Net.ComponentGroup.DevelopmentPrerequisites 16.3.29207.166
Microsoft.VisualStudio.Component.CoreBuildTools       16.7.30310.162
Microsoft.VisualStudio.Component.NuGet.BuildTools     16.1.28829.92
Microsoft.VisualStudio.Component.Roslyn.Compiler      16.0.28714.129
Microsoft.VisualStudio.Component.TypeScript.3.9       16.0.30322.227
Microsoft.VisualStudio.Web.BuildTools.ComponentGroup  16.0.28516.191
Microsoft.VisualStudio.Workload.MSBuildTools          16.0.28516.191
Microsoft.VisualStudio.Workload.WebBuildTools         16.7.30310.162
```

#### Related issue:
https://github.com/actions/virtual-environments/issues/1470

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
