### PR TITLE
[Ubuntu] Fix announcements rendering

### DIFF
--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -90,6 +90,7 @@
         },
         {
             "type": "shell",
+            "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}",
             "scripts":[
                 "{{template_dir}}/scripts/installers/preparemetadata.sh"
             ],
@@ -98,8 +99,7 @@
                 "METADATA_FILE={{user `metadata_file`}}",
                 "HELPER_SCRIPTS={{user `helper_script_folder`}}",
                 "ANNOUNCEMENTS={{user `announcements`}}"
-            ],
-            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+            ]
         },
         {
             "type": "shell",

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -93,6 +93,7 @@
         },
         {
             "type": "shell",
+            "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}",
             "scripts":[
                 "{{template_dir}}/scripts/installers/preparemetadata.sh"
             ],
@@ -101,8 +102,7 @@
                 "METADATA_FILE={{user `metadata_file`}}",
                 "HELPER_SCRIPTS={{user `helper_script_folder`}}",
                 "ANNOUNCEMENTS={{user `announcements`}}"
-            ],
-            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+            ]
         },
         {
             "type": "shell",

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -95,6 +95,7 @@
         },
         {
             "type": "shell",
+            "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}",
             "scripts":[
                 "{{template_dir}}/scripts/installers/preparemetadata.sh"
             ],
@@ -103,8 +104,7 @@
                 "METADATA_FILE={{user `metadata_file`}}",
                 "HELPER_SCRIPTS={{user `helper_script_folder`}}",
                 "ANNOUNCEMENTS={{user `announcements`}}"
-            ],
-            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+            ]
         },
         {
             "type": "shell",


### PR DESCRIPTION
# Description
It seems multi-line announcements can't be properly parsed when using `sh -c`, the error in the log is:
```
2020-09-08T20:18:48.0470937Z  mmsprodwcus0    2020/09/08 20:15:01 packer.exe: 2020/09/08 20:15:01 [DEBUG] starting remote command: sudo sh -c 'ANNOUNCEMENTS='| Announcements |
2020-09-08T20:18:48.0471878Z  mmsprodwcus0    2020/09/08 20:15:01 packer.exe: |-|
2020-09-08T20:18:48.0472816Z  mmsprodwcus0    2020/09/08 20:15:01 packer.exe: | [Clang/LLVM 10 will be set as a default one and Clang/LLVM 6 will be deprecated  for Ubuntu 20.04 on September, 16](https://github.com/actions/virtual-environments/issues/1536) |' HELPER_SCRIPTS='/imagegeneration/helpers' IMAGE_VERSION='20200908.1' METADATA_FILE='/imagegeneration/metadatafile' PACKER_BUILDER_TYPE='azure-arm' PACKER_BUILD_NAME='azure-arm'  /tmp/script_9317.sh'
2020-09-08T20:18:48.0473855Z  mmsprodwcus0    2020/09/08 20:15:01 ui error: ==> azure-arm: bash: Announcements: command not found
2020-09-08T20:18:48.0474322Z  mmsprodwcus0    2020/09/08 20:15:01 ui error: ==> azure-arm: bash: $'\r': command not found
2020-09-08T20:18:48.0474911Z  mmsprodwcus0    2020/09/08 20:15:01 packer.exe: 2020/09/08 20:15:01 [ERROR] Remote command exited with '1': sudo sh -c 'ANNOUNCEMENTS='| Announcements |
2020-09-08T20:18:48.0475400Z  mmsprodwcus0    2020/09/08 20:15:01 packer.exe: |-|
2020-09-08T20:18:48.0476627Z  mmsprodwcus0    2020/09/08 20:15:01 packer.exe: | [Clang/LLVM 10 will be set as a default one and Clang/LLVM 6 will be deprecated  for Ubuntu 20.04 on September, 16](https://github.com/actions/virtual-environments/issues/1536) |' HELPER_SCRIPTS='/imagegeneration/helpers' IMAGE_VERSION='20200908.1' METADATA_FILE='/imagegeneration/metadatafile' PACKER_BUILDER_TYPE='azure-arm' PACKER_BUILD_NAME='azure-arm'  /tmp/script_9317.sh'
2020-09-08T20:18:48.0477717Z  mmsprodwcus0    2020/09/08 20:15:01 packer.exe: 2020/09/08 20:15:01 [INFO] RPC endpoint: Communicator ended with: 1
```
However, switching to the default execute_command(with sudo) helps 
https://www.packer.io/docs/provisioners/shell#execute_command
![image](https://user-images.githubusercontent.com/48208649/92593272-84d27000-f2a9-11ea-85d1-f920461fcf0d.png)

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1090

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
