### PR TITLE
[Ubuntu] Fix gradle version

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -144,17 +144,17 @@ function Get-AntVersion {
 }
 
 function Get-GradleVersion {
-    $result = gradle -v | Out-String
-    $result -match "Gradle (?<version>\d+\.\d+\.\d+)" | Out-Null
-    $gradleVersion = $Matches.version
+    $gradleVersion = (gradle -v) -match "^Gradle \d" | Take-OutputPart -Part 1
     return "Gradle $gradleVersion"
 }
+
 function Get-MavenVersion {
     $result = mvn -version | Out-String
     $result -match "Apache Maven (?<version>\d+\.\d+\.\d+)" | Out-Null
     $mavenVersion = $Matches.version
     return "Maven $mavenVersion"
 }
+
 function Get-SbtVersion {
     $result = Get-CommandResult "sbt -version"
     $result.Output -match "sbt script version: (?<version>\d+\.\d+\.\d+)" | Out-Null


### PR DESCRIPTION
# Description
Current `(?<version>\d+\.\d+\.\d+)` regex doesn't suitable to match new Gradle 6.7 version.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1325

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
