### PR TITLE
macOS: gcc workaround

### DIFF
--- a/images/macos/provision/core/gcc.sh
+++ b/images/macos/provision/core/gcc.sh
@@ -6,6 +6,8 @@ brew install gcc@8
 echo "Installing GCC@9 using homebrew..."
 brew install gcc@9
 
+# Known issue with brew that prevent installation of multiple formulas
+# https://github.com/Homebrew/brew/issues/9100
 echo "Applying workaround for the GCC"
 cellarPath=$(brew --cellar gcc@8)
 gccVersion=$(ls $cellarPath | head -n1)

--- a/images/macos/provision/core/gcc.sh
+++ b/images/macos/provision/core/gcc.sh
@@ -5,3 +5,13 @@ brew install gcc@8
 
 echo "Installing GCC@9 using homebrew..."
 brew install gcc@9
+
+echo "Applying workaround for the GCC"
+cellarPath=$(brew --cellar gcc@8)
+gccVersion=$(ls $cellarPath | head -n1)
+fullCellarPath=$cellarPath/$gccVersion
+ln -s $fullCellarPath/bin/c++-8 /usr/local/bin/c++-8
+ln -s $fullCellarPath/bin/cpp-8 /usr/local/bin/cpp-8
+ln -s $fullCellarPath/bin/g++-8 /usr/local/bin/g++-8
+ln -s $fullCellarPath/bin/gcc-8 /usr/local/bin/gcc-8
+ln -s $fullCellarPath/bin/gfortran-8 /usr/local/bin/gfortran-8


### PR DESCRIPTION
# Description
Bug fixing
Currently, due to changed brew link logic, gcc-8 is unlinking during gcc-9 installation. I have created [an issue](https://github.com/Homebrew/brew/issues/9100) to brew repository to clarify is it a bug or not.

#### Related issue:
1448
## Check list
- [+] Related issue / work item is attached
- [+] Tests are written (if applicable)
