### PR TITLE
[Ubuntu] Add GCC 10

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -8,7 +8,7 @@ function Get-CPPVersions {
     $cppVersions = apt list --installed 2>&1 | Where-Object { $_ -match "g\+\+-\d+"} | ForEach-Object {
         $_ -match "now (?<version>\d+\.\d+\.\d+)-" | Out-Null
         $Matches.version
-    }
+    } | Sort-Object {[Version]$_}
     return "GNU C++ " + ($cppVersions -Join ", ")
 }
 
@@ -16,7 +16,7 @@ function Get-FortranVersions {
     $fortranVersions = apt list --installed 2>&1 | Where-Object { $_ -match "^gfortran-\d+"} | ForEach-Object {
         $_ -match "now (?<version>\d+\.\d+\.\d+)-" | Out-Null
         $Matches.version
-    }
+    } | Sort-Object {[Version]$_}
     return "GNU Fortran " + ($fortranVersions -Join ", ")
 }
 
@@ -28,7 +28,7 @@ function Get-ClangVersions {
             $_ -match "clang version (?<version>\d+\.\d+\.\d+)-" | Out-Null
             $Matches.version
         }
-    }
+    } | Sort-Object {[Version]$_}
     return "Clang " + ($clangVersions -Join ", ")
 }
 

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -6,8 +6,7 @@ function Get-OSName {
 
 function Get-CPPVersions {
     $cppVersions = apt list --installed 2>&1 | Where-Object { $_ -match "g\+\+-\d+"} | ForEach-Object {
-        $_ -match "now (?<version>\d+\.\d+\.\d+)-" | Out-Null
-        $Matches.version
+        & $_.Split("/")[0] --version | Select-Object -First 1 | Take-OutputPart -Part 3
     } | Sort-Object {[Version]$_}
     return "GNU C++ " + ($cppVersions -Join ", ")
 }

--- a/images/linux/scripts/installers/gcc.sh
+++ b/images/linux/scripts/installers/gcc.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs GNU C++
 ################################################################################
 
-
 function InstallGcc {
     version=$1
 
@@ -27,6 +26,7 @@ versions=(
     "g++-7"
     "g++-8"
     "g++-9"
+    "g++-10"
 )
 
 for version in ${versions[*]}

--- a/images/linux/scripts/installers/gcc.sh
+++ b/images/linux/scripts/installers/gcc.sh
@@ -4,6 +4,11 @@
 ##  Desc:  Installs GNU C++
 ################################################################################
 
+set -e
+
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/os.sh
+
 function InstallGcc {
     version=$1
 
@@ -26,10 +31,12 @@ versions=(
     "g++-7"
     "g++-8"
     "g++-9"
-    "g++-10"
 )
 
-for version in ${versions[*]}
-do
+if ! isUbuntu16; then
+    versions+=("g++-10")
+fi
+
+for version in ${versions[*]}; do
     InstallGcc $version
 done


### PR DESCRIPTION
# Description
In scope of this PR we add GCC 10 for Ubuntu 18.04/20.04 and fix output version order in markdown.

Gcc-10 is not available for Ubuntu 16.04.

#### Related issue:
https://github.com/actions/virtual-environments/issues/1604
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
