### PR TITLE
Add attempt count to macOS VM name

### DIFF
--- a/images.CI/macos/azure-pipelines/image-generation.yml
+++ b/images.CI/macos/azure-pipelines/image-generation.yml
@@ -13,6 +13,10 @@ jobs:
     clean: true
     fetchDepth: 1
 
+  - pwsh: |
+      Get-ChildItem Env:
+      exit 1
+
   - task: PowerShell@2
     displayName: 'Validate contributor permissions'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/pull/')

--- a/images.CI/macos/azure-pipelines/image-generation.yml
+++ b/images.CI/macos/azure-pipelines/image-generation.yml
@@ -7,15 +7,13 @@ jobs:
   variables:
   - group: Mac-Cloud Image Generation
   - group: Mac-Cloud Image Generation Key Vault
+  - name: VirtualMachineName
+    value: $(Build.BuildNumber).$(System.JobAttempt)
 
   steps:
   - checkout: self
     clean: true
     fetchDepth: 1
-
-  - pwsh: |
-      Get-ChildItem Env:
-      exit 1
 
   - task: PowerShell@2
     displayName: 'Validate contributor permissions'
@@ -60,7 +58,7 @@ jobs:
         -var="output_folder=$(output-folder)" `
         -var="vm_username=$(vm-username)" `
         -var="vm_password=$(vm-password)" `
-        -var="build_id=$(Build.BuildNumber)" `
+        -var="build_id=${{ variables.VirtualMachineName }}" `
         -var="baseimage_name=${{ parameters.base_image_name }}" `
         -var="github_feed_token=$(github-feed-token)" `
         -var="xcode_install_user=$(xcode-installation-user)" `
@@ -87,7 +85,7 @@ jobs:
       ls $(Common.TestResultsDirectory)
 
       echo "Put VM name to 'VM_Done_Name' file"
-      echo "$(Build.BuildNumber)" > "$(Build.ArtifactStagingDirectory)/VM_Done_Name"
+      echo "${{ variables.VirtualMachineName }}" > "$(Build.ArtifactStagingDirectory)/VM_Done_Name"
     displayName: Prepare artifact
 
   - bash: |


### PR DESCRIPTION
# Description
For now we can't rerun failed build, because it fails due to new virtual machine has the same name as previous VM. Adding attempt counter we create new virtual machine name on rerun failed build. 

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
