### PR TITLE
[macOS] Fix aws-sam-cli installation by rolling back brew formula

### DIFF
--- a/images/macos/provision/core/aws.sh
+++ b/images/macos/provision/core/aws.sh
@@ -5,6 +5,16 @@ brew install awscli
 
 echo Installing aws sam cli...
 brew tap aws/tap
+
+# Workaround for broken aws-sam-cli formula after this pr https://github.com/aws/homebrew-tap/pull/138
+cd "$(brew --repo aws/tap)"
+currentCommitId=$(git rev-parse --short HEAD)
+brokenCommitId="9d91002"
+if [ $currentCommitId == $brokenCommitId ]; then
+    # Checkout the latest working commit
+    git checkout b5b3afed932d
+fi
+
 brew install aws-sam-cli
 
 echo "Install aws cli session manager"


### PR DESCRIPTION
# Description
The latest aws-sam-cli is broken with the error after the PR https://github.com/aws/homebrew-tap/pull/138:
```
==> Pouring aws-sam-cli-1.4.0.sierra.bottle.tar.gz
🍺  /usr/local/Cellar/aws-sam-cli/1.4.0: 4,154 files, 85.8MB
thebestmbpever:~ mikhail.timofeev$ sam --version
dyld: Library not loaded: @executable_path/../.Python
  Referenced from: /usr/local/Cellar/aws-sam-cli/1.4.0/libexec/bin/python3.7
  Reason: image not found
Abort trap: 6
```
As a workaround, we can use the previous formula version.

#### Related issue:
n\a

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
