### PR TITLE
Print more informantion about cached Docker images linux

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -240,8 +240,15 @@ function Get-CachedDockerImages {
     return $images
 }
 
-function Get-CachedDockerImagesFullInfo {
-    return (sudo docker images --digests --format "* {{.Repository}}:{{.Tag}} {{.Digest}} {{.CreatedSince}}").Split("*") | Where-Object { $_ }
+function Get-CachedDockerImagesTableData {
+    return (sudo docker images --digests --format "*{{.Repository}}:{{.Tag}}|{{.Digest}} |{{.CreatedAt}}").Split("*")     | Where-Object { $_ } |  ForEach-Object {
+      $parts=$_.Split("|")
+      [PSCustomObject] @{
+             "Repository:Tag" = $parts[0]
+              "Digest" = $parts[1]
+              "Created" = $parts[2]
+         }
+    }
 }
 
 function Get-AptPackages {

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -240,6 +240,10 @@ function Get-CachedDockerImages {
     return $images
 }
 
+function Get-CachedDockerImagesFullInfo {
+    return (sudo docker images --digests --format "* {{.Repository}}:{{.Tag}} {{.Digest}} {{.CreatedSince}}").Split("*") | Where-Object { $_ }
+}
+
 function Get-AptPackages {
     $toolsetJson = Get-ToolsetContent
     $apt = $toolsetJson.apt

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -246,7 +246,7 @@ function Get-CachedDockerImagesTableData {
       [PSCustomObject] @{
              "Repository:Tag" = $parts[0]
               "Digest" = $parts[1]
-              "Created" = $parts[2]
+              "Created" = $parts[2].split(' ')[0]
          }
     }
 }

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -224,7 +224,7 @@ $markdown += Build-AndroidTable | New-MDTable
 $markdown += New-MDNewLine
 
 $markdown += New-MDHeader "Cached Docker images" -Level 3
-$markdown += New-MDList -Style Unordered -Lines @(Get-CachedDockerImages)
+$markdown += New-MDList -Style Unordered -Lines @(Get-CachedDockerImagesFullInfo)
 
 $markdown += New-MDHeader "Installed apt packages" -Level 3
 $markdown += New-MDList -Style Unordered -Lines @(Get-AptPackages)

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -224,7 +224,8 @@ $markdown += Build-AndroidTable | New-MDTable
 $markdown += New-MDNewLine
 
 $markdown += New-MDHeader "Cached Docker images" -Level 3
-$markdown += New-MDList -Style Unordered -Lines @(Get-CachedDockerImagesFullInfo)
+$markdown += Get-CachedDockerImagesTableData | New-MDTable
+$markdown += New-MDNewLine
 
 $markdown += New-MDHeader "Installed apt packages" -Level 3
 $markdown += New-MDList -Style Unordered -Lines @(Get-AptPackages)

--- a/images/macos/provision/core/pipx-packages.sh
+++ b/images/macos/provision/core/pipx-packages.sh
@@ -1,3 +1,4 @@
+#!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
 
 export PATH="$PATH:/opt/pipx_bin"


### PR DESCRIPTION
# Description
Improvement

Add too docker information listed in Software report the docker digest and age. 

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/1243

## Check list
- [x] Related issue / work item is attached
- [x] Changes are tested and related VM images are successfully generated
