### PR TITLE
[Image.CI] Move up the readme output stage

### DIFF
--- a/images.CI/linux-and-win/azure-pipelines/image-generation.yml
+++ b/images.CI/linux-and-win/azure-pipelines/image-generation.yml
@@ -42,6 +42,14 @@ jobs:
                         -GitHubFeedToken $(GITHUB_TOKEN)
 
   - task: PowerShell@2
+    displayName: 'Output Readme file content'
+    inputs:
+      targetType: 'inline'
+      script: |
+        $docsPath = Get-ChildItem -Path "images" -Include ${{ parameters.image_readme_name }} -Recurse -Depth 1 | Select-Object -First 1
+        Get-Content -Path $docsPath
+
+  - task: PowerShell@2
     displayName: 'Create release for VM deployment'
     inputs:
       targetType: filePath
@@ -52,14 +60,6 @@ jobs:
                         -Project $(RELEASE_TARGET_PROJECT) `
                         -ImageName ${{ parameters.image_type }} `
                         -AccessToken $(RELEASE_TARGET_TOKEN)
-
-  - task: PowerShell@2
-    displayName: 'Output Readme file content'
-    inputs:
-      targetType: 'inline'
-      script: |
-        $docsPath = Get-ChildItem -Path "images" -Include ${{ parameters.image_readme_name }} -Recurse -Depth 1 | Select-Object -First 1
-        Get-Content -Path $docsPath
 
   - task: PowerShell@2
     displayName: 'Clean up resources'


### PR DESCRIPTION
# Description
We should provide readme output before `Create release for VM deployment` step and not depend on the it if an error occurs - https://github.visualstudio.com/virtual-environments/_build/results?buildId=88861&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=5431112d-2b61-5a5f-7042-ef698f761043
