### PR TITLE
[Ubuntu] Install pwsh using dotnet tool

### DIFF
--- a/images/linux/scripts/installers/powershellcore.sh
+++ b/images/linux/scripts/installers/powershellcore.sh
@@ -9,7 +9,8 @@ source $HELPER_SCRIPTS/os.sh
 
 # Install Powershell
 if isUbuntu20 ; then
-    snap install powershell --classic --channel=edge/useedge
+    dotnet tool install --tool-path /opt/microsoft/powershell/7 powershell
+    ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
 fi
 
 if isUbuntu16 || isUbuntu18 ; then


### PR DESCRIPTION
# Description
After updating Az.Accounts module to the latest 2.1.2 version, snap powershell  unexpectedly raises a segfault when we invoke Import-Module Az.Accounts statement. As a fix we change installation approach to use `dotnet tool` util.

![image](https://user-images.githubusercontent.com/47745270/97961785-f966ee00-1dc4-11eb-9686-b19a57cda63d.png)

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
