### PR TITLE
Remove python@3.9 workaround

### DIFF
--- a/images/macos/provision/core/python.sh
+++ b/images/macos/provision/core/python.sh
@@ -5,14 +5,10 @@ echo "Installing Python Tooling"
 
 echo "Brew Installing Python 3"
 # Workaround to have both 3.8 & 3.9(which required by some brew formulas) in the system, but only 3.8 is linked
-/usr/local/bin/brew install python@3.8
-/usr/local/bin/brew install python@3.9
-/usr/local/bin/brew unlink python@3.9
-/usr/local/bin/brew unlink python@3.8
-/usr/local/bin/brew link python@3.8
+brew install python@3.8
 
 echo "Brew Installing Python 2"
 # Create local tap with formula due to python2 formula depreciation
-/usr/local/bin/brew tap-new local/python2
-FORMULA_PATH=$(/usr/local/bin/brew extract python@2 local/python2 | grep "Homebrew/Library/Taps")
-/usr/local/bin/brew install $FORMULA_PATH
+brew tap-new local/python2
+FORMULA_PATH=$(brew extract python@2 local/python2 | grep "Homebrew/Library/Taps")
+brew install $FORMULA_PATH


### PR DESCRIPTION
# Description
Some time ago we have faced with an issue where `python@3.9` formula breaks pip for `python@3.8` formula and we had to implement workaround for this issue in https://github.com/actions/virtual-environments/pull/1824

Recently, issue was fixed from brew side in https://github.com/Homebrew/homebrew-core/issues/62911
So this PR removing workaround

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
