### PR TITLE
[Windows] use `npm config` instead of `npm_config_cache`

### DIFF
--- a/images/win/scripts/Installers/Install-NodeLts.ps1
+++ b/images/win/scripts/Installers/Install-NodeLts.ps1
@@ -18,9 +18,7 @@ $env:Path = Get-MachinePath
 setx npm_config_prefix $PrefixPath /M
 $env:npm_config_prefix = $PrefixPath
 
-setx npm_config_cache $CachePath /M
-$env:npm_config_cache = $CachePath
-
+npm config set cache $CachePath --global
 npm config set registry http://registry.npmjs.org/
 
 npm install -g cordova


### PR DESCRIPTION
# Description

This commit change the way to set npm cache path from env to config file on Windows runners.

The `npm_config_cache` env, if set, will have highest priority, and harder to change.

One way to un-set this is add a global workflow env, like:
```
env:
  npm_config_cache: ''
```

This commit change the cache config to use `npm config set cache $CachePath --global`,
which should save the path under the global npmrc at: `C:\npm\prefix\etc\npmrc`,
and allow easier later reset with user/repo level `.npmrc` files.

For the record, my usage is to unify all platform's npm cache to `~/.npm/`,
then use the same cache action config on all platform to cache the folder.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
