### PR TITLE
[macOS] bash version output

### DIFF
--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -1,5 +1,10 @@
 Import-Module "$PSScriptRoot/../helpers/SoftwareReport.Helpers.psm1" -DisableNameChecking
 
+function Get-BashVersion {
+    $version = bash -c 'echo ${BASH_VERSION}'
+    return "Bash $version"
+}
+
 function Get-DotnetVersionList {
     $sdkRawList = Run-Command "dotnet --list-sdks"
     $sdkVersionList = $sdkRawList | ForEach-Object { Take-Part $_ -Part 0 }

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -54,6 +54,7 @@ if ($os.IsLessThanBigSur) {
 }
 
 $markdown += New-MDList -Style Unordered -Lines @(
+    (Get-BashVersion),
     "Node.js ${nodejsVersion}"
     "NVM ${nvmVersion}"
     "NVM - Cached node versions: ${nvmCachedVersions}"


### PR DESCRIPTION
# Description
Adding bash version output.

OS|Bash Version
---|--------------
macOS 10.15 |3.2.57(1)-release
macOS 11.0 |3.2.57(1)-release
#### Related issue:
https://github.com/actions/virtual-environments/issues/2232
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
