### PR TITLE
[MacOS] Exclude release candidates from XCODE_DEVELOPER_DIR variables

### DIFF
--- a/images/macos/provision/utils/xcode-utils.sh
+++ b/images/macos/provision/utils/xcode-utils.sh
@@ -55,7 +55,7 @@ runFirstLaunch() {
 }
 
 setXcodeDeveloperDirVariables() {
-    stable_xcode_versions=$(get_xcode_list_from_toolset | tr " " "\n" | grep -v "beta")
+    stable_xcode_versions=$(get_xcode_list_from_toolset | tr " " "\n" | grep -v "beta" | grep -v "Release_Candidate")
     major_versions=($(echo ${stable_xcode_versions[@]} | tr " " "\n" | cut -d '.' -f 1 | uniq))
     for MAJOR_VERSION in "${major_versions[@]}"
     do

--- a/images/macos/tests/Xcode.Tests.ps1
+++ b/images/macos/tests/Xcode.Tests.ps1
@@ -56,7 +56,7 @@ Describe "Xcode" {
     }
 
     Context "XCODE_DEVELOPER_DIR" {
-        $stableXcodeVersions = $XCODE_VERSIONS | ForEach-Object { $_.Split("_")[0] } | Where-Object { Test-XcodeStableRelease -Version $_ }
+        $stableXcodeVersions = $XCODE_VERSIONS | ForEach-Object { $_.Split("_")[0] } | Where-Object { (Test-XcodeStableRelease -Version $_) -and ($_ -notlike "*Release*Candidate*")}
         $majorXcodeVersions = $stableXcodeVersions | ForEach-Object { $_.Split(".")[0] } | Select-Object -Unique
         $testCases = $majorXcodeVersions | ForEach-Object {
             $majorXcodeVersion = $_

--- a/images/macos/tests/Xcode.Tests.ps1
+++ b/images/macos/tests/Xcode.Tests.ps1
@@ -56,7 +56,7 @@ Describe "Xcode" {
     }
 
     Context "XCODE_DEVELOPER_DIR" {
-        $stableXcodeVersions = $XCODE_VERSIONS | ForEach-Object { $_.Split("_")[0] } | Where-Object { (Test-XcodeStableRelease -Version $_) -and ($_ -notlike "*Release*Candidate*")}
+        $stableXcodeVersions = $XCODE_VERSIONS | Where-Object { $_ -notlike "*Release*Candidate*" } | ForEach-Object { $_.Split("_")[0] } | Where-Object { Test-XcodeStableRelease -Version $_ }
         $majorXcodeVersions = $stableXcodeVersions | ForEach-Object { $_.Split(".")[0] } | Select-Object -Unique
         $testCases = $majorXcodeVersions | ForEach-Object {
             $majorXcodeVersion = $_
@@ -84,7 +84,7 @@ Describe "Xcode" {
 }
 
 Describe "Xcode simulators" {
-    $XCODE_VERSIONS | Where-Object { Test-XcodeStableRelease -Version $_ } | ForEach-Object {
+    $XCODE_VERSIONS | Where-Object { $_ -notlike "*Release*Candidate*" } | ForEach-Object { $_.Split("_")[0] } | Where-Object { Test-XcodeStableRelease -Version $_ } | ForEach-Object {
         Switch-Xcode -Version $_
 
         Context "$_" {


### PR DESCRIPTION
# Description
RC versions of Xcode should be excluded from XCODE_DEVELOPER_DIR variables

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
