### PR TITLE
Improve GenerateResourcesAndImage.ps1 - Adapt for Unix

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -16,27 +16,42 @@ Function Get-PackerTemplatePath {
         [ImageType] $ImageType
     )
 
-    $relativePath = "N/A"
-
     switch ($ImageType) {
         ([ImageType]::Windows2016) {
-            $relativePath = "\images\win\windows2016.json"
+            $relativeTemplatePath = Join-Path "win" "windows2016.json"
         }
         ([ImageType]::Windows2019) {
-            $relativePath = "\images\win\windows2019.json"
+            $relativeTemplatePath = Join-Path "win" "windows2019.json"
         }
         ([ImageType]::Ubuntu1604) {
-            $relativePath = "\images\linux\ubuntu1604.json"
+            $relativeTemplatePath = Join-Path "linux" "ubuntu1604.json"
         }
         ([ImageType]::Ubuntu1804) {
-            $relativePath = "\images\linux\ubuntu1804.json"
+            $relativeTemplatePath = Join-Path "linux" "ubuntu1804.json"
         }
         ([ImageType]::Ubuntu2004) {
-            $relativePath = "\images\linux\ubuntu2004.json"
+            $relativeTemplatePath = Join-Path "linux" "ubuntu2004.json"
         }
+        default { throw "Unknown type of image" }
     }
 
-    return $RepositoryRoot + $relativePath;
+    $imageTemplatePath = [IO.Path]::Combine($RepositoryRoot, "images", $relativeTemplatePath)
+
+    if (-not (Test-Path $imageTemplatePath)) {
+        throw "Template for image '$ImageType' doesn't exist on path '$imageTemplatePath'"
+    }
+
+    return $imageTemplatePath;
+}
+
+Function Get-LatestCommit {
+    [CmdletBinding()]
+    param()
+
+    process {
+        Write-Host "Latest commit:"
+        git --no-pager log --pretty=format:"Date: %cd; Commit: %H - %s; Author: %an <%ae>" -1
+    }
 }
 
 Function Get-LatestCommit {
@@ -87,11 +102,11 @@ Function GenerateResourcesAndImage {
         [Parameter(Mandatory = $True)]
         [string] $ResourceGroupName,
         [Parameter(Mandatory = $True)]
-        [string] $ImageGenerationRepositoryRoot,
-        [Parameter(Mandatory = $True)]
         [ImageType] $ImageType,
         [Parameter(Mandatory = $True)]
         [string] $AzureLocation,
+        [Parameter(Mandatory = $False)]
+        [string] $ImageGenerationRepositoryRoot = $pwd,
         [Parameter(Mandatory = $False)]
         [int] $SecondsToWaitForServicePrincipalSetup = 30,
         [Parameter(Mandatory = $False)]
@@ -184,7 +199,12 @@ Function GenerateResourcesAndImage {
 
     Get-LatestCommit -ErrorAction SilentlyContinue
 
-    packer.exe build -on-error=ask `
+    $packerBinary = Get-Command "packer"
+    if (-not ($packerBinary)) {
+        throw "'packer' binary is not found on PATH"
+    }
+
+    & $packerBinary build -on-error=ask `
         -var "client_id=$($spClientId)" `
         -var "client_secret=$($ServicePrincipalClientSecret)" `
         -var "subscription_id=$($SubscriptionId)" `

--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -54,16 +54,6 @@ Function Get-LatestCommit {
     }
 }
 
-Function Get-LatestCommit {
-    [CmdletBinding()]
-    param()
-
-    process {
-        Write-Host "Latest commit:"
-        git log --pretty=format:"Date: %cd; Commit: %H - %s; Author: %an <%ae>" -1
-    }
-}
-
 Function GenerateResourcesAndImage {
     <#
         .SYNOPSIS


### PR DESCRIPTION
# Description
A bunch of improvements for `GenerateResourcesAndImage.ps1`. Mostly, they are needed to run this script on MacOS / Ubuntu.

Changes:
- Fix template paths
- Fix `Get-LatestCommit` to make sure that it doesn't block build
- Add proper error if packer doesn't exist + remove .exe extension
- Set default value for `$ImageGenerationRepositoryRoot`

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
