### PR TITLE
Workaround for apt db locked by WALinuxAgent v2

### DIFF
--- a/images/linux/scripts/base/apt-mock.sh
+++ b/images/linux/scripts/base/apt-mock.sh
@@ -11,17 +11,21 @@ for tool in apt apt-get apt-fast;do
 
 i=1
 while [ \$i -le 30 ];do
-  fuser /var/lib/dpkg/lock >/dev/null 2>&1
+  err=\$(mktemp)
+  $real_tool "\$@" 2>\$err
   result=\$?
   if [ \$result -eq  0 ];then
-    sleep 1
-    echo "/var/lib/dpkg/locked... retry \$i"
-    i=\$((i + 1))
-  else
     break
   fi
+  grep -q 'It is held by process' \$err
+  held=\$?
+  if [ \$held -ne  0 ];then
+    break
+  fi
+  sleep 1
+  echo "...retry \$i"
+  i=\$((i + 1))
 done
-$real_tool "\$@"
 EOT
   chmod +x $prefix/$tool
 done

--- a/images/linux/scripts/base/apt-mock.sh
+++ b/images/linux/scripts/base/apt-mock.sh
@@ -17,12 +17,13 @@ while [ \$i -le 30 ];do
   if [ \$result -eq  0 ];then
     break
   fi
-  grep -q 'It is held by process' \$err
+  grep -q 'Could not get lock' \$err
   held=\$?
   if [ \$held -ne  0 ];then
     break
   fi
-  sleep 1
+  cat \$err >&2
+  sleep 5
   echo "...retry \$i"
   i=\$((i + 1))
 done


### PR DESCRIPTION
# Description
Bug fixing

The PR replaces the retry logic based on fuser (see https://github.com/actions/virtual-environments/pull/1883) with 
the more robust check of apt stderr

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/1339

## Check list
- [x] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
