### PR TITLE
Remove mobile-center-cli package from MacOS images

### DIFF
--- a/images/macos/provision/core/node.sh
+++ b/images/macos/provision/core/node.sh
@@ -1,10 +1,5 @@
 source ~/utils/utils.sh
 
-node_common_modules=(
-  node-gyp
-  mobile-center-cli
-)
-
 node_catalina_modules=(
   appcenter-cli
   newman
@@ -40,8 +35,6 @@ echo Installing yarn...
 curl -o- -L https://yarnpkg.com/install.sh | bash
 
 if is_Less_BigSur; then
-    for module in ${node_common_modules[@]}; do
-        echo "Install $module"
-        npm install -g $module
-    done
+  echo "Install node-gyp"
+  npm install -g node-gyp
 fi

--- a/images/macos/provision/core/node.sh
+++ b/images/macos/provision/core/node.sh
@@ -18,6 +18,10 @@ if is_Less_Catalina; then
   npm install -g npm@3
   npm config set prefix /usr/local
 
+  # This step is required to install App Center CLI
+  echo Installing Omelette...
+  npm install -g omelette@0.4.14
+
   echo Installing App Center CLI...
   npm install -g appcenter-cli@^1.0.0
 else

--- a/images/macos/provision/core/node.sh
+++ b/images/macos/provision/core/node.sh
@@ -1,6 +1,6 @@
 source ~/utils/utils.sh
 
-node_catalina_modules=(
+node_modules=(
   appcenter-cli
   newman
 )
@@ -25,7 +25,7 @@ else
   brew install node@12
   brew link node@12 --force
 
-  for module in ${node_catalina_modules[@]}; do
+  for module in ${node_modules[@]}; do
     echo "Install $module"
     npm install -g $module
   done

--- a/images/macos/tests/Common.Tests.ps1
+++ b/images/macos/tests/Common.Tests.ps1
@@ -102,10 +102,6 @@ Describe "Common utilities" {
         "aliyun --version" | Should -ReturnZeroExitCode
     }
 
-    It "Mobile Center CLI" -Skip:($os.IsBigSur) {
-        "mobile-center --version" | Should -ReturnZeroExitCode
-    }
-
     Context "Nomad" -Skip:($os.IsBigSur) {
         It "Nomad CLI" {
             $result = Get-CommandResult "gem list"


### PR DESCRIPTION
# Description
We've run into an issue with the `mobile-center-cli` package during the image generation. We've noticed that the `mobile-center-cli` package is no longer supported. In scope of this PR we removed installation of the `mobile-center-cli` from all MacOS images.

#### Related issue: [#1300](https://github.com/actions/virtual-environments-internal/issues/1300)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
