### PR TITLE
Adds Perl version detection

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -49,6 +49,12 @@ function Get-NodeVersion {
     return "Node $nodeVersion"
 }
 
+function Get-PerlVersion {
+    $result = Get-CommandResult "perl --version | perl -ne 'print /(\d\.\d+\.\d+)/'"
+    $version = $result.Output
+    return "Perl $version"
+}
+
 function Get-PythonVersion {
     $result = Get-CommandResult "python --version"
     $version = $result.Output | Take-OutputPart -Part 1

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -50,8 +50,7 @@ function Get-NodeVersion {
 }
 
 function Get-PerlVersion {
-    $result = Get-CommandResult "perl --version | perl -ne 'print /(\d\.\d+\.\d+)/'"
-    $version = $result.Output
+    $version = $(perl -e 'print substr($^V,1)')
     return "Perl $version"
 }
 

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -38,6 +38,7 @@ $markdown += New-MDList -Style Unordered -Lines @(
         (Get-ErlangVersion),
         (Get-MonoVersion),
         (Get-NodeVersion),
+        (Get-PerlVersion),
         (Get-PythonVersion),
         (Get-Python3Version),
         (Get-RubyVersion),


### PR DESCRIPTION
# New tool

Perl is currently installed in all major Linux distributions, but it was not detected. This adds detection, guided by #2204. It fixes #2203 

#### Related issue:

#2203 #2204 

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
