### PR TITLE
Add cargo-tarpaulin to Linux

### DIFF
--- a/images/linux/scripts/installers/rust.sh
+++ b/images/linux/scripts/installers/rust.sh
@@ -21,13 +21,14 @@ rustup component add rustfmt clippy
 cargo install bindgen cbindgen
 cargo install cargo-audit
 cargo install cargo-outdated
+cargo install cargo-tarpaulin
 
 echo "Test installation of the Rust toochain"
 
 # Permissions
 chmod -R 777 $(dirname $RUSTUP_HOME)
 
-for cmd in rustup rustc rustdoc cargo rustfmt cargo-clippy bindgen cbindgen 'cargo audit' 'cargo outdated'; do
+for cmd in rustup rustc rustdoc cargo rustfmt cargo-clippy bindgen cbindgen 'cargo audit' 'cargo outdated' 'cargo-tarpaulin'; do
     if ! command -v $cmd --version; then
         echo "$cmd was not installed or is not found on the path"
         exit 1
@@ -58,3 +59,4 @@ DocumentInstalledItem "bindgen ($(bindgen --version 2>&1 | cut -d ' ' -f 2))"
 DocumentInstalledItem "cbindgen ($(cbindgen --version 2>&1 | cut -d ' ' -f 2))"
 DocumentInstalledItem "cargo audit ($(cargo audit --version 2>&1 | cut -d ' ' -f 2))"
 DocumentInstalledItem "cargo outdated ($(cargo outdated --version 2>&1 | cut -d ' ' -f 2))"
+DocumentInstalledItem "cargo tarpaulin ($(cargo tarpaulin --version 2>&1 | cut -d ' ' -f 2))"


### PR DESCRIPTION
# Description

This is for a new tool, `cargo-tarpaulin`, a Rust coverage measurement tool.

The total size of the image is about 12mb (locally for me), but since it takes about 6 minutes to build, I believe it's a good compromise having it in the image.

#### Related issue:

#1587 

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
