### PR TITLE
[Ubuntu] Replace 2>&1 to Get-CommandResult

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -5,14 +5,16 @@ function Get-OSName {
 }
 
 function Get-CPPVersions {
-    $cppVersions = apt list --installed 2>&1 | Where-Object { $_ -match "g\+\+-\d+"} | ForEach-Object {
+    $result = Get-CommandResult "apt list --installed" -Multiline
+    $cppVersions = $result.Output | Where-Object { $_ -match "g\+\+-\d+"} | ForEach-Object {
         & $_.Split("/")[0] --version | Select-Object -First 1 | Take-OutputPart -Part 3
     } | Sort-Object {[Version]$_}
     return "GNU C++ " + ($cppVersions -Join ", ")
 }
 
 function Get-FortranVersions {
-    $fortranVersions = apt list --installed 2>&1 | Where-Object { $_ -match "^gfortran-\d+"} | ForEach-Object {
+    $result = Get-CommandResult "apt list --installed" -Multiline
+    $fortranVersions = $result.Output | Where-Object { $_ -match "^gfortran-\d+"} | ForEach-Object {
         $_ -match "now (?<version>\d+\.\d+\.\d+)-" | Out-Null
         $Matches.version
     } | Sort-Object {[Version]$_}
@@ -21,7 +23,8 @@ function Get-FortranVersions {
 
 function Get-ClangVersions {
     $clangVersions = @()
-    $clangVersions = apt list --installed 2>&1 | Where-Object { $_ -match "^clang-\d+"} | ForEach-Object {
+    $result = Get-CommandResult "apt list --installed" -Multiline
+    $clangVersions = $result.Output | Where-Object { $_ -match "^clang-\d+"} | ForEach-Object {
         $clangCommand = ($_ -Split "/")[0]
         Invoke-Expression "$clangCommand --version" | Where-Object { $_ -match "clang version" } | ForEach-Object {
             $_ -match "clang version (?<version>\d+\.\d+\.\d+)-" | Out-Null
@@ -153,14 +156,15 @@ function Get-MavenVersion {
     return "Maven $mavenVersion"
 }
 function Get-SbtVersion {
-    $result = sbt -version 2>&1 | Out-String
-    $result -match "sbt script version: (?<version>\d+\.\d+\.\d+)" | Out-Null
+    $result = Get-CommandResult "sbt -version"
+    $result.Output -match "sbt script version: (?<version>\d+\.\d+\.\d+)" | Out-Null
     $sbtVersion = $Matches.version
     return "Sbt $sbtVersion"
 }
 
 function Get-PHPVersions {
-    return $(apt list --installed 2>&1) | Where-Object { $_ -match "^php\d+\.\d+/"} | ForEach-Object {
+    $result = Get-CommandResult "apt list --installed" -Multiline
+    return $result.Output | Where-Object { $_ -match "^php\d+\.\d+/"} | ForEach-Object {
         $_ -match "now (?<version>\d+\.\d+\.\d+)-" | Out-Null
         $Matches.version
     }

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -3,6 +3,8 @@ param (
     $OutputDirectory
 )
 
+$ErrorActionPreference = "Stop"
+
 Import-Module MarkdownPS
 Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Android.psm1") -DisableNameChecking
 Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Browsers.psm1") -DisableNameChecking

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -24,7 +24,8 @@ function Get-BazelVersion {
 }
 
 function Get-BazeliskVersion {
-    $bazeliskVersion = bazelisk version 2>&1 | Select-String "Bazelisk version:" | Take-OutputPart -Part 2 | Take-OutputPart -Part 0 -Delimiter "v"
+    $result = Get-CommandResult "bazelisk version" -Multiline
+    $bazeliskVersion = $result.Output | Select-String "Bazelisk version:" | Take-OutputPart -Part 2 | Take-OutputPart -Part 0 -Delimiter "v"
     return "Bazelisk $bazeliskVersion"
 }
 
@@ -77,12 +78,14 @@ function Get-DockerBuildxVersion {
 }
 
 function Get-GitVersion {
-    $gitVersion = git --version 2>&1 | Take-OutputPart -Part 2
+    $result = Get-CommandResult "git --version"
+    $gitVersion = $result.Output | Take-OutputPart -Part 2
     return "Git $gitVersion"
 }
 
 function Get-GitLFSVersion {
-    $gitlfsversion = git-lfs --version 2>&1 | Take-OutputPart -Part 0 | Take-OutputPart -Part 1 -Delimiter "/"
+    $result = Get-CommandResult "git-lfs --version"
+    $gitlfsversion = $result.Output | Take-OutputPart -Part 0 | Take-OutputPart -Part 1 -Delimiter "/"
     return "Git LFS $gitlfsversion"
 }
 
@@ -215,12 +218,14 @@ function Get-AlibabaCloudCliVersion {
 }
 
 function Get-AWSCliVersion {
-    $awsVersion = aws --version 2>&1 | Take-OutputPart -Part 0 | Take-OutputPart -Part 1 -Delimiter "/"
+    $result = Get-CommandResult "aws --version"
+    $awsVersion = $result.Output | Take-OutputPart -Part 0 | Take-OutputPart -Part 1 -Delimiter "/"
     return "AWS CLI $awsVersion"
 }
 
 function Get-AWSCliSessionManagerPluginVersion {
-    return "AWS CLI Session manager plugin $(session-manager-plugin --version 2>&1)"
+    $result = (Get-CommandResult "session-manager-plugin --version").Output
+    return "AWS CLI Session manager plugin $result"
 }
 
 function Get-AWSSAMVersion {
@@ -253,7 +258,8 @@ function Get-ORASCliVersion {
 }
 
 function Get-VerselCliversion {
-    return "$(vercel --version 2>&1 | Select-Object -First 1)"
+    $result = Get-CommandResult "vercel --version" -Multiline
+    return $result.Output | Select-Object -First 1
 }
 
 function Get-PulumiVersion {


### PR DESCRIPTION
# Description
In scope of this PR we set $ErrorActionPreference = "Stop" to prevent the image generation process if errors occur.
Changes:
- Add $ErrorActionPreference = "Stop"
- Replace 2>&1 to Get-CommandResult

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
