### PR TITLE
[Windows] PWSH - turns off the update notification feature

### DIFF
--- a/images/win/scripts/Installers/Install-PowershellCore.ps1
+++ b/images/win/scripts/Installers/Install-PowershellCore.ps1
@@ -5,4 +5,10 @@
 
 Invoke-Expression "& { $(Invoke-RestMethod https://aka.ms/install-powershell.ps1) } -UseMSI -Quiet"
 
+# about_update_notifications
+# While the update check happens during the first session in a given 24-hour period, for performance reasons,
+# the notification will only be shown on the start of subsequent sessions.
+# Also for performance reasons, the check will not start until at least 3 seconds after the session begins.
+[System.Environment]::SetEnvironmentVariable("POWERSHELL_UPDATECHECK", "Off", [System.EnvironmentVariableTarget]::Machine)
+
 Invoke-PesterTests -TestFile "Tools" -TestName "PowerShell Core"


### PR DESCRIPTION
# Description
While the update check happens during the first session in a given 24-hour period, for performance reasons, the notification will only be shown on the start of subsequent sessions. Also for performance reasons, the check will not start until at least 3 seconds after the session begins.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1435

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
