### PR TITLE
[macOS CI] Explicitly pass parameters for Connect-VCServer function

### DIFF
--- a/images.CI/macos/destroy-vm.ps1
+++ b/images.CI/macos/destroy-vm.ps1
@@ -39,7 +39,7 @@ param(
 Import-Module $PSScriptRoot\helpers.psm1 -DisableNameChecking
 
 # Connection to a vCenter Server system
-Connect-VCServer
+Connect-VCServer -VIServer $VIServer -VIUserName $VIUserName -VIPassword $VIPassword
 
 # Check vm clone status
 $chainId = (Get-VIEvent -Entity $VMName).ChainId

--- a/images.CI/macos/helpers.psm1
+++ b/images.CI/macos/helpers.psm1
@@ -6,6 +6,18 @@ Helper functions to use in images.CI scripts
 
 Function Connect-VCServer
 {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [System.String]$VIUserName,
+
+        [Parameter(Mandatory)]
+        [System.String]$VIPassword,
+
+        [Parameter(Mandatory)]
+        [System.String]$VIServer
+    )
+    
     try
     {
         # Preference

--- a/images.CI/macos/move-vm.ps1
+++ b/images.CI/macos/move-vm.ps1
@@ -46,7 +46,7 @@ param(
 Import-Module $PSScriptRoot\helpers.psm1 -DisableNameChecking
 
 # Connection to a vCenter Server system
-Connect-VCServer
+Connect-VCServer -VIServer $VIServer -VIUserName $VIUserName -VIPassword $VIPassword
 
 # Clear previously assigned tag with VM Name
 try {

--- a/images.CI/macos/select-datastore.ps1
+++ b/images.CI/macos/select-datastore.ps1
@@ -99,7 +99,7 @@ function Select-DataStore {
 }
 
 # Connection to a vCenter Server system
-Connect-VCServer
+Connect-VCServer -VIServer $VIServer -VIUserName $VIUserName -VIPassword $VIPassword
 
 # Get a target datastore for current deployment
 Select-DataStore -VMName $VMName -TagCategory $TagCategory


### PR DESCRIPTION
# Description
Connect-VCServer is broken with the new version of azdo powershell task. We need to pass parameters explicitly to fix the issue.

#### Related issue:
n\a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
