### PR TITLE
Improve dotnet SDKs installation

### DIFF
--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -57,15 +57,13 @@ sortedSdks=$(echo ${sdks[@]} | tr ' ' '\n' | grep -v preview | grep -v rc | grep
 extract_dotnet_sdk() {
     local ARCHIVE_NAME="$1"
     set -e
-    source="./tmp-$(basename -s .tar.gz $ARCHIVE_NAME)"; \
-    dest="/usr/share/dotnet"; \
-    echo "Extracting $ARCHIVE_NAME to $source"; \
-    mkdir "$source" && tar -C "$source" -xzf "$ARCHIVE_NAME"; \
-    mv -f $source/shared/Microsoft.AspNetCore.App/* $dest/shared/Microsoft.AspNetCore.App/; \
-    mv -f $source/shared/Microsoft.NETCore.App/* $dest/shared/Microsoft.NETCore.App/; \
-    mv -f $source/host/fxr/* $dest/host/fxr/; \
-    mv -f $source/sdk/* $dest/sdk/; \
-    rm -rf "$source" "$ARCHIVE_NAME"
+    dest="./tmp-$(basename -s .tar.gz $ARCHIVE_NAME)"; \
+    echo "Extracting $ARCHIVE_NAME to $dest"; \
+    mkdir "$dest" && tar -C "$dest" -xzf "$ARCHIVE_NAME"; \
+    rsync -qav --remove-source-files "$dest/shared/" /usr/share/dotnet/shared/; \
+    rsync -qav --remove-source-files "$dest/host/" /usr/share/dotnet/host/; \
+    rsync -qav --remove-source-files "$dest/sdk/" /usr/share/dotnet/sdk/; \
+    rm -rf "$dest" "$ARCHIVE_NAME"
 }
 
 # Download/install additional SDKs in parallel

--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -73,7 +73,6 @@ for tarball in *.tar.gz; do
     rm "$tarball") &
 done
 wait
-rm urls
 
 # Smoke test each SDK
 for sdk in $sortedSdks; do

--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -61,7 +61,7 @@ extract_dotnet_sdk() {
     echo "Extracting $ARCHIVE_NAME to $dest"; \
     mkdir "$dest" && tar -C "$dest" -xzf "$ARCHIVE_NAME"; \
     rsync -qav "$dest/shared/" /usr/share/dotnet/shared/; \
-    rsync -qav "$dest/host/frx" /usr/share/dotnet/host/frx; \
+    rsync -qav "$dest/host/" /usr/share/dotnet/host/; \
     rsync -qav "$dest/sdk/" /usr/share/dotnet/sdk/; \
     rm -rf "$dest" "$ARCHIVE_NAME"
 }

--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -57,12 +57,12 @@ sortedSdks=$(echo ${sdks[@]} | tr ' ' '\n' | grep -v preview | grep -v rc | grep
 extract_dotnet_sdk() {
     local ARCHIVE_NAME="$1"
     set -e
-    dest="./tmp-$(basename -s .tar.gz $ARCHIVE_NAME)"; \
-    echo "Extracting $ARCHIVE_NAME to $dest"; \
-    mkdir "$dest" && tar -C "$dest" -xzf "$ARCHIVE_NAME"; \
-    rsync -qav --remove-source-files "$dest/shared/" /usr/share/dotnet/shared/; \
-    rsync -qav --remove-source-files "$dest/host/" /usr/share/dotnet/host/; \
-    rsync -qav --remove-source-files "$dest/sdk/" /usr/share/dotnet/sdk/; \
+    dest="./tmp-$(basename -s .tar.gz $ARCHIVE_NAME)"
+    echo "Extracting $ARCHIVE_NAME to $dest"
+    mkdir "$dest" && tar -C "$dest" -xzf "$ARCHIVE_NAME"
+    rsync -qav --remove-source-files "$dest/shared/" /usr/share/dotnet/shared/
+    rsync -qav --remove-source-files "$dest/host/" /usr/share/dotnet/host/
+    rsync -qav --remove-source-files "$dest/sdk/" /usr/share/dotnet/sdk/
     rm -rf "$dest" "$ARCHIVE_NAME"
 }
 

--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -59,8 +59,8 @@ extract_dotnet_sdk() {
     set -e
     source="./tmp-$(basename -s .tar.gz $ARCHIVE_NAME)"; \
     dest="/usr/share/dotnet"; \
-    echo "Extracting $ARCHIVE_NAME to $dest"; \
-    mkdir "$dest" && tar -C "$dest" -xzf "$ARCHIVE_NAME"; \
+    echo "Extracting $ARCHIVE_NAME to $source"; \
+    mkdir "$source" && tar -C "$source" -xzf "$ARCHIVE_NAME"; \
     mv -f $source/shared/Microsoft.AspNetCore.App/* $dest/shared/Microsoft.AspNetCore.App/; \
     mv -f $source/shared/Microsoft.NETCore.App/* $dest/shared/Microsoft.NETCore.App/; \
     mv -f $source/host/fxr/* $dest/host/fxr/; \

--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -57,13 +57,15 @@ sortedSdks=$(echo ${sdks[@]} | tr ' ' '\n' | grep -v preview | grep -v rc | grep
 extract_dotnet_sdk() {
     local ARCHIVE_NAME="$1"
     set -e
-    dest="./tmp-$(basename -s .tar.gz $ARCHIVE_NAME)"; \
+    source="./tmp-$(basename -s .tar.gz $ARCHIVE_NAME)"; \
+    dest="/usr/share/dotnet"; \
     echo "Extracting $ARCHIVE_NAME to $dest"; \
     mkdir "$dest" && tar -C "$dest" -xzf "$ARCHIVE_NAME"; \
-    rsync -qav "$dest/shared/" /usr/share/dotnet/shared/; \
-    rsync -qav "$dest/host/" /usr/share/dotnet/host/; \
-    rsync -qav "$dest/sdk/" /usr/share/dotnet/sdk/; \
-    rm -rf "$dest" "$ARCHIVE_NAME"
+    mv -f $source/shared/Microsoft.AspNetCore.App/* $dest/shared/Microsoft.AspNetCore.App/; \
+    mv -f $source/shared/Microsoft.NETCore.App/* $dest/shared/Microsoft.NETCore.App/; \
+    mv -f $source/host/fxr/* $dest/host/fxr/; \
+    mv -f $source/sdk/* $dest/sdk/; \
+    rm -rf "$source" "$ARCHIVE_NAME"
 }
 
 # Download/install additional SDKs in parallel


### PR DESCRIPTION
# Description
Dotnet SDKs installation process include "curl" that needs to be replaced by "download_with_retry" function to make installation process less flaky due to network errors/timeouts.

#### Related issue: actions/virtual-environments#2038

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
