### PR TITLE
[Ubuntu20] Swap Ubuntu-20.04 powershell installation from snap to official package

### DIFF
--- a/images/linux/scripts/installers/azpowershell.sh
+++ b/images/linux/scripts/installers/azpowershell.sh
@@ -4,9 +4,6 @@
 ##  Desc:  Installed Azure PowerShell
 ################################################################################
 
-# Source the helpers for use with the script
-source $HELPER_SCRIPTS/os.sh
-
 # List of versions
 toolset="$INSTALLER_SCRIPT_FOLDER/toolset.json"
 versions=$(jq -r '.azureModules[] | select(.name | contains("az")) | .versions[]' $toolset)
@@ -18,10 +15,6 @@ pwsh -Command "Update-Module -Name PowerShellGet -Force"
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 for version in ${versions[@]}; do
     pwsh -Command "Save-Module -Name Az -LiteralPath /usr/share/az_$version -RequiredVersion $version -Force -Verbose"
-    if isUbuntu20; then
-        rm -rf "/usr/share/az_$version/Az.Accounts"
-        pwsh -Command "Save-Module -Name Az.Accounts -LiteralPath /usr/share/az_$version -RequiredVersion 1.9.5 -Force -Verbose"
-    fi
 done
 
 # Run tests to determine that the software installed as expected

--- a/images/linux/scripts/installers/powershellcore.sh
+++ b/images/linux/scripts/installers/powershellcore.sh
@@ -4,17 +4,8 @@
 ##  Desc:  Installs powershellcore
 ################################################################################
 
-# Source the helpers for use with the script
-source $HELPER_SCRIPTS/os.sh
-
 # Install Powershell
-if isUbuntu20 ; then
-    snap install powershell --classic --channel=edge/useedge
-fi
-
-if isUbuntu16 || isUbuntu18 ; then
-    apt-get install -y powershell
-fi
+apt-get install -y powershell
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"


### PR DESCRIPTION
# Description
On Ubuntu-20.04 PowerShell is installed from snap due to the lack of official support. It causes error in logs: mkrdir: cannot create directory /run/user/1001 : Permission denied that causes pipelines to fail if Fail on Standard Error checkbox is checked.
Powershell 7.1 has been recently released with native Ubuntu 20 support
https://github.com/PowerShell/powershell/releases

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1449
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
