### PR TITLE
[Windows] Fix Get-CodeQLBundleVersion output

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+
 Import-Module MarkdownPS
 Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Android.psm1") -DisableNameChecking
 Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Browsers.psm1") -DisableNameChecking

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -34,7 +34,7 @@ function Get-CodeQLBundleVersion {
     $CodeQLVersionsWildcard = Join-Path $Env:AGENT_TOOLSDIRECTORY -ChildPath "codeql" | Join-Path -ChildPath "*"
     $CodeQLVersionPath = Get-ChildItem $CodeQLVersionsWildcard | Select-Object -First 1 -Expand FullName
     $CodeQLPath = Join-Path $CodeQLVersionPath -ChildPath "x64" | Join-Path -ChildPath "codeql" | Join-Path -ChildPath "codeql.exe"
-    $CodeQLVersion = $($CodeQLPath version --quiet)
+    $CodeQLVersion = & $CodeQLPath version --quiet
     return "CodeQL Action Bundle $CodeQLVersion"
 }
 


### PR DESCRIPTION
# Description
The line contains incorrect statement that cause the errors:
 https://github.com/actions/virtual-environments/blob/b0f3f989abd744ea6bfcaf62fc5decf19f8853b6/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1#L37

```
char:36
+     $CodeQLVersion = $($CodeQLPath version --quiet)
+                                    ~~~~~~~
Unexpected token 'version' in expression or statement.

Import-Module : The specified module
'..\virtual-environments\images\win\scripts\SoftwareReport\SoftwareReport.Tools.psm1' was
not loaded because no valid module file was found in any module directory.
At line:1 char:1
```
 
#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1213

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
