### PR TITLE
[macOS] Add workaround to install edge 85 instead of the latest one

### DIFF
--- a/images/macos/provision/core/edge.sh
+++ b/images/macos/provision/core/edge.sh
@@ -1,7 +1,11 @@
 source ~/utils/utils.sh
 
 echo "Installing Microsoft Edge..."
+# Workaround to install version 85 since webdriver is broken for 86
+cd "$(brew --repo homebrew/homebrew-cask)"
+git checkout 81f9d08d2b9b7557c0178621078cf59d2c5db2bc
 brew cask install microsoft-edge
+git checkout master
 
 EDGE_INSTALLATION_PATH="/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"
 EDGE_VERSION=$("$EDGE_INSTALLATION_PATH" --version | cut -d' ' -f 3)
@@ -39,7 +43,7 @@ AUTOUPDATE_START="$HOME/Library/Preferences/com.microsoft.autoupdate2.plist"
 while [ ! -f "$AUTOUPDATE_START" ]
 do
     echo "Wait for MS update automatic installation"
-    sleep 30    
+    sleep 30
 done
 
 echo "kill autoupdate process"


### PR DESCRIPTION
# Description
Microsoft Edge webdriver is broken since version 86 with the following error:
```
Command 'msedgedriver --version' has finished with exit code
dyld: Library not loaded: @rpath/libc++.dylib   Referenced from: /usr/local/bin/msedgedriver   Reason: image not found

```

This PR hardcodes version 85 until we've found the root cause.

#### Related issue:
n\a

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
