### PR TITLE
[macOS] Improve select datastore script

### DIFF
--- a/images.CI/macos/azure-pipelines/image-generation.yml
+++ b/images.CI/macos/azure-pipelines/image-generation.yml
@@ -52,7 +52,8 @@ jobs:
     inputs:
       targetType: 'filePath'
       filePath: ./images.CI/macos/select-datastore.ps1
-      arguments: -VIServer "$(vcenter-server-v2)" `
+      arguments: -VMName "$(VirtualMachineName)" `
+                 -VIServer "$(vcenter-server-v2)" `
                  -VIUserName "$(vcenter-username-v2)" `
                  -VIPassword "$(vcenter-password-v2)"
 

--- a/images.CI/macos/azure-pipelines/image-generation.yml
+++ b/images.CI/macos/azure-pipelines/image-generation.yml
@@ -121,8 +121,8 @@ jobs:
     condition: always()
 
   - task: PowerShell@2
-    displayName: 'Move vm to cold storage'
-    condition: succeededOrFailed()
+    displayName: 'Move vm to cold storage and clear datastore tag'
+    condition: always()
     inputs:
       targetType: 'filePath'
       filePath: ./images.CI/macos/move-vm.ps1

--- a/images.CI/macos/move-vm.ps1
+++ b/images.CI/macos/move-vm.ps1
@@ -55,8 +55,6 @@ try {
     Write-Host "Tag with $VMName doesn't exist"
 }
 
