### PR TITLE
[macOS] Disable AzureRM aliases

### DIFF
--- a/images/macos/provision/core/powershell.sh
+++ b/images/macos/provision/core/powershell.sh
@@ -26,8 +26,8 @@ for module in ${psModules[@]}; do
     fi
 done
 
-# Enables AzureRm prefix aliases for Az modules
-sudo pwsh -command "& {Import-Module Az; Enable-AzureRmAlias -Scope LocalMachine}"
+# A dummy call to initialize .IdentityService directory
+pwsh -command "& {Import-Module Az}"
 
 # powershell link was removed in powershell-6.0.0-beta9
 sudo ln -s /usr/local/bin/pwsh /usr/local/bin/powershell

--- a/images/macos/provision/core/powershell.sh
+++ b/images/macos/provision/core/powershell.sh
@@ -34,6 +34,3 @@ sudo ln -s /usr/local/bin/pwsh /usr/local/bin/powershell
 
 # fix ~/.azure directory permissions
 sudo chown -R ${USER}: $HOME/.azure
-
-# fix permissions for Az.Account version 2.*
-sudo chown -R ${USER}: $HOME/.local/share/.IdentityService


### PR DESCRIPTION
# Description
Stop adding backward compatibility of Az and AzureRM by Enable-AzureRmAlias cmdlet.

#### Related issue:
https://github.com/actions/virtual-environments/issues/2090

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
