### PR TITLE
[Ubuntu] Move list of .Net Core versions to install to toolset

### DIFF
--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -10,8 +10,8 @@ source $HELPER_SCRIPTS/os.sh
 
 # Ubuntu 20 doesn't support EOL versions
 toolset="$INSTALLER_SCRIPT_FOLDER/toolset.json"
-LATEST_DOTNET_PACKAGES=$(jq -r '.dotnetCoreSdk.latest_dotnet_packages[]' $toolset)
-release_urls=$(jq -r '.dotnetCoreSdk.release_urls[]' $toolset)
+LATEST_DOTNET_PACKAGES=$(jq -r '.dotnet.aptPackages[]' $toolset)
+versions=$(jq -r '.dotnet.versions[]' $toolset)
 
 mksamples()
 {
@@ -44,7 +44,8 @@ done
 
 # Get list of all released SDKs from channels which are not end-of-life or preview
 sdks=()
-for release_url in ${release_urls[@]}; do
+for version in ${versions[@]}; do
+    release_url="https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/${version}/releases.json"
     echo "${release_url}"
     releases=$(curl "${release_url}")
     sdks=("${sdks[@]}" $(echo "${releases}" | jq '.releases[]' | jq '.sdk.version'))

--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -9,15 +9,9 @@ source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 
 # Ubuntu 20 doesn't support EOL versions
-if isUbuntu20 ; then
-    LATEST_DOTNET_PACKAGES=("dotnet-sdk-3.1")
-    release_urls=("https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json" "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json")
-fi
-
-if isUbuntu16 || isUbuntu18 ; then
-    LATEST_DOTNET_PACKAGES=("dotnet-sdk-3.0" "dotnet-sdk-3.1")
-    release_urls=("https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json" "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.0/releases.json" "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json")
-fi
+toolset="$INSTALLER_SCRIPT_FOLDER/toolset.json"
+LATEST_DOTNET_PACKAGES=$(jq -r '.dotnetCoreSdk.latest_dotnet_packages[]' $toolset)
+release_urls=$(jq -r '.dotnetCoreSdk.release_urls[]' $toolset)
 
 mksamples()
 {

--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -192,14 +192,12 @@
     "dotnet": {
         "aptPackages": [
             "dotnet-sdk-3.0",
-            "dotnet-sdk-3.1",
-            "dotnet-sdk-5.0"
+            "dotnet-sdk-3.1"
         ],
         "versions": [
             "2.1",
             "3.0",
-            "3.1",
-            "5.0"
+            "3.1"
         ]
     }
 }

--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -189,18 +189,17 @@
             "ubuntu:14.04"
         ]
     },
-    "dotnetCoreSdk": {
-        "latest_dotnet_packages": [
+    "dotnet": {
+        "aptPackages": [
             "dotnet-sdk-3.0",
             "dotnet-sdk-3.1",
             "dotnet-sdk-5.0"
         ],
-        "release_urls": [
-            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json",
-            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.0/releases.json",
-            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json",
-            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/5.0/releases.json"
-
+        "versions": [
+            "2.1",
+            "3.0",
+            "3.1",
+            "5.0"
         ]
     }
 }

--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -188,5 +188,19 @@
             "node:12-alpine",
             "ubuntu:14.04"
         ]
+    },
+    "dotnetCoreSdk": {
+        "latest_dotnet_packages": [
+            "dotnet-sdk-3.0",
+            "dotnet-sdk-3.1",
+            "dotnet-sdk-5.0"
+        ],
+        "release_urls": [
+            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json",
+            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.0/releases.json",
+            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json",
+            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/5.0/releases.json"
+
+        ]
     }
 }

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -193,17 +193,17 @@
             "cmd": "sam"
         }
     ],
-    "dotnetCoreSdk": {
-        "latest_dotnet_packages": [
+    "dotnet": {
+        "aptPackages": [
             "dotnet-sdk-3.0",
             "dotnet-sdk-3.1",
             "dotnet-sdk-5.0"
         ],
-        "release_urls": [
-            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json",
-            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.0/releases.json",
-            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json",
-            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/5.0/releases.json"
+        "versions": [
+            "2.1",
+            "3.0",
+            "3.1",
+            "5.0"
         ]
     }
 }

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -196,14 +196,12 @@
     "dotnet": {
         "aptPackages": [
             "dotnet-sdk-3.0",
-            "dotnet-sdk-3.1",
-            "dotnet-sdk-5.0"
+            "dotnet-sdk-3.1"
         ],
         "versions": [
             "2.1",
             "3.0",
-            "3.1",
-            "5.0"
+            "3.1"
         ]
     }
 }

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -192,5 +192,18 @@
             "package": "aws-sam-cli",
             "cmd": "sam"
         }
-    ]
+    ],
+    "dotnetCoreSdk": {
+        "latest_dotnet_packages": [
+            "dotnet-sdk-3.0",
+            "dotnet-sdk-3.1",
+            "dotnet-sdk-5.0"
+        ],
+        "release_urls": [
+            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json",
+            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.0/releases.json",
+            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json",
+            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/5.0/releases.json"
+        ]
+    }
 }

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -166,5 +166,16 @@
             "package": "aws-sam-cli",
             "cmd": "sam"
         }
-    ]
+    ],
+    "dotnetCoreSdk": {
+        "latest_dotnet_packages": [
+            "dotnet-sdk-3.1",
+            "dotnet-sdk-5.0"
+        ],
+        "release_urls": [
+            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json",
+            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json",
+            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/5.0/releases.json"
+        ]
+    }
 }

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -169,13 +169,11 @@
     ],
     "dotnet": {
         "aptPackages": [
-            "dotnet-sdk-3.1",
-            "dotnet-sdk-5.0"
+            "dotnet-sdk-3.1"
         ],
         "versions": [
             "2.1",
-            "3.1",
-            "5.0"
+            "3.1"
         ]
     }
 }

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -167,15 +167,15 @@
             "cmd": "sam"
         }
     ],
-    "dotnetCoreSdk": {
-        "latest_dotnet_packages": [
+    "dotnet": {
+        "aptPackages": [
             "dotnet-sdk-3.1",
             "dotnet-sdk-5.0"
         ],
-        "release_urls": [
-            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json",
-            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json",
-            "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/5.0/releases.json"
+        "versions": [
+            "2.1",
+            "3.1",
+            "5.0"
         ]
     }
 }


### PR DESCRIPTION
# Description
In scope of this PR we are we moving the list of .Net Core versions to toolset to simplify maintenance.

#### Related issue: [#1399](https://github.com/actions/virtual-environments-internal/issues/1399)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
