### PR TITLE
Move BizTalk Server lower in documentation

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -139,14 +139,6 @@ $markdown += New-MDList -Style Unordered -Lines @(
 $markdown += New-MDHeader "MSYS2" -Level 3
 $markdown += Get-PacmanVersion
 $markdown += New-MDNewLine
-
-if(Test-IsWin19)
-{
-    $markdown += New-MDHeader "BizTalk Server" -Level 3
-    $markdown += Get-BizTalkVersion
-    $markdown += New-MDNewLine
-}
-
 $markdown += New-MDHeader "Notes:" -Level 5
 $markdown += @'
 ```
@@ -156,6 +148,13 @@ Note: MSYS2 is pre-installed on image but not added to PATH.
 ```
 '@
 $markdown += New-MDNewLine
+
+if(Test-IsWin19)
+{
+    $markdown += New-MDHeader "BizTalk Server" -Level 3
+    $markdown += Get-BizTalkVersion
+    $markdown += New-MDNewLine
+}
 
 $markdown += New-MDHeader "Cached Tools" -Level 3
 $markdown += (Build-CachedToolsMarkdown)

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -149,7 +149,7 @@ Note: MSYS2 is pre-installed on image but not added to PATH.
 '@
 $markdown += New-MDNewLine
 
-if(Test-IsWin19)
+if (Test-IsWin19)
 {
     $markdown += New-MDHeader "BizTalk Server" -Level 3
     $markdown += Get-BizTalkVersion


### PR DESCRIPTION
# Description
Currently, "BizTalk Server" split MSYS section to two parts. Need to move it lower in documentation

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
