### PR TITLE
Update BuildNumber to include retry number

### DIFF
--- a/images.CI/macos/azure-pipelines/image-generation.yml
+++ b/images.CI/macos/azure-pipelines/image-generation.yml
@@ -11,6 +11,10 @@ jobs:
     value: $(Build.BuildNumber).$(System.JobAttempt)
 
   steps:
+  - bash: |
+      Write-Host "##vso[build.updatebuildnumber]${{ variables.VirtualMachineName }}"
+    displayName: Update BuildNumber
+
   - checkout: self
     clean: true
     fetchDepth: 1

--- a/images.CI/macos/azure-pipelines/image-generation.yml
+++ b/images.CI/macos/azure-pipelines/image-generation.yml
@@ -12,7 +12,7 @@ jobs:
 
   steps:
   - bash: |
-      Write-Host "##vso[build.updatebuildnumber]${{ variables.VirtualMachineName }}"
+      echo "##vso[build.updatebuildnumber]${{ variables.VirtualMachineName }}"
     displayName: Update BuildNumber
 
   - checkout: self


### PR DESCRIPTION
# Description
Currently, the name of VM is not equal to BuildNumber. It brings some issues and it is not clear how to find specific VM.
We need to update BuildNumber accordingly.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
