### PR TITLE
[Windows] Fail Windows image building on error in generation scripts

### DIFF
--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -162,12 +162,6 @@
         },
         {
             "type": "powershell",
-            "scripts": [
-                "{{ template_dir }}/scripts/Installers/Update-DockerImages.ps1"
-            ]
-        },
-        {
-            "type": "powershell",
             "valid_exit_codes": [
                 0,
                 3010
@@ -176,6 +170,7 @@
                 "TOOLSET_JSON_PATH={{user `toolset_json_path`}}"
             ],
             "scripts": [
+                "{{ template_dir }}/scripts/Installers/Update-DockerImages.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-VS.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-NET48.ps1",
                 "{{ template_dir }}/scripts/Installers/Windows2016/Install-SSDT.ps1"

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -170,12 +170,6 @@
         },
         {
             "type": "powershell",
-            "scripts": [
-                "{{ template_dir }}/scripts/Installers/Update-DockerImages.ps1"
-            ]
-        },
-        {
-            "type": "powershell",
             "valid_exit_codes": [
                 0,
                 3010
@@ -184,6 +178,7 @@
                 "TOOLSET_JSON_PATH={{user `toolset_json_path`}}"
             ],
             "scripts": [
+                "{{ template_dir }}/scripts/Installers/Update-DockerImages.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-VS.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-NET48.ps1"
             ],

--- a/images/win/scripts/Installers/Configure-Toolset.ps1
+++ b/images/win/scripts/Installers/Configure-Toolset.ps1
@@ -27,8 +27,6 @@ Function Set-DefaultVariables
     }
 }
 
-$ErrorActionPreference = "Stop"
-
 Import-Module -Name ImageHelpers -Force -DisableNameChecking
 
 # Define executables for cached tools

--- a/images/win/scripts/Installers/Configure-Toolset.ps1
+++ b/images/win/scripts/Installers/Configure-Toolset.ps1
@@ -27,8 +27,6 @@ Function Set-DefaultVariables
     }
 }
 
