### PR TITLE
[macOS] Az powershell modules fix

### DIFF
--- a/images/linux/scripts/installers/azpowershell.sh
+++ b/images/linux/scripts/installers/azpowershell.sh
@@ -15,6 +15,10 @@ else
     versions=$(jq -r '.azureModules[] | select(.name | contains("az")) | .versions[]' $toolset)
 fi
 
+# Update PowerShellGet to eliminate download errors
+pwsh -Command "Install-Module -Name PowerShellGet -Force"
+pwsh -Command "Update-Module -Name PowerShellGet -Force"
+
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 for version in ${versions[@]}; do
     pwsh -Command "Save-Module -Name Az -LiteralPath /usr/share/az_$version -RequiredVersion $version -Force"

--- a/images/linux/scripts/installers/azpowershell.sh
+++ b/images/linux/scripts/installers/azpowershell.sh
@@ -15,10 +15,6 @@ else
     versions=$(jq -r '.azureModules[] | select(.name | contains("az")) | .versions[]' $toolset)
 fi
 
-# Update PowerShellGet to eliminate download errors
-pwsh -Command "Install-Module -Name PowerShellGet -Force"
-pwsh -Command "Update-Module -Name PowerShellGet -Force"
-
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 for version in ${versions[@]}; do
     pwsh -Command "Save-Module -Name Az -LiteralPath /usr/share/az_$version -RequiredVersion $version -Force"

--- a/images/macos/provision/core/powershell.sh
+++ b/images/macos/provision/core/powershell.sh
@@ -9,6 +9,10 @@ brew cask install powershell
 # A dummy call of `az` to initialize ~/.azure directory before the modules are installed
 az -v
 
+# Update PowerShellGet to eliminate download errors
+pwsh -Command "Install-Module -Name PowerShellGet -Force"
+pwsh -Command "Update-Module -Name PowerShellGet -Force"
+
 # Install PowerShell modules
 psModules=$(get_toolset_value '.powershellModules[].name')
 for module in ${psModules[@]}; do

--- a/images/macos/provision/core/powershell.sh
+++ b/images/macos/provision/core/powershell.sh
@@ -21,7 +21,8 @@ for module in ${psModules[@]}; do
     else
         for version in ${moduleVersions[@]}; do
             echo " - $version"
-            pwsh -command "& {[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; Install-Module $module -RequiredVersion $version -Force -Scope AllUsers}"
+            tlsCommand="[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12"
+            pwsh -command "& {'${tlsCommand}'; Install-Module $module -RequiredVersion $version -Force -Scope AllUsers}"
         done
     fi
 done

--- a/images/macos/provision/core/powershell.sh
+++ b/images/macos/provision/core/powershell.sh
@@ -15,11 +15,11 @@ for module in ${psModules[@]}; do
     echo "Installing $module module"
     moduleVersions="$(get_toolset_value ".powershellModules[] | select(.name==\"$module\") | .versions[]?")"
     if [[ -z "$moduleVersions" ]];then
-        pwsh -command "& {Install-Module $module -Force -Scope AllUsers}"
+        pwsh -command "& {[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; Install-Module $module -Force -Scope AllUsers}"
     else
         for version in ${moduleVersions[@]}; do
             echo " - $version"
-            pwsh -command "& {Install-Module $module -RequiredVersion $version -Force -Scope AllUsers}"
+            pwsh -command "& {[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; Install-Module $module -RequiredVersion $version -Force -Scope AllUsers}"
         done
     fi
 done

--- a/images/macos/provision/core/powershell.sh
+++ b/images/macos/provision/core/powershell.sh
@@ -9,10 +9,6 @@ brew cask install powershell
 # A dummy call of `az` to initialize ~/.azure directory before the modules are installed
 az -v
 
-# Update PowerShellGet to eliminate download errors
-pwsh -Command "Install-Module -Name PowerShellGet -Force"
-pwsh -Command "Update-Module -Name PowerShellGet -Force"
-
 # Install PowerShell modules
 psModules=$(get_toolset_value '.powershellModules[].name')
 for module in ${psModules[@]}; do

--- a/images/macos/toolsets/toolset-10.13.json
+++ b/images/macos/toolsets/toolset-10.13.json
@@ -180,6 +180,7 @@
         ]
     },
     "powershellModules": [
+        {"name": "PowerShellGet"},
         {"name": "Az"},
         {"name": "MarkdownPS"},
         {"name": "Pester"}

--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -201,6 +201,7 @@
         ]
     },
     "powershellModules": [
+        {"name": "PowerShellGet"},
         {"name": "Az"},
         {"name": "MarkdownPS"},
         {"name": "Pester"}

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -110,6 +110,7 @@
         ]
     },
     "powershellModules": [
+        {"name": "PowerShellGet"},
         {"name": "Az"},
         {"name": "MarkdownPS"},
         {"name": "Pester"}

--- a/images/macos/toolsets/toolset-11.0.json
+++ b/images/macos/toolsets/toolset-11.0.json
@@ -52,6 +52,7 @@
         "addon-list": []
     },
     "powershellModules": [
+        {"name": "PowerShellGet"},
         {"name": "Az"},
         {"name": "MarkdownPS"},
         {"name": "Pester"}


### PR DESCRIPTION
# Description
Az modules installation is flaky at the moment. It uses PowershellGet module for downloading dependencies so it should be updated before actual installation

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
