### PR TITLE
[Ubuntu][Windows] Remove announcements from generation process

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -21,13 +21,6 @@ Restore-UserOwner
 
 $markdown = ""
 
-if ($env:ANNOUNCEMENTS) {
-    $markdown += $env:ANNOUNCEMENTS
-    $markdown += New-MDNewLine
-    $markdown += "***"
-    $markdown += New-MDNewLine
-}
-
 $OSName = Get-OSName
 $markdown += New-MDHeader "$OSName" -Level 1
 

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -21,8 +21,7 @@
         "image_version": "dev",
         "image_os": "ubuntu16",
         "github_feed_token": null,
-        "run_validation_diskspace": "false",
-        "announcements": "{{env `ANNOUNCEMENTS`}}"
+        "run_validation_diskspace": "false"
     },
     "sensitive-variables": [
         "client_secret",
@@ -312,8 +311,7 @@
             ],
             "environment_vars": [
                 "IMAGE_VERSION={{user `image_version`}}",
-                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}",
-                "ANNOUNCEMENTS={{user `announcements`}}"
+                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
             ]
         },
         {

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -21,8 +21,7 @@
         "image_version": "dev",
         "image_os": "ubuntu18",
         "github_feed_token": null,
-        "run_validation_diskspace": "false",
-        "announcements": "{{env `ANNOUNCEMENTS`}}"
+        "run_validation_diskspace": "false"
     },
     "sensitive-variables": [
         "client_secret",
@@ -316,8 +315,7 @@
             ],
             "environment_vars": [
                 "IMAGE_VERSION={{user `image_version`}}",
-                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}",
-                "ANNOUNCEMENTS={{user `announcements`}}"
+                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
             ]
         },
         {

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -23,8 +23,7 @@
         "github_feed_token": null,
         "run_validation_diskspace": "false",
         "go_default": "1.14",
-        "go_versions": "1.14",
-        "announcements": "{{env `ANNOUNCEMENTS`}}"
+        "go_versions": "1.14"
     },
     "sensitive-variables": [
         "client_secret",
@@ -326,8 +325,7 @@
             ],
             "environment_vars": [
                 "IMAGE_VERSION={{user `image_version`}}",
-                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}",
-                "ANNOUNCEMENTS={{user `announcements`}}"
+                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}"
             ]
         },
         {

--- a/images/win/announcements.md
+++ b/images/win/announcements.md
@@ -1,3 +1,0 @@
-| Announcements |
-|:-:|
-| [Replace SVN (1.8.17) by TortoiseSVN (1.14.x) on Windows images](https://github.com/actions/virtual-environments/issues/1318) |

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -10,13 +10,6 @@ Import-Module (Join-Path $PSScriptRoot "SoftwareReport.VisualStudio.psm1") -Disa
 
 $markdown = ""
 
-if ($env:ANNOUNCEMENTS) {
-    $markdown += $env:ANNOUNCEMENTS
-    $markdown += New-MDNewLine
-    $markdown += "***"
-    $markdown += New-MDNewLine
-}
-
 $OSName = Get-OSName
 $markdown += New-MDHeader "$OSName" -Level 1
 

--- a/images/win/windows2016.json
+++ b/images/win/windows2016.json
@@ -26,8 +26,7 @@
         "capture_name_prefix": "packer",
         "image_version": "dev",
         "image_os": "win16",
-        "github_feed_token": "{{env `GITHUB_FEED_TOKEN`}}",
-        "announcements": "{{env `ANNOUNCEMENTS`}}"
+        "github_feed_token": "{{env `GITHUB_FEED_TOKEN`}}"
     },
     "sensitive-variables": [
         "install_password",
@@ -362,8 +361,7 @@
                 "pwsh -File '{{user `image_folder`}}\\SoftwareReport\\SoftwareReport.Generator.ps1'"
             ],
             "environment_vars": [
-                "TOOLSET_JSON_PATH={{user `toolset_json_path`}}",
-                "ANNOUNCEMENTS={{user `announcements`}}"
+                "TOOLSET_JSON_PATH={{user `toolset_json_path`}}"
             ]
         },
         {

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -26,8 +26,7 @@
         "capture_name_prefix": "packer",
         "image_version": "dev",
         "image_os": "win19",
-        "github_feed_token": "{{env `GITHUB_FEED_TOKEN`}}",
-        "announcements": "{{env `ANNOUNCEMENTS`}}"
+        "github_feed_token": "{{env `GITHUB_FEED_TOKEN`}}"
     },
     "sensitive-variables": [
         "install_password",
@@ -360,8 +359,7 @@
                 "pwsh -File '{{user `image_folder`}}\\SoftwareReport\\SoftwareReport.Generator.ps1'"
             ],
             "environment_vars": [
-                "TOOLSET_JSON_PATH={{user `toolset_json_path`}}",
-                "ANNOUNCEMENTS={{user `announcements`}}"
+                "TOOLSET_JSON_PATH={{user `toolset_json_path`}}"
             ]
         },
         {


### PR DESCRIPTION
# Description
Announcements table is removed from generation process to avoid appearing it in PR description. Announcements will be added to the readme files later, when the commit is creating.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:
internal issue [#1462](https://github.com/actions/virtual-environments-internal/issues/1462)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
