### PR TITLE
[macOS] Deprecate openssl 1.0.2 and set 1.1 as the default one

### DIFF
--- a/images/macos/provision/core/openssl.sh
+++ b/images/macos/provision/core/openssl.sh
@@ -8,5 +8,5 @@ brew install openssl
 echo "Install openssl@1.1"
 brew install openssl@1.1
 
-# Set brew openssl@1.1 as the default one
+# Symlink brew openssl@1.1 to `/usr/local/bin` as Homebrew refuses
 ln -sf $(brew --prefix openssl@1.1)/bin/openssl /usr/local/bin/openssl

--- a/images/macos/provision/core/openssl.sh
+++ b/images/macos/provision/core/openssl.sh
@@ -5,7 +5,7 @@ source ~/utils/utils.sh
 echo "Install latest openssl"
 brew install openssl
 
-echo "Install latest openssl@1.1"
+echo "Install openssl@1.1"
 brew install openssl@1.1
 
 # Set brew openssl@1.1 as the default one

--- a/images/macos/provision/core/openssl.sh
+++ b/images/macos/provision/core/openssl.sh
@@ -2,24 +2,11 @@
 
 source ~/utils/utils.sh
 
-echo Installing OpenSSL...
+echo "Install latest openssl"
 brew install openssl
 
-# Install OpenSSL 1.0.2t
-# https://www.openssl.org/policies/releasestrat.html - Version 1.0.2 will be supported until 2019-12-31 (LTS)
-# To preserve backward compatibility with ruby-toolcache
-brew tap-new --no-git local/openssl
-FORMULA_PATH=$(brew extract openssl local/openssl | grep "Homebrew/Library/Taps")
-brew install $FORMULA_PATH
+echo "Install latest openssl@1.1"
+brew install openssl@1.1
 
-# Set OpenSSL 1.0.2t as default
-ln -sf /usr/local/Cellar/openssl@1.0.2t /usr/local/Cellar/openssl
-ln -sf /usr/local/Cellar/openssl/1.0.2t/bin/openssl /usr/local/bin/openssl
-rm /usr/local/opt/openssl
-ln -sf ../Cellar/openssl/1.0.2t /usr/local/opt/openssl
-
-# Resolve dot net core openssl dependency issue for agent
-# https://github.com/microsoft/azure-pipelines-agent/blob/master/docs/start/envosx.md
-mkdir -p /usr/local/lib/
-ln -s /usr/local/opt/openssl@1.0.2t/lib/libcrypto.1.0.0.dylib /usr/local/lib/
-ln -s /usr/local/opt/openssl@1.0.2t/lib/libssl.1.0.0.dylib /usr/local/lib/
+# Set brew openssl@1.1 as the default one
+ln -sf $(brew --prefix openssl@1.1)/bin/openssl /usr/local/bin/openssl

--- a/images/macos/tests/Common.Tests.ps1
+++ b/images/macos/tests/Common.Tests.ps1
@@ -167,7 +167,8 @@ Describe "Common utilities" {
         }
 
         It "Default OpenSSL version is 1.1" {
-            "openssl version" | Should -Match "OpenSSL 1.1"
+            $commandResult = Get-CommandResult "openssl version"
+            $commandResult.Output | Should -Match "OpenSSL 1.1"
         }
     }
 

--- a/images/macos/tests/Common.Tests.ps1
+++ b/images/macos/tests/Common.Tests.ps1
@@ -156,8 +156,14 @@ Describe "Common utilities" {
         "jq --version" | Should -ReturnZeroExitCode
     }
 
-    It "OpenSSL" {
-        "openssl version" | Should -ReturnZeroExitCode
+    Context "OpenSSL" {
+        It "OpenSSL is available" {
+            "openssl version" | Should -ReturnZeroExitCode
+        }
+
+        It "OpenSSL version is 1.1" {
+            "openssl version" | Should -Match "OpenSSL 1.1"
+        }
     }
 
     It "GnuPG" {

--- a/images/macos/tests/Common.Tests.ps1
+++ b/images/macos/tests/Common.Tests.ps1
@@ -161,7 +161,12 @@ Describe "Common utilities" {
             "openssl version" | Should -ReturnZeroExitCode
         }
 
-        It "OpenSSL version is 1.1" {
+        It "OpenSSL 1.1 path exists" {
+            $openSSLpath = "/usr/local/opt/openssl@1.1"
+            $openSSLpath | Should -Exist
+        }
+
+        It "Default OpenSSL version is 1.1" {
             "openssl version" | Should -Match "OpenSSL 1.1"
         }
     }


### PR DESCRIPTION
# Description
The Openssl 1.0.2 brew formula was deprecated a long time ago and that's painful to keep it on the image at the moment.
We decided to switch to 1.1 as the default and also install the latest version (it's the same 1.1 at the moment).

#### Related issue:
https://github.com/actions/virtual-environments/issues/2089

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
