### PR TITLE
[macOS] Update gh homebrew formula name

### DIFF
--- a/images/macos/provision/core/commonutils.sh
+++ b/images/macos/provision/core/commonutils.sh
@@ -19,7 +19,7 @@ binst_common_utils=(
     helm
     aliyun-cli
     bazelisk
-    github/gh/gh
+    gh
     p7zip
     ant
     yamllint


### PR DESCRIPTION
# Description

This PR updates the `gh` tool's homebrew formula name to use the updated formula name. The new formula can be seen [here](https://github.com/Homebrew/homebrew-core/blob/38d4781f10b61240c109ad08c4824e1c01f7ca82/Formula/gh.rb).

cc https://github.com/actions/virtual-environments/issues/1734

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated

