### PR TITLE
Fix credentials in GenerateResourcesAndImage.ps1

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -167,7 +167,9 @@ Function GenerateResourcesAndImage {
     New-AzStorageAccount -ResourceGroupName $ResourceGroupName -AccountName $storageAccountName -Location $AzureLocation -SkuName "Standard_LRS"
 
     $spDisplayName = [System.GUID]::NewGuid().ToString().ToUpper()
-    $sp = New-AzADServicePrincipal -DisplayName $spDisplayName -Password (ConvertTo-SecureString $ServicePrincipalClientSecret -AsPlainText -Force)
+    $credentials = New-Object -TypeName Microsoft.Azure.Commands.ActiveDirectory.PSADPasswordCredential -Property @{
+        StartDate=Get-Date; EndDate=Get-Date -Year 2024; Password=$ServicePrincipalClientSecret}
+    $sp = New-AzADServicePrincipal -DisplayName $spDisplayName -PasswordCredential $credentials
 
     $spAppId = $sp.ApplicationId
     $spClientId = $sp.ApplicationId

--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -167,8 +167,8 @@ Function GenerateResourcesAndImage {
     New-AzStorageAccount -ResourceGroupName $ResourceGroupName -AccountName $storageAccountName -Location $AzureLocation -SkuName "Standard_LRS"
 
     $spDisplayName = [System.GUID]::NewGuid().ToString().ToUpper()
-    $credentials = New-Object -TypeName Microsoft.Azure.Commands.ActiveDirectory.PSADPasswordCredential -Property @{
-        StartDate=Get-Date; EndDate=Get-Date -Year 2024; Password=$ServicePrincipalClientSecret}
+    $credentialProperties = @{ StartDate=Get-Date; EndDate=Get-Date -Year 2024; Password=$ServicePrincipalClientSecret }
+    $credentials = New-Object -TypeName Microsoft.Azure.Commands.ActiveDirectory.PSADPasswordCredential -Property $credentialProperties
     $sp = New-AzADServicePrincipal -DisplayName $spDisplayName -PasswordCredential $credentials
 
     $spAppId = $sp.ApplicationId


### PR DESCRIPTION
# Description
Bug: `New-AzADServicePrincipal` cmdlet is invoked with incorrect argument name and argument type: `Password` instead `PasswordCredential` and `<SecureString>` type instead `<PSADPasswordCredential[]>`. It throws the following error:
```
 GenerateResourcesAndImage : Cannot bind parameter 'PasswordCredential'. Cannot convert the
"System.Security.SecureString" value of type "System.Security.SecureString" to type
"Microsoft.Azure.Commands.ActiveDirectory.PSADPasswordCredential".
```

Az module doc about `New-AzADServicePrincipal`: [link](https://docs.microsoft.com/en-us/powershell/module/az.resources/new-azadserviceprincipal?view=azps-4.7.0)

These changes were tested locally and it works.

#### Related issue:
#1664 

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
