### PR TITLE
Fix spaces in ndk-build.cmd path

### DIFF
--- a/images/win/scripts/Installers/Update-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Update-AndroidSDK.ps1
@@ -81,6 +81,7 @@ if (Test-Path $ndkRoot) {
     setx ANDROID_SDK_ROOT $sdkRoot /M
     setx ANDROID_NDK_HOME $ndkRoot /M
     setx ANDROID_NDK_PATH $ndkRoot /M
+    (Get-Content "${ndkRoot}\ndk-build.cmd").replace('%~dp0\build\ndk-build.cmd','"%~dp0\build\ndk-build.cmd"')|Set-Content "${ndkRoot}\ndk-build.cmd"
 } else {
     Write-Host "NDK is not installed at path $ndk_root"
     exit 1

--- a/images/win/scripts/Installers/Update-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Update-AndroidSDK.ps1
@@ -81,7 +81,7 @@ if (Test-Path $ndkRoot) {
     setx ANDROID_SDK_ROOT $sdkRoot /M
     setx ANDROID_NDK_HOME $ndkRoot /M
     setx ANDROID_NDK_PATH $ndkRoot /M
-    (Get-Content "${ndkRoot}\ndk-build.cmd").replace('%~dp0\build\ndk-build.cmd','"%~dp0\build\ndk-build.cmd"')|Set-Content "${ndkRoot}\ndk-build.cmd"
+    (Get-Content -Encoding UTF8 "${ndkRoot}\ndk-build.cmd").replace('%~dp0\build\ndk-build.cmd','"%~dp0\build\ndk-build.cmd"')|Set-Content -Encoding UTF8 "${ndkRoot}\ndk-build.cmd"
 } else {
     Write-Host "NDK is not installed at path $ndk_root"
     exit 1


### PR DESCRIPTION
# Description
Bug fixing

C:\Program Files (x86)\Android\android-sdk\ndk-bundle\ndk-build.cmd

contains a line
```
%~dp0\build\ndk-build.cmd %*
```
and %~dp0 expands to a string with a spaces and causes the "Item not found" error

The PR adds the double quotes in order to make the command to work

#### Related issue: https://github.com/actions/virtual-environments/issues/1122

## Check list
- [x] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
