### PR TITLE
Cache Update

### DIFF
--- a/images/linux/scripts/base/apt.sh
+++ b/images/linux/scripts/base/apt.sh
@@ -20,13 +20,6 @@ echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
 # Uninstall unattended-upgrades
 apt-get remove unattended-upgrades
 
-#Update the cache
-apt-get update
-
-# Install aria2 and jq
-apt-get install aria2
-apt-get install jq
-
 # Use apt-fast for parallel downloads
 add-apt-repository -y ppa:apt-fast/stable
 
@@ -38,4 +31,5 @@ echo 'APT sources limited to the actual architectures'
 cat /etc/apt/sources.list
 
 apt-get update
-apt-get install apt-fast
+# Install aria2 , jq and apt-fast
+apt-get install aria2 jq apt-fast

--- a/images/linux/scripts/base/apt.sh
+++ b/images/linux/scripts/base/apt.sh
@@ -20,6 +20,9 @@ echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
 # Uninstall unattended-upgrades
 apt-get remove unattended-upgrades
 
+#Update the cache
+apt-get update
+
 # Install aria2 and jq
 apt-get install aria2
 apt-get install jq


### PR DESCRIPTION
Some base images of the ubuntu on AWS contains an outdated cache. So, when tries to installs the package we receive an error `unable to locate package`. To install the package, added the line `apt-get update`  to update the cache.

# Description
New tool, Bug fixing, or Improvement?  
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.  
**For new tools, please provide total size and installation time.**

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
