### PR TITLE
[Windows] Install PHP 8.0

### DIFF
--- a/images/win/scripts/Installers/Install-PHP.ps1
+++ b/images/win/scripts/Installers/Install-PHP.ps1
@@ -3,14 +3,9 @@
 ##  Desc:  Install PHP
 ################################################################################
 
-# Get latest PHP-7.4
-$url = "https://raw.githubusercontent.com/chocolatey-community/chocolatey-coreteampackages/master/automatic/php/php.json"
-$phpVersion = [System.Net.WebClient]::new().DownloadString($url) | ConvertFrom-Json
-$latestPHPVersion = $phpVersion.'7.4'
-
 # Install latest PHP in chocolatey
 $installDir = "c:\tools\php"
-Choco-Install -PackageName php -ArgumentList "--version=$latestPHPVersion","--force", "--params", "/InstallDir:$installDir"
+Choco-Install -PackageName php -ArgumentList "--force", "--params", "/InstallDir:$installDir"
 
 # Install latest Composer in chocolatey
 Choco-Install -PackageName composer -ArgumentList "--ia", "/DEV=$installDir /PHP=$installDir"


### PR DESCRIPTION
# Description
One of the dependencies of PHP 8.0 was the `visualstudio2019buildtools` package which caused  issue #1470. Now it has been fixed and depends on `vcredist140`  - https://github.com/chocolatey-community/chocolatey-coreteampackages/pull/1591

To preserve consistence with macOS and Ubuntu, PHP 8.0 will be pre-installed on Windows too.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1534

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
