### PR TITLE
[Ubuntu] Update CMake to 3.19.1

### DIFF
--- a/images/linux/scripts/installers/cmake.sh
+++ b/images/linux/scripts/installers/cmake.sh
@@ -9,7 +9,7 @@ echo "Checking to see if the installer script has already been run"
 if command -v cmake; then
     echo "cmake is already installed"
 else
-	curl -sL https://cmake.org/files/v3.17/cmake-3.17.0-Linux-x86_64.sh -o cmakeinstall.sh \
+	curl -sL https://cmake.org/files/v3.19/cmake-3.19.1-Linux-x86_64.sh -o cmakeinstall.sh \
 	&& chmod +x cmakeinstall.sh \
 	&& ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir \
 	&& rm cmakeinstall.sh


### PR DESCRIPTION
Update CMake from 3.17.0 to 3.19.1 on the Linux/Ubuntu images. Release notes: CMake [3.18](https://cmake.org/cmake/help/latest/release/3.18.html), [3,19](https://cmake.org/cmake/help/latest/release/3.19.html).

Windows and macOS images are updated automatically.
