### PR TITLE
[macOS] switch aws-cli installation to the pkg

### DIFF
--- a/images/macos/provision/core/aws.sh
+++ b/images/macos/provision/core/aws.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 echo Installing aws...
-brew install awscli
+curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+sudo installer -pkg AWSCLIV2.pkg -target /
+rm -rf AWSCLIV2.pkg
 
 echo Installing aws sam cli...
 brew tap aws/tap


### PR DESCRIPTION
# Description
Recently we've faced some unpredictable dependencies coming from brew aws-cli formula. According [to the docs ](https://docs.aws.amazon.com/cli/latest/userguide/install-macos.html) the recommended installation method is via a package. Furthermore, package installation consumes less space than the brew one and contains all required dependencies.
**Package**:
```
du -sh /usr/local/aws-cli
87M	/usr/local/aws-cli
```
**Brew** with python 3.9 preinstalled separately:
```
du -sh /usr/local/Cellar/awscli/2.0.57
114M	/usr/local/Cellar/awscli/2.0.57
```

#### Related issue:
https://github.com/actions/virtual-environments/issues/1819

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
