### PR TITLE
[macOS] Fix Xcode simulators section

### DIFF
--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -289,6 +289,8 @@ $markdown += New-MDList -Lines (Build-XamarinAndroidList) -Style Unordered
 $markdown += New-MDHeader "Unit Test Framework" -Level 4
 $markdown += New-MDList -Lines @(Get-NUnitVersion) -Style Unordered
 
+# First run doesn't provide full data about devices and runtimes
+Get-XcodeInfoList | Out-Null
 # Xcode section
 $xcodeInfo = Get-XcodeInfoList
 $markdown += New-MDHeader "Xcode" -Level 3
@@ -301,12 +303,9 @@ $markdown += New-MDHeader "Installed SDKs" -Level 4
 $markdown += Build-XcodeSDKTable $xcodeInfo | New-MDTable
 $markdown += New-MDNewLine
 
-# Disable simulators table on 11.0 beta for now since "simctl" tool doesn't work properly
-if (-not $os.IsBigSur) {
-    $markdown += New-MDHeader "Installed Simulators" -Level 4
-    $markdown += Build-XcodeSimulatorsTable $xcodeInfo | New-MDTable
-    $markdown += New-MDNewLine
-}
+$markdown += New-MDHeader "Installed Simulators" -Level 4
+$markdown += Build-XcodeSimulatorsTable $xcodeInfo | New-MDTable
+$markdown += New-MDNewLine
 
 # Android section
 $markdown += New-MDHeader "Android" -Level 3


### PR DESCRIPTION
# Description
After installing Xcode 12 xcrun simctl list --json doesn't provide full list of devices and runtimes after first lunch. The second attempt works as expected.

```
==> vsphere-clone: MethodInvocationException: /Users/runner/image-generation/software-report/SoftwareReport.Xcode.psm1:206
==> vsphere-clone: Line |
==> vsphere-clone:  206 |          return [PSCustomObject] @{
==> vsphere-clone:      |                 ~~~~~~~~~~~~~~~~~~~
==> vsphere-clone:      | Exception calling "Join" with "2" argument(s): "Value cannot
==> vsphere-clone:      | be null. (Parameter 'values')"
==> vsphere-clone: 
==> vsphere-clone: MethodInvocationException: /Users/runner/image-generation/software-report/SoftwareReport.Xcode.psm1:206
==> vsphere-clone: Line |
==> vsphere-clone:  206 |          return [PSCustomObject] @{
==> vsphere-clone:      |                 ~~~~~~~~~~~~~~~~~~~
==> vsphere-clone:      | Exception calling "Join" with "2" argument(s): "Value cannot
==> vsphere-clone:      | be null. (Parameter 'values')"
==> vsphere-clone: 
==> vsphere-clone: MethodInvocationException: /Users/runner/image-generation/software-report/SoftwareReport.Xcode.psm1:206
==> vsphere-clone: Line |
==> vsphere-clone:  206 |          return [PSCustomObject] @{
==> vsphere-clone:      |                 ~~~~~~~~~~~~~~~~~~~
==> vsphere-clone:      | Exception calling "Join" with "2" argument(s): "Value cannot
==> vsphere-clone:      | be null. (Parameter 'values')"

```

Example output:
```
| ----------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| iOS 13.7    | 11.7          | iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE (2nd generation)<br>iPad (7th generation)<br>iPad Air (3rd generation)<br>iPad Pro (11-inch) (2nd generation)<br>iPad Pro (12.9-inch) (4th generation)<br>iPad Pro (9.7-inch)                                                                                      |
| iOS 14.2    | 12.2          | iPod touch (7th generation)<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE (2nd generation)<br>iPad (7th generation)<br>iPad (8th generation)<br>iPad Air (3rd generation)<br>iPad Air (4th generation)<br>iPad Pro (11-inch) (2nd generation)<br>iPad Pro (12.9-inch) (4th generation)<br>iPad Pro (9.7-inch) |
| tvOS 13.4   | 11.7          | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                            |
| tvOS 14.2   | 12.2          | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                            |
 | watchOS 6.2 | 11.7          | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                                                                                                                                                     |
2020
```
#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1241
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
