### PR TITLE
Change "open" tool to "xip" on XCode archive extraction

### DIFF
--- a/images/macos/provision/utils/xcode-utils.sh
+++ b/images/macos/provision/utils/xcode-utils.sh
@@ -68,7 +68,7 @@ extractXcodeXip() {
     local XCODE_VERSION="$2"
     XCODE_XIP="${WORKING_DIR}/Xcode_${XCODE_VERSION// /_}.xip"
 
-    open -W $XCODE_XIP
+    cd "${WORKING_DIR}" && xip -x "${XCODE_XIP}"
 
     if [[ -d "${WORKING_DIR}/Xcode-beta.app" ]]; then
         mv -f "${WORKING_DIR}/Xcode-beta.app" "${WORKING_DIR}/Xcode.app"

--- a/images/macos/provision/utils/xcode-utils.sh
+++ b/images/macos/provision/utils/xcode-utils.sh
@@ -68,7 +68,9 @@ extractXcodeXip() {
     local XCODE_VERSION="$2"
     XCODE_XIP="${WORKING_DIR}/Xcode_${XCODE_VERSION// /_}.xip"
 
-    cd "${WORKING_DIR}" && xip -x "${XCODE_XIP}"
+    pushd $WORKING_DIR
+    xip -x "${XCODE_XIP}"
+    popd
 
     if [[ -d "${WORKING_DIR}/Xcode-beta.app" ]]; then
         mv -f "${WORKING_DIR}/Xcode-beta.app" "${WORKING_DIR}/Xcode.app"


### PR DESCRIPTION
# Description
Improvement
"Open" tool sometimes fails on unpacking xip archives while extracting Xcode (extracted files are harmed), "xip" utility is much more stable in both single and multi-thread unpacking without any performance degradation.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
