### PR TITLE
[linux] Az powershell modules fix

### DIFF
--- a/images/linux/scripts/installers/azpowershell.sh
+++ b/images/linux/scripts/installers/azpowershell.sh
@@ -7,6 +7,9 @@
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/os.sh
 
+# Force Tls 1.2 for web requests
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
 # List of versions
 if isUbuntu20 ; then
     versions=$(pwsh -Command '(Find-Module -Name Az).Version')

--- a/images/linux/scripts/installers/azpowershell.sh
+++ b/images/linux/scripts/installers/azpowershell.sh
@@ -7,9 +7,6 @@
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/os.sh
 
-# Force Tls 1.2 for web requests
-[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
-
 # List of versions
 if isUbuntu20 ; then
     versions=$(pwsh -Command '(Find-Module -Name Az).Version')
@@ -20,7 +17,8 @@ fi
 
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 for version in ${versions[@]}; do
-    pwsh -Command "Save-Module -Name Az -LiteralPath /usr/share/az_$version -RequiredVersion $version -Force"
+    pwsh -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12;
+    Save-Module -Name Az -LiteralPath /usr/share/az_$version -RequiredVersion $version -Force"
 done
 
 # Run tests to determine that the software installed as expected

--- a/images/linux/scripts/installers/azpowershell.sh
+++ b/images/linux/scripts/installers/azpowershell.sh
@@ -15,6 +15,10 @@ else
     versions=$(jq -r '.azureModules[] | select(.name | contains("az")) | .versions[]' $toolset)
 fi
 
+# Update PowerShellGet to eliminate download errors
+pwsh -Command "Install-Module -Name PowerShellGet -Force"
+pwsh -Command "Update-Module -Name PowerShellGet -Force"
+
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 for version in ${versions[@]}; do
     pwsh -Command "Save-Module -Name Az -LiteralPath /usr/share/az_$version -RequiredVersion $version -Force"

--- a/images/linux/scripts/installers/azpowershell.sh
+++ b/images/linux/scripts/installers/azpowershell.sh
@@ -17,8 +17,8 @@ fi
 
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 for version in ${versions[@]}; do
-    pwsh -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12;
-    Save-Module -Name Az -LiteralPath /usr/share/az_$version -RequiredVersion $version -Force"
+    tlsCommand="[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12"
+    pwsh -Command "'${tlsCommand}'; Save-Module -Name Az -LiteralPath /usr/share/az_$version -RequiredVersion $version -Force"
 done
 
 # Run tests to determine that the software installed as expected

--- a/images/linux/scripts/installers/azpowershell.sh
+++ b/images/linux/scripts/installers/azpowershell.sh
@@ -15,10 +15,6 @@ else
     versions=$(jq -r '.azureModules[] | select(.name | contains("az")) | .versions[]' $toolset)
 fi
 
-# Update PowerShellGet to eliminate download errors
-pwsh -Command "Install-Module -Name PowerShellGet -Force"
-pwsh -Command "Update-Module -Name PowerShellGet -Force"
-
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 for version in ${versions[@]}; do
     pwsh -Command "Save-Module -Name Az -LiteralPath /usr/share/az_$version -RequiredVersion $version -Force"

--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -90,6 +90,7 @@
     },
     "powershellModules": [
         {"name": "MarkdownPS"},
+        {"name": "PowerShellGet"},
         {"name": "Pester"}
     ],
     "azureModules": [

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -86,6 +86,7 @@
     },
     "powershellModules": [
         {"name": "MarkdownPS"},
+        {"name": "PowerShellGet"},
         {"name": "Pester"}
     ],
     "azureModules": [

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -67,6 +67,7 @@
     },
     "powershellModules": [
         {"name": "MarkdownPS"},
+        {"name": "PowerShellGet"},
         {"name": "Pester"}
     ],
     "apt": {

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -190,6 +190,7 @@
                 "{{template_dir}}/scripts/installers/pollinate.sh",
                 "{{template_dir}}/scripts/installers/postgresql.sh",
                 "{{template_dir}}/scripts/installers/powershellcore.sh",
+                "{{template_dir}}/scripts/installers/Install-PowerShellModules.ps1",
                 "{{template_dir}}/scripts/installers/pulumi.sh",
                 "{{template_dir}}/scripts/installers/ruby.sh",
                 "{{template_dir}}/scripts/installers/r.sh",
@@ -281,16 +282,6 @@
                 "{{template_dir}}/scripts/installers/cleanup.sh"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
-            "type": "shell",
-            "scripts": [
-                "{{template_dir}}/scripts/installers/Install-PowerShellModules.ps1"
-            ],
-            "environment_vars": [
-                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
-            ],
-            "execute_command": "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
         },
         {
             "type": "shell",

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -190,7 +190,6 @@
                 "{{template_dir}}/scripts/installers/pollinate.sh",
                 "{{template_dir}}/scripts/installers/postgresql.sh",
                 "{{template_dir}}/scripts/installers/powershellcore.sh",
-                "{{template_dir}}/scripts/installers/Install-PowerShellModules.ps1",
                 "{{template_dir}}/scripts/installers/pulumi.sh",
                 "{{template_dir}}/scripts/installers/ruby.sh",
                 "{{template_dir}}/scripts/installers/r.sh",
@@ -210,7 +209,6 @@
                 "{{template_dir}}/scripts/installers/swig.sh",
                 "{{template_dir}}/scripts/installers/netlify.sh",
                 "{{template_dir}}/scripts/installers/android.sh",
-                "{{template_dir}}/scripts/installers/azpowershell.sh",
                 "{{template_dir}}/scripts/installers/hosted-tool-cache.sh",
                 "{{template_dir}}/scripts/installers/pypy.sh",
                 "{{template_dir}}/scripts/installers/python.sh",
@@ -236,6 +234,27 @@
                 "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "scripts": [
+                "{{template_dir}}/scripts/installers/Install-PowerShellModules.ps1"
+            ],
+            "environment_vars": [
+                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
+            ],
+            "execute_command": "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "scripts": [
+                "{{template_dir}}/scripts/installers/azpowershell.sh"
+            ],
+            "environment_vars": [
+                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
+                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
+            ],
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {
             "type": "shell",

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -194,7 +194,6 @@
                 "{{template_dir}}/scripts/installers/pollinate.sh",
                 "{{template_dir}}/scripts/installers/postgresql.sh",
                 "{{template_dir}}/scripts/installers/powershellcore.sh",
-                "{{template_dir}}/scripts/installers/Install-PowerShellModules.ps1",
                 "{{template_dir}}/scripts/installers/pulumi.sh",
                 "{{template_dir}}/scripts/installers/ruby.sh",
                 "{{template_dir}}/scripts/installers/r.sh",
@@ -214,7 +213,6 @@
                 "{{template_dir}}/scripts/installers/swig.sh",
                 "{{template_dir}}/scripts/installers/netlify.sh",
                 "{{template_dir}}/scripts/installers/android.sh",
-                "{{template_dir}}/scripts/installers/azpowershell.sh",
                 "{{template_dir}}/scripts/installers/hosted-tool-cache.sh",
                 "{{template_dir}}/scripts/installers/pypy.sh",
                 "{{template_dir}}/scripts/installers/python.sh",
@@ -240,6 +238,27 @@
                 "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "scripts": [
+                "{{template_dir}}/scripts/installers/Install-PowerShellModules.ps1"
+            ],
+            "environment_vars": [
+                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
+            ],
+            "execute_command": "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "scripts": [
+                "{{template_dir}}/scripts/installers/azpowershell.sh"
+            ],
+            "environment_vars": [
+                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
+                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
+            ],
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {
             "type": "shell",

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -194,6 +194,7 @@
                 "{{template_dir}}/scripts/installers/pollinate.sh",
                 "{{template_dir}}/scripts/installers/postgresql.sh",
                 "{{template_dir}}/scripts/installers/powershellcore.sh",
+                "{{template_dir}}/scripts/installers/Install-PowerShellModules.ps1",
                 "{{template_dir}}/scripts/installers/pulumi.sh",
                 "{{template_dir}}/scripts/installers/ruby.sh",
                 "{{template_dir}}/scripts/installers/r.sh",
@@ -285,16 +286,6 @@
                 "{{template_dir}}/scripts/installers/cleanup.sh"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
-            "type": "shell",
-            "scripts": [
-                "{{template_dir}}/scripts/installers/Install-PowerShellModules.ps1"
-            ],
-            "environment_vars": [
-                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
-            ],
-            "execute_command": "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
         },
         {
             "type": "shell",

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -196,6 +196,7 @@
                 "{{template_dir}}/scripts/installers/pollinate.sh",
                 "{{template_dir}}/scripts/installers/postgresql.sh",
                 "{{template_dir}}/scripts/installers/powershellcore.sh",
+                "{{template_dir}}/scripts/installers/Install-PowerShellModules.ps1",
                 "{{template_dir}}/scripts/installers/pulumi.sh",
                 "{{template_dir}}/scripts/installers/ruby.sh",
                 "{{template_dir}}/scripts/installers/r.sh",
@@ -287,16 +288,6 @@
                 "{{template_dir}}/scripts/installers/cleanup.sh"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
-            "type": "shell",
-            "scripts": [
-                "{{template_dir}}/scripts/installers/Install-PowerShellModules.ps1"
-            ],
-            "environment_vars": [
-                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
-            ],
-            "execute_command": "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
         },
         {
             "type": "shell",

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -196,7 +196,6 @@
                 "{{template_dir}}/scripts/installers/pollinate.sh",
                 "{{template_dir}}/scripts/installers/postgresql.sh",
                 "{{template_dir}}/scripts/installers/powershellcore.sh",
-                "{{template_dir}}/scripts/installers/Install-PowerShellModules.ps1",
                 "{{template_dir}}/scripts/installers/pulumi.sh",
                 "{{template_dir}}/scripts/installers/ruby.sh",
                 "{{template_dir}}/scripts/installers/r.sh",
@@ -216,7 +215,6 @@
                 "{{template_dir}}/scripts/installers/swig.sh",
                 "{{template_dir}}/scripts/installers/netlify.sh",
                 "{{template_dir}}/scripts/installers/android.sh",
-                "{{template_dir}}/scripts/installers/azpowershell.sh",
                 "{{template_dir}}/scripts/installers/hosted-tool-cache.sh",
                 "{{template_dir}}/scripts/installers/pypy.sh",
                 "{{template_dir}}/scripts/installers/python.sh",
@@ -242,6 +240,27 @@
                 "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "scripts": [
+                "{{template_dir}}/scripts/installers/Install-PowerShellModules.ps1"
+            ],
+            "environment_vars": [
+                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
+            ],
+            "execute_command": "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "scripts": [
+                "{{template_dir}}/scripts/installers/azpowershell.sh"
+            ],
+            "environment_vars": [
+                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
+                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
+            ],
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {
             "type": "shell",


### PR DESCRIPTION
# Description
Az modules installation is flaky at the moment. It uses PowershellGet module for downloading dependencies so it should be updated before actual installation

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