-
-
 $vm = Get-VM $VMName
 
 if ($env:AGENT_JOBSTATUS -eq 'Failed') {

--- a/images.CI/macos/move-vm.ps1
+++ b/images.CI/macos/move-vm.ps1
@@ -48,6 +48,15 @@ Import-Module $PSScriptRoot\helpers.psm1 -DisableNameChecking
 # Connection to a vCenter Server system
 Connect-VCServer
 
+# Clear previously assigned tag with VM Name
+try {
+    Remove-Tag $VMName -Confirm:$false
+} catch {
+    Write-Host "Tag with $VMName doesn't exist"
+}
+
+
+
 $vm = Get-VM $VMName
 
 if ($env:AGENT_JOBSTATUS -eq 'Failed') {

--- a/images.CI/macos/select-datastore.ps1
+++ b/images.CI/macos/select-datastore.ps1
@@ -22,6 +22,10 @@ vCenter password (Example "12345678")
 param(
     [Parameter(Mandatory)]
     [ValidateNotNullOrEmpty()]
+    [string]$VMName,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
     [string]$VIServer,
 
     [Parameter(Mandatory)]
@@ -30,35 +34,69 @@ param(
 
     [Parameter(Mandatory)]
     [ValidateNotNullOrEmpty()]
-    [string]$VIPassword
+    [string]$VIPassword,
+
+    [string]$TagCategory = "Busy"
 )
 
 # Import helpers module
 Import-Module $PSScriptRoot\helpers.psm1 -DisableNameChecking
 
+function Select-DataStore {
+    param (
+        [string]$VMName,
+        [string]$TagCategory,
+        [string]$TemplateDatastore = "ds-local-Datastore-*",
+        [int]$ThresholdInGb = 400,
+        [int]$VMCount = 2,
+        [int]$Retries = 5
+    )
+
+    # 1. Name starts with ds-local-Datastore
+    # 2. FreespaceGB > 400 Gb
+    # 3. VM count on a datastore < 2
+
+    Write-Host "Start Datastore selection process..."
+    $allDatastores = Get-Datastore -Name $templateDatastore | Where-Object { $_.State -eq "Available" }
+    $buildDatastore = $allDatastores | Where-Object { $_.FreeSpaceGB -ge $thresholdInGb } | Where-Object {
+        $vmOnDatastore = @((Get-ChildItem -Path $_.DatastoreBrowserPath).Name -notmatch "^\.").Count
+        $vmOnDatastore -lt $vmCount
+    } | Select-Object -ExpandProperty Name -First 1
+
+    $tag = Get-Tag -Category $TagCategory -Name $VMName -ErrorAction Ignore
+    if (-not $tag)
+    {
+        $tag = New-Tag -Name $VMName -Category $TagCategory
+    }
+
+    New-TagAssignment -Tag $tag -Entity $buildDatastore | Out-Null
+
+    # Wait for 60 seconds to check if any other tags are assigned to the same datastore
+    Start-Sleep -Seconds 60
+    $tagAssignments = (Get-TagAssignment -Entity $buildDatastore).Tag.Name | Select-Object -First 2
+    $isAllow = $tagAssignments -contains $VMName
+
+    if ($isAllow)
+    {
+        Write-Host "Datastore selected successfully"
+        Write-Host "##vso[task.setvariable variable=buildDatastore;issecret=true]$buildDatastore"
+        return $buildDatastore
+    }
+
+    $retries--
+    if ($retries -le 0)
+    {
+        Write-Host "##vso[task.LogIssue type=error;]No datastores found for the condition"
+        exit 1
+    }
+
+    Write-Host "Datastore select failed, $retries left"
+    Select-DataStore -VMName $VMName -TagCategory $TagCategory -Retries $retries
+
+}
+
 # Connection to a vCenter Server system
 Connect-VCServer
 
 # Get a target datastore for current deployment
-# 1. Name starts with ds-local-Datastore
-# 2. FreespaceGB > 400 Gb
-# 3. VM count on a datastore < 2
-$templateDatastore = "ds-local-Datastore-*"
-$thresholdInGb = 400
-$vmCount = 2
-$allDatastores = Get-Datastore -Name $templateDatastore | Where-Object { $_.State -eq "Available" }
-$buildDatastore = $allDatastores | Where-Object { $_.FreeSpaceGB -ge $thresholdInGb } | Where-Object {
-            $vmOnDatastore = @((Get-ChildItem -Path $_.DatastoreBrowserPath).Name -notmatch "^\.").Count
-            $vmOnDatastore -lt $vmCount
-        } | Select-Object -ExpandProperty Name -First 1
-
-if ($buildDatastore)
-{
-    Write-Host "Datastore selected successfully"
-    Write-Host "##vso[task.setvariable variable=buildDatastore;issecret=true]$buildDatastore"
-}
-else
-{
-    Write-Host "##vso[task.LogIssue type=error;]No datastores found for the condition"
-    exit 1
-}
+Select-DataStore -VMName $VMName -TagCategory $TagCategory

--- a/images.CI/macos/select-datastore.ps1
+++ b/images.CI/macos/select-datastore.ps1
@@ -73,6 +73,7 @@ function Select-DataStore {
 
     # Wait for 60 seconds to check if any other tags are assigned to the same datastore
     Start-Sleep -Seconds 60
+    # Take only first 2 tags, all the others will go to the next round
     $tagAssignments = (Get-TagAssignment -Entity $buildDatastore).Tag.Name | Select-Object -First 2
     $isAllow = $tagAssignments -contains $VMName
 
@@ -83,6 +84,9 @@ function Select-DataStore {
         return
     }
 
+    # Remove the tag if datastore wasn't selected
+    Remove-Tag $tag -Confirm:$false
+
     $retries--
     if ($retries -le 0)
     {
@@ -92,7 +96,6 @@ function Select-DataStore {
 
     Write-Host "Datastore select failed, $retries left"
     Select-DataStore -VMName $VMName -TagCategory $TagCategory -Retries $retries
-
 }
 
 # Connection to a vCenter Server system

--- a/images.CI/macos/select-datastore.ps1
+++ b/images.CI/macos/select-datastore.ps1
@@ -80,7 +80,7 @@ function Select-DataStore {
     {
         Write-Host "Datastore selected successfully"
         Write-Host "##vso[task.setvariable variable=buildDatastore;issecret=true]$buildDatastore"
-        return $buildDatastore
+        return
     }
 
     $retries--


### PR DESCRIPTION
# Description
We have had a situation when 3 out of 4 scheduled builds were placed on the same datastore probably because there is some delay between datastore selections and VM files creation.
In this PR we implement the following logic:
- Build set the tag on datastore after selection
- Wait for 1 minute
- Only the first two tags will be able to book the datastore
- The third and all the other tags will be deleted and the build will go through all the process again up to 5 times
- Tag is deleted on the move-vm stage

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1360

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
