### PR TITLE
Add CMake 3.18 in Android SDK components to toolsets (win/linux).

### DIFF
--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -91,6 +91,7 @@
         "additional_tools": [
             "cmake;3.6.4111459",
             "cmake;3.10.2.4988404",
+            "cmake;3.18.1",
             "patcher;v4",
             "ndk-bundle",
             "platform-tools"

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -87,6 +87,7 @@
         "additional_tools": [
             "cmake;3.6.4111459",
             "cmake;3.10.2.4988404",
+            "cmake;3.18.1",
             "patcher;v4",
             "ndk-bundle",
             "platform-tools"

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -70,6 +70,7 @@
         ],
         "additional_tools": [
             "cmake;3.10.2.4988404",
+            "cmake;3.18.1",
             "patcher;v4",
             "ndk-bundle",
             "platform-tools"

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -160,6 +160,7 @@
         "additional_tools": [
             "cmake;3.6.4111459",
             "cmake;3.10.2.4988404",
+            "cmake;3.18.1",
             "patcher;v4",
             "ndk-bundle"
         ]

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -160,6 +160,7 @@
         "additional_tools": [
             "cmake;3.6.4111459",
             "cmake;3.10.2.4988404",
+            "cmake;3.18.1",
             "patcher;v4",
             "ndk-bundle"
         ]


### PR DESCRIPTION
# Description

This adds CMake 3.18.1 from Android SDK. The relevant information is at issue #2228.

#### Related issue:

https://github.com/actions/virtual-environments/issues/2228