### PR TITLE
[windows] Fix Haskell revision version installation and related tests

### DIFF
--- a/images/win/scripts/Installers/Install-Haskell.ps1
+++ b/images/win/scripts/Installers/Install-Haskell.ps1
@@ -17,7 +17,8 @@ ForEach ($version in $VersionsList)
 
 # Add default version of GHC to path, because choco formula updates path on user level
 $DefaultGhcVersion = $VersionsList | Select-Object -Last 1
-$DefaultGhcPath = Join-Path $env:ChocolateyInstall "lib\ghc.$DefaultGhcVersion\tools\ghc-$DefaultGhcVersion\bin"
+$DefaultGhcShortVersion = ([version]$DefaultGhcVersion).ToString(3)
+$DefaultGhcPath = Join-Path $env:ChocolateyInstall "lib\ghc.$DefaultGhcVersion\tools\ghc-$DefaultGhcShortVersion\bin"
 Add-MachinePathItem -PathItem $DefaultGhcPath
 
 Write-Host "Installing cabal..."

--- a/images/win/scripts/Tests/Haskell.Tests.ps1
+++ b/images/win/scripts/Tests/Haskell.Tests.ps1
@@ -9,7 +9,8 @@ Describe "Haskell" {
         $ghcVersion = $_
         $ghcShortVersion = ([version]$ghcVersion).ToString(3)
         @{
-            ghcVersion = $ghcShortVersion
+            ghcVersion = $ghcVersion
+            ghcShortVersion = $ghcShortVersion
             binGhcPath = Join-Path $chocoPackagesPath "ghc.$ghcVersion\tools\ghc-$ghcShortVersion\bin\ghc.exe"
         }
     }
@@ -19,11 +20,11 @@ Describe "Haskell" {
     }
 
     It "GHC <ghcVersion> is installed" -TestCases $ghcTestCases {
-        "$binGhcPath --version" | Should -MatchCommandOutput $ghcVersion
+        "$binGhcPath --version" | Should -MatchCommandOutput $ghcShortVersion
     }
 
-    It "GHC <defaultGhcVersion> is the default version and should be the latest installed" -TestCases @{defaultGhcVersion = $defaultGhcShortVersion} {
-        "ghc --version" | Should -MatchCommandOutput $defaultGhcVersion
+    It "GHC <defaultGhcVersion> is the default version and should be the latest installed" -TestCases @{defaultGhcShortVersion = $defaultGhcShortVersion} {
+        "ghc --version" | Should -MatchCommandOutput $defaultGhcShortVersion
     }
 
     It "Cabal is installed" {

--- a/images/win/scripts/Tests/Haskell.Tests.ps1
+++ b/images/win/scripts/Tests/Haskell.Tests.ps1
@@ -26,7 +26,7 @@ Describe "Haskell" {
         "$binGhcPath --version" | Should -MatchCommandOutput $ghcShortVersion
     }
 
-    It "GHC <defaultGhcVersion> is the default version and should be the latest installed" -TestCases @ghcDefaultCases {
+    It "GHC <defaultGhcVersion> is the default version and should be the latest installed" -TestCases $ghcDefaultCases {
         "ghc --version" | Should -MatchCommandOutput $defaultGhcShortVersion
     }
 

--- a/images/win/scripts/Tests/Haskell.Tests.ps1
+++ b/images/win/scripts/Tests/Haskell.Tests.ps1
@@ -3,12 +3,14 @@ Describe "Haskell" {
     [array]$ghcVersionList = Get-ChildItem -Path $chocoPackagesPath -Filter "ghc.*" | ForEach-Object { $_.Name.TrimStart("ghc.") }
     $ghcCount = $ghcVersionList.Count
     $defaultGhcVersion = $ghcVersionList | Sort-Object {[Version]$_} | Select-Object -Last 1
+    $defaultGhcShortVersion = ([version]$defaultGhcVersion).ToString(3)
 
     $ghcTestCases = $ghcVersionList | ForEach-Object {
         $ghcVersion = $_
+        $ghcShortVersion = ([version]$ghcVersion).ToString(3)
         @{
-            ghcVersion = $ghcVersion
-            binGhcPath = Join-Path $chocoPackagesPath "ghc.$ghcVersion\tools\ghc-$ghcVersion\bin\ghc.exe"
+            ghcVersion = $ghcShortVersion
+            binGhcPath = Join-Path $chocoPackagesPath "ghc.$ghcVersion\tools\ghc-$ghcShortVersion\bin\ghc.exe"
         }
     }
 
@@ -20,7 +22,7 @@ Describe "Haskell" {
         "$binGhcPath --version" | Should -MatchCommandOutput $ghcVersion
     }
 
-    It "GHC <defaultGhcVersion> is the default version and should be the latest installed" -TestCases @{defaultGhcVersion = $defaultGhcVersion} {
+    It "GHC <defaultGhcVersion> is the default version and should be the latest installed" -TestCases @{defaultGhcVersion = $defaultGhcShortVersion} {
         "ghc --version" | Should -MatchCommandOutput $defaultGhcVersion
     }
 

--- a/images/win/scripts/Tests/Haskell.Tests.ps1
+++ b/images/win/scripts/Tests/Haskell.Tests.ps1
@@ -3,7 +3,10 @@ Describe "Haskell" {
     [array]$ghcVersionList = Get-ChildItem -Path $chocoPackagesPath -Filter "ghc.*" | ForEach-Object { $_.Name.TrimStart("ghc.") }
     $ghcCount = $ghcVersionList.Count
     $defaultGhcVersion = $ghcVersionList | Sort-Object {[Version]$_} | Select-Object -Last 1
-    $defaultGhcShortVersion = ([version]$defaultGhcVersion).ToString(3)
+    $ghcDefaultCases = @{
+        defaultGhcVersion = $defaultGhcVersion
+        defaultGhcShortVersion = ([version]$defaultGhcVersion).ToString(3)
+    }
 
     $ghcTestCases = $ghcVersionList | ForEach-Object {
         $ghcVersion = $_
@@ -23,7 +26,7 @@ Describe "Haskell" {
         "$binGhcPath --version" | Should -MatchCommandOutput $ghcShortVersion
     }
 
-    It "GHC <defaultGhcVersion> is the default version and should be the latest installed" -TestCases @{defaultGhcShortVersion = $defaultGhcShortVersion} {
+    It "GHC <defaultGhcVersion> is the default version and should be the latest installed" -TestCases @ghcDefaultCases {
         "ghc --version" | Should -MatchCommandOutput $defaultGhcShortVersion
     }
 


### PR DESCRIPTION
# Description
Haskell versions with revisions(7.10.2.**1**, 8.10.2.**1**, etc) installed in the directory with a different pattern — not `C:\ProgramData\chocolatey\lib\ghc.8.10.2.1\tools\ghc-8.10.2.1` but `C:\ProgramData\chocolatey\lib\ghc.8.10.2.1\tools\ghc-8.10.2\bin`
This PR adds the capability to set such a version as a default one and also fixes all related Haskell tests to be compatible with these "revision" versions.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1331

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
