### PR TITLE
[Ubuntu] Fix CodeQL version output in markdown file

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -29,7 +29,7 @@ function Get-BazeliskVersion {
 }
 
 function Get-CodeQLBundleVersion {
-    $CodeQLVersionsWildcard = Join-Path $Env:AGENT_TOOLSDIRECTORY -ChildPath "codeql" | Join-Path -ChildPath "*"
+    $CodeQLVersionsWildcard = Join-Path $Env:AGENT_TOOLSDIRECTORY -ChildPath "CodeQL" | Join-Path -ChildPath "*"
     $CodeQLVersionPath = Get-ChildItem $CodeQLVersionsWildcard | Select-Object -First 1 -Expand FullName
     $CodeQLPath = Join-Path $CodeQLVersionPath -ChildPath "x64" | Join-Path -ChildPath "codeql" | Join-Path -ChildPath "codeql"
     $CodeQLVersion = & $CodeQLPath version --quiet


### PR DESCRIPTION
# Description
Currently `- CodeQL Action Bundle ` version is missing due to incorrect  directory case name. 

```
2020-09-30T17:25:09.6741308Z ==> azure-arm: [91mGet-ChildItem: [0m/imagegeneration/SoftwareReport/SoftwareReport.Tools.psm1:33
2020-09-30T17:25:09.6749043Z ==> azure-arm: [96m  33 | [0m â€¦    $CodeQLVersionPath = [96mGet-ChildItem $CodeQLVersionsWildcard[0m | Selec â€¦
2020-09-30T17:25:09.6761964Z ==> azure-arm: [91m[96m     | [91mCannot find path '/opt/hostedtoolcache/codeql' because it does
2020-09-30T17:25:09.6884852Z ==> azure-arm: [91mJoin-Path: [0m/imagegeneration/SoftwareReport/SoftwareReport.Tools.psm1:34
2020-09-30T17:25:09.6889840Z ==> azure-arm: [96mLine |
2020-09-30T17:25:09.6899425Z ==> azure-arm: [96m  34 | [0m     $CodeQLPath = Join-Path [96m$CodeQLVersionPath[0m -ChildPath "x64" | Joi â€¦
2020-09-30T17:25:09.6906188Z ==> azure-arm: [96m     | [91m                             ~~~~~~~~~~~~~~~~~~
2020-09-30T17:25:09.6916188Z ==> azure-arm: [91m[96m     | [91mCannot bind argument to parameter 'Path' because it is null.
2020-09-30T17:25:09.6930845Z ==> azure-arm: [0m
2020-09-30T17:25:09.6979686Z ==> azure-arm: [91mInvalidOperation: [0m/imagegeneration/SoftwareReport/SoftwareReport.Tools.psm1:35
2020-09-30T17:25:09.6983783Z ==> azure-arm: [96mLine |
2020-09-30T17:25:09.6989872Z ==> azure-arm: [96m  35 | [0m     $CodeQLVersion = & [96m$CodeQLPath[0m version --quiet
2020-09-30T17:25:09.6999229Z ==> azure-arm: [96m     | [91m                        ~~~~~~~~~~~
2020-09-30T17:25:09.7002549Z ==> azure-arm: [91m[96m     | [91mThe expression after '&' in a pipeline element produced an
2020-09-30T17:25:09.7013173Z ==> azure-arm: [96m     | [91mobject that was not valid. It must result in a command name, a
2020-09-30T17:25:09.7017091Z ==> azure-arm: [96m     | [91mscript block, or a CommandInfo object.
```
#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1240
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
