### PR TITLE
[Ubuntu] Add apt-fast version to readme

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -87,6 +87,7 @@ $markdown += New-MDHeader "Tools" -Level 3
 $toolsList = @(
     (Get-7zipVersion),
     (Get-AnsibleVersion),
+    (Get-AptFastVersion),
     (Get-AzCopy7Version),
     (Get-AzCopy10Version),
     (Get-BazelVersion),

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -9,7 +9,9 @@ function Get-AnsibleVersion {
 }
 
 function Get-AptFastVersion {
-    $aptFastVersion = man apt-fast | tail -n 1 | awk '{print $2}'
+    $result = Get-CommandResult "apt list --installed" -Multiline
+    $result.Output | Where-Object { $_ -match "apt-fast.*now (?<version>\d+\.\d+\.\d+)-" } | Out-Null
+    $aptFastVersion = $Matches.version
     return "apt-fast $aptFastVersion"
 }
 

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -8,6 +8,11 @@ function Get-AnsibleVersion {
     return "Ansible $ansibleVersion"
 }
 
+function Get-AptFastVersion {
+    $aptFastVersion = man apt-fast | tail -n 1 | awk '{print $2}'
+    return "apt-fast $aptFastVersion"
+}
+
 function Get-AzCopy7Version {
     $azcopy7Version = azcopy --version | Take-OutputPart -Part 1 | Take-OutputPart -Part 0 -Delimiter "-"
     return "AzCopy7 $azcopy7Version (available by ``azcopy`` alias)"

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -9,9 +9,7 @@ function Get-AnsibleVersion {
 }
 
 function Get-AptFastVersion {
-    $result = Get-CommandResult "apt list --installed" -Multiline
-    $result.Output | Where-Object { $_ -match "apt-fast.*now (?<version>\d+\.\d+\.\d+)-" } | Out-Null
-    $aptFastVersion = $Matches.version
+    $aptFastVersion = (dpkg-query --showformat='${Version}' --show apt-fast).Split('-')[0]
     return "apt-fast $aptFastVersion"
 }
 


### PR DESCRIPTION
# Description
We don't have apt-fast version in the readme even though some customers would like to see it.
There is no `apt-fast --version` or something similar, so the simplest way to get the version is `apt-get list -installed`

#### Related issue:
https://github.com/actions/virtual-environments/issues/1841

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
