### PR TITLE
[Ubuntu] bash version output

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -4,6 +4,11 @@ function Get-OSName {
     lsb_release -ds
 }
 
+function Get-BashVersion {
+    $version = bash -c 'echo ${BASH_VERSION}'
+    return "Bash $version"
+}
+
 function Get-CPPVersions {
     $result = Get-CommandResult "apt list --installed" -Multiline
     $cppVersions = $result.Output | Where-Object { $_ -match "g\+\+-\d+"} | ForEach-Object {

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -32,6 +32,7 @@ $markdown += New-MDHeader "Installed Software" -Level 2
 $markdown += New-MDHeader "Language and Runtime" -Level 3
 
 $markdown += New-MDList -Style Unordered -Lines @(
+        (Get-BashVersion),
         (Get-CPPVersions),
         (Get-FortranVersions),
         (Get-ClangVersions),


### PR DESCRIPTION
# Description
Adding bash version output. 
OS|Bash Version
---|--------------
Ubuntu 16.04 |Bash 4.3.48(1)-release
Ubuntu 18.04 |Bash 4.4.20(1)-release
Ubuntu 20.04 |Bash 5.0.17(1)-release

#### Related issue:
https://github.com/actions/virtual-environments/issues/2232
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
