### PR TITLE
[Ubuntu] Add MediaInfo package

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -103,6 +103,7 @@ $toolsList = @(
     (Get-KubectlVersion),
     (Get-KustomizeVersion),
     (Get-LeiningenVersion),
+    (Get-MediainfoVersion),
     (Get-M4Version),
     (Get-HGVersion),
     (Get-MinikubeVersion),

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -157,6 +157,11 @@ function Get-LeiningenVersion {
     return "$(lein -v | Take-OutputPart -Part 0,1)"
 }
 
+function Get-MediainfoVersion {
+    $mediainfoVersion = (mediainfo --version | Select-Object -Index 1 | Take-OutputPart -Part 2).Replace('v', '')
+    return "MediaInfo $mediainfoVersion"
+}
+
 function Get-NewmanVersion {
     return "Newman $(newman --version)"
 }

--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -165,6 +165,7 @@
             "ftp",
             "jq",
             "m4",
+            "mediainfo",
             "netcat",
             "parallel",
             "patchelf",

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -160,6 +160,7 @@
             "ftp",
             "jq",
             "m4",
+            "mediainfo",
             "netcat",
             "parallel",
             "patchelf",

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -134,6 +134,7 @@
             "ftp",
             "jq",
             "m4",
+            "mediainfo",
             "netcat",
             "parallel",
             "patchelf",


### PR DESCRIPTION
# Description
This adds the `MediaInfo` package as suggested in https://github.com/actions/virtual-environments/issues/2185

> command-line utility for reading information from audio/video files

#### Related issue
- https://github.com/actions/virtual-environments/issues/2185

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
