### PR TITLE
Do not set "needs triage" to Annoucements

### DIFF
--- a/.github/workflows/issue-triager.yml
+++ b/.github/workflows/issue-triager.yml
@@ -24,9 +24,21 @@ jobs:
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          github.issues.addLabels({
+          const issueLabels = await github.issues.listLabelsOnIssue({
             issue_number: context.issue.number,
             owner: context.repo.owner,
-            repo: context.repo.repo,
-            labels: ['needs triage']
-          })
+            repo: context.repo.repo
+          });
+
+          const isAnnouncement = issueLabels.data && issueLabels.data
+            .map(label => label.name)
+            .includes('announcement');
+
+          if (!isAnnouncement) {
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['needs triage']
+            })
+          }


### PR DESCRIPTION
# Description
Updated triage bot to avoid setting of "needs triage" to announcements


#### Related issue: [N\A]

## Check list
- [ n/a] Related issue / work item is attached
- [n/a ] Tests are written (if applicable)
- [n/a ] Documentation is updated (if applicable)
- [n/a ] Changes are tested and related VM images are successfully generated
