### PR TITLE
[macOS] Apple Worldwide Developer Relations Intermediate Certificate Expiration

### DIFF
--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -19,3 +19,12 @@ sudo rm -f /var/vm/sleepimage
 
 # Change screen resolution to the maximum supported for 4Mb video memory
 sudo "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1176 885
+
+# https://developer.apple.com/support/expiration/
+# Enterprise iOS Distribution Certificates generated between February 7 and September 1st, 2020 will expire on February 7, 2023.
+# Rotate the certificate before expiration to ensure your apps are installed and signed with an active certificate.
+# Confirm that the correct intermediate certificate is installed by verifying the expiration date is set to 2030.
+# sudo security delete-certificate -Z FF6797793A3CD798DC5B2ABEF56F73EDC9F83A64 /Library/Keychains/System.keychain
+curl https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer --output $HOME/AppleWWDRCAG3.cer --silent
+sudo security add-trusted-cert -d -r unspecified -k /Library/Keychains/System.keychain $HOME/AppleWWDRCAG3.cer
+rm $HOME/AppleWWDRCAG3.cer

--- a/images/macos/tests/Common.Tests.ps1
+++ b/images/macos/tests/Common.Tests.ps1
@@ -12,6 +12,14 @@ Describe "Disk free space" {
     }
 }
 
+Describe "Certificate" {
+    It "Apple Worldwide Developer Relations Certification Authority[expired: 2030-02] is installed" {
+        $sha1Hash = "06EC06599F4ED0027CC58956B4D3AC1255114F35"
+        $certs = security find-certificate -a -c Worldwide -p -Z | Out-String
+        $certs | Should -Match $sha1Hash
+    }
+}
+
 Describe "Git" {
     It "git is installed" {
         "git --version" | Should -ReturnZeroExitCode
@@ -161,7 +169,7 @@ Describe "Common utilities" {
     It "PostgreSQL-Client" {
         "psql --version" | Should -ReturnZeroExitCode
     }
-    
+
     It "PostgreSQL-Server" {
         "pg_config --version" | Should -ReturnZeroExitCode
     }
@@ -178,11 +186,11 @@ Describe "Common utilities" {
         Get-WhichTool "php" | Should -Not -BeLike "/usr/bin/php*"
         "php --version" | Should -ReturnZeroExitCode
     }
-    
+
     It "Composer" {
         "composer --version" | Should -ReturnZeroExitCode
     }
-    
+
     It "R" -Skip:($os.IsBigSur) {
         "R --version" | Should -ReturnZeroExitCode
     }
@@ -198,7 +206,7 @@ Describe "Common utilities" {
     It "bazelisk" {
         "bazelisk version" | Should -ReturnZeroExitCode
     }
-    
+
     It "Julia" {
         "julia --version" | Should -ReturnZeroExitCode
     }
@@ -252,7 +260,7 @@ Describe "Browsers" {
     It "Microsoft Edge Driver" {
         "msedgedriver --version" | Should -ReturnZeroExitCode
     }
-    
+
     It "Firefox" {
         $firefoxLocation = "/Applications/Firefox.app/Contents/MacOS/firefox"
         $firefoxLocation | Should -Exist
@@ -304,7 +312,7 @@ Describe "Haskell" -Skip:($os.IsHighSierra) {
     It "GHC" {
         "ghc --version" | Should -ReturnZeroExitCode
     }
-    
+
     It "Cabal" {
         "cabal --version" | Should -ReturnZeroExitCode
     }
@@ -327,7 +335,7 @@ Describe "Gcc" -Skip:($os.IsHighSierra) {
         param (
             [string] $GccVersion
         )
-        
+
         "gcc-$GccVersion --version" | Should -ReturnZeroExitCode
     }
 }


### PR DESCRIPTION
# Description
Enterprise iOS Distribution Certificates generated between February 7 and September 1st, 2020 will expire on February 7, 2023. Rotate the certificate before expiration to ensure your apps are installed and signed with an active certificate.

Enterprise iOS Distribution Certificates generated after September 2, 2020 require the new intermediate certificate installed on any machines that will be code signing. Xcode 11.4.1 or later automatically downloads the new Apple Worldwide Developer Relations Intermediate Certificate, and it is also available directly from the Certificate Authority page. Confirm that the correct intermediate certificate is installed by verifying the expiration date is set to 2030.

#### Related issue:
https://github.com/actions/virtual-environments/issues/1620

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
