### PR TITLE
Deprecate Boost 1.69.0 from Windows images

### DIFF
--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -73,7 +73,6 @@
             "platform" : "win32",
             "toolset": "msvc14.1",
             "versions": [
-                "1.69.0",
                 "1.72.0"
             ]
         }

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -71,16 +71,6 @@
             "url" : "https://raw.githubusercontent.com/actions/boost-versions/main/versions-manifest.json",
             "arch": "x86_64",
             "platform" : "win32",
-            "toolset": "msvc14.1",
-            "versions": [
-                "1.69.0"
-            ]
-        },
-        {
-            "name": "Boost",
-            "url" : "https://raw.githubusercontent.com/actions/boost-versions/main/versions-manifest.json",
-            "arch": "x86_64",
-            "platform" : "win32",
             "toolset": "msvc14.2",
             "versions": [
                 "1.72.0"


### PR DESCRIPTION
# Description
Related announcements:
- https://github.com/actions/virtual-environments/issues/1847
