### PR TITLE
[Ubuntu] Fix Openshift-client installation

### DIFF
--- a/images/linux/scripts/installers/oc.sh
+++ b/images/linux/scripts/installers/oc.sh
@@ -5,10 +5,10 @@
 ################################################################################
 
 # Install the oc CLI
-curl "https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz" > oc.tar.gz
-tar xvzf oc.tar.gz
-rm oc.tar.gz
-mv oc /usr/local/bin
+DOWNLOAD_URL="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz"
+PACKAGE_TAR_NAME="oc.tar.gz"
+download_with_retries $DOWNLOAD_URL "/tmp" $PACKAGE_TAR_NAME
+tar xvzf "/tmp/$PACKAGE_TAR_NAME" -C "/usr/local/bin"
 
 # Validate the installation
 echo "Validate the installation"

--- a/images/linux/scripts/installers/oc.sh
+++ b/images/linux/scripts/installers/oc.sh
@@ -4,6 +4,8 @@
 ##  Desc:  Installs the OC CLI
 ################################################################################
 
+source $HELPER_SCRIPTS/install.sh
+
 # Install the oc CLI
 DOWNLOAD_URL="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz"
 PACKAGE_TAR_NAME="oc.tar.gz"


### PR DESCRIPTION
# Description
Recent Ubuntu builds are failing due to invalid openshift-client download link. [[Link](https://github.visualstudio.com/virtual-environments/_build/results?buildId=90789&view=results) to the build example]. In scope of this PR we are fixing the download  link and adding download with retries logic.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
