### PR TITLE
macOS 11.0 (20201020 update)

### DIFF
--- a/images/macos/macos-11.0-Readme.md
+++ b/images/macos/macos-11.0-Readme.md
@@ -1,56 +1,58 @@
 | Announcements |
 |-|
-| [Default Xcode will be changed to Xcode 12.0 on October, 20](https://github.com/actions/virtual-environments/issues/1712) |
-| [Xcode 11.0, 11.1, 11.4.0 will be deprecated on October, 20](https://github.com/actions/virtual-environments/issues/1688) |
-| [Remove Xcode 12 beta 6 from MacOS Catalina image in favor of Xcode 12.2 beta 1 on October 13](https://github.com/actions/virtual-environments/issues/1646) |
+| [[macOS] Built-in Python 2.7 will be used on macOS instead of Homebrew formula on November, 3rd.](https://github.com/actions/virtual-environments/issues/1848) |
+| [macOS 11.0 (Big Sur) is available as a preview 🚀](https://github.com/actions/virtual-environments/issues/1814) |
+| [[macOS] Default Ruby version will be changed to 2.7 on October, 26](https://github.com/actions/virtual-environments/issues/1775) |
+| [Default Xcode will be changed to Xcode 12.0.1 on October, 20](https://github.com/actions/virtual-environments/issues/1712) |
+| [Xcode 11.0, 11.1, 11.4.0 will be deprecated on November, 5](https://github.com/actions/virtual-environments/issues/1688) |
 ***
 # macOS 11.0 info
-- System Version: macOS 11.0 (20A5384c)
+- System Version: macOS 11.0 (20A5395g)
 - Kernel Version: Darwin 20.1.0
-- Image Version: 20201002.1
+- Image Version: 20201020.1
 
 ## Installed Software
 ### Language and Runtime
-- Clang/LLVM 10.0.1
+- Clang/LLVM 11.0.0
 - gcc-8 (Homebrew GCC 8.4.0_1) 8.4.0 - available by `gcc-8` alias
 - gcc-9 (Homebrew GCC 9.3.0) 9.3.0 - available by `gcc-9` alias
 - GNU Fortran (Homebrew GCC 8.4.0_1) 8.4.0  - available by `gfortran-8` alias
 - GNU Fortran (Homebrew GCC 9.3.0) 9.3.0  - available by `gfortran-9` alias
-- Node.js v12.18.4
-- NVM 0.35.3
-- NVM - Cached node versions: v6.17.1 v8.17.0 v10.22.1 v12.18.4 v13.14.0 v14.13.0
+- Node.js v12.19.0
+- NVM 0.36.0
+- NVM - Cached node versions: v6.17.1 v8.17.0 v10.22.1 v12.19.0 v13.14.0 v14.14.0
 - Python 2.7.17
-- Python 3.8.5
+- Python 3.8.6
 - Ruby 2.7.2p137
-- .NET SDK 2.1.300 2.1.301 2.1.302 2.1.401 2.1.402 2.1.403 2.1.500 2.1.502 2.1.503 2.1.504 2.1.505 2.1.506 2.1.507 2.1.602 2.1.603 2.1.604 2.1.607 2.1.700 2.1.701 2.1.801 2.1.802 2.1.803 2.1.804 2.1.805 2.1.806 2.1.807 2.1.808 2.1.809 2.1.810 3.1.100 3.1.101 3.1.200 3.1.201 3.1.300 3.1.301 3.1.302 3.1.401 3.1.402
-- Go 1.15.2
+- .NET SDK 2.1.300 2.1.301 2.1.302 2.1.401 2.1.402 2.1.403 2.1.500 2.1.502 2.1.503 2.1.504 2.1.505 2.1.506 2.1.507 2.1.602 2.1.603 2.1.604 2.1.607 2.1.700 2.1.701 2.1.801 2.1.802 2.1.803 2.1.804 2.1.805 2.1.806 2.1.807 2.1.808 2.1.809 2.1.810 2.1.811 3.1.100 3.1.101 3.1.200 3.1.201 3.1.300 3.1.301 3.1.302 3.1.401 3.1.402 3.1.403
+- Go 1.15.3
 - PHP 7.4.11
 - julia 1.5.2
 
 ### Package Management
 - Vcpkg 2020.06.15
-- Pip 20.1.1 (python 3.8)
+- Pip 20.2.3 (python 3.8)
 - Bundler version 2.1.4
 - Carthage 0.36.0
 - CocoaPods 1.9.3
-- Homebrew 2.5.2
-- NPM 6.14.6
+- Homebrew 2.5.6
+- NPM 6.14.8
 - Yarn 1.22.5
 - NuGet 5.6.0.6489
 - Miniconda 4.8.3
 - RubyGems 3.1.4
-- Composer 1.10.13
+- Composer 1.10.15
 
 ### Project Management
 - Apache Maven 3.6.3
-- Gradle 6.6.1
+- Gradle 6.7
 - Apache Ant(TM) 1.10.9
 
 ### Utilities
-- Curl 7.72.0
-- Git: 2.28.0
+- Curl 7.73.0
+- Git: 2.29.0
 - Git LFS: 2.12.0
-- GitHub CLI: 1.0.0
+- GitHub CLI: 1.1.0
 - Hub CLI: 2.14.2
 - GNU Wget 1.20.3
 - Subversion (SVN) 1.14.0
@@ -58,45 +60,45 @@
 - OpenSSL 1.0.2t  10 Sep 2019 `(/usr/local/opt/openssl -> /usr/local/Cellar/openssl@1.0.2t/1.0.2t)`
 - jq 1.6
 - gpg (GnuPG) 2.2.23
-- psql (PostgreSQL) 12.4
-- PostgreSQL 12.4
+- psql (PostgreSQL) 13.0
+- PostgreSQL 13.0
 - aria2 1.35.0
 - azcopy 10.6.0
 - zstd 1.4.5
-- bazel 3.5.1
-- bazelisk 1.6.1
+- bazel 3.7.0
+- bazelisk 1.7.3
 - helm v3.3.4+ga61ce56
-- mongo v4.4.0
-- mongod v4.4.0
+- mongo v4.4.1
+- mongod v4.4.1
 - 7-Zip 16.02
 - Newman 5.2.0
 
 ### Tools
-- Fastlane 2.162.0
-- Cmake 3.18.3
-- App Center CLI 2.7.1
-- Azure CLI 2.12.1
-- AWS CLI 2.0.54
-- AWS SAM CLI 1.4.0
+- Fastlane 2.164.0
+- Cmake 3.18.4
+- App Center CLI 2.7.2
+- Azure CLI 2.13.0
+- AWS CLI 2.0.57
+- AWS SAM CLI 1.6.2
 - AWS Session Manager CLI 1.1.61.0
-- Aliyun CLI 3.0.59
+- Aliyun CLI 3.0.60
 - GHCup v0.1.11
-- GHC 8.8.4
+- GHC 8.10.2
 - Cabal 3.2.0.0
-- Stack 2.3.3
+- Stack 2.5.1
 
 ### Linters
-- yamllint 1.24.2
+- yamllint 1.25.0
 - SwiftLint 0.40.3
 
 ### Browsers
-- Safari 14.0.1 (16610.2.6.1.6)
-- SafariDriver 14.0.1 (16610.2.6.1.6)
-- Google Chrome 85.0.4183.121 
-- ChromeDriver 85.0.4183.87
-- Microsoft Edge 85.0.564.68 
-- MSEdgeDriver 85.0.564.63
-- Mozilla Firefox 81.0.1
+- Safari 14.0.1 (16610.2.8.1.1)
+- SafariDriver 14.0.1 (16610.2.8.1.1)
+- Google Chrome 86.0.4240.80 
+- ChromeDriver 86.0.4240.22
+- Microsoft Edge 85.0.564.70 
+- MSEdgeDriver 85.0.564.70
+- Mozilla Firefox 81.0.2
 - geckodriver 0.27.0
 
 ### Java
@@ -114,22 +116,23 @@
 #### Python
 - 3.7.9
 - 3.8.6
+- 3.9.0
 
 #### Node.js
 - 10.22.1
-- 12.18.4
-- 14.13.0
+- 12.19.0
+- 14.14.0
 
 #### Go
-- 1.15.2
+- 1.15.3
 
 ### Rust Tools
-- Rust 1.46.0
+- Rust 1.47.0
 - Rustup 1.22.1
 
 #### Packages
 - Bindgen 0.55.1
-- Cbindgen 0.14.6
+- Cbindgen 0.15.0
 - Cargo-outdated v0.9.11
 - Cargo-audit 0.12.1
 
@@ -139,7 +142,7 @@
 #### PowerShell Modules
 | Module     | Version |
 | ---------- | ------- |
-| Az         | 4.7.0   |
+| Az         | 4.8.0   |
 | MarkdownPS | 1.9     |
 | Pester     | 5.0.4   |
 
@@ -166,8 +169,8 @@
 ### Xcode
 | Version        | Build    | Path                         |
 | -------------- | -------- | ---------------------------- |
-| 12.2           | 12B5025f | /Applications/Xcode_12.2.app |
-| 12.0           | 12A8189n | /Applications/Xcode_12.app   |
+| 12.2 (beta)    | 12B5035g | /Applications/Xcode_12.2.app |
+| 12.1           | 12A7403  | /Applications/Xcode_12.1.app |
 | 11.7 (default) | 11E801a  | /Applications/Xcode_11.7.app |
 
 #### Xcode Support Tools
@@ -177,28 +180,41 @@
 #### Installed SDKs
 | SDK                     | SDK Name             | Xcode Version |
 | ----------------------- | -------------------- | ------------- |
-| macOS 10.15             | macosx10.15          | 11.7          |
-| macOS 11.0              | macosx11.0           | 12.0, 12.2    |
+| macOS 10.15             | macosx10.15          | 11.7, 12.1    |
+| macOS 11.0              | macosx11.0           | 12.2          |
 | iOS 13.7                | iphoneos13.7         | 11.7          |
-| iOS 14.0                | iphoneos14.0         | 12.0          |
+| iOS 14.1                | iphoneos14.1         | 12.1          |
 | iOS 14.2                | iphoneos14.2         | 12.2          |
 | Simulator - iOS 13.7    | iphonesimulator13.7  | 11.7          |
-| Simulator - iOS 14.0    | iphonesimulator14.0  | 12.0          |
+| Simulator - iOS 14.1    | iphonesimulator14.1  | 12.1          |
 | Simulator - iOS 14.2    | iphonesimulator14.2  | 12.2          |
 | tvOS 13.4               | appletvos13.4        | 11.7          |
-| tvOS 14.0               | appletvos14.0        | 12.0          |
+| tvOS 14.0               | appletvos14.0        | 12.1          |
 | tvOS 14.2               | appletvos14.2        | 12.2          |
 | Simulator - tvOS 13.4   | appletvsimulator13.4 | 11.7          |
-| Simulator - tvOS 14.0   | appletvsimulator14.0 | 12.0          |
+| Simulator - tvOS 14.0   | appletvsimulator14.0 | 12.1          |
 | Simulator - tvOS 14.2   | appletvsimulator14.2 | 12.2          |
 | watchOS 6.2             | watchos6.2           | 11.7          |
-| watchOS 7.0             | watchos7.0           | 12.0          |
+| watchOS 7.0             | watchos7.0           | 12.1          |
 | watchOS 7.1             | watchos7.1           | 12.2          |
 | Simulator - watchOS 6.2 | watchsimulator6.2    | 11.7          |
-| Simulator - watchOS 7.0 | watchsimulator7.0    | 12.0          |
+| Simulator - watchOS 7.0 | watchsimulator7.0    | 12.1          |
 | Simulator - watchOS 7.1 | watchsimulator7.1    | 12.2          |
-| DriverKit 19.0          | driverkit.macosx19.0 | 11.7          |
-| DriverKit 20.0          | driverkit.macosx20.0 | 12.0, 12.2    |
+| DriverKit 19.0          | driverkit.macosx19.0 | 11.7, 12.1    |
+| DriverKit 20.0          | driverkit.macosx20.0 | 12.2          |
+
+#### Installed Simulators
+| OS          | Xcode Version | Simulators                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| ----------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| iOS 13.7    | 11.7          | iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE (2nd generation)<br>iPad (7th generation)<br>iPad Air (3rd generation)<br>iPad Pro (11-inch) (2nd generation)<br>iPad Pro (12.9-inch) (4th generation)<br>iPad Pro (9.7-inch)                                                                                                                                                           |
+| iOS 14.1    | 12.1          | iPod touch (7th generation)<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPhone 12<br>iPhone 12 mini<br>iPhone 12 Pro<br>iPhone 12 Pro Max<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE (2nd generation)<br>iPad (7th generation)<br>iPad (8th generation)<br>iPad Air (3rd generation)<br>iPad Air (4th generation)<br>iPad Pro (11-inch) (2nd generation)<br>iPad Pro (12.9-inch) (4th generation)<br>iPad Pro (9.7-inch) |
+| iOS 14.2    | 12.2          | iPod touch (7th generation)<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPhone 12<br>iPhone 12 mini<br>iPhone 12 Pro<br>iPhone 12 Pro Max<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE (2nd generation)<br>iPad (7th generation)<br>iPad (8th generation)<br>iPad Air (3rd generation)<br>iPad Air (4th generation)<br>iPad Pro (11-inch) (2nd generation)<br>iPad Pro (12.9-inch) (4th generation)<br>iPad Pro (9.7-inch) |
+| tvOS 13.4   | 11.7          | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                 |
+| tvOS 14.0   | 12.1          | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                 |
+| tvOS 14.2   | 12.2          | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                 |
+| watchOS 6.2 | 11.7          | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                                                                                                                                                                                                                          |
+| watchOS 7.0 | 12.1          | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm<br>Apple Watch Series 6 - 40mm<br>Apple Watch Series 6 - 44mm                                                                                                                                                                                                                                            |
+| watchOS 7.1 | 12.2          | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm<br>Apple Watch Series 6 - 40mm<br>Apple Watch Series 6 - 44mm                                                                                                                                                                                                                                            |
 
 ### Android
 | Package Name               | Version                                                                                                           |


### PR DESCRIPTION
| Announcements |
|-|
| [[macOS] Built-in Python 2.7 will be used on macOS instead of Homebrew formula on November, 3rd.](https://github.com/actions/virtual-environments/issues/1848) |
| [macOS 11.0 (Big Sur) is available as a preview 🚀](https://github.com/actions/virtual-environments/issues/1814) |
| [[macOS] Default Ruby version will be changed to 2.7 on October, 26](https://github.com/actions/virtual-environments/issues/1775) |
| [Default Xcode will be changed to Xcode 12.0.1 on October, 20](https://github.com/actions/virtual-environments/issues/1712) |
| [Xcode 11.0, 11.1, 11.4.0 will be deprecated on November, 5](https://github.com/actions/virtual-environments/issues/1688) |
***
# macOS 11.0 info
- System Version: macOS 11.0 (20A5395g)
- Image Version: 20201020.1
## Installed Software
### Language and Runtime
- Clang/LLVM 11.0.0
- Node.js v12.19.0
- NVM 0.36.0
- NVM - Cached node versions: v6.17.1 v8.17.0 v10.22.1 v12.19.0 v13.14.0 v14.14.0
- Python 3.8.6
- .NET SDK 2.1.300 2.1.301 2.1.302 2.1.401 2.1.402 2.1.403 2.1.500 2.1.502 2.1.503 2.1.504 2.1.505 2.1.506 2.1.507 2.1.602 2.1.603 2.1.604 2.1.607 2.1.700 2.1.701 2.1.801 2.1.802 2.1.803 2.1.804 2.1.805 2.1.806 2.1.807 2.1.808 2.1.809 2.1.810 2.1.811 3.1.100 3.1.101 3.1.200 3.1.201 3.1.300 3.1.301 3.1.302 3.1.401 3.1.402 3.1.403
- Go 1.15.3
### Package Management
- Pip 20.2.3 (python 3.8)
- Homebrew 2.5.6
- NPM 6.14.8
- Composer 1.10.15
### Project Management
- Gradle 6.7
### Utilities
- Curl 7.73.0
- Git: 2.29.0
- GitHub CLI: 1.1.0
- psql (PostgreSQL) 13.0
- PostgreSQL 13.0
- bazel 3.7.0
- bazelisk 1.7.3
- mongo v4.4.1
- mongod v4.4.1
### Tools
- Fastlane 2.164.0
- Cmake 3.18.4
- App Center CLI 2.7.2
- Azure CLI 2.13.0
- AWS CLI 2.0.57
- AWS SAM CLI 1.6.2
- Aliyun CLI 3.0.60
- GHC 8.10.2
- Stack 2.5.1
### Linters
- yamllint 1.25.0
### Browsers
- Safari 14.0.1 (16610.2.8.1.1)
- SafariDriver 14.0.1 (16610.2.8.1.1)
- Google Chrome 86.0.4240.80 
- ChromeDriver 86.0.4240.22
- Microsoft Edge 85.0.564.70 
- MSEdgeDriver 85.0.564.70
- Mozilla Firefox 81.0.2
### Cached Tools
#### Python
- 3.9.0
#### Node.js
- 12.19.0
- 14.14.0
#### Go
- 1.15.3
### Rust Tools
- Rust 1.47.0
#### Packages
- Cbindgen 0.15.0
### PowerShell Tools
#### PowerShell Modules
| Module     | Version |
| ---------- | ------- |
| Az         | 4.8.0   |
### Xcode
| Version        | Build    | Path                         |
| -------------- | -------- | ---------------------------- |
| 12.2 (beta)    | 12B5035g | /Applications/Xcode_12.2.app |
| 12.1           | 12A7403  | /Applications/Xcode_12.1.app |
#### Installed SDKs
| SDK                     | SDK Name             | Xcode Version |
| ----------------------- | -------------------- | ------------- |
| macOS 10.15             | macosx10.15          | 11.7, 12.1    |
| macOS 11.0              | macosx11.0           | 12.2          |
| iOS 14.1                | iphoneos14.1         | 12.1          |
| Simulator - iOS 14.1    | iphonesimulator14.1  | 12.1          |
| tvOS 14.0               | appletvos14.0        | 12.1          |
| Simulator - tvOS 14.0   | appletvsimulator14.0 | 12.1          |
| watchOS 7.0             | watchos7.0           | 12.1          |
| Simulator - watchOS 7.0 | watchsimulator7.0    | 12.1          |
| DriverKit 19.0          | driverkit.macosx19.0 | 11.7, 12.1    |
| DriverKit 20.0          | driverkit.macosx20.0 | 12.2          |
#### Installed Simulators
| OS          | Xcode Version | Simulators                                                                                                                                                                                                                                                                                                                                                                                                                        |
| ----------- | ------------- | -------