### PR TITLE
[Windows] Install approved haskell versions only

### DIFF
--- a/images/win/scripts/Installers/Install-Haskell.ps1
+++ b/images/win/scripts/Installers/Install-Haskell.ps1
@@ -4,7 +4,7 @@
 ################################################################################
 
 # Get 3 latest versions of GHC
-[Version[]] $ChocoVersionsOutput = & choco search ghc --allversions --limit-output | Where-Object { $_.StartsWith("ghc|") } | ForEach-Object { $_.TrimStart("ghc|") }
+[Version[]] $ChocoVersionsOutput = & choco search ghc --allversions | Where-Object { $_.StartsWith("ghc ") -and $_ -match "Approved"} | ForEach-Object { [regex]::matches($_, "\d+(\.\d+){2,}").value }
 $MajorMinorGroups = $ChocoVersionsOutput | Sort-Object -Descending | Group-Object { $_.ToString(2) } | Select-Object -First 3
 $VersionsList = $MajorMinorGroups | ForEach-Object { $_.Group | Select-Object -First 1 } | Sort-Object
 


### PR DESCRIPTION
# Description
Currently, our version query for haskell doesn't take care of broken packages so 8.10.2.1 package, which is currently broken, marked as the latest one.
![image](https://user-images.githubusercontent.com/48208649/95666194-01ce5f00-0b60-11eb-8c0e-e69f8ab83192.png)

To avoid this situation we need one more condition to filter unapproved versions.

#### Related issue:
n\a

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
