### PR TITLE
Move the list of Docker images to toolset on Windows

### DIFF
--- a/images/win/scripts/Installers/Update-DockerImages.ps1
+++ b/images/win/scripts/Installers/Update-DockerImages.ps1
@@ -16,18 +16,7 @@ function DockerPull {
     }
 }
 
-if (Test-IsWin16) {
-  DockerPull mcr.microsoft.com/windows/servercore:ltsc2016
-  DockerPull mcr.microsoft.com/windows/nanoserver:10.0.14393.953
-  DockerPull mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2016
-  DockerPull mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2016
+$dockerToolset = (Get-ToolsetContent).docker
+foreach($dockerImage in $dockerToolset.images) {
+  DockerPull $dockerImage
 }
-
-if (Test-IsWin19) {
-  DockerPull mcr.microsoft.com/windows/servercore:ltsc2019
-  DockerPull mcr.microsoft.com/windows/nanoserver:1809
-  DockerPull mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2019
-  DockerPull mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019
-}
-
-DockerPull microsoft/aspnetcore-build:1.0-2.0

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -231,5 +231,14 @@
         ],
         "vsix": [
         ]
+    },
+    "docker": {
+        "images": [
+            "mcr.microsoft.com/windows/servercore:ltsc2016",
+            "mcr.microsoft.com/windows/nanoserver:10.0.14393.953",
+            "mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2016",
+            "mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2016",
+            "microsoft/aspnetcore-build:1.0-2.0"
+        ]
     }
 }

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -283,5 +283,14 @@
                 "id": "VSInstallerProjects"
             }
         ]
+    },
+    "docker": {
+        "images": [
+            "mcr.microsoft.com/windows/servercore:ltsc2019",
+            "mcr.microsoft.com/windows/nanoserver:1809",
+            "mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2019",
+            "mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019",
+            "microsoft/aspnetcore-build:1.0-2.0"
+        ]
     }
 }


### PR DESCRIPTION
# Description
In scope of this [work item](https://github.com/actions/virtual-environments-internal/issues/1215) we have moved the list of Docker images to toolset on Windows and updated the Update-DockerImages.ps1 script

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: [#1215](https://github.com/actions/virtual-environments-internal/issues/1215)

## Check list
- [x] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
