### PR TITLE
[Image.CI] Pick up a random datastore by condition

### DIFF
--- a/images.CI/macos/select-datastore.ps1
+++ b/images.CI/macos/select-datastore.ps1
@@ -61,7 +61,7 @@ function Select-DataStore {
     $buildDatastore = $allDatastores | Where-Object { $_.FreeSpaceGB -ge $thresholdInGb } | Where-Object {
         $vmOnDatastore = @((Get-ChildItem -Path $_.DatastoreBrowserPath).Name -notmatch "^\.").Count
         $vmOnDatastore -lt $vmCount
-    } | Select-Object -ExpandProperty Name -First 1
+    } | Get-Random | Select-Object -ExpandProperty Name
 
     $tag = Get-Tag -Category $TagCategory -Name $VMName -ErrorAction Ignore
     if (-not $tag)


### PR DESCRIPTION
There is a chance, we can face with the logical bug on condition that `$buildDatastore` value is not changed, but we already have had two or more tags , in that case we will never pick up a datastore.
