### PR TITLE
[Ubuntu] Remove chmod for homebrew directory

### DIFF
--- a/images/linux/scripts/installers/homebrew.sh
+++ b/images/linux/scripts/installers/homebrew.sh
@@ -12,9 +12,6 @@ source $HELPER_SCRIPTS/etc-environment.sh
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
 
-# Make brew files and directories writable by any user
-sudo chmod -R o+w $HOMEBREW_PREFIX
-
 # Update /etc/environemnt
 ## Put HOMEBREW_* variables
 brew shellenv|grep 'export HOMEBREW'|sed -E 's/^export (.*);$/\1/' | sudo tee -a /etc/environment


### PR DESCRIPTION
# Description
We don't need to `chmod` brew directory and make it "dirty" after this script https://github.com/actions/virtual-environments/blob/main/images/linux/post-generation/homebrew-permissions.sh

#### Related issue:
https://github.com/actions/virtual-environments/issues/1568

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
