### PR TITLE
[macOS] Rework retry helper function

### DIFF
--- a/images/macos/provision/utils/utils.sh
+++ b/images/macos/provision/utils/utils.sh
@@ -5,22 +5,28 @@ download_with_retries() {
     local URL="$1"
     local DEST="${2:-.}"
     local NAME="${3:-${URL##*/}}"
+    local COMPRESSED="$4"
 
-    echo "Downloading $URL..."
-    wget $URL   --output-document="$DEST/$NAME" \
-                --tries=30 \
-                --wait 30 \
-                --retry-connrefused \
-                --retry-on-host-error \
-                --retry-on-http-error=429,500,502,503 \
-                --no-verbose
-
-    if [ $? != 0 ]; then
-        echo "Could not download $URL; Exiting build!"
-        exit 1
+    if [[ $COMPRESSED == "compressed" ]]; then
+        COMMAND="curl $URL -4 -sL --compressed -o '$DEST/$NAME'"
+    else
+        COMMAND="curl $URL -4 -sL -o '$DEST/$NAME'"
     fi
 
-    return 0
+    echo "Downloading $URL..."
+    i=20
+    while [ $i -gt 0 ]; do
+        ((i--))
+        eval $COMMAND
+        if [ $? != 0 ]; then
+            sleep 30
+        else
+            return 0
+        fi
+    done
+
+    echo "Could not download $URL"
+    return 1
 }
 
 is_BigSur() {

--- a/images/macos/provision/utils/utils.sh
+++ b/images/macos/provision/utils/utils.sh
@@ -14,13 +14,16 @@ download_with_retries() {
     fi
 
     echo "Downloading $URL..."
-    i=20
-    while [ $i -gt 0 ]; do
-        ((i--))
+    retries=20
+    interval=30
+    while [ $retries -gt 0 ]; do
+        ((retries--))
         eval $COMMAND
         if [ $? != 0 ]; then
-            sleep 30
+            echo "Unable to download $URL, next attempt in $interval sec, $retries attempts left"
+            sleep $interval
         else
+            echo "$URL was downloaded successfully to $DEST/$NAME"
             return 0
         fi
     done


### PR DESCRIPTION
# Description
Replaced wget to curl in retry helper and added explicit cycle for retrying (similarly retry helper in Linux).

#### Related issue:
Internal issue [#1031](https://github.com/actions/virtual-environments-internal/issues/1031)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
