### PR TITLE
[macOS] Set 6_12_0 as default Xamarin bundle

### DIFF
--- a/images/macos/provision/core/audiodevice.sh
+++ b/images/macos/provision/core/audiodevice.sh
@@ -12,8 +12,3 @@ brew install sox
 echo "set Soundflower (2ch) as input/output device"
 SwitchAudioSource -s "Soundflower (2ch)" -t input
 SwitchAudioSource -s "Soundflower (2ch)" -t output
-
-echo "grant microphone permission for simulators"
-sudo sqlite3 ~/Library/Application\ Support/com.apple.TCC/TCC.db "insert into access values('kTCCServiceMicrophone','com.apple.CoreSimulator.SimulatorTrampoline', 0,1,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1576347152)"
-sudo sqlite3 /Library/Application\ Support/com.apple.TCC/TCC.db "insert into access values('kTCCServiceMicrophone','/usr/local/opt/runner/runprovisioner.sh', 1,1,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1576661342)"
-sudo sqlite3 ~/Library/Application\ Support/com.apple.TCC/TCC.db "insert into access values('kTCCServiceMicrophone','/usr/local/opt/runner/runprovisioner.sh', 1,1,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1576661342)"

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -19,35 +19,35 @@
         "android-versions": [
             "11.0.2.0", "10.3.1.4", "10.2.0.100", "10.1.3.7", "10.0.6.2"
         ],
-        "bundle-default": "latest",
+        "bundle-default": "6_12_0",
         "bundles": [
             {
                 "symlink": "6_12_1",
                 "mono":"6.12",
                 "ios": "14.0",
                 "mac": "6.20",
-                "android": "11.0" 
+                "android": "11.0"
             },
             {
                 "symlink": "6_12_0",
                 "mono":"6.12",
                 "ios": "13.20",
                 "mac": "6.20",
-                "android": "11.0" 
+                "android": "11.0"
             },
             {
                 "symlink": "6_10_0",
                 "mono":"6.10",
                 "ios": "13.18",
                 "mac": "6.18",
-                "android": "10.3" 
+                "android": "10.3"
             },
             {
                 "symlink": "6_8_1",
                 "mono":"6.8",
                 "ios": "13.16",
                 "mac": "6.16",
-                "android": "10.2" 
+                "android": "10.2"
             },
             {
                 "symlink": "6_8_0",

--- a/images/macos/toolsets/toolset-11.0.json
+++ b/images/macos/toolsets/toolset-11.0.json
@@ -19,21 +19,21 @@
         "android-versions": [
             "11.0.2.0"
         ],
-        "bundle-default": "latest",
+        "bundle-default": "6_12_0",
         "bundles": [
             {
                 "symlink": "6_12_1",
                 "mono":"6.12",
                 "ios": "14.0",
                 "mac": "6.20",
-                "android": "11.0" 
+                "android": "11.0"
             },
             {
                 "symlink": "6_12_0",
                 "mono":"6.12",
                 "ios": "13.20",
                 "mac": "6.20",
-                "android": "11.0" 
+                "android": "11.0"
             }
         ]
     },


### PR DESCRIPTION
# Description
Xamarin iOS 14 requires Xcode 12, so we can't set it by default along with Xcode 11.7.
The default Xcode will be switched to 12 in 2-3 weeks.
As an addition permissions for audio devices were moved to the base image since they are not functional during the image generation because of enabled SIP.

#### Related issue:
https://github.com/actions/virtual-environments/issues/1712

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
