### PR TITLE
[macOS] Clarify clang versions

### DIFF
--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -71,10 +71,10 @@ function Get-FortranVersion {
 }
 
 function Get-ClangLLVMVersion {
-    $locationsList = @('', '$(brew --prefix llvm)/bin/')
+    $locationsList = @("$((Get-Command clang).Source)", '$(brew --prefix llvm)/bin/clang')
     $locationsList | Foreach-Object {
-        $version = Run-Command "${_}clang --version" | Select-Object -First 1 | Take-Part -Part 1 -Delimiter "version"
-        "Clang/LLVM $version " + $(if(${_} -ne "") {"- available on ``${_}clang``"} else {"is default"})
+        $version = Run-Command "${_} --version" | Select-Object -First 1 | Take-Part -Part 1 -Delimiter "version"
+        "Clang/LLVM $version " + $(if(${_} -Match "brew") {"- available on ``${_}``"} else {"is default"})
     }
 }
 

--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -71,8 +71,11 @@ function Get-FortranVersion {
 }
 
 function Get-ClangLLVMVersion {
-    $clangLLVMVersion = Run-Command "$(brew --prefix llvm)/bin/clang --version" | Select-Object -First 1 | Take-Part -Part 2
-    "Clang/LLVM $clangLLVMVersion"
+    $locationsList = @('', '$(brew --prefix llvm)/bin/')
+    $locationsList | Foreach-Object {
+        $version = Run-Command "${_}clang --version" | Select-Object -First 1 | Take-Part -Part 1 -Delimiter "version"
+        "Clang/LLVM $version " + $(if(${_} -ne "") {"- available on ``${_}clang``"} else {"is default"})
+    }
 }
 
 function Get-NVMVersion {

--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -73,8 +73,9 @@ function Get-FortranVersion {
 function Get-ClangLLVMVersion {
     $locationsList = @("$((Get-Command clang).Source)", '$(brew --prefix llvm)/bin/clang')
     $locationsList | Foreach-Object {
-        $version = Run-Command "${_} --version" | Select-Object -First 1 | Take-Part -Part 1 -Delimiter "version"
-        "Clang/LLVM $version " + $(if(${_} -Match "brew") {"- available on ``${_}``"} else {"is default"})
+        (Run-Command "${_} --version" | Out-String) -match "(?<version>\d+\.\d+\.\d+)" | Out-Null
+        $version = $Matches.version
+        "Clang/LLVM $version " + $(if(${_} -Match "brew") {"is available on ``${_}``"} else {"is default"})
     }
 }
 


### PR DESCRIPTION
# Description
Currently only the brew installation of clang is documented. This PR adds the clang version from Xcode installation to the appropriate docs section.

#### Related issue: actions/virtual-environments#2143

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
