### PR TITLE
MSBuild/CL.exe fails to launch when called from a nodeJS script via Yarn 

### DIFF
--- a/images/win/scripts/Installers/Install-NodeLts.ps1
+++ b/images/win/scripts/Installers/Install-NodeLts.ps1
@@ -17,11 +17,11 @@ Choco-Install -PackageName nodejs-lts -ArgumentList "--force"
 Add-MachinePathItem $PrefixPath
 $env:Path = Get-MachinePath
 
-setx NPM_CONFIG_PREFIX $PrefixPath /M
-$env:NPM_CONFIG_PREFIX = $PrefixPath
+setx npm_config_prefix $PrefixPath /M
+$env:npm_config_prefix = $PrefixPath
 
-setx NPM_CONFIG_CACHE $CachePath /M
-$env:NPM_CONFIG_CACHE = $CachePath
+setx npm_config_cache $CachePath /M
+$env:npm_config_cache = $CachePath
 
 npm config set registry http://registry.npmjs.org/
 


### PR DESCRIPTION
# Description
New tool, Bug fixing, or Improvement?   Bug

Some tools like Yarn will spawn nodeJS via CreateProcess and pass an environment block that contains duplicated environment variables, e.g:
![image](https://user-images.githubusercontent.com/22989529/92636645-90636e00-f28c-11ea-9b48-e7b0f3f08ad4.png)

Windows doesn't do any checking of environment variables being duplicated in CreateProcess so the node.exe process gets created with the two names. Then in our case, MSBuild gets launched from within node.exe, which later launches CL.exe and other build tools.

The Azure DevOps CI pipeline sets NPM_CONFIG_CACHE (all caps), while yarn will add the lowercase npm_config_cache to the environment block when a process is launched via child_process.exec()

As a result of this, we are hitting an error in our CI because MultiTaskTool is probably putting variables in a case-insensitive dictionary and doesn't expect to find the same variable twice:
C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\Microsoft.CppCommon.targets(375,5): error MSB6001: Invalid command line switch for "CL.exe". System.ArgumentException: Item has already been added. Key in dictionary: 'NPM_CONFIG_CACHE' Key being added: 'npm_config_cache' [D:\a\1\s\vnext\Common\Common.vcxproj]

See example run:  https://dev.azure.com/ms/react-native-windows/_build/results?buildId=107982&view=logs&j=5435db8c-d05a-5d7b-87ca-9953c4461652&t=397ce80a-0141-5d29-7c56-c592461a0308&l=4585


#### Related issue:
https://github.com/dotnet/msbuild/issues/5726

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
