### PR TITLE
OSX: Rust tools: install 'rustfmt' and 'clippy'

### DIFF
--- a/images/macos/provision/core/rust.sh
+++ b/images/macos/provision/core/rust.sh
@@ -11,6 +11,7 @@ CARGO_HOME=$HOME/.cargo
 source $CARGO_HOME/env
 
 echo Install common tools...
+rustup component add rustfmt clippy
 cargo install bindgen cbindgen cargo-audit cargo-outdated
 
 echo Cleanup Cargo registry cached data...


### PR DESCRIPTION
Make installed Rust components the same as for Ubuntu. See also: 
https://github.com/actions/virtual-environments/blob/f38833acec5cc1c3239474f8135b23c17cb72351/images/linux/scripts/installers/rust.sh

# Description

See: https://github.com/actions/virtual-environments/issues/1916

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated

Fixes: #1916 

@maxim-lobanov 