-Import-Module -Name ImageHelpers -Force -DisableNameChecking
-
 # Define executables for cached tools
 $toolsEnvironmentVariables = @{
     Python = @{

--- a/images/win/scripts/Installers/Download-ToolCache.ps1
+++ b/images/win/scripts/Installers/Download-ToolCache.ps1
@@ -62,8 +62,6 @@ Function Set-DefaultRubyVersion {
     Invoke-Expression "gem update --system"
 }
 
-Import-Module -Name ImageHelpers -Force
-
 $FeedPrefix = "https://npm.pkg.github.com"
 $AccessToken = $env:GITHUB_FEED_TOKEN
 

--- a/images/win/scripts/Installers/Finalize-VM.ps1
+++ b/images/win/scripts/Installers/Finalize-VM.ps1
@@ -6,8 +6,6 @@
 Write-Host "Cleanup WinSxS"
 Dism.exe /online /Cleanup-Image /StartComponentCleanup /ResetBase
 
-$ErrorActionPreference = 'silentlycontinue'
-
 Write-Host "Clean up various directories"
 @(
     "C:\\Recovery",
@@ -30,4 +28,5 @@ Write-Host "Clean up various directories"
 $winInstallDir = "$env:windir\\Installer"
 New-Item -Path $winInstallDir -ItemType Directory -Force
 
-$ErrorActionPreference = 'Continue'
+# Remove AllUsersAllHosts profile
+Remove-Item $profile.AllUsersAllHosts -Force

--- a/images/win/scripts/Installers/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/Initialize-VM.ps1
@@ -30,6 +30,9 @@ function Disable-UserAccessControl {
     Write-Host "User Access Control (UAC) has been disabled."
 }
 
+# Enable $ErrorActionPreference='Stop' for AllUsersAllHosts
+Add-Content -Path $profile.AllUsersAllHosts -Value '$ErrorActionPreference="Stop"'
+
 # Set TLS1.2
 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor "Tls12"
 

--- a/images/win/scripts/Installers/Install-AzureCosmosDbEmulator.ps1
+++ b/images/win/scripts/Installers/Install-AzureCosmosDbEmulator.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install Azure CosmosDb Emulator
 ####################################################################################
 
-Import-Module -Name ImageHelpers -Force
-
 $InstallerName = "AzureCosmosDBEmulator.msi"
 $InstallerUrl = "https://aka.ms/cosmosdb-emulator"
 

--- a/images/win/scripts/Installers/Install-AzureModules.ps1
+++ b/images/win/scripts/Installers/Install-AzureModules.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install Azure PowerShell modules
 ################################################################################
 
-$ErrorActionPreference = "Stop"
-
 # The correct Modules need to be saved in C:\Modules
 $installPSModulePath = $env:PSMODULES_ROOT_FOLDER
 if (-not (Test-Path -LiteralPath $installPSModulePath))

--- a/images/win/scripts/Installers/Install-Chrome.ps1
+++ b/images/win/scripts/Installers/Install-Chrome.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install Google Chrome
 ################################################################################
 
-Import-Module -Name ImageHelpers -Force
-
 # Download and install latest Chrome browser
 $ChromeInstallerFile = "chrome_installer.exe"
 $ChromeInstallerUrl = "https://dl.google.com/chrome/install/375.126/${ChromeInstallerFile}"

--- a/images/win/scripts/Installers/Install-CloudFoundryCli.ps1
+++ b/images/win/scripts/Installers/Install-CloudFoundryCli.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install Cloud Foundry CLI
 ################################################################################
 
-Import-Module -Name ImageHelpers
-
 # Download the latest cf cli exe
 $CloudFoundryCliName = "cf-cli.zip"
 $CloudFoundryCliUrl = "https://packages.cloudfoundry.org/stable?release=windows64-exe&source=github"

--- a/images/win/scripts/Installers/Install-DACFx.ps1
+++ b/images/win/scripts/Installers/Install-DACFx.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install SQL Server® Data-Tier Application Framework (DACFx) for Windows
 ####################################################################################
 
-Import-Module -Name ImageHelpers -Force
-
 $InstallerName = "DacFramework.msi"
 $InstallerUrl = "https://go.microsoft.com/fwlink/?linkid=2134206"
 

--- a/images/win/scripts/Installers/Install-Firefox.ps1
+++ b/images/win/scripts/Installers/Install-Firefox.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install Mozilla Firefox
 ################################################################################
 
-Import-Module -Name ImageHelpers -Force
-
 # Install and configure Firefox browser
 Write-Host "Install latest Firefox browser..."
 $VersionsManifest = Invoke-RestMethod "https://product-details.mozilla.org/1.0/firefox_versions.json"

--- a/images/win/scripts/Installers/Install-Git.ps1
+++ b/images/win/scripts/Installers/Install-Git.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install Git for Windows
 ################################################################################
 
-Import-Module -Name ImageHelpers
-
 function getSimpleValue([string] $url, [string] $filename ) {
     $fullpath = "${env:Temp}\$filename"
     Invoke-WebRequest -Uri $url -OutFile $fullpath

--- a/images/win/scripts/Installers/Install-JavaTools.ps1
+++ b/images/win/scripts/Installers/Install-JavaTools.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install various JDKs and java tools
 ################################################################################
 
-Import-Module -Name ImageHelpers -Force
-
 function Set-JavaPath {
     param (
         [string] $Version,

--- a/images/win/scripts/Installers/Install-Miniconda.ps1
+++ b/images/win/scripts/Installers/Install-Miniconda.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install the latest version of Miniconda and set $env:CONDA
 ################################################################################
 
-Import-Module -Name ImageHelpers -Force
-
 $CondaDestination = "C:\Miniconda"
 
 # Lock to Miniconda 4.6 until we do the work to run `conda init` for the vsts user

--- a/images/win/scripts/Installers/Install-NET48.ps1
+++ b/images/win/scripts/Installers/Install-NET48.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install .NET 4.8
 ################################################################################
 
-Import-Module -Name ImageHelpers -Force
-
 # .NET 4.8 Dev pack
 $InstallerName = "ndp48-devpack-enu.exe"
 $InstallerUrl = "https://download.visualstudio.microsoft.com/download/pr/014120d7-d689-4305-befd-3cb711108212/0307177e14752e359fde5423ab583e43/${InstallerName}"

--- a/images/win/scripts/Installers/Install-NodeLts.ps1
+++ b/images/win/scripts/Installers/Install-NodeLts.ps1
@@ -4,8 +4,6 @@
 ##         Must run after python is configured
 ################################################################################
 
-Import-Module -Name ImageHelpers -Force
-
 $PrefixPath = 'C:\npm\prefix'
 $CachePath = 'C:\npm\cache'
 

--- a/images/win/scripts/Installers/Install-PHP.ps1
+++ b/images/win/scripts/Installers/Install-PHP.ps1
@@ -2,7 +2,6 @@
 ##  File:  Install-PHP.ps1
 ##  Desc:  Install PHP
 ################################################################################
-Import-Module -Name ImageHelpers
 
 # Install latest PHP in chocolatey
 $installDir = "c:\tools\php"

--- a/images/win/scripts/Installers/Install-PHP.ps1
+++ b/images/win/scripts/Installers/Install-PHP.ps1
@@ -2,8 +2,6 @@
 ##  File:  Install-PHP.ps1
 ##  Desc:  Install PHP
 ################################################################################
-$ErrorActionPreference = "Stop"
-
 Import-Module -Name ImageHelpers
 
 # Install latest PHP in chocolatey

--- a/images/win/scripts/Installers/Install-PostgreSQL.ps1
+++ b/images/win/scripts/Installers/Install-PostgreSQL.ps1
@@ -1,5 +1,3 @@
-$ErrorActionPreference = "Stop"
-
 #Define user and password for PostgreSQL database
 $pgUser = "postgres"
 $pgPwd = "root"

--- a/images/win/scripts/Installers/Install-PowerShellModules.ps1
+++ b/images/win/scripts/Installers/Install-PowerShellModules.ps1
@@ -1,5 +1,3 @@
-$ErrorActionPreference = "Stop"
-
 # Set TLS1.2
 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor "Tls12"
 

--- a/images/win/scripts/Installers/Install-PyPy.ps1
+++ b/images/win/scripts/Installers/Install-PyPy.ps1
@@ -82,7 +82,6 @@ function Install-PyPy
     }
 }
 
-$ErrorActionPreference = "Stop"
 Import-Module -Name ImageHelpers -Force -DisableNameChecking
 
 # Get PyPy content from toolset

--- a/images/win/scripts/Installers/Install-PyPy.ps1
+++ b/images/win/scripts/Installers/Install-PyPy.ps1
@@ -82,8 +82,6 @@ function Install-PyPy
     }
 }
 
-Import-Module -Name ImageHelpers -Force -DisableNameChecking
-
 # Get PyPy content from toolset
 $pypyTools = Get-ToolsetContent | Select-Object -ExpandProperty toolcache | Where-Object Name -eq "PyPy"
 

--- a/images/win/scripts/Installers/Install-Rust.ps1
+++ b/images/win/scripts/Installers/Install-Rust.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install Rust for Windows
 ################################################################################
 
-Import-Module -Name ImageHelpers
-
 # Rust Env
 $env:RUSTUP_HOME = "C:\Rust\.rustup"
 $env:CARGO_HOME = "C:\Rust\.cargo"

--- a/images/win/scripts/Installers/Install-SQLPowerShellTools.ps1
+++ b/images/win/scripts/Installers/Install-SQLPowerShellTools.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install SQL PowerShell tool
 ################################################################################
 
-Import-Module -Name ImageHelpers -Force
-
 $BaseUrl = "https://download.microsoft.com/download/8/7/2/872BCECA-C849-4B40-8EBE-21D48CDF1456/ENU/x64"
 
 # install required MSIs

--- a/images/win/scripts/Installers/Install-Sbt.ps1
+++ b/images/win/scripts/Installers/Install-Sbt.ps1
@@ -2,7 +2,6 @@
 ##  File:  Install-Sbt.ps1
 ##  Desc:  Install sbt for Windows
 ################################################################################
-Import-Module -Name ImageHelpers
 
 # Install the latest version of sbt.
 # See https://chocolatey.org/packages/sbt

--- a/images/win/scripts/Installers/Install-Sbt.ps1
+++ b/images/win/scripts/Installers/Install-Sbt.ps1
@@ -2,8 +2,6 @@
 ##  File:  Install-Sbt.ps1
 ##  Desc:  Install sbt for Windows
 ################################################################################
-$ErrorActionPreference = "Stop"
-
 Import-Module -Name ImageHelpers
 
 # Install the latest version of sbt.

--- a/images/win/scripts/Installers/Install-Selenium.ps1
+++ b/images/win/scripts/Installers/Install-Selenium.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install Selenium Server standalone
 ################################################################################
 
-Import-Module -Name ImageHelpers -Force
-
 # Acquire latest Selenium release number from GitHub API
 $latestReleaseUrl = "https://api.github.com/repos/SeleniumHQ/selenium/releases/latest"
 try {

--- a/images/win/scripts/Installers/Install-Toolset.ps1
+++ b/images/win/scripts/Installers/Install-Toolset.ps1
@@ -29,8 +29,6 @@ Function Install-Asset {
     Pop-Location
 }
 
-Import-Module -Name ImageHelpers -Force
-
 # Get toolcache content from toolset
 $ToolsToInstall = @("Python", "Node", "Boost", "Go")
 

--- a/images/win/scripts/Installers/Install-Toolset.ps1
+++ b/images/win/scripts/Installers/Install-Toolset.ps1
@@ -29,8 +29,6 @@ Function Install-Asset {
     Pop-Location
 }
 
-$ErrorActionPreference = "Stop"
-
 Import-Module -Name ImageHelpers -Force
 
 # Get toolcache content from toolset

--- a/images/win/scripts/Installers/Install-VS.ps1
+++ b/images/win/scripts/Installers/Install-VS.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install Visual Studio
 ################################################################################
 
-$ErrorActionPreference = "Stop"
-
 $toolset = Get-ToolsetContent
 $requiredComponents = $toolset.visualStudio.workloads | ForEach-Object { "--add $_" }
 $workLoads = @(

--- a/images/win/scripts/Installers/Install-Vcpkg.ps1
+++ b/images/win/scripts/Installers/Install-Vcpkg.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install vcpkg
 ################################################################################
 
-Import-Module -Name ImageHelpers -Force
-
 $Uri = 'https://github.com/Microsoft/vcpkg.git'
 $InstallDir = 'C:\vcpkg'
 $VcpkgExecPath = 'vcpkg.exe'

--- a/images/win/scripts/Installers/Install-Vsix.ps1
+++ b/images/win/scripts/Installers/Install-Vsix.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install the Visual Studio Extensions from toolset.json
 ###################################################################################
 
-$ErrorActionPreference = "Stop"
-
 $toolset = Get-ToolsetContent
 $vsixPackagesList = $toolset.visualStudio.vsix
 if (-not $vsixPackagesList) {

--- a/images/win/scripts/Installers/Install-WDK.ps1
+++ b/images/win/scripts/Installers/Install-WDK.ps1
@@ -4,9 +4,6 @@
 ################################################################################
 
 # Requires Windows SDK with the same version number as the WDK
-
-Import-Module -Name ImageHelpers -Force
-
 if (Test-IsWin19)
 {
     $winSdkUrl = "https://go.microsoft.com/fwlink/p/?linkid=2120843"

--- a/images/win/scripts/Installers/Install-WinAppDriver.ps1
+++ b/images/win/scripts/Installers/Install-WinAppDriver.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install Windows Application Driver (WinAppDriver)
 ####################################################################################
 
-Import-Module -Name ImageHelpers -Force
-
 $InstallerName = "WindowsApplicationDriver.msi"
 $InstallerUrl = "https://github.com/Microsoft/WinAppDriver/releases/download/v1.1/${InstallerName}"
 

--- a/images/win/scripts/Installers/Install-Wix.ps1
+++ b/images/win/scripts/Installers/Install-Wix.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install WIX.
 ################################################################################
 
-Import-Module -Name ImageHelpers -Force
-
 Choco-Install -PackageName wixtoolset -ArgumentList "--force"
 
 if(Test-IsWin19)

--- a/images/win/scripts/Installers/Update-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Update-AndroidSDK.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install and update Android SDK and tools
 ################################################################################
 
-$ErrorActionPreference = "Stop"
-
 # Install the standard Android SDK licenses. In the past, there wasn't a better way to do this,
 # so we are base64-encoding a zip of the licenses directory from another installation.
 # To create this base64 string, create a zip file that contains nothing but a 'licenses' folder,

--- a/images/win/scripts/Installers/Windows2016/Install-SSDT.ps1
+++ b/images/win/scripts/Installers/Windows2016/Install-SSDT.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install SQL Server Data Tools for Windows
 ################################################################################
 
-Import-Module -Name ImageHelpers -Force
-
 #SSDT for Visual Studio 2017
 #The link down below points to the latest version of SSDT for Visual Studio 2017
 $InstallerName = "SSDT-Setup-ENU.exe"

--- a/images/win/scripts/Installers/Windows2016/Install-Win81SDK.ps1
+++ b/images/win/scripts/Installers/Windows2016/Install-Win81SDK.ps1
@@ -3,8 +3,6 @@
 ##  Desc:  Install Windows 8.1 SDK
 ################################################################################
 
-Import-Module -Name ImageHelpers -Force
-
 $InstallerName = "sdksetup.exe"
 $InstallerUrl = "http://download.microsoft.com/download/B/0/C/B0C80BA3-8AD6-4958-810B-6882485230B5/standalonesdk/${InstallerName}"
 $ArgumentList = ("/quiet", "/norestart")

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -1,5 +1,3 @@
-$ErrorActionPreference = "Stop"
-
 Import-Module MarkdownPS
 Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Android.psm1") -DisableNameChecking
 Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Browsers.psm1") -DisableNameChecking


### PR DESCRIPTION
# Description
Add $ErrorActionPreference = "Stop" to all image generation scripts to stop generation process in case of any error.

Changes:
- Remove all $ErrorActionPreference = "Stop" statements from scripts
- Set $ErrorActionPreference="Stop" for AllUsersAllHosts [Initialize-VM.ps1]
- Remove at the end of image generation [Finalize-VM.ps1]
- Remove Import-Module -Name ImageHelpers

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1226

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
