### PR TITLE
[Ubuntu] Fix add key in containers.sh script

### DIFF
--- a/images/linux/scripts/installers/containers.sh
+++ b/images/linux/scripts/installers/containers.sh
@@ -8,7 +8,8 @@
 install_packages=(podman buildah skopeo)
 source /etc/os-release
 sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-wget -qO - https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key | apt-key add -
+wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key -O Release.key
+apt-key add Release.key
 apt-get update -qq
 apt-get -qq -y install ${install_packages[@]}
 mkdir -p /etc/containers

--- a/images/linux/scripts/installers/containers.sh
+++ b/images/linux/scripts/installers/containers.sh
@@ -8,8 +8,7 @@
 install_packages=(podman buildah skopeo)
 source /etc/os-release
 sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key -O Release.key
-apt-key add - < Release.key
+wget -qO - https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key | apt-key add -
 apt-get update -qq
 apt-get -qq -y install ${install_packages[@]}
 mkdir -p /etc/containers


### PR DESCRIPTION
# Description
Currently, apt-mock.sh incorrectly parses `<`. Use the `add key` command without `>`  is resolved the issue.

```
==> azure-arm: Provisioning with shell script: C:\agent\_work\7\s\images\linux/scripts/installers/containers.sh
==> azure-arm: 2020-12-02 17:17:31 URL:https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/Release.key [1093/1093] -> "Release.key" [1]
==> azure-arm: Warning: apt-key output should not be parsed (stdout is not a terminal)
==> azure-arm: gpg: can't connect to the agent: IPC connect call failed
    azure-arm: ...retry 1
```

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1554

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
