### PR TITLE
[Windows] Add bash wrapper from git

### DIFF
--- a/images/win/scripts/Installers/Configure-Shell.ps1
+++ b/images/win/scripts/Installers/Configure-Shell.ps1
@@ -3,8 +3,8 @@ $shellPath = "C:\shells"
 New-Item -Path $shellPath -ItemType Directory | Out-Null
 
 # sh and bash <--> C:\msys64\usr\bin\bash.exe
-New-Item -ItemType SymbolicLink -Path "$shellPath\bash.exe" -Target "C:\msys64\usr\bin\bash.exe" | Out-Null
-New-Item -ItemType SymbolicLink -Path "$shellPath\sh.exe" -Target "C:\msys64\usr\bin\sh.exe" | Out-Null
+New-Item -ItemType SymbolicLink -Path "$shellPath\bash.exe" -Target "C:\msys64\bin\bash.exe" | Out-Null
+New-Item -ItemType SymbolicLink -Path "$shellPath\sh.exe" -Target "C:\msys64\bin\sh.exe" | Out-Null
 
 # WSL is available on Windows Server 2019
 if (Test-IsWin19)

--- a/images/win/scripts/Installers/Install-Msys2.ps1
+++ b/images/win/scripts/Installers/Install-Msys2.ps1
@@ -95,4 +95,10 @@ if (Test-Path "C:\Program Files\Git\etc\ssh")
   ssh-keyscan -t rsa ssh.dev.azure.com >> "C:\Program Files\Git\etc\ssh\ssh_known_hosts"
 }
 
+# Copy bash wrapper from git
+$wrapperPath = "C:\msys64\bin"
+New-Item -Path $wrapperPath -ItemType Directory -Force | Out-Null
+Copy-Item -Path "$env:ProgramFiles\Git\bin\bash.exe" -Destination $wrapperPath
+Copy-Item -Path "$env:ProgramFiles\Git\bin\sh.exe" -Destination $wrapperPath
+
 Invoke-PesterTests -TestFile "MSYS2"

--- a/images/win/scripts/Tests/Shell.Tests.ps1
+++ b/images/win/scripts/Tests/Shell.Tests.ps1
@@ -1,7 +1,7 @@
 Describe "Shell" {
     $shellTestCases = @(
-        @{Name = "C:\shells\bash.exe"; Target = "C:\msys64\usr\bin\bash.exe"},
-        @{Name = "C:\shells\sh.exe"; Target = "C:\msys64\usr\bin\sh.exe"},
+        @{Name = "C:\shells\bash.exe"; Target = "C:\msys64\bin\bash.exe"},
+        @{Name = "C:\shells\sh.exe"; Target = "C:\msys64\bin\sh.exe"},
         @{Name = "C:\shells\gitbash.exe"; Target = "$env:ProgramFiles\Git\bin\bash.exe"},
         @{Name = "C:\shells\msysbash.exe"; Target = "C:\msys64\usr\bin\bash.exe"}
     )


### PR DESCRIPTION
# Description
In scope of the https://github.com/actions/virtual-environments/pull/1648 PR we removed Git internal tools from PATH. In the migration process we found an issue related to how to correct prepare environment before running commands in the bash shell.

Issue:
If we try to invoke a find command, it runs the default `C:\Windows\System32\find.exe` Windows program instead of  `C:\msys64\usr\bin\find.exe` and  `PATH` order is incorrect( `/mingw64/bin:/usr/bin` in the PATH should be before C:\Windows\System32):
```
PS > bash -c 'echo $PATH'
/c/shells:/c/Program Files/MongoDB/Server/4.4/bin:/c/aliyun-cli:/c/ProgramData/kind:/c/vcpkg:/c/cf-cli:

PS >bash -c 'where find'
C:\Windows\System32\find.exe
C:\msys64\usr\bin\find.exe

PS > bash -c 'find'
FIND: Parameter format not correct
```
We should explicitly invoke `bash` shell with the parameter `-login` to set up PATH ordering, because the `C:\msys64\etc\profile` script is not sourced if a parameter -login is not  explicitly set. That's why we need a launcher with predefined parameters.

Fix:
According to the article - https://www.msys2.org/wiki/Launchers/, we should use follow command or use a launcher:
`C:\\msys64\\usr\\bin\\env MSYSTEM=MINGW64 MSYS2_PATH_TYPE=inherit /usr/bin/bash -l -c 'find'`

We choose the  "git wrapper" launcher with predefine settings in source code by default - https://github.com/git-for-windows/MINGW-packages/tree/main/mingw-w64-git:

1. bash -login
2. MSYSTEM=MINGW64
3. MSYS2_PATH_TYPE=inherit

Invoke find command:
```
# check PATH
PS > C:\msys64\bin\bash.exe -c 'echo $PATH'
/mingw64/bin:/usr/bin:/c/Users/testAdm2/bin:/c/shells:/c/Program Files/MongoDB/Server/4.4/bin

PS > C:\msys64\bin\bash.exe -c 'where find'
C:\msys64\usr\bin\find.exe
C:\Windows\System32\find.exe

PS > C:\msys64\bin\bash.exe -c 'find /bin | tail -n 5'
/bin/zstdcat.exe
/bin/zstdgrep
/bin/zstdless
/bin/zstdmt.exe
/bin/[.exe
```

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1397

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
