### PR TITLE
[macOS] Remove R and virtualbox packages for macOS Big Sur

### DIFF
--- a/images/macos/provision/core/commonutils.sh
+++ b/images/macos/provision/core/commonutils.sh
@@ -43,7 +43,6 @@ done
 if is_BigSur; then
     bcask_common_utils=(
         julia
-        vagrant
     )
 else
     bcask_common_utils=(

--- a/images/macos/provision/core/commonutils.sh
+++ b/images/macos/provision/core/commonutils.sh
@@ -40,13 +40,11 @@ for package in ${binst_common_utils[@]}; do
 done
 
 # brew cask install
-if is_BigSur; then
-    bcask_common_utils=(
-        julia
-    )
-else
-    bcask_common_utils=(
-        julia
+bcask_common_utils=(
+    julia
+)
+if is_Less_BigSur; then
+    bcask_common_utils+=(
         virtualbox
         vagrant
         r

--- a/images/macos/provision/core/commonutils.sh
+++ b/images/macos/provision/core/commonutils.sh
@@ -43,6 +43,7 @@ done
 bcask_common_utils=(
     julia
 )
+
 if is_Less_BigSur; then
     bcask_common_utils+=(
         virtualbox

--- a/images/macos/provision/core/commonutils.sh
+++ b/images/macos/provision/core/commonutils.sh
@@ -40,12 +40,19 @@ for package in ${binst_common_utils[@]}; do
 done
 
 # brew cask install
-bcask_common_utils=(
-    julia
-    virtualbox
-    vagrant
-    r
-)
+if is_BigSur; then
+    bcask_common_utils=(
+        julia
+        vagrant
+    )
+else
+    bcask_common_utils=(
+        julia
+        virtualbox
+        vagrant
+        r
+    )
+fi
 
 for package in ${bcask_common_utils[@]}; do
     echo "Install $package"

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -142,7 +142,6 @@ $bazelVersion = Run-Command "bazel --version" | Take-Part -Part 0 -Delimiter "-"
 $bazeliskVersion = Run-Command "bazelisk version" | Select-String "Bazelisk version:" | Take-Part -Part 1 -Delimiter ":"
 $packerVersion = Run-Command "packer --version"
 $helmVersion = Run-Command "helm version --short"
-$vagrant = Run-Command "vagrant -v"
 $mongo = Run-Command "mongo --version" | Select-String "MongoDB shell version" | Take-Part -Part 3
 $mongod = Run-Command "mongod --version" | Select-String "db version " | Take-Part -Part 2
 $p7zip = Run-Command "7z i" | Select-String "7-Zip" | Take-Part -Part 0,2
@@ -168,10 +167,8 @@ $markdown += New-MDList -Style Unordered -NoNewLine -Lines @(
     $bazelVersion,
     "bazelisk $($bazeliskVersion.Trim())",
     "helm $helmVersion",
-    "virtualbox $vbox",
     "mongo $mongo",
     "mongod $mongod",
-    "$vagrant",
     $p7zip
 )
 if ($os.IsHigherThanMojave) {
@@ -179,10 +176,12 @@ if ($os.IsHigherThanMojave) {
     $markdown += New-MDList -Lines "Newman $newmanVersion" -Style Unordered -NoNewLine
 }
 if ($os.IsLessThanBigSur) {
+    $vagrant = Run-Command "vagrant -v"
     $vbox = Run-Command "vboxmanage -v"
     $parallelVersion = Run-Command "parallel --version" | Select-String "GNU parallel" | Select-Object -First 1
     $markdown += New-MDList -Style Unordered -Lines @(
-        $vbox
+        "virtualbox $vbox",
+        $vagrant,
         $parallelVersion
     )
 }

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -55,6 +55,10 @@ if ( -not $os.IsHighSierra) {
     $markdown += New-MDList -Style Unordered -NoNewLine -Lines $lines
 }
 
+if ($os.IsLessThanBigSur) {
+    $markdown += New-MDList -Style Unordered -Lines @(Get-RVersion) -NoNewLine
+}
+
 $markdown += New-MDList -Style Unordered -Lines @(
     "Node.js ${nodejsVersion}"
     "NVM ${nvmVersion}"
@@ -63,7 +67,6 @@ $markdown += New-MDList -Style Unordered -Lines @(
     $python3Version,
     "Ruby ${rubyVersion}",
     (Get-DotnetVersionList),
-    (Get-RVersion),
     "Go ${goVersion}",
     "$phpVersion",
     "$juliaVersion"
@@ -139,7 +142,6 @@ $bazelVersion = Run-Command "bazel --version" | Take-Part -Part 0 -Delimiter "-"
 $bazeliskVersion = Run-Command "bazelisk version" | Select-String "Bazelisk version:" | Take-Part -Part 1 -Delimiter ":"
 $packerVersion = Run-Command "packer --version"
 $helmVersion = Run-Command "helm version --short"
-$vbox = Run-Command "vboxmanage -v"
 $vagrant = Run-Command "vagrant -v"
 $mongo = Run-Command "mongo --version" | Select-String "MongoDB shell version" | Take-Part -Part 3
 $mongod = Run-Command "mongod --version" | Select-String "db version " | Take-Part -Part 2
@@ -177,8 +179,12 @@ if ($os.IsHigherThanMojave) {
     $markdown += New-MDList -Lines "Newman $newmanVersion" -Style Unordered -NoNewLine
 }
 if ($os.IsLessThanBigSur) {
+    $vbox = Run-Command "vboxmanage -v"
     $parallelVersion = Run-Command "parallel --version" | Select-String "GNU parallel" | Select-Object -First 1
-    $markdown += New-MDList -Lines $parallelVersion -Style Unordered
+    $markdown += New-MDList -Style Unordered -Lines @(
+        $vbox
+        $parallelVersion
+    )
 }
 $markdown += New-MDNewLine
 
@@ -190,9 +196,9 @@ $azureCLIVersion = Run-Command "az -v" | Select-String "^azure-cli" | Take-Part 
 $awsVersion = Run-Command "aws --version" | Take-Part -Part 0 | Take-Part -Delimiter "/" -Part 1
 $aliyunVersion = Run-Command "aliyun --version" | Select-String "Alibaba Cloud Command Line Interface Version " | Take-Part -Part 6
 $awsSamVersion = Run-Command "sam --version" | Take-Part -Part 3
-$awsSessionManagerVersion = Run-Command "session-manager-plugin --version" 
+$awsSessionManagerVersion = Run-Command "session-manager-plugin --version"
 $ghcUpVersion = Run-Command "ghcup --version" | Take-Part -Part 5
-$ghcVersion = Run-Command "ghc --version" | Take-Part -Part 7 
+$ghcVersion = Run-Command "ghc --version" | Take-Part -Part 7
 $cabalVersion = Run-Command "cabal --version" | Take-Part -Part 3
 $stackVersion = Run-Command "stack --version" | Take-Part -Part 1 | ForEach-Object {$_.replace(",","")}
 

--- a/images/macos/tests/Common.Tests.ps1
+++ b/images/macos/tests/Common.Tests.ps1
@@ -103,7 +103,7 @@ Describe "Common utilities" {
             $result = Get-CommandResult "gem list"
             $result.Output | Should -BeLike "*nomad-cli*"
         }
-    
+
         It "Nomad CLI IPA" {
             "ipa --version" | Should -ReturnZeroExitCode
         }
@@ -163,7 +163,7 @@ Describe "Common utilities" {
     It "PostgreSQL-Client" {
         "psql --version" | Should -ReturnZeroExitCode
     }
-    
+
     It "PostgreSQL-Server" {
         "pg_config --version" | Should -ReturnZeroExitCode
     }
@@ -180,11 +180,11 @@ Describe "Common utilities" {
         Get-WhichTool "php" | Should -Not -BeLike "/usr/bin/php*"
         "php --version" | Should -ReturnZeroExitCode
     }
-    
+
     It "Composer" {
         "composer --version" | Should -ReturnZeroExitCode
     }
-    
+
     It "R" -Skip:($os.IsBigSur) {
         "R --version" | Should -ReturnZeroExitCode
     }
@@ -200,7 +200,7 @@ Describe "Common utilities" {
     It "bazelisk" {
         "bazelisk version" | Should -ReturnZeroExitCode
     }
-    
+
     It "Julia" {
         "julia --version" | Should -ReturnZeroExitCode
     }
@@ -213,7 +213,7 @@ Describe "Common utilities" {
         "helm version --short" | Should -ReturnZeroExitCode
     }
 
-    It "virtualbox" {
+    It "virtualbox" -Skip:($os.IsBigSur) {
         "vboxmanage -v" | Should -ReturnZeroExitCode
     }
 
@@ -254,7 +254,7 @@ Describe "Browsers" {
     It "Microsoft Edge Driver" {
         "msedgedriver --version" | Should -ReturnZeroExitCode
     }
-    
+
     It "Firefox" {
         $firefoxLocation = "/Applications/Firefox.app/Contents/MacOS/firefox"
         $firefoxLocation | Should -Exist
@@ -306,7 +306,7 @@ Describe "Haskell" -Skip:($os.IsHighSierra) {
     It "GHC" {
         "ghc --version" | Should -ReturnZeroExitCode
     }
-    
+
     It "Cabal" {
         "cabal --version" | Should -ReturnZeroExitCode
     }
@@ -329,7 +329,7 @@ Describe "Gcc" -Skip:($os.IsHighSierra) {
         param (
             [string] $GccVersion
         )
-        
+
         "gcc-$GccVersion --version" | Should -ReturnZeroExitCode
     }
 }

--- a/images/macos/tests/Common.Tests.ps1
+++ b/images/macos/tests/Common.Tests.ps1
@@ -217,7 +217,7 @@ Describe "Common utilities" {
         "vboxmanage -v" | Should -ReturnZeroExitCode
     }
 
-    It "vagrant" {
+    It "vagrant" -Skip:($os.IsBigSur) {
         "vagrant --version" | Should -ReturnZeroExitCode
     }
 


### PR DESCRIPTION
# Description
1. R - postflight script for R  contains incorrect regex conditions due to that there are no symlinks in /usr/local/bin
```
if uname -r | grep '^1[5-9]' >/dev/null; then
    ## 15.0 and higher don't allow messing with /usr/bin
    ## so use /usr/local/bin instead
    if [ ! -e /usr/local/bin ]; then
	mkdir -p /usr/local/bin
    fi
    cd /usr/local/bin
fi
```
2. virtualbox - currently doesn't support macOS Big Sur[[Big Sur Host Issues]( https://forums.virtualbox.org/viewtopic.php?f=39&t=98763) ] and unable to start vm

3. vagrant - tied to VirtualBox
#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1176

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
