### PR TITLE
[macOS] Add http code 404 to download with retry function

### DIFF
--- a/images/macos/provision/utils/utils.sh
+++ b/images/macos/provision/utils/utils.sh
@@ -12,7 +12,7 @@ download_with_retries() {
                 --wait 30 \
                 --retry-connrefused \
                 --retry-on-host-error \
-                --retry-on-http-error=429,500,502,503 \
+                --retry-on-http-error=404,429,500,502,503 \
                 --no-verbose
 
     if [ $? != 0 ]; then


### PR DESCRIPTION
# Description
Xamarin downloads sometimes fail with error 404, but rerun doesn't face with it.
This PR adds HTTP code 404 to available wget retry codes.

#### Related issue:
n\a

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
