### PR TITLE
[Ubuntu] Do not install obsolete Android build-tools packages

### DIFF
--- a/images/linux/scripts/installers/android.sh
+++ b/images/linux/scripts/installers/android.sh
@@ -67,7 +67,7 @@ additional=$(jq -r '.android.additional_tools[]' $toolset)
 components=( "${extras[@]}" "${addons[@]}" "${additional[@]}" )
 
 availablePlatforms=($(${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --list | sed -n '/Available Packages:/,/^$/p' | grep "platforms;android-" | cut -d"|" -f 1))
-allBuildTools=($(${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --list --include_obsolete | grep "build-tools;" | cut -d"|" -f 1 | sort -u))
+allBuildTools=($(${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --list | grep "build-tools;" | cut -d"|" -f 1 | sort -u))
 availableBuildTools=$(echo ${allBuildTools[@]//*rc[0-9]/})
 
 filter_components_by_version $minimumPlatformVersion "${availablePlatforms[@]}"

--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -64,7 +64,7 @@
     ],
     "android": {
         "platform_min_version": "10",
-        "build_tools_min_version": "17.0.0",
+        "build_tools_min_version": "19.1.0",
         "extra_list": [
             "android;m2repository",
             "google;m2repository",

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -64,7 +64,7 @@
     ],
     "android": {
         "platform_min_version": "17",
-        "build_tools_min_version": "17.0.0",
+        "build_tools_min_version": "19.1.0",
         "extra_list": [
             "android;m2repository",
             "google;m2repository",


### PR DESCRIPTION
# Description
Currently, we are installing a bunch of Android build-tools packages that are marked as obsolete. We are going to stop installing them on images starting of October, 20.

Changes:
- remove parameter --include_obsolete
- set build_tools_min_version": "19.1.0"

#### Related issue:
https://github.com/actions/virtual-environments/issues/1743

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
