### PR TITLE
[images.CI] Delete macOS VMs on build canceling

### DIFF
--- a/images.CI/macos/azure-pipelines/image-generation.yml
+++ b/images.CI/macos/azure-pipelines/image-generation.yml
@@ -105,3 +105,14 @@ jobs:
       failTaskOnFailedTests: true
     displayName: Publish test results
     condition: always()
+
+  - task: PowerShell@2
+    displayName: 'Destroy VM (if build canceled only)'
+    condition: eq(variables['Agent.JobStatus'], 'Canceled')
+    inputs:
+      targetType: 'filePath'
+      filePath: ./images.CI/macos/destroy-vm.ps1
+      arguments: -VIServer "$(vcenter-server-v2)" `
+                 -VIUserName "$(vcenter-username-v2)" `
+                 -VIPassword "$(vcenter-password-v2)" `
+                 -VMName "${{ variables.VirtualMachineName }}"

--- a/images.CI/macos/azure-pipelines/image-generation.yml
+++ b/images.CI/macos/azure-pipelines/image-generation.yml
@@ -112,7 +112,7 @@ jobs:
     inputs:
       targetType: 'filePath'
       filePath: ./images.CI/macos/destroy-vm.ps1
-      arguments: -VIServer "$(vcenter-server-v2)" `
+      arguments: -VMName "${{ variables.VirtualMachineName }}" `
+                 -VIServer "$(vcenter-server-v2)" `
                  -VIUserName "$(vcenter-username-v2)" `
                  -VIPassword "$(vcenter-password-v2)" `
-                 -VMName "${{ variables.VirtualMachineName }}"

--- a/images.CI/macos/azure-pipelines/image-generation.yml
+++ b/images.CI/macos/azure-pipelines/image-generation.yml
@@ -115,4 +115,4 @@ jobs:
       arguments: -VMName "${{ variables.VirtualMachineName }}" `
                  -VIServer "$(vcenter-server-v2)" `
                  -VIUserName "$(vcenter-username-v2)" `
-                 -VIPassword "$(vcenter-password-v2)" `
+                 -VIPassword "$(vcenter-password-v2)"

--- a/images.CI/macos/destroy-vm.ps1
+++ b/images.CI/macos/destroy-vm.ps1
@@ -1,19 +1,19 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)]
-    [ValidateNotNullorEmpty()]
+    [ValidateNotNullOrEmpty()]
     [string]$VMName,
 
     [Parameter(Mandatory)]
-    [ValidateNotNullorEmpty()]
+    [ValidateNotNullOrEmpty()]
     [string]$VIServer,
 
     [Parameter(Mandatory)]
-    [ValidateNotNullorEmpty()]
+    [ValidateNotNullOrEmpty()]
     [string]$VIUserName,
 
     [Parameter(Mandatory)]
-    [ValidateNotNullorEmpty()]
+    [ValidateNotNullOrEmpty()]
     [string]$VIPassword
 )
 

--- a/images.CI/macos/destroy-vm.ps1
+++ b/images.CI/macos/destroy-vm.ps1
@@ -1,0 +1,71 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullorEmpty()]
+    [string]$VIServer,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullorEmpty()]
+    [string]$VIUserName,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullorEmpty()]
+    [string]$VIPassword,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullorEmpty()]
+    [string]$VMName
+)
+
+$ProgressPreference = "SilentlyContinue"
+$WarningPreference = "SilentlyContinue"
+
+# connection to a vCenter Server system
+try
+{
+    $null = Set-PowerCLIConfiguration -Scope Session -InvalidCertificateAction Ignore -ParticipateInCEIP $false -Confirm:$false -WebOperationTimeoutSeconds 600
+    $securePassword = ConvertTo-SecureString -String $VIPassword -AsPlainText -Force
+    $cred = New-Object System.Management.Automation.PSCredential($VIUserName, $securePassword)
+    $null = Connect-VIServer -Server $VIServer -Credential $cred -ErrorAction Stop
+    Write-Host "##[debug]Connecting to the server....."
+}
+catch
+{
+    Write-Host "##vso[task.LogIssue type=error;]VISphere connection error"
+    exit 1
+}
+
+# remove VM
+$vm = Get-VM -Name $VMName -ErrorAction SilentlyContinue
+$vmState = $vm.PowerState
+
+if ($vm)
+{
+    $vmState = $vm.PowerState
+    if ($vmState -ne 'PoweredOff')
+    {
+        try
+        {
+            Stop-VM -VM $vm -Confirm:$false -ErrorAction Stop
+            Write-Host "VM '$VMName' has been powered off"
+        }
+        catch
+        {
+            Write-Host "##vso[task.LogIssue type=error;]ERROR: unable to shutdown '$VMName'"
+        }
+    }
+
+    try
+    {
+        Remove-VM -VM $vm -DeletePermanently -Confirm:$false -ErrorAction Stop
+        Write-Host "VM '$VMName' has been removed"
+    }
+    catch
+    {
+        Write-Host "##vso[task.LogIssue type=error;]ERROR: unable to remove '$VMName'"
+    }
+}
+else
+{
+    Write-Host "VM '$VMName' not found"
+}

