### PR TITLE
[Ubuntu20] remove reboot from packer json.

### DIFF
--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -78,14 +78,6 @@
         },
         {
             "type": "shell",
-            "expect_disconnect": true,
-            "scripts": [
-                "{{template_dir}}/scripts/base/reboot.sh"
-            ],
-            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
-            "type": "shell",
             "script": "{{template_dir}}/scripts/base/apt.sh",
             "environment_vars": [
                 "DEBIAN_FRONTEND=noninteractive"


### PR DESCRIPTION
# Description
Improvement
Some of our build fails due to unexpected issue with apt.sh script, which most probably caused by reboot step.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1508

## Check list
- [+] Related issue / work item is attached

