### PR TITLE
[Ubuntu] Use official repository to install clang

### DIFF
--- a/images/linux/scripts/installers/clang.sh
+++ b/images/linux/scripts/installers/clang.sh
@@ -16,7 +16,7 @@ function InstallClang {
         ./llvm.sh $version
         apt-get install -y "clang-format-$version"
     else
-        apt-get install -y "clang-$version" "lldb-$version" "lld-$version" apt-get install -y "clang-format-$version"
+        apt-get install -y "clang-$version" "lldb-$version" "lld-$version" "clang-format-$version"
     fi
 
     # Run tests to determine that the software installed as expected

--- a/images/linux/scripts/installers/clang.sh
+++ b/images/linux/scripts/installers/clang.sh
@@ -12,11 +12,11 @@ function InstallClang {
     local version=$1
 
     echo "Installing clang-$version..."
-    if [[ $version =~ (9|10) ]]; then
+    if [[ $version =~ 9 ]] && isUbuntu16; then
         ./llvm.sh $version
         apt-get install -y "clang-format-$version"
     else
-        apt-get install -y "clang-$version" "lldb-$version" "lld-$version" "clang-format-$version"
+        apt-get install -y "clang-$version" "lldb-$version" "lld-$version" apt-get install -y "clang-format-$version"
     fi
 
     # Run tests to determine that the software installed as expected


### PR DESCRIPTION
# Description
In scope of this PR we decided to install clang from from official repository for  Ubuntu 18.04/20.04 and use llvm.sh for clang-9 on Ubuntu-16.04 only(missing in the official repository). In that way, we don't need to add llvm repository manually when we need to install additional packages(e.g.: apt-get install clang-tidy-10).

#### Related issue:
https://github.com/actions/virtual-environments/issues/1536

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
