### PR TITLE
Remove nested post-generation folder.

### DIFF
--- a/images/win/windows2016.json
+++ b/images/win/windows2016.json
@@ -85,7 +85,7 @@
         {
             "type": "file",
             "source": "{{ template_dir }}/post-generation",
-            "destination": "C:/post-generation"
+            "destination": "C:/"
         },
         {
             "type": "file",

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -85,7 +85,7 @@
         {
             "type": "file",
             "source": "{{ template_dir }}/post-generation",
-            "destination": "C:/post-generation"
+            "destination": "C:/"
         },
         {
             "type": "file",


### PR DESCRIPTION
# Description
Improvement
According to the [packer documentation ](https://www.packer.io/docs/provisioners/file#directory-uploads), it is required to copy folder into directy itself without trailing slash, or using trailing slash right after directory. Currently, we have nested folder inside C:\post-generation folder.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1191

## Check list
- [+] Related issue / work item is attached

