### PR TITLE
[Ubuntu] Default Python will be switched to 3.8 on Ubuntu 20.04

### DIFF
--- a/images/linux/scripts/installers/python.sh
+++ b/images/linux/scripts/installers/python.sh
@@ -9,12 +9,12 @@ set -e
 source $HELPER_SCRIPTS/os.sh
 
 # Install Python, Python 3, pip, pip3
-if isUbuntu16 || isUbuntu18 ; then
+if isUbuntu16 || isUbuntu18; then
     apt-get install -y --no-install-recommends python python-dev python-pip python3 python3-dev python3-pip
 fi
 
-if isUbuntu20 ; then
-    apt-get install -y --no-install-recommends python3 python3-dev python3-pip python-is-python3
+if isUbuntu20; then
+    apt-get install -y --no-install-recommends python3 python3-dev python3-pip
     ln -s /usr/bin/pip3 /usr/bin/pip
 fi
 

--- a/images/linux/scripts/installers/python.sh
+++ b/images/linux/scripts/installers/python.sh
@@ -4,19 +4,18 @@
 ##  Desc:  Installs Python 2/3
 ################################################################################
 
+set -e
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/os.sh
 
 # Install Python, Python 3, pip, pip3
-if isUbuntu20 ; then
-    apt-get install -y --no-install-recommends python3 python3-dev python3-pip
-
-    curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py
-    python2 get-pip.py
-fi
-
 if isUbuntu16 || isUbuntu18 ; then
     apt-get install -y --no-install-recommends python python-dev python-pip python3 python3-dev python3-pip
+fi
+
+if isUbuntu20 ; then
+    apt-get install -y --no-install-recommends python3 python3-dev python3-pip python-is-python3
+    ln -s /usr/bin/pip3 /usr/bin/pip
 fi
 
 # Run tests to determine that the software installed as expected

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -96,7 +96,7 @@
             "locales",
             "openssh-client",
             "pkg-config",
-            "python-is-python2",
+            "python-is-python3",
             "rpm",
             "texinfo",
             "tk",


### PR DESCRIPTION
# Description
Currently, Python 2.7 is set by default on Ubuntu 20.04. Python 2 was sunsetted on Jan 1 2020 and this version is not supported anymore. In scope of this PR we set the default Python to 3.8 on Ubuntu 20.04.

Alias:
```
/usr/bin/python -> /usr/bin/python3 ->  /usr/bin/python3.8
/usr/bin/pip -> /usr/bin/pip3
```

#### Related issue:
https://github.com/actions/virtual-environments/issues/1591

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
