### PR TITLE
[Ubuntu] Optimize Linux OS settings for better performance

### DIFF
--- a/images/linux/scripts/base/reboot.sh
+++ b/images/linux/scripts/base/reboot.sh
@@ -4,5 +4,8 @@
 ##  Desc:  Reboot VM
 ################################################################################
 
+echo "Update grub before reboot"
+update-grub
+
 echo "Reboot VM"
 sudo reboot

--- a/images/linux/scripts/installers/configure-environment.sh
+++ b/images/linux/scripts/installers/configure-environment.sh
@@ -30,3 +30,8 @@ echo 'vm.max_map_count=262144' | tee -a /etc/sysctl.conf
 
 # tune swappiness to 10, docs: https://www.kernel.org/doc/Documentation/sysctl/vm.txt
 echo 'vm.swappiness=10' | tee -a /etc/sysctl.conf
+
+# grub settings
+mkdir -p /etc/default/grub.d
+# configure transparent hugepages (thp) to be used when opted in with "madvise" instead of enabling by default
+echo 'GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX transparent_hugepage=madvise"' >> /etc/default/grub.d/99-thp.cfg

--- a/images/linux/scripts/installers/configure-environment.sh
+++ b/images/linux/scripts/installers/configure-environment.sh
@@ -13,7 +13,7 @@ sed -i 's/ResourceDisk.Format=n/ResourceDisk.Format=y/g' /etc/waagent.conf
 sed -i 's/ResourceDisk.EnableSwap=n/ResourceDisk.EnableSwap=y/g' /etc/waagent.conf
 sed -i 's/ResourceDisk.SwapSizeMB=0/ResourceDisk.SwapSizeMB=4096/g' /etc/waagent.conf
 # Use performance optimized mount options, docs: https://www.kernel.org/doc/Documentation/filesystems/ext4.txt
-sed -i 's/ResourceDisk.MountOptions=None/ResourceDisk.MountOptions=nodiscard,barrier=0,commit=999999,data=writeback/g' /etc/waagent.conf
+sed -i 's/ResourceDisk.MountOptions=None/ResourceDisk.MountOptions=data=writeback,commit=999999,barrier=0,nodiscard,relatime/g' /etc/waagent.conf
 
 # Add localhost alias to ::1 IPv6
 sed -i 's/::1 ip6-localhost ip6-loopback/::1     localhost ip6-localhost ip6-loopback/g' /etc/hosts
@@ -35,6 +35,8 @@ echo 'vm.swappiness=10' | tee -a /etc/sysctl.conf
 mkdir -p /etc/default/grub.d
 # configure transparent hugepages (thp) to be used when opted in with "madvise" instead of enabling by default
 echo 'GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX transparent_hugepage=madvise"' >> /etc/default/grub.d/99-thp.cfg
+# configure default mount options for the root filesystem
+echo 'GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX rootflags=data=writeback,commit=999999,barrier=0,nodiscard,relatime"' >> /etc/default/grub.d/99-rootflags.cfg
 
 # disable fstrim.timer & fstrim.service if services exist, there's no need to run discard/trim for the disk
 systemctl disable fstrim.timer || true

--- a/images/linux/scripts/installers/configure-environment.sh
+++ b/images/linux/scripts/installers/configure-environment.sh
@@ -35,3 +35,7 @@ echo 'vm.swappiness=10' | tee -a /etc/sysctl.conf
 mkdir -p /etc/default/grub.d
 # configure transparent hugepages (thp) to be used when opted in with "madvise" instead of enabling by default
 echo 'GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX transparent_hugepage=madvise"' >> /etc/default/grub.d/99-thp.cfg
+
+# disable fstrim.timer & fstrim.service if services exist, there's no need to run discard/trim for the disk
+systemctl disable fstrim.timer || true
+systemctl disable fstrim.service || true

