### PR TITLE
[Linux, macOS] Improve nvm installer

### DIFF
--- a/images/linux/scripts/installers/nvm.sh
+++ b/images/linux/scripts/installers/nvm.sh
@@ -7,7 +7,8 @@
 
 export NVM_DIR="/etc/skel/.nvm"
 mkdir $NVM_DIR
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+VERSION=$(curl -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r '.tag_name')
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$VERSION/install.sh | bash
 echo 'export NVM_DIR=$HOME/.nvm' | tee -a /etc/skel/.bash_profile
 echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm' | tee -a /etc/skel/.bash_profile
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"

--- a/images/macos/provision/core/nvm.sh
+++ b/images/macos/provision/core/nvm.sh
@@ -6,7 +6,8 @@
 ###########################################################################
 source ~/utils/utils.sh
 
-curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.3/install.sh | bash
+VERSION=$(curl -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r '.tag_name')
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$VERSION/install.sh | bash
 
 if [ $? -eq 0 ]; then
         . ~/.bashrc
@@ -23,13 +24,13 @@ if [ $? -eq 0 ]; then
         nvm alias node12 lts/erbium
         nvm alias node13 v13
         nvm alias node14 v14
-        
+
         if is_Catalina || is_BigSur; then
                 # set system node as default
                 nvm alias default system
         fi
 else
-        echo error 
+        echo error
 fi
 
 echo "Node version manager has been installed successfully"


### PR DESCRIPTION
# Description
~New tool~, ~Bug fixing~, or Improvement?

Current nvm installer scripts, both on Linux and macOS, are requiring manual updates on every new nvm release. This change is to make it more automated, and to keep up with the latest releases of nvm. It also fixes a small redirect problem in macOS script. URL was pointing to the old repository, and now it's the correct one. I understand you don't accept any external contributions to macOS images, if you prefer, I can split the changes and create a PR for Linux, and an issue for macOS.

#### Related issue: N/A

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
