### PR TITLE
[Ubuntu] Migrate tests for CLI tools to Pester

### DIFF
--- a/images/linux/scripts/helpers/invoke-tests.sh
+++ b/images/linux/scripts/helpers/invoke-tests.sh
@@ -9,5 +9,5 @@ invoke_tests() {
     local TEST_NAME="$2"
 
     pwsh -Command "Import-Module '$HELPER_SCRIPTS/Tests.Helpers.psm1' -DisableNameChecking
-        Invoke-PesterTests -TestFile $TEST_FILE -TestName $TEST_NAME"
+        Invoke-PesterTests -TestFile \"$TEST_FILE\" -TestName \"$TEST_NAME\""
 }

--- a/images/linux/scripts/installers/aliyun-cli.sh
+++ b/images/linux/scripts/installers/aliyun-cli.sh
@@ -12,6 +12,5 @@ wget -P /tmp $URL
 tar xzvf /tmp/aliyun-cli-linux-*-amd64.tgz
 mv aliyun /usr/local/bin
 
-#Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
 invoke_tests "CLI.Tools" "Aliyun CLI"

--- a/images/linux/scripts/installers/aliyun-cli.sh
+++ b/images/linux/scripts/installers/aliyun-cli.sh
@@ -4,15 +4,14 @@
 ##  Desc:  Installs Alibaba Cloud CLI
 ################################################################################
 
