### PR TITLE
Remove unattended upgrades

### DIFF
--- a/images/linux/scripts/base/apt.sh
+++ b/images/linux/scripts/base/apt.sh
@@ -17,7 +17,7 @@ echo "APT::Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries
 # Configure apt to always assume Y
 echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
 
-# Uninstall unattended-upgrade
+# Uninstall unattended-upgrades
 apt-get remove unattended-upgrades
 
 # Install aria2 and jq

--- a/images/linux/scripts/base/apt.sh
+++ b/images/linux/scripts/base/apt.sh
@@ -17,6 +17,9 @@ echo "APT::Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries
 # Configure apt to always assume Y
 echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
 
+# Uninstall unattended-upgrade
+apt-get remove unattended-upgrades
+
 # Install aria2 and jq
 apt-get install aria2
 apt-get install jq


### PR DESCRIPTION
# Description
Sometimes build process fails on apt-get/dpkg locks, unattended-upgrades can be one of the reasons of these failures.

#### Related issue: actions/virtual-environments#1120

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
