### PR TITLE
[macOS] Explicitly set Az powershell version 4.8

### DIFF
--- a/images/macos/provision/core/powershell.sh
+++ b/images/macos/provision/core/powershell.sh
@@ -34,3 +34,6 @@ sudo ln -s /usr/local/bin/pwsh /usr/local/bin/powershell
 
 # fix ~/.azure directory permissions
 sudo chown -R ${USER}: $HOME/.azure
+
+# fix permissions for Az.Account version 2.*
+sudo chown -R ${USER}: $HOME/.local/share/.IdentityService

--- a/images/macos/toolsets/toolset-10.13.json
+++ b/images/macos/toolsets/toolset-10.13.json
@@ -180,7 +180,12 @@
         ]
     },
     "powershellModules": [
-        {"name": "Az"},
+        {
+            "name": "Az",
+            "versions": [
+                "4.8.0"
+            ]
+        },
         {"name": "MarkdownPS"},
         {"name": "Pester"}
     ],

--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -201,7 +201,12 @@
         ]
     },
     "powershellModules": [
-        {"name": "Az"},
+        {
+            "name": "Az",
+            "versions": [
+                "4.8.0"
+            ]
+        },
         {"name": "MarkdownPS"},
         {"name": "Pester"}
     ],

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -117,7 +117,12 @@
         ]
     },
     "powershellModules": [
-        {"name": "Az"},
+        {
+            "name": "Az",
+            "versions": [
+                "4.8.0"
+            ]
+        },
         {"name": "MarkdownPS"},
         {"name": "Pester"}
     ],

--- a/images/macos/toolsets/toolset-11.0.json
+++ b/images/macos/toolsets/toolset-11.0.json
@@ -59,7 +59,12 @@
         "addon-list": []
     },
     "powershellModules": [
-        {"name": "Az"},
+        {
+            "name": "Az",
+            "versions": [
+                "4.8.0"
+            ]
+        },
         {"name": "MarkdownPS"},
         {"name": "Pester"}
     ],


### PR DESCRIPTION
# Description
Az PowerShell version 5 contains a lot of breaking changes, we should stay at 4.8 for a few more weeks until these issues are resolved.

#### Related issue:
n\a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
