### PR TITLE
Add Android Emulator to software report for all images

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -49,6 +49,10 @@ function Build-AndroidTable {
             "Version" = Get-AndroidBuildToolVersions -PackageInfo $packageInfo
         },
         @{
+            "Package" = "Android emulator"
+            "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android Emulator"
+        },
+        @{
             "Package" = "Google APIs"
             "Version" = Get-AndroidGoogleAPIsVersions -PackageInfo $packageInfo
         },
@@ -145,3 +149,4 @@ function Get-AndroidGoogleAPIsVersions {
     }
     return ($versions -Join "<br>")
 }
+

--- a/images/macos/software-report/SoftwareReport.Android.psm1
+++ b/images/macos/software-report/SoftwareReport.Android.psm1
@@ -55,6 +55,10 @@ function Build-AndroidTable {
             "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android SDK Platform-Tools"
         },
         @{
+            "Package" = "Android emulator"
+            "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android Emulator"
+        },
+        @{
             "Package" = "Google APIs"
             "Version" = Get-AndroidGoogleAPIsVersions -PackageInfo $packageInfo
         },

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -51,6 +51,10 @@ function Build-AndroidTable {
             "Version" = Get-AndroidBuildToolVersions -PackageInfo $packageInfo
         },
         @{
+            "Package" = "Android emulator"
+            "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android Emulator"
+        },
+        @{
             "Package" = "NDK"
             "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "ndk-bundle"
         },
@@ -147,3 +151,4 @@ function Get-AndroidGoogleAPIsVersions {
     }
     return ($versions -Join "<br>")
 }
+


### PR DESCRIPTION
# Description
Improvement

Recently, we had an incident related to version of Android Emulator. We should add version of emulator to software report to avoid such issues in future

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/1499

## Check list
- [x] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
