### PR TITLE
Fix dot net test issue with 5.0 version

### DIFF
--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -62,7 +62,7 @@ function InstallAllValidSdks()
 
     # Consider all channels except preview/eol channels.
     # Sort the channels in ascending order
-    $dotnetChannels = $dotnetChannels.'releases-index' | Where-Object { (!$_."support-phase".Equals('preview') -and !$_."support-phase".Equals('eol')) } | Sort-Object { [Version] $_."channel-version" }
+    $dotnetChannels = $dotnetChannels.'releases-index' | Where-Object { (!$_."support-phase".Equals('preview') -and !$_."support-phase".Equals('eol') -and !$_."support-phase".Equals('rc')) } | Sort-Object { [Version] $_."channel-version" }
 
     # Download installation script.
     $installationName = "dotnet-install.ps1"

--- a/images/win/scripts/Tests/DotnetSDK.Tests.ps1
+++ b/images/win/scripts/Tests/DotnetSDK.Tests.ps1
@@ -1,6 +1,6 @@
 $releaseIndexUrl = "https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases-index.json"
 $dotnetChannels = (New-Object system.net.webclient).DownloadString($releaseIndexUrl) | ConvertFrom-Json
-$dotnetVersions = $dotnetChannels.'releases-index' | Where-Object { (!$_."support-phase".Equals('preview') -and !$_."support-phase".Equals('eol')) } | Select-Object -ExpandProperty "channel-version"
+$dotnetVersions = $dotnetChannels.'releases-index' | Where-Object { (!$_."support-phase".Equals('preview') -and !$_."support-phase".Equals('eol') -and !$_."support-phase".Equals('rc')) } | Select-Object -ExpandProperty "channel-version"
 
 Describe "Dotnet SDK" {
 


### PR DESCRIPTION
# Description
- fix for falling tests with dot net on windows images, because we download rc version.
![image](https://user-images.githubusercontent.com/28229110/93194138-6ad4d980-f750-11ea-805b-961fbab7eb3f.png)


#### Related issue: https://github.com/actions/virtual-environments-internal/issues/1130

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
