### PR TITLE
Add Android tools to PATH

### DIFF
--- a/images/linux/scripts/installers/android.sh
+++ b/images/linux/scripts/installers/android.sh
@@ -30,6 +30,7 @@ ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
 echo "ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT}" | tee -a /etc/environment
 prependEtcEnvironmentPath "${ANDROID_SDK_ROOT}/tools"
 prependEtcEnvironmentPath "${ANDROID_SDK_ROOT}/tools/bin"
+prependEtcEnvironmentPath "${ANDROID_SDK_ROOT}/platform-tools"
 
 # ANDROID_HOME is deprecated, but older versions of Gradle rely on it
 echo "ANDROID_HOME=${ANDROID_SDK_ROOT}" | tee -a /etc/environment

--- a/images/linux/scripts/installers/android.sh
+++ b/images/linux/scripts/installers/android.sh
@@ -28,6 +28,8 @@ function filter_components_by_version {
 ANDROID_ROOT=/usr/local/lib/android
 ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
 echo "ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT}" | tee -a /etc/environment
+prependEtcEnvironmentPath "${ANDROID_SDK_ROOT}/tools"
+prependEtcEnvironmentPath "${ANDROID_SDK_ROOT}/tools/bin"
 
 # ANDROID_HOME is deprecated, but older versions of Gradle rely on it
 echo "ANDROID_HOME=${ANDROID_SDK_ROOT}" | tee -a /etc/environment

--- a/images/macos/provision/configuration/environment/bashrc
+++ b/images/macos/provision/configuration/environment/bashrc
@@ -14,7 +14,7 @@ export AGENT_TOOLSDIRECTORY=$HOME/hostedtoolcache
 export RUNNER_TOOL_CACHE=$HOME/hostedtoolcache
 
 export PATH=/Library/Frameworks/Mono.framework/Versions/Current/Commands:$PATH
-export PATH=$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools:$ANDROID_NDK_HOME:$PATH
+export PATH=$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$ANDROID_NDK_HOME:$PATH
 export PATH=/usr/local/go/bin:$PATH
 export PATH=/usr/local/bin:/usr/local/sbin:~/bin:~/.yarn/bin:$PATH
 export PATH="/usr/local/opt/curl/bin:$PATH"

--- a/images/win/scripts/Installers/Update-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Update-AndroidSDK.ps1
@@ -29,11 +29,12 @@ $androidToolset = (Get-ToolsetContent).android
 
 $sdkRoot = "C:\Program Files (x86)\Android\android-sdk"
 
-# Emulator on Windows does not work from $sdkRoot\tools
-Add-MachinePathItem "$sdkRoot\emulator"
 Add-MachinePathItem "$sdkRoot\tools"
 Add-MachinePathItem "$sdkRoot\tools\bin"
 Add-MachinePathItem "$sdkRoot\platform-tools"
+
+# Emulator on Windows does not work from $sdkRoot\tools
+Add-MachinePathItem "$sdkRoot\emulator"
 
 $sdkManager = "$sdkRoot\tools\bin\sdkmanager.bat"
 

--- a/images/win/scripts/Installers/Update-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Update-AndroidSDK.ps1
@@ -28,6 +28,13 @@ Expand-Archive -Path .\android-sdk-licenses.zip -DestinationPath 'C:\Program Fil
 $androidToolset = (Get-ToolsetContent).android
 
 $sdkRoot = "C:\Program Files (x86)\Android\android-sdk"
+
+# Emulator on Windows does not work from $sdkRoot\tools
+Add-MachinePathItem "$sdkRoot\emulator"
+Add-MachinePathItem "$sdkRoot\tools"
+Add-MachinePathItem "$sdkRoot\tools\bin"
+Add-MachinePathItem "$sdkRoot\platform-tools"
+
 $sdkManager = "$sdkRoot\tools\bin\sdkmanager.bat"
 
 & $sdkManager --sdk_root=$sdkRoot "platform-tools"


### PR DESCRIPTION
# Description

This adds to PATH:
```
${ANDROID_SDK_ROOT}/tools
${ANDROID_SDK_ROOT}/tools/bin
${ANDROID_SDK_ROOT}/platform-tools
```

As a result, these tools will be available without additional prefixes, among others:
```
sdkmanager
avdmanager
emulator
adb
```

This also harmonizes the tool availability accross environments, because currently macos already includes `${ANDROID_SDK_ROOT}/tools` and `${ANDROID_SDK_ROOT}/platform-tools`, while linux and windows do not.

I do understand that macos contributions cannot be accepted, and I have only included the change for the illustration of the full picture. In the current state the PR is meant for discussion, and if there is general acceptance, I will remove the macos change, create issues, generate VMs and test locally.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
