### PR TITLE
fix user on rust and brew scripts

### DIFF
--- a/images/linux/post-generation/homebrew-permissions.sh
+++ b/images/linux/post-generation/homebrew-permissions.sh
@@ -5,7 +5,7 @@
 brew_folder="/home/linuxbrew/"
 if [ -d "$brew_folder" ]; then
     brew_folder_owner=$(ls -ld $brew_folder | awk '{print $3}')
-    if [ "$USER" != "$brew_folder_owner" ]; then
-        chown "$USER":docker -R $brew_folder
+    if [ "$SUDO_USER" != "$brew_folder_owner" ]; then
+        chown "$SUDO_USER":docker -R $brew_folder
     fi
 fi

--- a/images/linux/post-generation/homebrew-permissions.sh
+++ b/images/linux/post-generation/homebrew-permissions.sh
@@ -4,12 +4,7 @@
 # https://github.com/actions/virtual-environments/issues/1568
 
 brew_folder="/home/linuxbrew/"
-
-if [ "$GITHUB_ACTIONS" = "true" ]; then
-    homebrew_user="runner"
-else
-    homebrew_user="vsts"
-fi
+homebrew_user=$(cut -d: -f1 /etc/passwd | tail -1)
 
 if [ -d "$brew_folder" ]; then
     brew_folder_owner=$(ls -ld $brew_folder | awk '{print $3}')

--- a/images/linux/post-generation/homebrew-permissions.sh
+++ b/images/linux/post-generation/homebrew-permissions.sh
@@ -2,10 +2,18 @@
 
 # Fix permissions for Homebrew
 # https://github.com/actions/virtual-environments/issues/1568
+
 brew_folder="/home/linuxbrew/"
+
+if [ "$GITHUB_ACTIONS" = "true" ]; then
+    homebrew_user="runner"
+else
+    homebrew_user="vsts"
+fi
+
 if [ -d "$brew_folder" ]; then
     brew_folder_owner=$(ls -ld $brew_folder | awk '{print $3}')
-    if [ "$SUDO_USER" != "$brew_folder_owner" ]; then
-        chown "$SUDO_USER":docker -R $brew_folder
+    if [ "$homebrew_user" != "$brew_folder_owner" ]; then
+        chown "$homebrew_user":docker -R $brew_folder
     fi
 fi

--- a/images/linux/post-generation/rust-permissions.sh
+++ b/images/linux/post-generation/rust-permissions.sh
@@ -4,12 +4,7 @@
 # https://github.com/actions/virtual-environments/issues/572
 
 rust_folder="/usr/share/rust"
-
-if [ "$GITHUB_ACTIONS" = "true" ]; then
-    rust_user="runner"
-else
-    rust_user="vsts"
-fi
+rust_user=$(cut -d: -f1 /etc/passwd | tail -1)
 
 if [ -d "$rust_folder" ]; then
     rust_folder_owner=$(ls -ld $rust_folder | awk '{print $3}')

--- a/images/linux/post-generation/rust-permissions.sh
+++ b/images/linux/post-generation/rust-permissions.sh
@@ -2,10 +2,18 @@
 
 # Fix permissions for the Rust folder
 # https://github.com/actions/virtual-environments/issues/572
+
 rust_folder="/usr/share/rust"
+
+if [ "$GITHUB_ACTIONS" = "true" ]; then
+    rust_user="runner"
+else
+    rust_user="vsts"
+fi
+
 if [ -d "$rust_folder" ]; then
     rust_folder_owner=$(ls -ld $rust_folder | awk '{print $3}')
-    if [ "$SUDO_USER" != "$rust_folder_owner" ]; then
-        chown "$SUDO_USER":docker -R $rust_folder
+    if [ "$rust_user" != "$rust_folder_owner" ]; then
+        chown "$rust_user":docker -R $rust_folder
     fi
 fi

--- a/images/linux/post-generation/rust-permissions.sh
+++ b/images/linux/post-generation/rust-permissions.sh
@@ -5,7 +5,7 @@
 rust_folder="/usr/share/rust"
 if [ -d "$rust_folder" ]; then
     rust_folder_owner=$(ls -ld $rust_folder | awk '{print $3}')
-    if [ "$USER" != "$rust_folder_owner" ]; then
-        chown "$USER":docker -R $rust_folder
+    if [ "$SUDO_USER" != "$rust_folder_owner" ]; then
+        chown "$SUDO_USER":docker -R $rust_folder
     fi
 fi


### PR DESCRIPTION
# Description
Fixed post-deployment scripts on Linux. 
Scripts are executed via sudo and $USER environment variable value is "root", but these script should set permissions according to actual user, the $SUDO_USER variable is an appropriate option.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: actions/virtual-environments-internal#1189

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
