### PR TITLE
Update Line 122 for cobertura URL

### DIFF
--- a/images/win/scripts/Installers/Install-JavaTools.ps1
+++ b/images/win/scripts/Installers/Install-JavaTools.ps1
@@ -119,7 +119,7 @@ setx M2_REPO $m2_repo /M
 setx MAVEN_OPTS $maven_opts /M
 
 # Download cobertura jars
-$uri = 'https://downloads.sourceforge.net/project/cobertura/cobertura/2.1.1/cobertura-2.1.1-bin.zip'
+$uri = 'https://repo1.maven.org/maven2/net/sourceforge/cobertura/cobertura/2.1.1/cobertura-2.1.1-bin.zip'
 $coberturaPath = "C:\cobertura-2.1.1"
 
 $archivePath = Start-DownloadWithRetry -Url $uri -Name "cobertura.zip"


### PR DESCRIPTION
A better url without sourceforge redirections

# Description
Improvement
The tool was giving problems due the sourceforge redirects or changes how to download files, the change is for a Maven Repo direct URL

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [X] Changes are tested and related VM images are successfully generated