--- a/images.CI/macos/destroy-vm.ps1
+++ b/images.CI/macos/destroy-vm.ps1
@@ -50,7 +50,6 @@ if ($chainId)
         catch
         {
             Write-Host "##vso[task.LogIssue type=error;]ERROR: unable to cancel the task"
-            exit 1
         }
     }
 }

--- a/images.CI/macos/destroy-vm.ps1
+++ b/images.CI/macos/destroy-vm.ps1
@@ -64,7 +64,7 @@ if ($vm)
     {
         try
         {
-            Stop-VM -VM $vm -Confirm:$false -ErrorAction Stop
+            $null = Stop-VM -VM $vm -Confirm:$false -ErrorAction Stop
             Write-Host "VM '$VMName' has been powered off"
         }
         catch

--- a/images.CI/macos/destroy-vm.ps1
+++ b/images.CI/macos/destroy-vm.ps1
@@ -2,6 +2,10 @@
 param(
     [Parameter(Mandatory)]
     [ValidateNotNullorEmpty()]
+    [string]$VMName,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullorEmpty()]
     [string]$VIServer,
 
     [Parameter(Mandatory)]
@@ -10,11 +14,7 @@ param(
 
     [Parameter(Mandatory)]
     [ValidateNotNullorEmpty()]
-    [string]$VIPassword,
-
-    [Parameter(Mandatory)]
-    [ValidateNotNullorEmpty()]
-    [string]$VMName
+    [string]$VIPassword
 )
 
 $ProgressPreference = "SilentlyContinue"
@@ -27,7 +27,7 @@ try
     $securePassword = ConvertTo-SecureString -String $VIPassword -AsPlainText -Force
     $cred = New-Object System.Management.Automation.PSCredential($VIUserName, $securePassword)
     $null = Connect-VIServer -Server $VIServer -Credential $cred -ErrorAction Stop
-    Write-Host "##[debug]Connecting to the server....."
+    Write-Host "Connection to the VIServer has been established"
 }
 catch
 {
@@ -35,7 +35,7 @@ catch
     exit 1
 }
 
-# remove VM
+# remove a vm
 $vm = Get-VM -Name $VMName -ErrorAction SilentlyContinue
 $vmState = $vm.PowerState
 

--- a/images.CI/macos/destroy-vm.ps1
+++ b/images.CI/macos/destroy-vm.ps1
@@ -46,7 +46,6 @@ if ($chainId)
         {
             Stop-Task -Task $task -Confirm:$false -ErrorAction Stop
             Write-Host "The vm '$VMName' clone task has been cancelled"
-            exit 0
         }
         catch
         {
@@ -58,7 +57,6 @@ if ($chainId)
 
 # remove a vm
 $vm = Get-VM -Name $VMName -ErrorAction SilentlyContinue
-$vmState = $vm.PowerState
 
 if ($vm)
 {


### PR DESCRIPTION
# Description
Currently, we don't delete any macOS VMs on build canceling.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1248

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
