### PR TITLE
Get VS install log content on error

### DIFF
--- a/images/win/scripts/ImageHelpers/VisualStudioHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/VisualStudioHelpers.ps1
@@ -57,6 +57,11 @@ Function Install-VisualStudio
             }
 
             Write-Host "Non zero exit code returned by the installation process : $exitCode"
+            Get-ChildItem -Path $env:TEMP\* -Include 'dd_bootstrapper*.log', 'dd_client*.log', 'dd_setup*.log' -File |
+                ForEach-Object -Process {
+                    Write-Host -Object "Log file: $($_.Name)"
+                    Get-Content -Path $_.FullName | Write-Host
+                }
             exit $exitCode
         }
     }


### PR DESCRIPTION
Fixes #1854 

# Description
Improvement

On a non-zero exit code, get the content of the Visual Studio install
log files from the temp folder, and include the contents of those logs
in the output of the packer build.

**For new tools, please provide total size and installation time.**

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ x ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
