### PR TITLE
[Windows] Fix PyPy versions filter to avoid release candidates

### DIFF
--- a/images/win/scripts/Installers/Install-PyPy.ps1
+++ b/images/win/scripts/Installers/Install-PyPy.ps1
@@ -97,8 +97,8 @@ foreach($pypyTool in $pypyTools)
     foreach($pypyVersion in $pypyTool.versions)
     {
         # Query latest PyPy version
-        $filter = '{0}{1}-*-{2}.zip' -f $pypyTool.name, $pypyVersion, $pypyTool.platform
-        $latestMajorPyPyVersion = $pypyVersions | Where-Object {$_.name -like $filter} | Select-Object -First 1
+        $filter = '{0}{1}-v[0-9]+\.[0-9]+\.[0-9]+-{2}.zip' -f $pypyTool.name, $pypyVersion, $pypyTool.platform
+        $latestMajorPyPyVersion = $pypyVersions | Where-Object {$_.name -match $filter} | Select-Object -First 1
 
         if ($latestMajorPyPyVersion)
         {

--- a/images/win/scripts/Installers/Install-PyPy.ps1
+++ b/images/win/scripts/Installers/Install-PyPy.ps1
@@ -97,7 +97,7 @@ foreach($pypyTool in $pypyTools)
     foreach($pypyVersion in $pypyTool.versions)
     {
         # Query latest PyPy version
-        $filter = '{0}{1}-v[0-9]+\.[0-9]+\.[0-9]+-{2}.zip' -f $pypyTool.name, $pypyVersion, $pypyTool.platform
+        $filter = '{0}{1}-v\d+\.\d+\.\d+-{2}.zip' -f $pypyTool.name, $pypyVersion, $pypyTool.platform
         $latestMajorPyPyVersion = $pypyVersions | Where-Object {$_.name -match $filter} | Select-Object -First 1
 
         if ($latestMajorPyPyVersion)


### PR DESCRIPTION
# Description
It turned out the filter for PyPy versions doesn't avoid rc versions.

#### Related issue:
n\a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
