### PR TITLE
[macOS] Remove workaround for MS edge webdriver

### DIFF
--- a/images/macos/provision/core/edge.sh
+++ b/images/macos/provision/core/edge.sh
@@ -3,11 +3,7 @@
 source ~/utils/utils.sh
 
 echo "Installing Microsoft Edge..."
-# Workaround to install version 85 since webdriver is broken for 86
-cd "$(brew --repo homebrew/homebrew-cask)"
-git checkout 81f9d08d2b9b7557c0178621078cf59d2c5db2bc
 brew cask install microsoft-edge
-git checkout master
 
 EDGE_INSTALLATION_PATH="/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"
 EDGE_VERSION=$("$EDGE_INSTALLATION_PATH" --version | cut -d' ' -f 3)


### PR DESCRIPTION
# Description
Edge webdriver 86.0.622.51 has been fixed recently. We don't need this workaround anymore.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1290

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
