### PR TITLE
[macOS] Install Python2 from pkg installer

### DIFF
--- a/images/macos/provision/core/python.sh
+++ b/images/macos/provision/core/python.sh
@@ -7,11 +7,14 @@ echo "Installing Python Tooling"
 echo "Brew Installing Python 3"
 brew install python@3.9
 
-echo "Brew Installing Python 2"
-# Create local tap with formula due to python2 formula depreciation
-brew tap-new --no-git local/python2
-FORMULA_PATH=$(brew extract python@2 local/python2 | grep "Homebrew/Library/Taps")
-brew install $FORMULA_PATH
+echo "Install latest Python 2"
+Python2Url="https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg"
+download_with_retries $Python2Url "/tmp" "python2.pkg"
+sudo installer -pkg /tmp/python2.pkg -target /
+pip install --upgrade pip
+
+echo "Install Python2 certificates"
+bash -c "/Applications/Python\ 2.7/Install\ Certificates.command"
 
 echo "Installing pipx"
 export PIPX_BIN_DIR=/usr/local/opt/pipx_bin


### PR DESCRIPTION
# Description
Due to maintenance concerns, we are going to stop installing Python 2.7 from the Homebrew formula, which was deprecated at the beginning of 2020, and instead, use the official macOS pkg installer available by the following link
https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg
This package installs pip along with the python, but the version is outdated so the update required. Also, the GUI installation process requires to run the install certificates command after successful installation:

![image](https://user-images.githubusercontent.com/48208649/101460350-8401b680-394a-11eb-868f-953ba7a57f2f.png)

The corresponding step added to the installation script.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1543

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
