### PR TITLE
Fix Rustup installation after update on 1.23.0

### DIFF
--- a/images/macos/provision/core/rust.sh
+++ b/images/macos/provision/core/rust.sh
@@ -8,7 +8,6 @@ rustup-init -y --no-modify-path --default-toolchain=stable --profile=minimal
 
 echo Initialize environment variables...
 CARGO_HOME=$HOME/.cargo
-source $CARGO_HOME/env
 
 echo Install common tools...
 rustup component add rustfmt clippy


### PR DESCRIPTION
# Description
Recently, Rustup was updated to 1.23.0. After this change `$CARGO_HOME/env` file is not presented anymore.
Removing invocation of this file, since brew adds `$CARGO_HOME/bin` to PATH without it

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/1533

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
