### PR TITLE
Implement script to parse provisioners duration from packer diagnostic logs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
     // When enabled, will trim trailing whitespace when you save a file.
-    "files.trimTrailingWhitespace": true,
-    "[markdown]": {
-        "files.trimTrailingWhitespace": false
-    },
+    "files.trimTrailingWhitespace": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
-    // When enabled, will trim trailing whitespace when you save a file.
     "files.trimTrailingWhitespace": false
 }

--- a/images.CI/linux-and-win/azure-pipelines/image-generation.yml
+++ b/images.CI/linux-and-win/azure-pipelines/image-generation.yml
@@ -31,7 +31,6 @@ jobs:
         $ImageType = "${{ parameters.image_type }}"
         $TemplateDirectoryName = if ($ImageType.StartsWith("ubuntu")) { "linux" } else { "win" }
         $TemplateDirectoryPath = Join-Path "images" $TemplateDirectoryName | Resolve-Path
-        Write-Host $TemplateDirectoryPath
         $TemplatePath = Join-Path $TemplateDirectoryPath "$ImageType.json"
         Write-Host "##vso[task.setvariable variable=TemplateDirectoryPath;]$TemplateDirectoryPath"
         Write-Host "##vso[task.setvariable variable=TemplatePath;]$TemplatePath"
@@ -41,7 +40,6 @@ jobs:
     inputs:
       targetType: filePath
       filePath: ./images.CI/linux-and-win/build-image.ps1
-      pwsh: true
       arguments: -ResourcesNamePrefix $(Build.BuildId) `
                         -ClientId $(CLIENT_ID) `
                         -ClientSecret $(CLIENT_SECRET) `

--- a/images.CI/linux-and-win/azure-pipelines/image-generation.yml
+++ b/images.CI/linux-and-win/azure-pipelines/image-generation.yml
@@ -62,8 +62,7 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        $docsPath = Get-ChildItem -Path "images" -Include ${{ parameters.image_readme_name }} -Recurse -Depth 1 | Select-Object -First 1
-        Get-Content -Path $docsPath
+        Get-Content -Path (Join-Path "$(TemplateDirectoryPath)" "${{ parameters.image_readme_name }}")
 
   - task: PowerShell@2
     displayName: 'Print provisioners duration'

--- a/images.CI/linux-and-win/azure-pipelines/image-generation.yml
+++ b/images.CI/linux-and-win/azure-pipelines/image-generation.yml
@@ -6,9 +6,10 @@
 
 jobs:
 - job:
-  pool: ci-agent-pool
+  displayName: Image Generation (${{ parameters.image_type }})
   timeoutInMinutes: 600
   cancelTimeoutInMinutes: 30
+  pool: ci-agent-pool
   variables:
   - group: Image Generation Variables
 
@@ -21,16 +22,30 @@ jobs:
       filePath: ./images.CI/download-repo.ps1
       arguments: -RepoUrl $(CUSTOM_REPOSITORY_URL) `
                  -RepoBranch $(CUSTOM_REPOSITORY_BRANCH)
+    
+  - task: PowerShell@2
+    displayName: 'Set image template variables'
+    inputs:
+      targetType: 'inline'
+      script: |
+        $ImageType = "${{ parameters.image_type }}"
+        $TemplateDirectoryName = if ($ImageType.StartsWith("ubuntu")) { "linux" } else { "win" }
+        $TemplateDirectoryPath = Join-Path "images" $TemplateDirectoryName | Resolve-Path
+        Write-Host $TemplateDirectoryPath
+        $TemplatePath = Join-Path $TemplateDirectoryPath "$ImageType.json"
+        Write-Host "##vso[task.setvariable variable=TemplateDirectoryPath;]$TemplateDirectoryPath"
+        Write-Host "##vso[task.setvariable variable=TemplatePath;]$TemplatePath"
 
   - task: PowerShell@2
     displayName: 'Build VM'
     inputs:
       targetType: filePath
       filePath: ./images.CI/linux-and-win/build-image.ps1
+      pwsh: true
       arguments: -ResourcesNamePrefix $(Build.BuildId) `
                         -ClientId $(CLIENT_ID) `
                         -ClientSecret $(CLIENT_SECRET) `
-                        -Image ${{ parameters.image_type }} `
+                        -TemplatePath $(TemplatePath) `
                         -ResourceGroup $(AZURE_RESOURCE_GROUP) `
                         -StorageAccount $(AZURE_STORAGE_ACCOUNT) `
                         -SubscriptionId $(AZURE_SUBSCRIPTION) `
@@ -40,6 +55,9 @@ jobs:
                         -VirtualNetworkRG $(BUILD_AGENT_VNET_RESOURCE_GROUP) `
                         -VirtualNetworkSubnet $(BUILD_AGENT_SUBNET_NAME) `
                         -GitHubFeedToken $(GITHUB_TOKEN)
