### PR TITLE
Add cargo-tarpaulin to Windows

### DIFF
--- a/images/win/scripts/Installers/Install-Rust.ps1
+++ b/images/win/scripts/Installers/Install-Rust.ps1
@@ -22,7 +22,7 @@ $env:Path = Get-MachinePath
 
 # Install common tools
 rustup component add rustfmt clippy
-cargo install bindgen cbindgen cargo-audit cargo-outdated
+cargo install bindgen cbindgen cargo-audit cargo-outdated cargo-tarpaulin
 
 # Run script at startup for all users
 $cmdRustSymScript = @"

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -53,6 +53,10 @@ function Get-CargoOutdatedVersion {
     return cargo outdated --version
 }
 
+function Get-CargoTarpaulinVersion {
+    return cargo tarpaulin --version
+}
+
 function Get-PythonVersion {
     return & python --version
 }

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -130,7 +130,8 @@ $markdown += New-MDList -Style Unordered -Lines @(
     (Get-BindgenVersion),
     (Get-CbindgenVersion),
     (Get-CargoAuditVersion),
-    (Get-CargoOutdatedVersion)
+    (Get-CargoOutdatedVersion),
+    (Get-CargoTarpaulinVersion)
 )
 
 $markdown += New-MDHeader "Browsers and webdrivers" -Level 3

--- a/images/win/scripts/Tests/Rust.Tests.ps1
+++ b/images/win/scripts/Tests/Rust.Tests.ps1
@@ -5,6 +5,7 @@ Describe "Rust" {
         @{ToolName = "cargo"; binPath = "C:\Rust\.cargo\bin\cargo.exe"}
         @{ToolName = "cargo audit"; binPath = "C:\Rust\.cargo\bin\cargo-audit.exe"}
         @{ToolName = "cargo outdated"; binPath = "C:\Rust\.cargo\bin\cargo-outdated.exe"}
+        @{ToolName = "cargo tarpaulin"; binPath = "C:\Rust\.cargo\bin\cargo-tarpaulin.exe"}
     )
 
     $rustEnvNotExists = @(


### PR DESCRIPTION
# Description

This is for a new tool, `cargo-tarpaulin`, a Rust coverage measurement tool.

The total size of the image is about 12mb (locally for me), but since it takes about 6 minutes to build, I believe it's a good compromise having it in the image.

#### Related issue:

#1587

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
