### PR TITLE
[Windows] Provide Visual Studio setup error logs

### DIFF
--- a/images/win/scripts/ImageHelpers/VisualStudioHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/VisualStudioHelpers.ps1
@@ -49,6 +49,13 @@ Function Install-VisualStudio
         }
         else
         {
+            $setupErrorLogPath = "$env:TEMP\dd_setup_*_errors.log"
+            if (Test-Path -Path $setupErrorLogPath)
+            {
+                $logErrors = Get-Content -Path $setupErrorLogPath -Raw
+                Write-Host "$logErrors"
+            }
+
             Write-Host "Non zero exit code returned by the installation process : $exitCode"
             exit $exitCode
         }


### PR DESCRIPTION
# Description
We don't log any errors during Visual Studio installation process except `exitCode` . Fix: display log `"$env:TEMP\dd_setup_*_errors.log"` output to the console.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1336

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
