### PR TITLE
[macOS] Revert "Freeze xcodeproj 1.18.0"

### DIFF
--- a/images/macos/provision/core/rubygem.sh
+++ b/images/macos/provision/core/rubygem.sh
@@ -4,14 +4,6 @@ source ~/utils/utils.sh
 echo Updating RubyGems...
 gem update --system
 
-
-# Freeze xcodeproj 1.18.0 because version 1.19.0 contains breaking changes related to CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER flag
-# Related issues:
-# - https://github.com/CocoaPods/CocoaPods/issues/10153
-# - https://github.com/actions/virtual-environments/issues/1804
-# Need to revisit when Cocoapods 1.10.0 is released and added to VM
-gem install xcodeproj -v 1.18.0
-
 echo Installing xcode-install utility...
 gem install xcode-install --force
 


### PR DESCRIPTION
# Description
The issue has been fixed in cocoapods 1.10.0 https://github.com/CocoaPods/CocoaPods/issues/10153 so we don't need this workaround anymore.

#### Related issue:
https://github.com/actions/virtual-environments/issues/1804

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
