### PR TITLE
[ImageBuild] Fix templatepath and image variables

### DIFF
--- a/images.CI/linux-and-win/build-image.ps1
+++ b/images.CI/linux-and-win/build-image.ps1
@@ -16,10 +16,11 @@ param(
 
 if (-not (Test-Path $TemplatePath))
 {
-    Write-Error "'-Image' parameter is not valid. You have to specify correct image type."
+    Write-Error "'-TemplatePath' parameter is not valid. You have to specify correct Template Path"
     exit 1
 }
 
+$Image = [io.path]::GetFileNameWithoutExtension($TemplatePath)
 $TempResourceGroupName = "${ResourcesNamePrefix}_${Image}"
 $InstallPassword = [System.GUID]::NewGuid().ToString().ToUpper()
 


### PR DESCRIPTION
# Description
Currently `$Image` variable is empty, this PR fixes it.

#### Related issue:
n\a

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