+    env:
+      PACKER_LOG: 1
+      PACKER_LOG_PATH: $(Build.ArtifactStagingDirectory)/packer-log.txt
 
   - task: PowerShell@2
     displayName: 'Output Readme file content'
@@ -48,6 +66,15 @@ jobs:
       script: |
         $docsPath = Get-ChildItem -Path "images" -Include ${{ parameters.image_readme_name }} -Recurse -Depth 1 | Select-Object -First 1
         Get-Content -Path $docsPath
+
+  - task: PowerShell@2
+    displayName: 'Print provisioners duration'
+    inputs:
+      targetType: 'filePath'
+      filePath: ./images.CI/measure-provisioners-duration.ps1
+      arguments: -PackerLogPath "$(Build.ArtifactStagingDirectory)/packer-log.txt" `
+                        -PrefixToPathTrim "$(TemplateDirectoryPath)" `
+                        -PrintTopNLongest 25
 
   - task: PowerShell@2
     displayName: 'Create release for VM deployment'

--- a/images.CI/linux-and-win/build-image.ps1
+++ b/images.CI/linux-and-win/build-image.ps1
@@ -1,5 +1,5 @@
 param(
-    [String] [Parameter (Mandatory=$true)] $Image,
+    [String] [Parameter (Mandatory=$true)] $TemplatePath,
     [String] [Parameter (Mandatory=$true)] $ClientId,
     [String] [Parameter (Mandatory=$true)] $ClientSecret,
     [String] [Parameter (Mandatory=$true)] $GitHubFeedToken,
@@ -14,8 +14,7 @@ param(
     [String] [Parameter (Mandatory=$true)] $VirtualNetworkSubnet
 )
 
-$TemplatePath = (Get-ChildItem -Path "images" -Include "$Image.json" -Recurse -Depth 2).FullName
-if (-not $TemplatePath)
+if (-not (Test-Path $TemplatePath))
 {
     Write-Error "'-Image' parameter is not valid. You have to specify correct image type."
     exit 1

--- a/images.CI/macos/azure-pipelines/image-generation.yml
+++ b/images.CI/macos/azure-pipelines/image-generation.yml
@@ -87,9 +87,10 @@ jobs:
             $sensitiveString -eq $null
         }
     displayName: 'Build VM'
-    env:
-      PACKER_LOG: 0
     workingDirectory: 'images/macos'
+    env:
+      PACKER_LOG: 1
+      PACKER_LOG_PATH: $(Agent.TempDirectory)/packer-log.txt
 
   - bash: |
       echo "Copy image output files"
@@ -111,6 +112,14 @@ jobs:
     inputs:
       ArtifactName: 'Built_VM_Artifacts'
     displayName: Publish Artifacts
+
+  - task: PowerShell@2
+    displayName: 'Print provisioners duration'
+    inputs:
+      targetType: 'filePath'
+      filePath: ./images.CI/measure-provisioners-duration.ps1
+      arguments: -PackerLogPath "$(Agent.TempDirectory)/packer-log.txt" `
+                        -PrintTopNLongest 25
 
   - task: PublishTestResults@2
     inputs:

--- a/images.CI/measure-provisioners-duration.ps1
+++ b/images.CI/measure-provisioners-duration.ps1
@@ -1,6 +1,7 @@
 param(
-    [string]$PackerLogPath = "$env:HOME/Downloads/temp2/packer-mac.txt",
-    [string]$PrefixToPathTrim = "",
+    [Parameter(Mandatory=$true)]
+    [string]$PackerLogPath,
+    [string]$PrefixToPathTrim,
     [int]$PrintTopNLongest = 25
 )
 
@@ -111,7 +112,7 @@ $provisionersList | ForEach-Object {
 }
 Write-Host "Total provisioners time: $totalProvisionersTime"
 
-if ($PrintTopNLongest -and ($PrintTopNLongest -gt 0)) {
+if ($PrintTopNLongest -gt 0) {
     Write-Host "`n`nTop longest provisioners:"
     $provisionersList | ForEach-Object {
         if ($_.SubItems.Length -gt 0) { $_.SubItems } else { @{ Command = $_.ProvisionerType; Duration = $_.Duration } }

--- a/images.CI/measure-provisioners-duration.ps1
+++ b/images.CI/measure-provisioners-duration.ps1
@@ -12,7 +12,7 @@ $EndProvisionerRegex = "^${DateTimeRegex} ${TelemetryLineRegex} ending (.+)$"
 $ShellScriptSubItemRegex = "${DateTimeRegex} ui: ==> .+: Provisioning with \w+ script: (.+)"
 $DownloadUploadSubItemRegex = "${DateTimeRegex} ui: ==> .+: (Downloading .+|Uploading .+)"
 
-function New-ProvisionerItem {
+function Start-ProvisionerItem {
     param([string]$ProvisionerType, [string]$StartTime)
 
     return @{
@@ -22,7 +22,7 @@ function New-ProvisionerItem {
     }
 }
 
-function Complete-ProvisionerItem {
+function End-ProvisionerItem {
     param([object]$Provisioner, [string]$EndTime)
 
     $Provisioner.EndTime = [DateTime]::Parse($EndTime)
@@ -86,11 +86,11 @@ Get-Content $PackerLogPath | ForEach-Object {
     if ($_ -match $StartProvisionerRegex) {
         Assert-StartProvisioner -Provisioner $currentProvisioner -ProvisionerType $Matches[2]
 
-        $currentProvisioner = New-ProvisionerItem -ProvisionerType $Matches[2] -StartTime $Matches[1]
+        $currentProvisioner = Start-ProvisionerItem -ProvisionerType $Matches[2] -StartTime $Matches[1]
     } elseif (($_ -match $EndProvisionerRegex) -and $currentProvisioner) {
         Assert-EndProvisioner -Provisioner $currentProvisioner -ProvisionerType $Matches[2]
 
-        Complete-ProvisionerItem -Provisioner $currentProvisioner -EndTime $Matches[1]
+        End-ProvisionerItem -Provisioner $currentProvisioner -EndTime $Matches[1]
         Add-ProvisionerSubItem -Provisioner $currentProvisioner -Command $null -DateTime $Matches[1]
         $provisionersList += $currentProvisioner
         $currentProvisioner = $null

--- a/images.CI/measure-provisioners-duration.ps1
+++ b/images.CI/measure-provisioners-duration.ps1
@@ -1,0 +1,121 @@
+param(
+    [string]$PackerLogPath = "$env:HOME/Downloads/temp2/packer-mac.txt",
+    [string]$PrefixToPathTrim = "",
+    [int]$PrintTopNLongest = 25
+)
+
+$DateTimeRegex = "(\d+\/\d+\/\d+ \d+:\d+:\d+)"
+$TelemetryLineRegex = "\[INFO\] \(telemetry\)"
+$StartProvisionerRegex = "^${DateTimeRegex} ${TelemetryLineRegex} Starting provisioner (.+)$"
+$EndProvisionerRegex = "^${DateTimeRegex} ${TelemetryLineRegex} ending (.+)$"
+$ShellScriptSubItemRegex = "${DateTimeRegex} ui: ==> .+: Provisioning with \w+ script: (.+)"
+$DownloadUploadSubItemRegex = "${DateTimeRegex} ui: ==> .+: (Downloading .+|Uploading .+)"
+
+function New-ProvisionerItem {
+    param([string]$ProvisionerType, [string]$StartTime)
+
+    return @{
+        ProvisionerType = $ProvisionerType
+        StartTime = [DateTime]::Parse($StartTime)
+        SubItems = @()
+    }
+}
+
+function Complete-ProvisionerItem {
+    param([object]$Provisioner, [string]$EndTime)
+
+    $Provisioner.EndTime = [DateTime]::Parse($EndTime)
+    $Provisioner.Duration = New-TimeSpan -Start $Provisioner.StartTime -End $Provisioner.EndTime
+}
+
+function Add-ProvisionerSubItem {
+    param([object]$Provisioner, [string]$Command, [string]$DateTime)
+
+    $lastItem = $Provisioner.SubItems | Select-Object -Last 1
+    if ($lastItem) {
+        $lastItem.EndTime = [DateTime]::Parse($DateTime)
+        $lastItem.Duration = New-TimeSpan -Start $lastItem.StartTime -End $lastItem.EndTime
+    }
+
+    if ($Command) {
+        if ($PrefixToPathTrim) { $Command = $Command.Replace($PrefixToPathTrim, ".") }
+        $Provisioner.SubItems += @{
+            Command = $Command
+            StartTime = [DateTime]::Parse($DateTime)
+        }
+    }
+}
+
+function Invoke-TryFindProvisionerSubItem {
+    param([object]$Provisioner, [string] $Line)
+
+    if ($Provisioner.ProvisionerType -in "powershell", "shell", "windows-shell") {
+        if ($Line -match $ShellScriptSubItemRegex) {
+            Add-ProvisionerSubItem -Provisioner $Provisioner -Command $Matches[2] -DateTime $Matches[1]
+        }
+    } elseif ($Provisioner.ProvisionerType -eq "file") {
+        if ($Line -match $DownloadUploadSubItemRegex) {
+            Add-ProvisionerSubItem -Provisioner $Provisioner -Command $Matches[2] -DateTime $Matches[1]
+        }
+    }
+}
+
+function Assert-StartProvisioner {
+    param([object]$Provisioner, [string]$ProvisionerType)
+    if ($null -ne $Provisioner) {
+        throw "New provisioner '$ProvisionerType' has been started but previous '$($Provisioner.ProvisionerType)' was not finished yet"
+    }
+}
+
+function Assert-EndProvisioner {
+    param([object]$Provisioner, [string]$ProvisionerType)
+    if (($null -ne $Provisioner) -and ($Provisioner.ProvisionerType -ne $ProvisionerType)) {
+        throw "Expected end of '$($Provisioner.ProvisionerType)' provisioner but found end of '$ProvisionerType'"
+    }
+}
+
+$provisionersList = @()
+$currentProvisioner = $null
+
+if ((Get-Content $PackerLogPath -Raw) -notmatch $TelemetryLineRegex) {
+    throw "Packer log doesn't contain diagnostic information. Env PACKER_LOG must be set to 1"
+}
+ 
+Get-Content $PackerLogPath | ForEach-Object {
+    if ($_ -match $StartProvisionerRegex) {
+        Assert-StartProvisioner -Provisioner $currentProvisioner -ProvisionerType $Matches[2]
+
+        $currentProvisioner = New-ProvisionerItem -ProvisionerType $Matches[2] -StartTime $Matches[1]
+    } elseif (($_ -match $EndProvisionerRegex) -and $currentProvisioner) {
+        Assert-EndProvisioner -Provisioner $currentProvisioner -ProvisionerType $Matches[2]
+
+        Complete-ProvisionerItem -Provisioner $currentProvisioner -EndTime $Matches[1]
+        Add-ProvisionerSubItem -Provisioner $currentProvisioner -Command $null -DateTime $Matches[1]
+        $provisionersList += $currentProvisioner
+        $currentProvisioner = $null
+    } elseif ($currentProvisioner) {
+        Invoke-TryFindProvisionerSubItem -Provisioner $currentProvisioner -Line $_
+    }
+}
+$totalProvisionersTime = New-TimeSpan
+$provisionersList | ForEach-Object { $totalProvisionersTime = $totalProvisionersTime.Add($_.Duration) }
+
+# Print information about provisioners in order of execution
+Write-Host "Build timeline:"
+$provisionersList | ForEach-Object {
+    Write-Host "- $($_.Duration) | $($_.ProvisionerType)"
+    $_.SubItems | ForEach-Object {
+        Write-Host "      $($_.Duration) | $($_.Command)"
+    }
+    Write-Host ""
+}
+Write-Host "Total provisioners time: $totalProvisionersTime"
+
+if ($PrintTopNLongest -and ($PrintTopNLongest -gt 0)) {
+    Write-Host "`n`nTop longest provisioners:"
+    $provisionersList | ForEach-Object {
+        if ($_.SubItems.Length -gt 0) { $_.SubItems } else { @{ Command = $_.ProvisionerType; Duration = $_.Duration } }
+    } | Sort-Object { $_.Duration } | Select-Object -Last $PrintTopNLongest | ForEach-Object {
+        Write-Host "- $($_.Duration) | $($_.Command)"
+    }
+}


### PR DESCRIPTION
# Description
This PR adds script `measure-provisioners-duration.ps1` to repo. This script parses packer diagnostic logs and determine the duration of every step. As a result, it prints the following output:
- The whole build timeline 
![image](https://user-images.githubusercontent.com/16715858/100331188-e40a6b80-2fe0-11eb-8f1f-e8b97b0ef8c8.png)
- The Top 25 longest provisioners
![image](https://user-images.githubusercontent.com/16715858/100331244-f5ec0e80-2fe0-11eb-83e4-a38c8c808a0e.png)

All changes:
- Move logic to find template to the separate step on Windows / Linux to reuse it later and avoid code duplication
- Set `PACKER_LOG: 1`. image generation logs will still contain only short log. But diagnostic logs will be saved to separate file.

Build examples:
- https://dev.azure.com/github/virtual-environments/_build/results?buildId=90048&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=8b69240d-5eca-52e7-db53-21813d4d30a5
- https://dev.azure.com/github/virtual-environments/_build/results?buildId=90047&view=logs&j=80d86624-2c9a-5cad-9434-144b838e69fb&t=027aaa20-7755-5366-f0d4-a9dbdf9aa415

## Purpose of these changes:
- Find bottlenecks in image generation (what script take the most of the time)
- Analyze new PRs, when someone adds new software. We can take a look at logs of this step and check quickly how much time new script takes.


#### Related issue: https://github.com/actions/virtual-environments-internal/issues/1498

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
