### PR TITLE
fix sporadic build fails

### DIFF
--- a/images/linux/scripts/base/apt-mock-remove.sh
+++ b/images/linux/scripts/base/apt-mock-remove.sh
@@ -2,6 +2,6 @@
 
 prefix=/usr/local/bin
 
-for tool in apt apt-get apt-fast;do
+for tool in apt apt-get apt-fast apt-key;do
   sudo rm -f $prefix/$tool
 done

--- a/images/linux/scripts/base/apt-mock.sh
+++ b/images/linux/scripts/base/apt-mock.sh
@@ -20,7 +20,11 @@ while [ \$i -le 30 ];do
   grep -q 'Could not get lock' \$err
   held=\$?
   if [ \$held -ne  0 ];then
-    break
+    grep -q 'Could not open file /var/lib/apt/lists' \$err
+    held=\$?
+    if [ \$held -ne  0 ];then
+      break
+    fi
   fi
   cat \$err >&2
   sleep 5
@@ -30,3 +34,4 @@ done
 EOT
   chmod +x $prefix/$tool
 done
+

--- a/images/linux/scripts/base/apt-mock.sh
+++ b/images/linux/scripts/base/apt-mock.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -e
 
-set -x
 # A temporary workaround for https://github.com/Azure/azure-linux-extensions/issues/1238
 
 prefix=/usr/local/bin
@@ -17,38 +16,34 @@ while [ \$i -le 30 ];do
   $real_tool "\$@" 2>\$err
   result=\$?
   cat \$err >&2
-  if [ \$result -eq  0 ];then
-    # no errors, continue
-    rm \$err
+
+  # no errors, continue
+  test \$result -eq  0 && break
+
+  retry=false
+
+  if grep -q 'Could not get lock' \$err;then
+    # apt db locked needs retry
+    retry=true
+  elif grep -q 'Could not open file /var/lib/apt/lists' \$err;then
+    # apt update is not completed, needs retry
+    retry=true
+  elif grep -q 'IPC connect call failed' \$err;then
+    ## TODO:
+    ## the delay should help with gpg-agent not ready
+    ## if it is not then uncomment the folloing lines in order to
+    ## force restart gpg-agent
+    #  pkill -9 gpg-agent
+    #  sleep 1
+    #  source <(gpg-agent --daemon)
+    retry=true
+  fi
+
+  rm \$err
+  if [ \$retry = false ]; then
     break
   fi
-  # some error exists, check for apt db locked
-  grep -q 'Could not get lock' \$err
-  result=\$?
-  if [ \$result -ne  0 ];then
-    # some error exists, check for apt update is not complete
-    grep -q 'Could not open file /var/lib/apt/lists' \$err
-    result=\$?
-    if [ \$result -ne  0 ];then
-      # some error exists, check for gpg-agent is busy or not run yet
-      grep -q 'IPC connect call failed' \$err
-      result=\$?
-      if [ \$result -ne  0 ];then
-        # some unhandled error, continue
-        rm \$err
-        break
-      # # TODO:
-      # # the delay should help with gpg-agent not ready
-      # # if it is not uncomment the folloing lines in order to
-      # # force restart gpg-agent
-      # else
-      #  pkill -9 gpg-agent
-      #  sleep 1
-      #  source <(gpg-agent --daemon)
-      fi
-    fi
-  fi
-  rm \$err
+
   sleep 5
   echo "...retry \$i"
   i=\$((i + 1))
@@ -56,4 +51,3 @@ done
 EOT
   chmod +x $prefix/$tool
 done
-

--- a/images/linux/scripts/base/apt-mock.sh
+++ b/images/linux/scripts/base/apt-mock.sh
@@ -4,8 +4,8 @@
 
 prefix=/usr/local/bin
 
-for tool in apt apt-get apt-fast apt-key;do
-  real_tool=`which $tool`
+for real_tool in /usr/bin/apt /usr/bin/apt-get /usr/bin/apt-fast /usr/bin/apt-key;do
+  tool=`basename $real_tool`
   cat >$prefix/$tool <<EOT
 #!/bin/sh
 

--- a/images/linux/scripts/base/apt-mock.sh
+++ b/images/linux/scripts/base/apt-mock.sh
@@ -5,7 +5,8 @@ set -x
 
 prefix=/usr/local/bin
 
-for tool in apt apt-get apt-fast;do
+for tool in apt apt-get apt-fast apt-key;do
+  which $tool || continue
   real_tool=`which $tool`
   cat >$prefix/$tool <<EOT
 #!/bin/sh

