### PR TITLE
[Windows] Set PHP-7.4 as default

### DIFF
--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -269,6 +269,7 @@ function Get-VSExtensionVersion
     $instanceFolders = Get-ChildItem -Path "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances"
     if ($instanceFolders -is [array])
     {
+        Write-Host ($instanceFolders | Out-String)
         Write-Host ($instanceFolders | Get-ChildItem | Out-String)
         Write-Host "More than one instance installed"
         exit 1
@@ -280,7 +281,7 @@ function Get-VSExtensionVersion
 
     if (-not $packageVersion)
     {
-        Write-Host "installed package $packageName for Visual Studio 2019 was not found"
+        Write-Host "Installed package $packageName for Visual Studio 2019 was not found"
         exit 1
     }
 

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -269,6 +269,7 @@ function Get-VSExtensionVersion
     $instanceFolders = Get-ChildItem -Path "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances"
     if ($instanceFolders -is [array])
     {
+        Write-Host ($instanceFolders | Get-ChildItem | Out-String)
         Write-Host "More than one instance installed"
         exit 1
     }

--- a/images/win/scripts/Installers/Install-PHP.ps1
+++ b/images/win/scripts/Installers/Install-PHP.ps1
@@ -3,9 +3,14 @@
 ##  Desc:  Install PHP
 ################################################################################
 
+# Get latest PHP-7.4
+$url = "https://raw.githubusercontent.com/chocolatey-community/chocolatey-coreteampackages/master/automatic/php/php.json"
+$phpVersion = [System.Net.WebClient]::new().DownloadString($url) | ConvertFrom-Json
+$latestPHPVersion = $phpVersion.'7.4'
+
 # Install latest PHP in chocolatey
 $installDir = "c:\tools\php"
-Choco-Install -PackageName php -ArgumentList "--force", "--params", "/InstallDir:$installDir"
+Choco-Install -PackageName php -ArgumentList "--version=$latestPHPVersion","--force", "--params", "/InstallDir:$installDir"
 
 # Install latest Composer in chocolatey
 Choco-Install -PackageName composer -ArgumentList "--ia", "/DEV=$installDir /PHP=$installDir"


### PR DESCRIPTION
# Description
Currently, during image generation process we install the latest version of PHP. At time of writing the current version of PHP is 8.0. One of the dependencies of PHP 8.0 is the `visualstudio2019buildtools` package which causes another issue  https://github.com/actions/virtual-environments/issues/1470.
```
2020-11-30T14:08:31.7820834Z     vhd: By installing you accept licenses for the packages.
2020-11-30T14:08:33.2822538Z     vhd: Progress: Downloading visualstudio2019buildtools 16.8.2.0... 100%
2020-11-30T14:08:34.1117278Z     vhd: Progress: Downloading chocolatey-visualstudio.extension 1.8.1... 100%
2020-11-30T14:08:35.4864619Z     vhd: Progress: Downloading dotnetfx 4.8.0.20190930... 100%
2020-11-30T14:08:37.0665171Z     vhd: Progress: Downloading chocolatey-dotnetfx.extension 1.0.1... 100%
2020-11-30T14:08:37.0669457Z     vhd: Progress: Downloading visualstudio-installer 2.0.1... 100%
2020-11-30T14:08:41.3145424Z     vhd: Progress: Downloading php 8.0.0... 100%
```

PS: choco list with the flag returns only the latest version of a package:
```
-a, --all, --allversions, --all-versions
     AllVersions - include results from all versions
```
Example:
```
PS > choco list -e php -a -r
php|8.0.0
```

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1534
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
