### PR TITLE
[macOS] Switch Xamarin bundle to the latest one for 10.15

### DIFF
--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -19,7 +19,7 @@
         "android-versions": [
             "11.0.2.0", "10.3.1.4", "10.2.0.100", "10.1.3.7", "10.0.6.2"
         ],
-        "bundle-default": "6_12_0",
+        "bundle-default": "latest",
         "bundles": [
             {
                 "symlink": "6_12_1",

--- a/images/macos/toolsets/toolset-11.0.json
+++ b/images/macos/toolsets/toolset-11.0.json
@@ -19,7 +19,7 @@
         "android-versions": [
             "11.0.2.0"
         ],
-        "bundle-default": "6_12_0",
+        "bundle-default": "latest",
         "bundles": [
             {
                 "symlink": "6_12_1",

--- a/images/macos/toolsets/toolset-11.0.json
+++ b/images/macos/toolsets/toolset-11.0.json
@@ -2,7 +2,7 @@
     "xcode": {
         "default": "11.7",
         "versions": [
-            "12.2_beta", "12.1_GM_seed", "11.7"
+            "12.2_beta", "11.7"
         ]
     },
     "xamarin": {
@@ -19,7 +19,7 @@
         "android-versions": [
             "11.0.2.0"
         ],
-        "bundle-default": "latest",
+        "bundle-default": "6_12_0",
         "bundles": [
             {
                 "symlink": "6_12_1",


### PR DESCRIPTION
# Description
Xamarin iOS 14 required for Xcode 12 so along with changing default Xcode we have to change the default xamarin bundle too.
Xcode 12.1 removed from macOS 11 since it's not supported on Big Sur.

#### Related issue:
https://github.com/actions/virtual-environments/issues/1712

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
