### PR TITLE
Handle DNS error and errors in the child processes

### DIFF
--- a/images/linux/scripts/base/apt-mock.sh
+++ b/images/linux/scripts/base/apt-mock.sh
@@ -13,11 +13,10 @@ i=1
 while [ \$i -le 30 ];do
   err=\$(mktemp)
   $real_tool "\$@" 2>\$err
-  result=\$?
-  cat \$err >&2
 
-  # no errors, continue
-  test \$result -eq 0 && break
+  # no errors, break the loop and continue normal flow
+  test -f \$err || break
+  cat \$err >&2
 
   retry=false
 
@@ -29,6 +28,9 @@ while [ \$i -le 30 ];do
     retry=true
   elif grep -q 'IPC connect call failed' \$err;then
     # the delay should help with gpg-agent not ready
+    retry=true
+  elif grep -q 'Temporary failure in name resolution' \$err;then
+    # It looks like DNS is not updated with random generated hostname yet
     retry=true
   fi
 


### PR DESCRIPTION
# Description
Bug fixing and Improvement

Аdd fix for build error
```
==> azure-arm: Provisioning with shell script: C:\agent\_work\9\s\images\linux/scripts/base/apt.sh
==> azure-arm: sudo: unable to resolve host pkrvmjd4gkmsxeh: Temporary failure in name resolution
==> azure-arm: Removed /etc/systemd/system/timers.target.wants/apt-daily.timer.
==> azure-arm: Removed /etc/systemd/system/timers.target.wants/apt-daily-upgrade.timer.
==> azure-arm: sudo: unable to resolve host pkrvmjd4gkmsxeh: Temporary failure in name resolution
```

Handle the case error has happened in the child process by removing the check for exit code and always 
grep err log

Handle the case the err log has not been created at all

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/1472

## Check list
- [x] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
