### PR TITLE
[Windows] bash version output

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -8,6 +8,11 @@ function Get-OSVersion {
     return "OS Version: $OSVersion Build $OSBuild"
 }
 
+function Get-BashVersion {
+    $version = bash -c 'echo ${BASH_VERSION}'
+    return "Bash $version"
+}
+
 function Get-JavaVersionsList {
     param(
         [string] $DefaultVersion

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -32,6 +32,7 @@ $markdown += New-MDHeader "Language and Runtime" -Level 3
 
 $markdown += New-MDList -Lines (Get-JavaVersionsList -DefaultVersion "1.8.0") -Style Unordered -NoNewLine
 $markdown += New-MDList -Style Unordered -Lines @(
+    (Get-BashVersion),
     (Get-PythonVersion),
     (Get-RubyVersion),
     (Get-GoVersion),


### PR DESCRIPTION
# Description
Adding bash version output.

OS|Bash Version
---|--------------
Windows Server 2016 |Bash 4.4.23(1)-release
Windows Server 2019 |Bash 4.4.23(1)-release

#### Related issue:
https://github.com/actions/virtual-environments/issues/2232
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
