### PR TITLE
[Windows] Resize disk using powershell and don't use disk D for a diskpart script

### DIFF
--- a/images/win/scripts/Installers/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/Initialize-VM.ps1
@@ -128,11 +128,7 @@ if (Test-IsWin19) {
 }
 
 # Expand disk size of OS drive
-New-Item -Path d:\ -Name cmds.txt -ItemType File -Force
-Add-Content -Path d:\cmds.txt "SELECT VOLUME=C`r`nEXTEND"
-
-$expandResult = (diskpart /s 'd:\cmds.txt')
-Write-Host $expandResult
-
-Write-Host "Disk sizes after expansion"
-wmic logicaldisk get size,freespace,caption
+$driveLetter = "C"
+$size = Get-PartitionSupportedSize -DriveLetter $driveLetter
+Resize-Partition -DriveLetter $driveLetter -Size $size.SizeMax
+Get-Partition | Select-Object DriveLetter, PartitionNumber, Size

--- a/images/win/scripts/Installers/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/Initialize-VM.ps1
@@ -131,4 +131,4 @@ if (Test-IsWin19) {
 $driveLetter = "C"
 $size = Get-PartitionSupportedSize -DriveLetter $driveLetter
 Resize-Partition -DriveLetter $driveLetter -Size $size.SizeMax
-Get-Partition | Select-Object DriveLetter, PartitionNumber, Size
+Get-Volume | Select-Object DriveLetter, SizeRemaining, Size | Sort-Object DriveLetter

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -13,7 +13,7 @@
         "virtual_network_resource_group_name": "{{env `VNET_RESOURCE_GROUP`}}",
         "virtual_network_subnet_name": "{{env `VNET_SUBNET`}}",
         "private_virtual_network_with_public_ip": "{{env `PRIVATE_VIRTUAL_NETWORK_WITH_PUBLIC_IP`}}",
-        "vm_size": "Standard_D4_v2",
+        "vm_size": "Standard_DS4_v2",
         "run_scan_antivirus": "false",
         "root_folder": "C:",
         "toolset_json_path": "{{env `TEMP`}}\\toolset.json",


### PR DESCRIPTION
# Description
Currently, we use a temp disk to store a  diskpart script which can cause an issue on a system without disk `'D'`.

Changes:
- Use powershell cmdlets to expand disk size
- Remove the temporary diskpart script
- Set vm size for Windows Server 2019 to `Standard_DS4_v2` 

#### Related issue:
https://github.com/actions/virtual-environments/issues/1842
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
