### PR TITLE
[Windows] Workaround for missing Edge webriver

### DIFF
--- a/images/win/scripts/Installers/Install-Edge.ps1
+++ b/images/win/scripts/Installers/Install-Edge.ps1
@@ -17,15 +17,21 @@ Write-Host "Get the Microsoft Edge WebDriver version..."
 $RegistryPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths"
 $EdgePath = (Get-ItemProperty "$RegistryPath\msedge.exe").'(default)'
 [version]$EdgeVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($EdgePath).ProductVersion
-#$EdgeDriverVersionUrl = "https://msedgedriver.azureedge.net/LATEST_RELEASE_$($EdgeVersion.Major)"
+$EdgeDriverVersionUrl = "https://msedgedriver.azureedge.net/LATEST_RELEASE_$($EdgeVersion.Major)"
 
-#$EdgeDriverVersionFile = Start-DownloadWithRetry -Url $EdgeDriverVersionUrl -Name "versioninfo.txt" -DownloadPath $EdgeDriverPath
-Add-Content -Path "${EdgeDriverPath}\versioninfo.txt" -Value "85.0.564.51"
+$EdgeDriverVersionFile = Start-DownloadWithRetry -Url $EdgeDriverVersionUrl -Name "versioninfo.txt" -DownloadPath $EdgeDriverPath
 
 Write-Host "Download Microsoft Edge WebDriver..."
 $EdgeDriverLatestVersion = Get-Content -Path "${EdgeDriverPath}\versioninfo.txt"
 $EdgeDriverArchName = "edgedriver_win64.zip"
-$EdgeDriverDownloadUrl="https://msedgedriver.azureedge.net/${EdgeDriverLatestVersion}/${EdgeDriverArchName}"
+# A temporary workaround to install the previous driver version because 85.0.564.60 for win64 doesn't exist
+if ($EdgeDriverLatestVersion -eq "85.0.564.60")
+{
+    $EdgeDriverLatestVersion = "85.0.564.51"
+    Set-Content -Path "${EdgeDriverPath}\versioninfo.txt" -Value $EdgeDriverLatestVersion
+}
+
+$EdgeDriverDownloadUrl = "https://msedgedriver.azureedge.net/${EdgeDriverLatestVersion}/${EdgeDriverArchName}"
 
 $EdgeDriverArchPath = Start-DownloadWithRetry -Url $EdgeDriverDownloadUrl -Name $EdgeDriverArchName
 

--- a/images/win/scripts/Installers/Install-Edge.ps1
+++ b/images/win/scripts/Installers/Install-Edge.ps1
@@ -22,13 +22,13 @@ $EdgeDriverVersionUrl = "https://msedgedriver.azureedge.net/LATEST_RELEASE_$($Ed
 $EdgeDriverVersionFile = Start-DownloadWithRetry -Url $EdgeDriverVersionUrl -Name "versioninfo.txt" -DownloadPath $EdgeDriverPath
 
 Write-Host "Download Microsoft Edge WebDriver..."
-$EdgeDriverLatestVersion = Get-Content -Path "${EdgeDriverPath}\versioninfo.txt"
+$EdgeDriverLatestVersion = Get-Content -Path $EdgeDriverVersionFile
 $EdgeDriverArchName = "edgedriver_win64.zip"
 # A temporary workaround to install the previous driver version because 85.0.564.60 for win64 doesn't exist
 if ($EdgeDriverLatestVersion -eq "85.0.564.60")
 {
     $EdgeDriverLatestVersion = "85.0.564.51"
-    Set-Content -Path "${EdgeDriverPath}\versioninfo.txt" -Value $EdgeDriverLatestVersion
+    Set-Content -Path $EdgeDriverVersionFile -Value $EdgeDriverLatestVersion
 }
 
 $EdgeDriverDownloadUrl = "https://msedgedriver.azureedge.net/${EdgeDriverLatestVersion}/${EdgeDriverArchName}"

--- a/images/win/scripts/Installers/Install-Edge.ps1
+++ b/images/win/scripts/Installers/Install-Edge.ps1
@@ -17,12 +17,13 @@ Write-Host "Get the Microsoft Edge WebDriver version..."
 $RegistryPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths"
 $EdgePath = (Get-ItemProperty "$RegistryPath\msedge.exe").'(default)'
 [version]$EdgeVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($EdgePath).ProductVersion
-$EdgeDriverVersionUrl = "https://msedgedriver.azureedge.net/LATEST_RELEASE_$($EdgeVersion.Major)"
+#$EdgeDriverVersionUrl = "https://msedgedriver.azureedge.net/LATEST_RELEASE_$($EdgeVersion.Major)"
 
-$EdgeDriverVersionFile = Start-DownloadWithRetry -Url $EdgeDriverVersionUrl -Name "versioninfo.txt" -DownloadPath $EdgeDriverPath
+#$EdgeDriverVersionFile = Start-DownloadWithRetry -Url $EdgeDriverVersionUrl -Name "versioninfo.txt" -DownloadPath $EdgeDriverPath
+Add-Content -Path "${EdgeDriverPath}\versioninfo.txt" -Value "85.0.564.51"
 
 Write-Host "Download Microsoft Edge WebDriver..."
-$EdgeDriverLatestVersion = Get-Content -Path $EdgeDriverVersionFile
+$EdgeDriverLatestVersion = Get-Content -Path "${EdgeDriverPath}\versioninfo.txt"
 $EdgeDriverArchName = "edgedriver_win64.zip"
 $EdgeDriverDownloadUrl="https://msedgedriver.azureedge.net/${EdgeDriverLatestVersion}/${EdgeDriverArchName}"
 


### PR DESCRIPTION
# Description
Webdriver win64 for version 85.0.564.60 doesn't exist thus all windows builds are broken. Temporary hardcode 85.0.564.51 installation.

#### Related issue:
n\a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
