### PR TITLE
[macOS] Hardcode PyPy 7.3.1 for macOS-10.13

### DIFF
--- a/images/macos/provision/core/pypy.sh
+++ b/images/macos/provision/core/pypy.sh
@@ -77,6 +77,8 @@ for toolsetVersion in $toolsetVersions; do
     # PyPy 7.3.2 for High Sierra is broken, use 7.3.1 instead https://foss.heptapod.net/pypy/pypy/-/issues/3311
     if is_HighSierra; then
         versionPattern="v7.3.1-"
+        # PyPy 7.3.1 relies on system libffi.6.dylib, which is not existed in in libffi 3.3 release. As a workaround symlink can be created
+        ln -s libffi.7.dylib /usr/local/opt/libffi/lib/libffi.6.dylib
     fi
 
     latestMajorPyPyVersion=$(echo "${pypyVersions}" | grep -E "pypy${toolsetVersion}-${versionPattern}" | head -1)

--- a/images/macos/provision/core/pypy.sh
+++ b/images/macos/provision/core/pypy.sh
@@ -68,19 +68,17 @@ function InstallPyPy
 
 uri="https://downloads.python.org/pypy/"
 pypyVersions=$(curl -4 -s --compressed $uri | grep 'osx64' | awk -v uri="$uri" -F'>|<' '{print uri$5}')
-
 toolsetVersions=$(get_toolset_value '.toolcache[] | select(.name | contains("PyPy")) | .versions[]')
+versionPattern="v[0-9]+\.[0-9]+\.[0-9]+-"
+
+# PyPy 7.3.2 for High Sierra is broken, use 7.3.1 instead https://foss.heptapod.net/pypy/pypy/-/issues/3311
+if is_HighSierra; then
+    versionPattern="v7.3.1-"
+    # PyPy 7.3.1 relies on system libffi.6.dylib, which is not existed in in libffi 3.3 release. As a workaround symlink can be created
+    ln -s libffi.7.dylib /usr/local/opt/libffi/lib/libffi.6.dylib
+fi
 
 for toolsetVersion in $toolsetVersions; do
-    versionPattern="v[0-9]+\.[0-9]+\.[0-9]+-"
-
-    # PyPy 7.3.2 for High Sierra is broken, use 7.3.1 instead https://foss.heptapod.net/pypy/pypy/-/issues/3311
-    if is_HighSierra; then
-        versionPattern="v7.3.1-"
-        # PyPy 7.3.1 relies on system libffi.6.dylib, which is not existed in in libffi 3.3 release. As a workaround symlink can be created
-        ln -s libffi.7.dylib /usr/local/opt/libffi/lib/libffi.6.dylib
-    fi
-
     latestMajorPyPyVersion=$(echo "${pypyVersions}" | grep -E "pypy${toolsetVersion}-${versionPattern}" | head -1)
     if [[ -z "$latestMajorPyPyVersion" ]]; then
         echo "Failed to get PyPy version '$toolsetVersion'"

--- a/images/macos/provision/core/pypy.sh
+++ b/images/macos/provision/core/pypy.sh
@@ -66,16 +66,20 @@ function InstallPyPy
     rm -f $PACKAGE_TAR_TEMP_PATH
 }
 
-# PyPy 7.3.1 relies on system libffi.6.dylib, which is not existed in in libffi 3.3 release. As a workaround symlink can be created
-ln -s libffi.7.dylib /usr/local/opt/libffi/lib/libffi.6.dylib
-
 uri="https://downloads.python.org/pypy/"
 pypyVersions=$(curl -4 -s --compressed $uri | grep 'osx64' | awk -v uri="$uri" -F'>|<' '{print uri$5}')
 
 toolsetVersions=$(get_toolset_value '.toolcache[] | select(.name | contains("PyPy")) | .versions[]')
 
 for toolsetVersion in $toolsetVersions; do
-    latestMajorPyPyVersion=$(echo "${pypyVersions}" | grep -E "pypy${toolsetVersion}-v[0-9]+\.[0-9]+\.[0-9]+-" | head -1)
+    versionPattern="v[0-9]+\.[0-9]+\.[0-9]+-"
+
+    # PyPy 7.3.2 for High Sierra is broken, use 7.3.1 instead https://foss.heptapod.net/pypy/pypy/-/issues/3311
+    if is_HighSierra; then
+        versionPattern="v7.3.1-"
+    fi
+
+    latestMajorPyPyVersion=$(echo "${pypyVersions}" | grep -E "pypy${toolsetVersion}-${versionPattern}" | head -1)
     if [[ -z "$latestMajorPyPyVersion" ]]; then
         echo "Failed to get PyPy version '$toolsetVersion'"
         exit 1


### PR DESCRIPTION
# Description
The recently released PyPy 7.3.2 for High Sierra is broken and is already fixed in the main PyPy branch but not yet released https://foss.heptapod.net/pypy/pypy/-/issues/3311
To avoid build failures 7.3.1 can be installed for HS.
As an additional change — workaround for 7.3.1 removed from 10.14 & 10.15 PyPy installations.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1217

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