+source $HELPER_SCRIPTS/invoke-tests.sh
+
 # Install Alibaba Cloud CLI
 URL=$(curl -s https://api.github.com/repos/aliyun/aliyun-cli/releases/latest | jq -r '.assets[].browser_download_url | select(contains("aliyun-cli-linux"))')
 wget -P /tmp $URL
 tar xzvf /tmp/aliyun-cli-linux-*-amd64.tgz
 mv aliyun /usr/local/bin
 
-# Run tests to determine that the software installed as expected
+#Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
-if ! command -v aliyun ; then
-    echo "aliyun was not installed"
-    exit 1
-fi
+invoke_tests "CLI.Tools" "Aliyun CLI"

--- a/images/linux/scripts/installers/aliyun-cli.sh
+++ b/images/linux/scripts/installers/aliyun-cli.sh
@@ -12,5 +12,4 @@ wget -P /tmp $URL
 tar xzvf /tmp/aliyun-cli-linux-*-amd64.tgz
 mv aliyun /usr/local/bin
 
-echo "Testing to make sure that script performed as expected, and basic scenarios work"
 invoke_tests "CLI.Tools" "Aliyun CLI"

--- a/images/linux/scripts/installers/aws-sam-cli.sh
+++ b/images/linux/scripts/installers/aws-sam-cli.sh
@@ -24,6 +24,5 @@ $Python3BinDir/python3 -m pip install setuptools
 $Python3BinDir/python3 setup.py install
 ln -sf ${Python3BinDir}/sam /usr/local/bin/sam
 
-# Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
 invoke_tests "CLI.Tools" "AWS SAM CLI"

--- a/images/linux/scripts/installers/aws-sam-cli.sh
+++ b/images/linux/scripts/installers/aws-sam-cli.sh
@@ -24,5 +24,4 @@ $Python3BinDir/python3 -m pip install setuptools
 $Python3BinDir/python3 setup.py install
 ln -sf ${Python3BinDir}/sam /usr/local/bin/sam
 
-echo "Testing to make sure that script performed as expected, and basic scenarios work"
 invoke_tests "CLI.Tools" "AWS SAM CLI"

--- a/images/linux/scripts/installers/aws-sam-cli.sh
+++ b/images/linux/scripts/installers/aws-sam-cli.sh
@@ -5,6 +5,8 @@
 ##         Requires Python >=3.6, must be run as non-root user after toolset installation
 ################################################################################
 
+source $HELPER_SCRIPTS/invoke-tests.sh
+
 # Download latest aws sam cli sources
 TarballUrl=$(curl -s https://api.github.com/repos/aws/aws-sam-cli/releases/latest | jq -r '.tarball_url')
 TarballPath="/tmp/aws-sam-cli.tar.gz"
@@ -24,7 +26,4 @@ ln -sf ${Python3BinDir}/sam /usr/local/bin/sam
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
-if ! sam --version; then
-    echo "AWS SAM CLI was not installed"
-    exit 1
-fi
+invoke_tests "CLI.Tools" "AWS SAM CLI"

--- a/images/linux/scripts/installers/aws.sh
+++ b/images/linux/scripts/installers/aws.sh
@@ -27,5 +27,4 @@ fi
 curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
 sudo dpkg -i session-manager-plugin.deb
 
-echo "Testing to make sure that script performed as expected, and basic scenarios work"
 invoke_tests "CLI.Tools" "AWS"

--- a/images/linux/scripts/installers/aws.sh
+++ b/images/linux/scripts/installers/aws.sh
@@ -27,6 +27,5 @@ fi
 curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
 sudo dpkg -i session-manager-plugin.deb
 
-# Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
 invoke_tests "CLI.Tools" "AWS"

--- a/images/linux/scripts/installers/aws.sh
+++ b/images/linux/scripts/installers/aws.sh
@@ -5,6 +5,7 @@
 ################################################################################
 
 source $HELPER_SCRIPTS/os.sh
+source $HELPER_SCRIPTS/invoke-tests.sh
 
 # Install the AWS CLI v1 on Ubuntu16 and Ubuntu18, and AWS CLI v2 on Ubuntu20
 if isUbuntu20 ; then
@@ -23,19 +24,9 @@ if isUbuntu16 || isUbuntu18 ; then
     rm -rf awscli-bundle
 fi
 
-# Validate the installation
-echo "Validate the installation"
-if ! command -v aws; then
-    echo "aws was not installed"
-    exit 1
-fi
-
 curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
 sudo dpkg -i session-manager-plugin.deb
 
-sessionPlugin=$(session-manager-plugin)
-echo "$sessionPlugin"
-if ! [[ $sessionPlugin == *"was installed successfully"* ]]
-then
-    exit 1
-fi
+# Run tests to determine that the software installed as expected
+echo "Testing to make sure that script performed as expected, and basic scenarios work"
+invoke_tests "CLI.Tools" "AWS"

--- a/images/linux/scripts/installers/azure-cli.sh
+++ b/images/linux/scripts/installers/azure-cli.sh
@@ -4,12 +4,11 @@
 ##  Desc:  Installed Azure CLI (az)
 ################################################################################
 
+source $HELPER_SCRIPTS/invoke-tests.sh
+
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
-if ! command -v az; then
-    echo "azure-cli was not installed"
-    exit 1
-fi
+invoke_tests "CLI.Tools" "Azure CLI"

--- a/images/linux/scripts/installers/azure-cli.sh
+++ b/images/linux/scripts/installers/azure-cli.sh
@@ -9,5 +9,4 @@ source $HELPER_SCRIPTS/invoke-tests.sh
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
-echo "Testing to make sure that script performed as expected, and basic scenarios work"
 invoke_tests "CLI.Tools" "Azure CLI"

--- a/images/linux/scripts/installers/azure-cli.sh
+++ b/images/linux/scripts/installers/azure-cli.sh
@@ -9,6 +9,5 @@ source $HELPER_SCRIPTS/invoke-tests.sh
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
-# Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
 invoke_tests "CLI.Tools" "Azure CLI"

--- a/images/linux/scripts/installers/azure-devops-cli.sh
+++ b/images/linux/scripts/installers/azure-devops-cli.sh
@@ -14,5 +14,4 @@ echo "AZURE_EXTENSION_DIR=$AZURE_EXTENSION_DIR" | tee -a /etc/environment
 # install azure devops Cli extension
 az extension add -n azure-devops
 
-echo "Testing to make sure that script performed as expected, and basic scenarios work"
 invoke_tests "CLI.Tools" "Azure DevOps CLI"

--- a/images/linux/scripts/installers/azure-devops-cli.sh
+++ b/images/linux/scripts/installers/azure-devops-cli.sh
@@ -4,6 +4,8 @@
 ##  Desc:  Installed Azure DevOps CLI (az devops)
 ################################################################################
 
+source $HELPER_SCRIPTS/invoke-tests.sh
+
 # AZURE_EXTENSION_DIR shell variable defines where modules are installed
 # https://docs.microsoft.com/en-us/cli/azure/azure-cli-extensions-overview
 export AZURE_EXTENSION_DIR=/opt/az/azcliextensions
@@ -12,11 +14,6 @@ echo "AZURE_EXTENSION_DIR=$AZURE_EXTENSION_DIR" | tee -a /etc/environment
 # install azure devops Cli extension
 az extension add -n azure-devops
 
-# check to determine if extension was installed or not
-if [ $? -eq 0 ]
-then
-    echo "azure DevOps Cli extension was installed"
-else
-    echo "azure DevOps Cli extension was not installed"
-    exit 1
-fi
+# Run tests to determine that the software installed as expected
+echo "Testing to make sure that script performed as expected, and basic scenarios work"
+invoke_tests "CLI.Tools" "Azure DevOps CLI"

--- a/images/linux/scripts/installers/azure-devops-cli.sh
+++ b/images/linux/scripts/installers/azure-devops-cli.sh
@@ -14,6 +14,5 @@ echo "AZURE_EXTENSION_DIR=$AZURE_EXTENSION_DIR" | tee -a /etc/environment
 # install azure devops Cli extension
 az extension add -n azure-devops
 
-# Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
 invoke_tests "CLI.Tools" "Azure DevOps CLI"

--- a/images/linux/scripts/installers/github-cli.sh
+++ b/images/linux/scripts/installers/github-cli.sh
@@ -13,5 +13,4 @@ wget $url
 apt install ./gh_*_linux_amd64.deb
 rm gh_*_linux_amd64.deb
 
-echo "Testing to make sure that script performed as expected, and basic scenarios work"
 invoke_tests "CLI.Tools" "GitHub CLI"

--- a/images/linux/scripts/installers/github-cli.sh
+++ b/images/linux/scripts/installers/github-cli.sh
@@ -5,6 +5,8 @@
 ##         Must be run as non-root user after homebrew
 ################################################################################
 
+source $HELPER_SCRIPTS/invoke-tests.sh
+
 # Install GitHub CLI
 url=$(curl -s https://api.github.com/repos/cli/cli/releases/latest | jq -r '.assets[].browser_download_url|select(contains("linux") and contains("amd64") and contains(".deb"))')
 wget $url
@@ -13,7 +15,4 @@ rm gh_*_linux_amd64.deb
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
-if ! gh --version; then
-    echo "GitHub CLI was not installed"
-    exit 1
-fi
+invoke_tests "CLI.Tools" "GitHub CLI"

--- a/images/linux/scripts/installers/github-cli.sh
+++ b/images/linux/scripts/installers/github-cli.sh
@@ -13,6 +13,5 @@ wget $url
 apt install ./gh_*_linux_amd64.deb
 rm gh_*_linux_amd64.deb
 
-# Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
 invoke_tests "CLI.Tools" "GitHub CLI"

--- a/images/linux/scripts/installers/google-cloud-sdk.sh
+++ b/images/linux/scripts/installers/google-cloud-sdk.sh
@@ -4,15 +4,14 @@
 ##  Desc:  Installs the Google Cloud SDK
 ################################################################################
 
+source $HELPER_SCRIPTS/invoke-tests.sh
+
 # Install the Google Cloud SDK
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 sudo apt-get update -y
 sudo apt-get install -y google-cloud-sdk
 
-# Validate the installation
-echo "Validate the installation"
-if ! command -v gcloud; then
-    echo "gcloud was not installed"
-    exit 1
-fi
+# Run tests to determine that the software installed as expected
+echo "Testing to make sure that script performed as expected, and basic scenarios work"
+invoke_tests "CLI.Tools" "Google Cloud SDK"

--- a/images/linux/scripts/installers/google-cloud-sdk.sh
+++ b/images/linux/scripts/installers/google-cloud-sdk.sh
@@ -12,5 +12,4 @@ curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyr
 sudo apt-get update -y
 sudo apt-get install -y google-cloud-sdk
 
-echo "Testing to make sure that script performed as expected, and basic scenarios work"
 invoke_tests "CLI.Tools" "Google Cloud SDK"

--- a/images/linux/scripts/installers/google-cloud-sdk.sh
+++ b/images/linux/scripts/installers/google-cloud-sdk.sh
@@ -12,6 +12,5 @@ curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyr
 sudo apt-get update -y
 sudo apt-get install -y google-cloud-sdk
 
-# Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
 invoke_tests "CLI.Tools" "Google Cloud SDK"

--- a/images/linux/scripts/installers/oc.sh
+++ b/images/linux/scripts/installers/oc.sh
@@ -13,6 +13,5 @@ PACKAGE_TAR_NAME="oc.tar.gz"
 download_with_retries $DOWNLOAD_URL "/tmp" $PACKAGE_TAR_NAME
 tar xvzf "/tmp/$PACKAGE_TAR_NAME" -C "/usr/local/bin"
 
-# Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
 invoke_tests "CLI.Tools" "OC CLI"

--- a/images/linux/scripts/installers/oc.sh
+++ b/images/linux/scripts/installers/oc.sh
@@ -13,5 +13,4 @@ PACKAGE_TAR_NAME="oc.tar.gz"
 download_with_retries $DOWNLOAD_URL "/tmp" $PACKAGE_TAR_NAME
 tar xvzf "/tmp/$PACKAGE_TAR_NAME" -C "/usr/local/bin"
 
-echo "Testing to make sure that script performed as expected, and basic scenarios work"
 invoke_tests "CLI.Tools" "OC CLI"

--- a/images/linux/scripts/installers/oc.sh
+++ b/images/linux/scripts/installers/oc.sh
@@ -5,6 +5,7 @@
 ################################################################################
 
 source $HELPER_SCRIPTS/install.sh
+source $HELPER_SCRIPTS/invoke-tests.sh
 
 # Install the oc CLI
 DOWNLOAD_URL="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz"
@@ -12,9 +13,6 @@ PACKAGE_TAR_NAME="oc.tar.gz"
 download_with_retries $DOWNLOAD_URL "/tmp" $PACKAGE_TAR_NAME
 tar xvzf "/tmp/$PACKAGE_TAR_NAME" -C "/usr/local/bin"
 
-# Validate the installation
-echo "Validate the installation"
-if ! command -v oc; then
-    echo "oc was not installed"
-    exit 1
-fi
+# Run tests to determine that the software installed as expected
+echo "Testing to make sure that script performed as expected, and basic scenarios work"
+invoke_tests "CLI.Tools" "OC CLI"

--- a/images/linux/scripts/installers/oras-cli.sh
+++ b/images/linux/scripts/installers/oras-cli.sh
@@ -17,5 +17,4 @@ cd /tmp
 download_with_retries $ORAS_CLI_DOWNLOAD_URL
 tar -zxvf $ORAS_CLI_ARCHIVE -C /usr/local/bin oras
 
-echo "Testing to make sure that script performed as expected, and basic scenarios work"
 invoke_tests "CLI.Tools" "Oras CLI"

--- a/images/linux/scripts/installers/oras-cli.sh
+++ b/images/linux/scripts/installers/oras-cli.sh
@@ -17,6 +17,5 @@ cd /tmp
 download_with_retries $ORAS_CLI_DOWNLOAD_URL
 tar -zxvf $ORAS_CLI_ARCHIVE -C /usr/local/bin oras
 
-# Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
 invoke_tests "CLI.Tools" "Oras CLI"

--- a/images/linux/scripts/installers/oras-cli.sh
+++ b/images/linux/scripts/installers/oras-cli.sh
@@ -5,6 +5,7 @@
 ################################################################################
 
 source $HELPER_SCRIPTS/install.sh
+source $HELPER_SCRIPTS/invoke-tests.sh
 
 # Determine latest ORAS CLI version
 ORAS_CLI_LATEST_VERSION_URL=https://api.github.com/repos/deislabs/oras/releases/latest
@@ -18,7 +19,4 @@ tar -zxvf $ORAS_CLI_ARCHIVE -C /usr/local/bin oras
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
-if ! oras version; then
-    echo "ORAS CLI was not installed"
-    exit 1
-fi
+invoke_tests "CLI.Tools" "Oras CLI"

--- a/images/linux/scripts/installers/vercel.sh
+++ b/images/linux/scripts/installers/vercel.sh
@@ -12,6 +12,5 @@ npm i -g vercel
 echo "Creating the symlink for [now] command to vercel CLI"
 ln -s /usr/local/bin/vercel /usr/local/bin/now
 
-# Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
 invoke_tests "CLI.Tools" "Vercel CLI"

--- a/images/linux/scripts/installers/vercel.sh
+++ b/images/linux/scripts/installers/vercel.sh
@@ -4,21 +4,19 @@
 ##  Desc:  Installs the Vercel CLI
 ################################################################################
 
+source $HELPER_SCRIPTS/invoke-tests.sh
+
 # Install the Vercel CLI
 npm i -g vercel
 
-# Validate the installation
-echo "Validate the installation"
-if ! command -v vercel; then
-    echo "Vercel CLI was not installed"
-    exit 1
-fi
+# Run tests to determine that the software installed as expected
+echo "Testing to make sure that script performed as expected, and basic scenarios work"
+invoke_tests "CLI.Tools" "Vercel CLI"
+
 
 echo "Creating the symlink for [now] command to vercel CLI"
 ln -s /usr/local/bin/vercel /usr/local/bin/now
 
-echo "Validate the link"
-if ! command -v now; then
-    echo "[Now] symlink to Vercel CLI was not created"
-    exit 1
-fi
+# Run tests to determine that the software installed as expected
+echo "Testing to make sure that script performed as expected, and basic scenarios work"
+invoke_tests "CLI.Tools" "Vercel CLI"

--- a/images/linux/scripts/installers/vercel.sh
+++ b/images/linux/scripts/installers/vercel.sh
@@ -9,11 +9,6 @@ source $HELPER_SCRIPTS/invoke-tests.sh
 # Install the Vercel CLI
 npm i -g vercel
 
-# Run tests to determine that the software installed as expected
-echo "Testing to make sure that script performed as expected, and basic scenarios work"
-invoke_tests "CLI.Tools" "Vercel CLI"
-
-
 echo "Creating the symlink for [now] command to vercel CLI"
 ln -s /usr/local/bin/vercel /usr/local/bin/now
 

--- a/images/linux/scripts/installers/vercel.sh
+++ b/images/linux/scripts/installers/vercel.sh
@@ -12,5 +12,4 @@ npm i -g vercel
 echo "Creating the symlink for [now] command to vercel CLI"
 ln -s /usr/local/bin/vercel /usr/local/bin/now
 
-echo "Testing to make sure that script performed as expected, and basic scenarios work"
 invoke_tests "CLI.Tools" "Vercel CLI"

--- a/images/linux/scripts/tests/CLI.Tools.Tests.ps1
+++ b/images/linux/scripts/tests/CLI.Tools.Tests.ps1
@@ -1,0 +1,72 @@
+
+Describe "Azure CLI" {
+    It "Azure CLI" {
+        "az --version" | Should -ReturnZeroExitCode
+    }
+}
+
+Describe "Azure DevOps CLI" {
+    It "az devops" {
+        "az devops -h" | Should -ReturnZeroExitCode
+    }
+}
+
+Describe "Aliyun CLI" {
+    It "Aliyun CLI" {
+        "aliyun version" | Should -ReturnZeroExitCode
+    }
+}
+
+Describe "AWS" {
+    It "AWS CLI" {
+        "aws --version" | Should -ReturnZeroExitCode
+    }
+
+    It "Session Manager Plugin for the AWS CLI" {
+        session-manager-plugin | Out-String | Should -Match "plugin was installed successfully"
+    }
+}
+
+Describe "AWS SAM CLI" {
+    It "AWS SAM CLI" {
+        "sam --version" | Should -ReturnZeroExitCode
+    }
+}
+
+Describe "GitHub CLI" {
+    It "gh cli" {
+        "gh --version" | Should -ReturnZeroExitCode
+    }
+
+    It "hub is installed" {
+        "hub --version" | Should -ReturnZeroExitCode
+    }
+}
+
+Describe "Google Cloud SDK" {
+    It "Google Cloud SDK" {
+        "gcloud --version" | Should -ReturnZeroExitCode
+    }
+}
+
+Describe "OC CLI" {
+    It "OC CLI" {
+        "oc version" | Should -ReturnZeroExitCode
+    }
+}
+
+Describe "Oras CLI" {
+    It "Oras CLI" {
+        "oras version" | Should -ReturnZeroExitCode
+    }
+}
+
+Describe "Vercel CLI" {
+    It "Vercel CLI" {
+        "vercel version" | Should -ReturnZeroExitCode
+    }
+
+    It "Validate the symlink link [now]" {
+        "now" | Should -ReturnZeroExitCode
+    }
+}

--- a/images/linux/scripts/tests/CLI.Tools.Tests.ps1
+++ b/images/linux/scripts/tests/CLI.Tools.Tests.ps1
@@ -63,10 +63,10 @@ Describe "Oras CLI" {
 
 Describe "Vercel CLI" {
     It "Vercel CLI" {
-        "vercel version" | Should -ReturnZeroExitCode
+        "vercel --version" | Should -ReturnZeroExitCode
     }
 
     It "Validate the symlink link [now]" {
-        "now" | Should -ReturnZeroExitCode
+        "now --version" | Should -ReturnZeroExitCode
     }
 }


### PR DESCRIPTION
# Description
In scope of this PR we are migrating tests for CLI tools to Pester (see list of tools in related issue).

#### Related issue: [#1576](https://github.com/actions/virtual-environments-internal/issues/1576)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
