### PR TITLE
Update contribution guide for MacOS image to prevent customers contributing to MacOS source

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,8 @@ New tool, Bug fixing, or Improvement?
 Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.  
 **For new tools, please provide total size and installation time.**
 
+<!-- Currently, we don't accept external contributions to MacOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->
+
 #### Related issue:
 
 ## Check list

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@ New tool, Bug fixing, or Improvement?
 Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.  
 **For new tools, please provide total size and installation time.**
 
-<!-- Currently, we don't accept external contributions to MacOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->
+<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->
 
 #### Related issue:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,8 @@ Add `Invoke-PesterTests -TestFile <testFileName> [-TestName <describeName>]` at 
   - Use `DocumentInstalledItem "<add to docs>"` helper for building documentation.
 
 ### macOS
-We are in the process of preparing our macOS source to live in this repo so we can take contributions from the community. Until then, we appreciate your patience and ask you continue to make tool requests by filing issues.
+MacOS source lives in this repository and available for everyone. However, MacOS image-generation CI doesn't support external contributions yet so we are not ready to accept pull-requests for now.
+We are in the process of preparing MacOS CI to accept contributions. Until then, we appreciate your patience and ask you continue to make tool requests by filing issues.
 
 ## Resources
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Add `Invoke-PesterTests -TestFile <testFileName> [-TestName <describeName>]` at 
   - Use `DocumentInstalledItem "<add to docs>"` helper for building documentation.
 
 ### macOS
-macOS source lives in this repository and available for everyone. However, macOS image-generation CI doesn't support external contributions yet so we are not ready to accept pull-requests for now.
+macOS source lives in this repository and available for everyone. However, macOS image-generation CI doesn't support external contributions yet so we are not able to accept pull-requests for now.
 We are in the process of preparing macOS CI to accept contributions. Until then, we appreciate your patience and ask you continue to make tool requests by filing issues.
 
 ## Resources

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Add `Invoke-PesterTests -TestFile <testFileName> [-TestName <describeName>]` at 
   - Use `DocumentInstalledItem "<add to docs>"` helper for building documentation.
 
 ### macOS
-MacOS source lives in this repository and available for everyone. However, MacOS image-generation CI doesn't support external contributions yet so we are not ready to accept pull-requests for now.
+macOS source lives in this repository and available for everyone. However, MacOS image-generation CI doesn't support external contributions yet so we are not ready to accept pull-requests for now.
 We are in the process of preparing MacOS CI to accept contributions. Until then, we appreciate your patience and ask you continue to make tool requests by filing issues.
 
 ## Resources

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Here are a few things you can do that will increase the likelihood of your pull 
 ## How to add new tool
 ### General rules
 - For every new tool add validation scripts and update software report script to make sure that it is included to documentation
-- If the tool is available in other platforms (MacOS, Windows, Linux), make sure you include it in as many as possible.
+- If the tool is available in other platforms (macOS, Windows, Linux), make sure you include it in as many as possible.
 - If installing a few versions of the tool, consider putting the list of versions in the corresponding `toolset.json` file. It will help other customers to configure their builds flexibly. See [toolset-windows-2016.json](images/win/toolsets/toolset-2019.json) as example.
 - Use consistent naming across all files
 - Validation scripts should be simple and shouldn't change image content
@@ -51,8 +51,8 @@ Add `Invoke-PesterTests -TestFile <testFileName> [-TestName <describeName>]` at 
   - Use `DocumentInstalledItem "<add to docs>"` helper for building documentation.
 
 ### macOS
-macOS source lives in this repository and available for everyone. However, MacOS image-generation CI doesn't support external contributions yet so we are not ready to accept pull-requests for now.
-We are in the process of preparing MacOS CI to accept contributions. Until then, we appreciate your patience and ask you continue to make tool requests by filing issues.
+macOS source lives in this repository and available for everyone. However, macOS image-generation CI doesn't support external contributions yet so we are not ready to accept pull-requests for now.
+We are in the process of preparing macOS CI to accept contributions. Until then, we appreciate your patience and ask you continue to make tool requests by filing issues.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The "ubuntu-latest" YAML workflow label still uses the Ubuntu 18.04 virtual envi
 
 ***Looking for other Linux distributions?*** We do not plan to offer other Linux distributions. We recommend using Docker if you'd like to build using other distributions with the hosted virtual environments. Alternatively, you can leverage [self-hosted runners] and fully customize your environment to your needs.
 
-***Where is the macOS source?*** We are in the process of preparing our macOS source to live in this repo so we can take contributions from the community. Until then, we appreciate your patience and ask you continue to make tool requests by filing issues.
+***How to contribute to macOS source?*** MacOS source lives in this repository and available for everyone. However, MacOS image-generation CI doesn't support external contributions yet so we are not ready to accept pull-requests for now.
+We are in the process of preparing MacOS CI to accept contributions. Until then, we appreciate your patience and ask you continue to make tool requests by filing issues.
 
 ## Software Guidelines
 In general, these are the guidelines we consider when deciding what to pre-install:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The "ubuntu-latest" YAML workflow label still uses the Ubuntu 18.04 virtual envi
 
 ***Looking for other Linux distributions?*** We do not plan to offer other Linux distributions. We recommend using Docker if you'd like to build using other distributions with the hosted virtual environments. Alternatively, you can leverage [self-hosted runners] and fully customize your environment to your needs.
 
-***How to contribute to macOS source?*** macOS source lives in this repository and available for everyone. However, MacOS image-generation CI doesn't support external contributions yet so we are not ready to accept pull-requests for now.
+***How to contribute to macOS source?*** macOS source lives in this repository and available for everyone. However, MacOS image-generation CI doesn't support external contributions yet so we are not able to accept pull-requests for now.
 We are in the process of preparing MacOS CI to accept contributions. Until then, we appreciate your patience and ask you continue to make tool requests by filing issues.
 
 ## Software Guidelines

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The "ubuntu-latest" YAML workflow label still uses the Ubuntu 18.04 virtual envi
 
 ***Looking for other Linux distributions?*** We do not plan to offer other Linux distributions. We recommend using Docker if you'd like to build using other distributions with the hosted virtual environments. Alternatively, you can leverage [self-hosted runners] and fully customize your environment to your needs.
 
-***How to contribute to macOS source?*** MacOS source lives in this repository and available for everyone. However, MacOS image-generation CI doesn't support external contributions yet so we are not ready to accept pull-requests for now.
+***How to contribute to macOS source?*** macOS source lives in this repository and available for everyone. However, MacOS image-generation CI doesn't support external contributions yet so we are not ready to accept pull-requests for now.
 We are in the process of preparing MacOS CI to accept contributions. Until then, we appreciate your patience and ask you continue to make tool requests by filing issues.
 
 ## Software Guidelines


### PR DESCRIPTION
# Description
Since our MacOS CI doesn't support external contributions, we would like to update contribution guide to prevent customers about contributing to MacOS source.

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
