### PR TITLE
[Ubuntu] Fix pipx output in the software report generator

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -248,5 +248,6 @@ function Get-AptPackages {
 }
 
 function Get-PipxVersion {
-    return "Pipx $(pipx --version 2> $null)"
+    $result = (Get-CommandResult "pipx --version").Output
+    return "Pipx $result"
 }


### PR DESCRIPTION
# Description
Due to $ErrorActionPreference = "Stop" in the software report generator we need to acquire pipx version via Get-CommandResult to avoid build failures.
Without Get-Command:
![image](https://user-images.githubusercontent.com/48208649/95689373-f9862a80-0c18-11eb-9de4-5b7d6dd2cc6c.png)
With Get-Command
![image](https://user-images.githubusercontent.com/48208649/95689385-102c8180-0c19-11eb-8fef-46b04d8e6cdf.png)

#### Related issue:
n\a

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
