### PR TITLE
[Ubuntu] Add php-dev and php-pear

### DIFF
--- a/images/linux/scripts/installers/php.sh
+++ b/images/linux/scripts/installers/php.sh
@@ -66,7 +66,6 @@ for version in $php_versions; do
 
     if [[ $version == "5.6" || $version == "7.0" || $version == "7.1" ]]; then
         apt-fast install -y --no-install-recommends php$version-mcrypt php$version-recode
-        apt-get remove --purge -yq php$version-dev
     fi
 
     if [[ $version == "7.2" || $version == "7.3" ]]; then
@@ -81,12 +80,11 @@ apt-fast install -y --no-install-recommends \
     php-memcache \
     php-memcached \
     php-mongodb \
+    php-pear \
     php-redis \
     php-xdebug \
     php-yaml \
     php-zmq
-
-apt-get remove --purge -yq php7.2-dev
 
 apt-fast install -y --no-install-recommends snmp
 
@@ -113,13 +111,19 @@ mv phpunit /usr/local/bin/phpunit
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
-for cmd in php $php_versions composer phpunit; do
-    if [[ $cmd =~ ^[0-9] ]]; then
-        cmd="php$cmd"
-    fi
-
+for cmd in composer pear pecl phpunit; do
     if ! command -v $cmd; then
         echo "$cmd was not installed"
+        exit 1
+    fi
+done
+
+for version in $php_versions; do
+    if ! command -v php$version; then
+        echo "php$version was not installed"
+        exit 1
+    elif ! command -v php-config$version || ! command -v phpize$version; then
+        echo "php$version-dev was not installed"
         exit 1
     fi
 done


### PR DESCRIPTION
# Description

- New tool
- Added `php-dev` for each supported PHP version and `php-pear`. It fixes #1944
- Should take around 500kb for `php-dev` for each PHP version and around `280kb` for php-pear. 
- Time taken will not change much, as time taken to install `php-pear` will be offset by time taken to remove `php-dev`.

#### Related issue: #1944 

## Check list
- [X] Related issue / work item is attached
- [X] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated