### PR TITLE
[Windows] Fix Update-DockerImages.ps1 installation

### DIFF
--- a/images/win/Windows2016-Azure.json
+++ b/images/win/Windows2016-Azure.json
@@ -162,12 +162,6 @@
         },
         {
             "type": "powershell",
-            "scripts": [
-                "{{ template_dir }}/scripts/Installers/Update-DockerImages.ps1"
-            ]
-        },
-        {
-            "type": "powershell",
             "valid_exit_codes": [
                 0,
                 3010
@@ -176,6 +170,7 @@
                 "TOOLSET_JSON_PATH={{user `toolset_json_path`}}"
             ],
             "scripts": [
+                "{{ template_dir }}/scripts/Installers/Update-DockerImages.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-VS.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-NET48.ps1",
                 "{{ template_dir }}/scripts/Installers/Windows2016/Install-SSDT.ps1"

--- a/images/win/Windows2019-Azure.json
+++ b/images/win/Windows2019-Azure.json
@@ -184,6 +184,7 @@
                 "TOOLSET_JSON_PATH={{user `toolset_json_path`}}"
             ],
             "scripts": [
+                "{{ template_dir }}/scripts/Installers/Update-DockerImages.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-VS.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-NET48.ps1"
             ],

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -230,4 +230,8 @@ $markdown += New-MDHeader "Android" -Level 3
 $markdown += Build-AndroidTable | New-MDTable
 $markdown += New-MDNewLine
 
+# Docker images section
+$markdown += New-MDHeader "Cached Docker images" -Level 3
+$markdown += New-MDList -Style Unordered -Lines @(Get-CachedDockerImages)
+
 $markdown | Out-File -FilePath "C:\InstalledSoftware.md"


### PR DESCRIPTION
# Description
Currently, Update-DockerImages.ps1 doesn't work properly due to missing TOOLSET_JSON_PATH.

Changes:
- Add TOOLSET_JSON_PATH
- Return "Cached Docker images"

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1244
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
