### PR TITLE
[Ubuntu 20] Switch docker-moby installation to prod channel

### DIFF
--- a/images/linux/scripts/installers/docker-moby.sh
+++ b/images/linux/scripts/installers/docker-moby.sh
@@ -9,11 +9,6 @@ set -e
 source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 
-# There is no stable docker-moby for Ubuntu 20 at the moment
-if isUbuntu20 ; then
-    add-apt-repository "deb [arch=amd64,armhf,arm64] https://packages.microsoft.com/ubuntu/20.04/prod testing main"
-fi
-
 # Check to see if docker is already installed
 docker_package=moby
 echo "Determing if Docker ($docker_package) is installed"

--- a/images/linux/scripts/installers/docker-moby.sh
+++ b/images/linux/scripts/installers/docker-moby.sh
@@ -7,7 +7,6 @@ set -e
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
-source $HELPER_SCRIPTS/os.sh
 
 # Check to see if docker is already installed
 docker_package=moby


### PR DESCRIPTION
# Description
Docker-moby packages for Ubuntu 20 were pushed to the prod channel so we can switch to it and get rid of OS condition.

#### Related issue:
n\a

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
