### PR TITLE
[macOS] Get rid of NDK version check test

### DIFF
--- a/images/macos/tests/Android.Tests.ps1
+++ b/images/macos/tests/Android.Tests.ps1
@@ -68,13 +68,13 @@ Describe "Android" {
         }
     }
 
-    Context "Legacy NDK versions" -Skip:($os.IsBigSur) {
-        It "Android NDK version is 21" {
-            $ndkBundlePath = Join-Path $ANDROID_SDK_DIR "ndk-bundle" "source.properties"
-            $rawContent = Get-Content $ndkBundlePath -Raw
-            $rawContent | Should -BeLikeExactly "*Revision = 21.*"
-        }
+    It "Android NDK version is 22" {
+        $ndkBundlePath = Join-Path $ANDROID_SDK_DIR "ndk-bundle" "source.properties"
+        $rawContent = Get-Content $ndkBundlePath -Raw
+        $rawContent | Should -BeLikeExactly "*Revision = 22.*"
+    }
 
+    Context "Legacy NDK versions" -Skip:($os.IsBigSur) {
         It "Android NDK version r18b is installed" {
             $ndk18BundlePath = Join-Path $ANDROID_SDK_DIR "ndk" "18.1.5063045" "source.properties"
             $rawContent = Get-Content $ndk18BundlePath -Raw

--- a/images/macos/tests/Android.Tests.ps1
+++ b/images/macos/tests/Android.Tests.ps1
@@ -68,12 +68,6 @@ Describe "Android" {
         }
     }
 
-    It "Android NDK version is 22" {
-        $ndkBundlePath = Join-Path $ANDROID_SDK_DIR "ndk-bundle" "source.properties"
-        $rawContent = Get-Content $ndkBundlePath -Raw
-        $rawContent | Should -BeLikeExactly "*Revision = 22.*"
-    }
-
     Context "Legacy NDK versions" -Skip:($os.IsBigSur) {
         It "Android NDK version r18b is installed" {
             $ndk18BundlePath = Join-Path $ANDROID_SDK_DIR "ndk" "18.1.5063045" "source.properties"


### PR DESCRIPTION
# Description
Android NDK test started to fail because of updated NDK:
```
    vsphere-clone:  Context Legacy NDK versions
    vsphere-clone:    [-] Android NDK version is 21 50ms (45ms|4ms)
    vsphere-clone:     Expected case sensitive like wildcard '*Revision = 21.*' to match 'Pkg.Desc = Android NDK
    vsphere-clone:     Pkg.Revision = 22.0.7026061
    vsphere-clone:     ', but it did not match.
    vsphere-clone:     at $rawContent | Should -BeLikeExactly "*Revision = 21.*", /Users/runner/image-generation/tests/Android.Tests.ps1:75
    vsphere-clone:     at <ScriptBlock>, /Users/runner/image-generation/tests/Android.Tests.ps1:75
```

As we decided to install the latest version every time, we don't need this test anymore.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1615

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
