### PR TITLE
added a swiftc symlink

### DIFF
--- a/images/linux/scripts/installers/swift.sh
+++ b/images/linux/scripts/installers/swift.sh
@@ -16,11 +16,17 @@ mv swift-$swift_version-RELEASE-ubuntu$image_label /usr/share/swift
 SWIFT_PATH="/usr/share/swift/usr/bin"
 SWIFT_BIN="$SWIFT_PATH/swift"
 ln -s "$SWIFT_BIN" /usr/local/bin/swift
+ln -s "$SWIFT_BIN" /usr/local/bin/swiftc
 echo "SWIFT_PATH=$SWIFT_PATH" | tee -a /etc/environment
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
 if ! command -v swift; then
     echo "Swift was not installed"
+    exit 1
+fi
+
+if ! command -v swiftc; then
+    echo "Swiftc is not linked to swift binary"
     exit 1
 fi

--- a/images/linux/scripts/installers/swift.sh
+++ b/images/linux/scripts/installers/swift.sh
@@ -15,8 +15,9 @@ mv swift-$swift_version-RELEASE-ubuntu$image_label /usr/share/swift
 
 SWIFT_PATH="/usr/share/swift/usr/bin"
 SWIFT_BIN="$SWIFT_PATH/swift"
+SWIFTC_BIN="$SWIFT_PATH/swiftc"
 ln -s "$SWIFT_BIN" /usr/local/bin/swift
-ln -s "$SWIFT_BIN" /usr/local/bin/swiftc
+ln -s "$SWIFTC_BIN" /usr/local/bin/swiftc
 echo "SWIFT_PATH=$SWIFT_PATH" | tee -a /etc/environment
 
 # Run tests to determine that the software installed as expected


### PR DESCRIPTION
# Description
There is a need to have a swiftc symlink point to swift binary for some tools (such as bazel's swift rules) 

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: actions/virtual-environments#1827

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
