### PR TITLE
[macOS] Disable spotlight indexing

### DIFF
--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -28,3 +28,6 @@ sudo "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1176 885
 curl https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer --output $HOME/AppleWWDRCAG3.cer --silent
 sudo security add-trusted-cert -d -r unspecified -k /Library/Keychains/System.keychain $HOME/AppleWWDRCAG3.cer
 rm $HOME/AppleWWDRCAG3.cer
+
+# Disable spotlight indexing to prevent possible high CPU usage after startup
+sudo mdutil -ai off


### PR DESCRIPTION
# Description
It turned out we have a few CPU-consuming processes on the base image after the generation. These mdworker processes belong to spotlight search indexing, and it looks like we don't use spotlight at all so the indexing can be safely turned off.
![image](https://user-images.githubusercontent.com/48208649/94399668-7ec90400-0170-11eb-96cb-b469ffd4b90e.png)

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1212

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
