### PR TITLE
Implement additional feature for stopping and renaming the unstable VMs in case of failure

### DIFF
--- a/images.CI/macos/move-vm.ps1
+++ b/images.CI/macos/move-vm.ps1
@@ -48,12 +48,21 @@ Import-Module $PSScriptRoot\helpers.psm1 -DisableNameChecking
 # Connection to a vCenter Server system
 Connect-VCServer
 
-try
-{
-    Get-VM $VMName | Move-VM -Datastore $TargetDataStore -ErrorAction Stop
-    Write-Host "VM has been moved successfully to target datastore '$TargetDataStore'"
+$Vm = Get-VM $VMName
+
+if($env:AGENT_JOBSTATUS -eq 'Failed') {
+    try {
+        Stop-Vm -Vm $Vm -Confirm:$false -ErrorAction Stop
+        Set-Vm -Vm $Vm -Name "${VMName}_failed" -Confirm:$false -ErrorAction Stop
+        Write-Host "VM has been successfully powered off and renamed to [${VMName}_failed]"
+    } catch {
+        Write-Host "##vso[task.LogIssue type=error;]Failed to power off and rename VM '$VMName'"
+    }
 }
-catch
-{
+
+try {
+    Move-VM -Vm $Vm -Datastore $TargetDataStore -ErrorAction Stop
+    Write-Host "VM has been moved successfully to target datastore '$TargetDataStore'"
+} catch {
     Write-Host "##vso[task.LogIssue type=error;]Failed to move VM '$VMName' to target datastore '$TargetDataStore'"
 }

--- a/images.CI/macos/move-vm.ps1
+++ b/images.CI/macos/move-vm.ps1
@@ -48,7 +48,7 @@ Import-Module $PSScriptRoot\helpers.psm1 -DisableNameChecking
 # Connection to a vCenter Server system
 Connect-VCServer
 
-$vm = Get-VM $vMName
+$vm = Get-VM $VMName
 
 if ($env:AGENT_JOBSTATUS -eq 'Failed') {
     try {
@@ -58,7 +58,7 @@ if ($env:AGENT_JOBSTATUS -eq 'Failed') {
         Set-VM -VM $vm -Name "${VMName}_failed" -Confirm:$false -ErrorAction Stop
         Write-Host "VM has been successfully powered off and renamed to [${VMName}_failed]"
     } catch {
-        Write-Host "##vso[task.LogIssue type=error;]Failed to power off and rename VM '$vMName'"
+        Write-Host "##vso[task.LogIssue type=error;]Failed to power off and rename VM '$VMName'"
     }
 }
 
@@ -66,5 +66,5 @@ try {
     Move-VM -Vm $vm -Datastore $TargetDataStore -ErrorAction Stop
     Write-Host "VM has been moved successfully to target datastore '$TargetDataStore'"
 } catch {
-    Write-Host "##vso[task.LogIssue type=error;]Failed to move VM '$vMName' to target datastore '$TargetDataStore'"
+    Write-Host "##vso[task.LogIssue type=error;]Failed to move VM '$VMName' to target datastore '$TargetDataStore'"
 }

--- a/images.CI/macos/move-vm.ps1
+++ b/images.CI/macos/move-vm.ps1
@@ -23,7 +23,7 @@ vCenter password (Example "12345678")
 param(
     [Parameter(Mandatory)]
     [ValidateNotNullOrEmpty()]
-    [string]$vMName,
+    [string]$VMName,
 
     [Parameter(Mandatory)]
     [ValidateNotNullOrEmpty()]

--- a/images.CI/macos/move-vm.ps1
+++ b/images.CI/macos/move-vm.ps1
@@ -52,7 +52,9 @@ $Vm = Get-VM $VMName
 
 if($env:AGENT_JOBSTATUS -eq 'Failed') {
     try {
-        Stop-Vm -Vm $Vm -Confirm:$false -ErrorAction Stop
+        if($Vm.PowerState -ne "PoweredOff") {
+            Stop-Vm -Vm $Vm -Confirm:$false -ErrorAction Stop
+        }
         Set-Vm -Vm $Vm -Name "${VMName}_failed" -Confirm:$false -ErrorAction Stop
         Write-Host "VM has been successfully powered off and renamed to [${VMName}_failed]"
     } catch {

--- a/images.CI/macos/move-vm.ps1
+++ b/images.CI/macos/move-vm.ps1
@@ -23,7 +23,7 @@ vCenter password (Example "12345678")
 param(
     [Parameter(Mandatory)]
     [ValidateNotNullOrEmpty()]
-    [string]$VMName,
+    [string]$vMName,
 
     [Parameter(Mandatory)]
     [ValidateNotNullOrEmpty()]
@@ -48,23 +48,23 @@ Import-Module $PSScriptRoot\helpers.psm1 -DisableNameChecking
 # Connection to a vCenter Server system
 Connect-VCServer
 
-$Vm = Get-VM $VMName
+$vm = Get-VM $vMName
 
-if($env:AGENT_JOBSTATUS -eq 'Failed') {
+if ($env:AGENT_JOBSTATUS -eq 'Failed') {
     try {
-        if($Vm.PowerState -ne "PoweredOff") {
-            Stop-Vm -Vm $Vm -Confirm:$false -ErrorAction Stop
+        if($vm.PowerState -ne "PoweredOff") {
+            Stop-VM -VM $vm -Confirm:$false -ErrorAction Stop
         }
-        Set-Vm -Vm $Vm -Name "${VMName}_failed" -Confirm:$false -ErrorAction Stop
+        Set-VM -VM $vm -Name "${VMName}_failed" -Confirm:$false -ErrorAction Stop
         Write-Host "VM has been successfully powered off and renamed to [${VMName}_failed]"
     } catch {
-        Write-Host "##vso[task.LogIssue type=error;]Failed to power off and rename VM '$VMName'"
+        Write-Host "##vso[task.LogIssue type=error;]Failed to power off and rename VM '$vMName'"
     }
 }
 
 try {
-    Move-VM -Vm $Vm -Datastore $TargetDataStore -ErrorAction Stop
+    Move-VM -Vm $vm -Datastore $TargetDataStore -ErrorAction Stop
     Write-Host "VM has been moved successfully to target datastore '$TargetDataStore'"
 } catch {
-    Write-Host "##vso[task.LogIssue type=error;]Failed to move VM '$VMName' to target datastore '$TargetDataStore'"
+    Write-Host "##vso[task.LogIssue type=error;]Failed to move VM '$vMName' to target datastore '$TargetDataStore'"
 }

--- a/images/macos/provision/core/xcode-clt.sh
+++ b/images/macos/provision/core/xcode-clt.sh
@@ -41,5 +41,3 @@ while ! is_clt_installed; do
     echo "Wait $sleepInterval seconds before the next check for installed Command Line Tools"
     sleep $sleepInterval
 done
-
-exit 1

--- a/images/macos/provision/core/xcode-clt.sh
+++ b/images/macos/provision/core/xcode-clt.sh
@@ -41,3 +41,5 @@ while ! is_clt_installed; do
     echo "Wait $sleepInterval seconds before the next check for installed Command Line Tools"
     sleep $sleepInterval
 done
+
+exit 1


### PR DESCRIPTION
# Description
Improvement - move-vm.ps1 will stop  and rename unstable VMs in case of failure before moving.
Test failure: https://github.visualstudio.com/virtual-environments/_build/results?buildId=85939&view=logs&j=80d86624-2c9a-5cad-9434-144b838e69fb&t=027aaa20-7755-5366-f0d4-a9dbdf9aa415

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1335

## Check list
- [X] Related issue / work item is attached
- [X] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
