### PR TITLE
[Ubuntu] Freeze Az.Accounts module for Ubuntu 20

### DIFF
--- a/images/linux/scripts/base/apt.sh
+++ b/images/linux/scripts/base/apt.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -e
 
-export DEBIAN_FRONTEND=noninteractive
-apt-get -yq update
-apt-get -yq dist-upgrade
-
 # Stop and disable apt-daily upgrade services;
 systemctl stop apt-daily.timer
 systemctl disable apt-daily.timer
@@ -16,7 +12,7 @@ systemctl disable apt-daily-upgrade.service
 sudo sed -i 's/APT::Periodic::Update-Package-Lists "1"/APT::Periodic::Update-Package-Lists "0"/' /etc/apt/apt.conf.d/20auto-upgrades
 
 # Enable retry logic for apt up to 10 times
-echo "APT::Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries 
+echo "APT::Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries
 
 # Configure apt to always assume Y
 echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes

--- a/images/linux/scripts/base/repos.sh
+++ b/images/linux/scripts/base/repos.sh
@@ -16,4 +16,7 @@ curl -L https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 
 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
 mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
-apt-get update
+
+# update
+apt-get -yq update
+apt-get -yq dist-upgrade

--- a/images/linux/scripts/installers/azpowershell.sh
+++ b/images/linux/scripts/installers/azpowershell.sh
@@ -18,6 +18,10 @@ pwsh -Command "Update-Module -Name PowerShellGet -Force"
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 for version in ${versions[@]}; do
     pwsh -Command "Save-Module -Name Az -LiteralPath /usr/share/az_$version -RequiredVersion $version -Force -Verbose"
+    if isUbuntu20; then
+        rm -rf "/usr/share/az_$version/Az.Accounts"
+        pwsh -Command "Save-Module -Name Az.Accounts -LiteralPath /usr/share/az_$version -RequiredVersion 1.9.5 -Force -Verbose"
+    fi
 done
 
 # Run tests to determine that the software installed as expected

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -72,6 +72,9 @@
         {
             "type": "shell",
             "script": "{{template_dir}}/scripts/base/apt.sh",
+            "environment_vars": [
+                "DEBIAN_FRONTEND=noninteractive"
+            ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -75,6 +75,9 @@
         {
             "type": "shell",
             "script": "{{template_dir}}/scripts/base/apt.sh",
+            "environment_vars": [
+                "DEBIAN_FRONTEND=noninteractive"
+            ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -76,7 +76,18 @@
         },
         {
             "type": "shell",
+            "expect_disconnect": true,
+            "scripts": [
+                "{{template_dir}}/scripts/base/reboot.sh"
+            ],
+            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
             "script": "{{template_dir}}/scripts/base/apt.sh",
+            "environment_vars": [
+                "DEBIAN_FRONTEND=noninteractive"
+            ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {


### PR DESCRIPTION
# Description
PowerShell Core 7,on Ubuntu20, was causing segmentation faults (segfaults) after powershell modules were updating to Az 5.0 and Az.Accounts 2.1.2. 
Fix: use hardcoded version Az=4.8.0 and Az.Accounts=1.9.5.

## Check list
- [n/a] Related issue / work item is attached
- [n/a] Tests are written (if applicable)
- [n/a] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
