### PR TITLE
[Ubuntu] Reset homebrew git repository to restore file permissions

### DIFF
--- a/images/linux/post-generation/homebrew-permissions.sh
+++ b/images/linux/post-generation/homebrew-permissions.sh
@@ -3,6 +3,10 @@
 # Fix permissions for Homebrew
 # https://github.com/actions/virtual-environments/issues/1568
 
+# Reset brew repository directory to make the brew clean after chmoding /home
+cd $(brew --prefix)/Homebrew
+git reset --hard
+
 brew_folder="/home/linuxbrew/"
 homebrew_user=$(cut -d: -f1 /etc/passwd | tail -1)
 

--- a/images/linux/post-generation/homebrew-permissions.sh
+++ b/images/linux/post-generation/homebrew-permissions.sh
@@ -4,7 +4,7 @@
 # https://github.com/actions/virtual-environments/issues/1568
 
 # Reset brew repository directory to make the brew clean after chmoding /home
-cd $(brew --prefix)/Homebrew
+cd $(brew --repo)
 git reset --hard
 
 brew_folder="/home/linuxbrew/"


### PR DESCRIPTION
# Description
Homebrew version reported as dirty due to the fact that /home directory permissions recursively changed to 777 during VM provision. This PR resets brew directory permission to the default ones.

#### Related issue:
https://github.com/actions/virtual-environments/issues/1568

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
