### PR TITLE
Fix image link in initialize job step

### DIFF
--- a/images/macos/provision/configuration/preimagedata.sh
+++ b/images/macos/provision/configuration/preimagedata.sh
@@ -9,10 +9,10 @@ os_version=$(sw_vers -productVersion)
 os_build=$(sw_vers -buildVersion)
 label_version=$(echo $os_version | cut -d. -f1,2)
 image_label="macos-${label_version}"
-software_url="https://github.com/actions/virtual-environments/blob/${image_label}/${image_version}/images/macos/${image_label}-Readme.md"
+release_label="macOS-${label_version}"
+software_url="https://github.com/actions/virtual-environments/blob/${release_label}/${image_version}/images/macos/${image_label}-Readme.md"
 
-if is_Catalina || is_BigSur; then
-  cat <<EOF > $imagedata_file
+cat <<EOF > $imagedata_file
     [
       {
         "group": "Operating System",
@@ -24,7 +24,6 @@ if is_Catalina || is_BigSur; then
       }
     ]
 EOF
-fi
 
 echo "export ImageVersion=$image_version" >> $HOME/.bashrc
 echo "export ImageOS=$IMAGE_OS" >> $HOME/.bashrc


### PR DESCRIPTION
# Description
Recently, macos tag name was changed from `macos-10.15` to `macOS-10.15`. need to fix the content of image file accordingly. 
Also put the same file to MacOS 10.13, MacOS 10.14 because now we have all readme files in virtual-environments repository

#### Related issue: https://github.com/actions/virtual-environments/issues/1992

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
