### PR TITLE
[macOS] Fix Rustup version in the software documentation

### DIFF
--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -45,7 +45,7 @@ function Get-Cargoaudit {
 }
 
 function Get-RustupVersion {
-    $rustupVersion = Run-Command "rustup --version" | Take-Part -Part 1
+    $rustupVersion = Run-Command "rustup --version" | Select-Object -First 1 | Take-Part -Part 1
     return "Rustup ${rustupVersion}"
 }
 


### PR DESCRIPTION
# Description
The output of the `rustup --version` command was changed and this caused problems with the macOS software documentation. In scope of this PR we fixed it.

#### Related issue: [#1542](https://github.com/actions/virtual-environments-internal/issues/1542)

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
