### PR TITLE
[macOS] Add pester test for pip3 path

### DIFF
--- a/images/macos/tests/Python.Tests.ps1
+++ b/images/macos/tests/Python.Tests.ps1
@@ -31,4 +31,10 @@ Describe "Python" {
     It "Pip 3 is available" {
         "pip3 --version" | Should -ReturnZeroExitCode
     }
+
+    It "Pip 3 and Python 3 came from the same brew formula" {
+        $pip3Path = Split-Path (readlink (which pip3))
+        $python3Path = Split-Path (readlink (which python3))
+        $pip3Path | Should -BeExactly $python3Path
+    }
 }


### PR DESCRIPTION
# Description
There was a bug recently when pip3 was linked to the python3 version differing from the default one. We'd missed that during image generation and received a few issues.
This PR adds a test for such a case.

#### Related issue:
https://github.com/actions/virtual-environments/issues/1819
https://github.com/actions/virtual-environments/issues/1818

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