--- a/images/linux/scripts/base/apt-mock.sh
+++ b/images/linux/scripts/base/apt-mock.sh
@@ -5,7 +5,6 @@
 prefix=/usr/local/bin
 
 for tool in apt apt-get apt-fast apt-key;do
-  which $tool || continue
   real_tool=`which $tool`
   cat >$prefix/$tool <<EOT
 #!/bin/sh
@@ -18,7 +17,7 @@ while [ \$i -le 30 ];do
   cat \$err >&2
 
   # no errors, continue
-  test \$result -eq  0 && break
+  test \$result -eq 0 && break
 
   retry=false
 
@@ -29,13 +28,7 @@ while [ \$i -le 30 ];do
     # apt update is not completed, needs retry
     retry=true
   elif grep -q 'IPC connect call failed' \$err;then
-    ## TODO:
-    ## the delay should help with gpg-agent not ready
-    ## if it is not then uncomment the folloing lines in order to
-    ## force restart gpg-agent
-    #  pkill -9 gpg-agent
-    #  sleep 1
-    #  source <(gpg-agent --daemon)
+    # the delay should help with gpg-agent not ready
     retry=true
   fi
 

--- a/images/linux/scripts/base/apt-mock.sh
+++ b/images/linux/scripts/base/apt-mock.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 
+set -x
 # A temporary workaround for https://github.com/Azure/azure-linux-extensions/issues/1238
 
 prefix=/usr/local/bin
@@ -14,7 +15,9 @@ while [ \$i -le 30 ];do
   err=\$(mktemp)
   $real_tool "\$@" 2>\$err
   result=\$?
+  cat \$err >&2
   if [ \$result -eq  0 ];then
+    rm \$err
     break
   fi
   grep -q 'Could not get lock' \$err
@@ -23,10 +26,11 @@ while [ \$i -le 30 ];do
     grep -q 'Could not open file /var/lib/apt/lists' \$err
     held=\$?
     if [ \$held -ne  0 ];then
+      rm \$err
       break
     fi
   fi
-  cat \$err >&2
+  rm \$err
   sleep 5
   echo "...retry \$i"
   i=\$((i + 1))

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -63,6 +63,11 @@
         },
         {
             "type": "shell",
+            "script": "{{template_dir}}/scripts/base/apt-mock.sh",
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
             "scripts": [
                 "{{template_dir}}/scripts/base/repos.sh"
             ],
@@ -74,11 +79,6 @@
             "environment_vars": [
                 "DEBIAN_FRONTEND=noninteractive"
             ],
-            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
-            "type": "shell",
-            "script": "{{template_dir}}/scripts/base/apt-mock.sh",
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -63,6 +63,11 @@
         },
         {
             "type": "shell",
+            "script": "{{template_dir}}/scripts/base/apt-mock.sh",
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
             "scripts": [
                 "{{template_dir}}/scripts/base/repos.sh"
             ],
@@ -77,11 +82,6 @@
             "environment_vars": [
                 "DEBIAN_FRONTEND=noninteractive"
             ],
-            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
-            "type": "shell",
-            "script": "{{template_dir}}/scripts/base/apt-mock.sh",
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -65,6 +65,11 @@
         },
         {
             "type": "shell",
+            "script": "{{template_dir}}/scripts/base/apt-mock.sh",
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
             "scripts": [
                 "{{template_dir}}/scripts/base/repos.sh"
             ],
@@ -87,11 +92,6 @@
             "environment_vars": [
                 "DEBIAN_FRONTEND=noninteractive"
             ],
-            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
-            "type": "shell",
-            "script": "{{template_dir}}/scripts/base/apt-mock.sh",
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {


### PR DESCRIPTION
# Description
Improvement

The `apt-get update` sporadically fails with the error output like 
```
==> azure-arm: E: Could not open file /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_focal-backports_universe_i18n_Translation-en - open (2: No such file or directory)
==> azure-arm: E: Could not open file /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_focal-backports_universe_binary-amd64_Packages - open (2: No such file or directory)
==> azure-arm: E: Could not open file /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_focal-
``` 

As a workaround the apt is mocked with the script to check the output for the specific error and rerun the command after a delay

The `apt get` sporadically fails with the error output like 
```
gpg: can't connect to the agent: IPC connect call failed
```

Currently it is solved with the retry. 

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/1472

## Check list
- [x] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
