### PR TITLE
add sccache 

### DIFF
--- a/images/linux/scripts/installers/rust.sh
+++ b/images/linux/scripts/installers/rust.sh
@@ -21,13 +21,14 @@ rustup component add rustfmt clippy
 cargo install bindgen cbindgen
 cargo install cargo-audit
 cargo install cargo-outdated
+cargo install sccache
 
 echo "Test installation of the Rust toochain"
 
 # Permissions
 chmod -R 777 $(dirname $RUSTUP_HOME)
 
-for cmd in rustup rustc rustdoc cargo rustfmt cargo-clippy bindgen cbindgen 'cargo audit' 'cargo outdated'; do
+for cmd in rustup rustc rustdoc cargo rustfmt cargo-clippy bindgen cbindgen 'cargo audit' 'cargo outdated' sccache; do
     if ! command -v $cmd --version; then
         echo "$cmd was not installed or is not found on the path"
         exit 1
@@ -58,3 +59,4 @@ DocumentInstalledItem "bindgen ($(bindgen --version 2>&1 | cut -d ' ' -f 2))"
 DocumentInstalledItem "cbindgen ($(cbindgen --version 2>&1 | cut -d ' ' -f 2))"
 DocumentInstalledItem "cargo audit ($(cargo audit --version 2>&1 | cut -d ' ' -f 2))"
 DocumentInstalledItem "cargo outdated ($(cargo outdated --version 2>&1 | cut -d ' ' -f 2))"
+DocumentInstalledItem "sccache ($(sccache --version 2>&1 | cut -d ' ' -f 2))"

--- a/images/macos/provision/core/rust.sh
+++ b/images/macos/provision/core/rust.sh
@@ -13,7 +13,7 @@ CARGO_HOME=$HOME/.cargo
 source $CARGO_HOME/env
 
 echo Install common tools...
-cargo install bindgen cbindgen cargo-audit cargo-outdated
+cargo install bindgen cbindgen cargo-audit cargo-outdated sccache
 
 echo Cleanup Cargo registry cached data...
 rm -rf $CARGO_HOME/registry/*

--- a/images/win/scripts/Installers/Install-Rust.ps1
+++ b/images/win/scripts/Installers/Install-Rust.ps1
@@ -22,7 +22,7 @@ $env:Path = Get-MachinePath
 
 # Install common tools
 rustup component add rustfmt clippy
-cargo install bindgen cbindgen cargo-audit cargo-outdated
+cargo install bindgen cbindgen cargo-audit cargo-outdated sccache
 
 # Run script at startup for all users
 $cmdRustSymScript = @"

--- a/images/win/scripts/Tests/Rust.Tests.ps1
+++ b/images/win/scripts/Tests/Rust.Tests.ps1
@@ -5,6 +5,7 @@ Describe "Rust" {
         @{ToolName = "cargo"; binPath = "C:\Rust\.cargo\bin\cargo.exe"}
         @{ToolName = "cargo audit"; binPath = "C:\Rust\.cargo\bin\cargo-audit.exe"}
         @{ToolName = "cargo outdated"; binPath = "C:\Rust\.cargo\bin\cargo-outdated.exe"}
+        @{ToolName = "sccache"; binPath = "C:\Rust\.cargo\bin\sccache.exe"}
     )
 
     $rustEnvNotExists = @(


### PR DESCRIPTION
# Description
New tool, Bug fixing, or Improvement?  New tool

This adds [sccache](https://github.com/mozilla/sccache), a popular compiler caching tool used by Rust, Mozilla, and a large number of other projects.  Compiling from scratch in a standard Github Actions pipeline takes roughly 9 minutes.  Coupling sccache with `actions/cache@v1` drastically improves build times for many projects.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