--- a/images/linux/scripts/installers/configure-environment.sh
+++ b/images/linux/scripts/installers/configure-environment.sh
@@ -12,6 +12,8 @@ echo 'export XDG_CONFIG_HOME=$HOME/.config' | tee -a /etc/skel/.bashrc
 sed -i 's/ResourceDisk.Format=n/ResourceDisk.Format=y/g' /etc/waagent.conf
 sed -i 's/ResourceDisk.EnableSwap=n/ResourceDisk.EnableSwap=y/g' /etc/waagent.conf
 sed -i 's/ResourceDisk.SwapSizeMB=0/ResourceDisk.SwapSizeMB=4096/g' /etc/waagent.conf
+# Use performance optimized mount options, docs: https://www.kernel.org/doc/Documentation/filesystems/ext4.txt
+sed -i 's/ResourceDisk.MountOptions=None/ResourceDisk.MountOptions=nodiscard,nobarrier,commit=999999,data=writeback/g' /etc/waagent.conf
 
 # Add localhost alias to ::1 IPv6
 sed -i 's/::1 ip6-localhost ip6-loopback/::1     localhost ip6-localhost ip6-loopback/g' /etc/hosts

--- a/images/linux/scripts/installers/configure-environment.sh
+++ b/images/linux/scripts/installers/configure-environment.sh
@@ -13,7 +13,7 @@ sed -i 's/ResourceDisk.Format=n/ResourceDisk.Format=y/g' /etc/waagent.conf
 sed -i 's/ResourceDisk.EnableSwap=n/ResourceDisk.EnableSwap=y/g' /etc/waagent.conf
 sed -i 's/ResourceDisk.SwapSizeMB=0/ResourceDisk.SwapSizeMB=4096/g' /etc/waagent.conf
 # Use performance optimized mount options, docs: https://www.kernel.org/doc/Documentation/filesystems/ext4.txt
-sed -i 's/ResourceDisk.MountOptions=None/ResourceDisk.MountOptions=nodiscard,nobarrier,commit=999999,data=writeback/g' /etc/waagent.conf
+sed -i 's/ResourceDisk.MountOptions=None/ResourceDisk.MountOptions=nodiscard,barrier=0,commit=999999,data=writeback/g' /etc/waagent.conf
 
 # Add localhost alias to ::1 IPv6
 sed -i 's/::1 ip6-localhost ip6-loopback/::1     localhost ip6-localhost ip6-loopback/g' /etc/hosts

--- a/images/linux/scripts/installers/configure-environment.sh
+++ b/images/linux/scripts/installers/configure-environment.sh
@@ -25,3 +25,6 @@ chmod -R 777 $AGENT_TOOLSDIRECTORY
 # https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
 # https://www.suse.com/support/kb/doc/?id=000016692
 echo 'vm.max_map_count=262144' | tee -a /etc/sysctl.conf
+
+# tune swappiness to 10, docs: https://www.kernel.org/doc/Documentation/sysctl/vm.txt
+echo 'vm.swappiness=10' | tee -a /etc/sysctl.conf


### PR DESCRIPTION
### Motivation

The goal of this PR is to optimize Linux OS settings for better performance.

#1939 is a related issue, but this is PR is not directly addressing that issue. These changes are about general improvements for tuning Linux OS settings for CI use cases where data durability isn't the main concern.

### Modifications

* tune `vm.swappiness` to a reasonable value (`10`). Currently using the default `60`, which isn't optimal for CI environments where more RAM might be needed for running the application and dependent services. 
* tune root filesystem (/) and resource disk (/mnt) mount options for performance (ref [Azure docs about barrier=0](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/optimization#adding-disks-for-size-and-performance-targets))
  * `data=writeback,commit=999999,barrier=0,nodiscard,relatime`
  * disable `discard` which is enabled by default for the root filesystem. [`discard` might have performance implications, as stated in Azure documentation](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/attach-disk-portal#trimunmap-support-for-linux-in-azure): "In some cases, the discard option may have performance implications."
* Set `transparent_hugepage` boot option to `madvise` (sets `/sys/kernel/mm/transparent_hugepage/enabled=madvise`)
* Disable `fstrim.timer` and `fstrim.service` so that SSD discard/trim isn't run at all
