### PR TITLE
[Ubuntu] Fix pipx version on software report

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -249,5 +249,7 @@ function Get-AptPackages {
 
 function Get-PipxVersion {
     $result = (Get-CommandResult "pipx --version").Output
-    return "Pipx $result"
+    $result -match "(?<version>\d+\.\d+\.\d+\.?\d*)" | Out-Null
+    $pipxVersion = $Matches.Version
+    return "Pipx $pipxVersion"
 }


### PR DESCRIPTION
# Description
`pipx --version` command writes some symbols to stderr:

![Screenshot 2020-10-12 at 10 57 48 AM](https://user-images.githubusercontent.com/7628945/95724277-d8582500-0c7e-11eb-9c02-d5189198752a.png)

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
