### PR TITLE
[Ubuntu] Fix erlang version output

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -32,9 +32,7 @@ function Get-ClangVersions {
 }
 
 function Get-ErlangVersion {
-    $result = Get-CommandResult "erl -version"
-    $result.Output -match "version (?<version>\d+\.\d+\.\d+)" | Out-Null
-    $version = $Matches.version
+    $version = (erl -eval 'erlang:display(erlang:system_info(version)), halt().' -noshell).Trim('"')
     return "Erlang $version"
 }
 


### PR DESCRIPTION
# Description
Currently, Erlang version is missing in the markdown documentation due to incorrect regex pattern(current version 11.1).  Fix: use eval to  get system_info(version).

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1246

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
