### PR TITLE
[macOS] Fix openssl on Big Sur

### DIFF
--- a/images/macos/provision/core/openssl.sh
+++ b/images/macos/provision/core/openssl.sh
@@ -8,12 +8,6 @@ export PATH="/usr/local/bin:/usr/local/sbin:~/bin:$PATH"
 echo Installing OpenSSL...
 /usr/local/bin/brew install openssl
 
-if is_BigSur; then
-    ln -sf $(/usr/local/bin/brew --prefix openssl)/bin/openssl /usr/local/bin/openssl
-    ln -sf $(/usr/local/bin/brew --prefix openssl) /usr/local/opt/openssl
-    exit 0
-fi
-
 # Install OpenSSL 1.0.2t
 # https://www.openssl.org/policies/releasestrat.html - Version 1.0.2 will be supported until 2019-12-31 (LTS)
 # To preserve backward compatibility with ruby-toolcache

--- a/images/macos/provision/core/openssl.sh
+++ b/images/macos/provision/core/openssl.sh
@@ -9,7 +9,8 @@ echo Installing OpenSSL...
 /usr/local/bin/brew install openssl
 
 if is_BigSur; then
-    ln -sf $(brew --prefix openssl)/bin/openssl /usr/local/bin/openssl
+    ln -sf $(/usr/local/bin/brew --prefix openssl)/bin/openssl /usr/local/bin/openssl
+    ln -sf $(/usr/local/bin/brew --prefix openssl) /usr/local/opt/openssl
     exit 0
 fi
 


### PR DESCRIPTION
# Description
It turned out we need openssl 1.0.2t for pre-cached python.

#### Related issue:
https://github.com/actions/virtual-environments/issues/1745
https://github.com/actions/virtual-environments-internal/issues/1327

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
