### PR TITLE
[Ubuntu] Fix image generation for Ubuntu20

### DIFF
--- a/images/linux/scripts/base/apt.sh
+++ b/images/linux/scripts/base/apt.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -e
 
-export DEBIAN_FRONTEND=noninteractive
-apt-get -yq update
-apt-get -yq dist-upgrade
-
 # Stop and disable apt-daily upgrade services;
 systemctl stop apt-daily.timer
 systemctl disable apt-daily.timer
@@ -16,7 +12,7 @@ systemctl disable apt-daily-upgrade.service
 sudo sed -i 's/APT::Periodic::Update-Package-Lists "1"/APT::Periodic::Update-Package-Lists "0"/' /etc/apt/apt.conf.d/20auto-upgrades
 
 # Enable retry logic for apt up to 10 times
-echo "APT::Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries 
+echo "APT::Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries
 
 # Configure apt to always assume Y
 echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes

--- a/images/linux/scripts/base/repos.sh
+++ b/images/linux/scripts/base/repos.sh
@@ -16,4 +16,7 @@ curl -L https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 
 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
 mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
-apt-get update
+
+# update
+apt-get -yq update
+apt-get -yq dist-upgrade

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -72,6 +72,9 @@
         {
             "type": "shell",
             "script": "{{template_dir}}/scripts/base/apt.sh",
+            "environment_vars": [
+                "DEBIAN_FRONTEND=noninteractive"
+            ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -75,6 +75,9 @@
         {
             "type": "shell",
             "script": "{{template_dir}}/scripts/base/apt.sh",
+            "environment_vars": [
+                "DEBIAN_FRONTEND=noninteractive"
+            ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -76,7 +76,18 @@
         },
         {
             "type": "shell",
+            "expect_disconnect": true,
+            "scripts": [
+                "{{template_dir}}/scripts/base/reboot.sh"
+            ],
+            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
             "script": "{{template_dir}}/scripts/base/apt.sh",
+            "environment_vars": [
+                "DEBIAN_FRONTEND=noninteractive"
+            ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {


### PR DESCRIPTION
# Description
The following error appeared during Ubuntu20 image generation on mmsprodwcus0.
Need to collect additional information and ask for help from Canonical.
```
2020-11-05T03:12:39.6168065Z  mmsprodwcus0    2020/11/05 03:08:37 ui error: ==> azure-arm: E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/c/c-ares/libc-ares2_1.15.0-1build1_amd64.deb  Temporary failure resolving 'azure.archive.ubuntu.com'
2020-11-05T03:12:39.6168997Z  mmsprodwcus0    2020/11/05 03:08:37 ui error: ==> azure-arm: E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/libs/libssh2/libssh2-1_1.8.0-2.1build1_amd64.deb  Temporary failure resolving 'azure.archive.ubuntu.com'
2020-11-05T03:12:39.6169949Z  mmsprodwcus0    2020/11/05 03:08:37 ui error: ==> azure-arm: E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/a/aria2/libaria2-0_1.35.0-1build1_amd64.deb  Temporary failure resolving 'azure.archive.ubuntu.com'
2020-11-05T03:12:39.6170865Z  mmsprodwcus0    2020/11/05 03:08:37 ui error: ==> azure-arm: E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/a/aria2/aria2_1.35.0-1build1_amd64.deb  Temporary failure resolving 'azure.archive.ubuntu.com'
```

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1408

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
