### PR TITLE
Add cargo-tarpaulin to macOS

### DIFF
--- a/images/macos/provision/core/rust.sh
+++ b/images/macos/provision/core/rust.sh
@@ -13,7 +13,7 @@ CARGO_HOME=$HOME/.cargo
 source $CARGO_HOME/env
 
 echo Install common tools...
-cargo install bindgen cbindgen cargo-audit cargo-outdated
+cargo install bindgen cbindgen cargo-audit cargo-outdated cargo-tarpaulin
 
 echo Cleanup Cargo registry cached data...
 rm -rf $CARGO_HOME/registry/*

--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -44,6 +44,11 @@ function Get-Cargoaudit {
     return "Cargo-audit $cargoAuditVersion"
 }
 
+function Get-Cargotarpaulin {
+    $cargoTarpaulinVersion = Run-Command "cargo tarpaulin --version" | Take-Part -Part 1
+    return "Cargo-tarpaulin $cargoTarpaulinVersion"
+}
+
 function Get-RustupVersion {
     $rustupVersion = Run-Command "rustup --version" | Take-Part -Part 1
     return "Rustup ${rustupVersion}"

--- a/images/macos/tests/Common.Tests.ps1
+++ b/images/macos/tests/Common.Tests.ps1
@@ -293,6 +293,10 @@ Describe "Rust" -Skip:($os.IsHighSierra) {
         It "Cargo outdated" {
             "cargo outdated --version" | Should -ReturnZeroExitCode
         }
+
+        It "Cargo tarpaulin" {
+            "cargo tarpaulin --version" | Should -ReturnZeroExitCode
+        }
     }
 }
 


### PR DESCRIPTION
# Description

This is for a new tool, `cargo-tarpaulin`, a Rust coverage measurement tool. This is the PR for macOS.

The total size of the image is about 12mb (locally for me), but since it takes about 6 minutes to build, I believe it's a good compromise having it in the image.

#### Related issue:

#1587 

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
