### PR TITLE
[macOS] install swiftlint from pkg

### DIFF
--- a/images/macos/provision/core/commonutils.sh
+++ b/images/macos/provision/core/commonutils.sh
@@ -56,16 +56,5 @@ for package in ${bcask_common_utils[@]}; do
     brew cask install $package
 done
 
-# Brew supports swiftlint only for Catalina and above
-if is_Catalina || is_BigSur; then
-    brew install swiftlint
-fi
-
-if is_Mojave; then
-    swiftlintUrl=$(curl -s "https://api.github.com/repos/realm/SwiftLint/releases/latest" | jq -r '.assets[].browser_download_url | select(contains("SwiftLint.pkg"))')
-    download_with_retries $swiftlintUrl "/tmp" "SwiftLint.pkg"
-    sudo installer -pkg /tmp/SwiftLint.pkg -target /
-fi
-
 # Invoke bazel to download the latest bazel version via bazelisk
 bazel

--- a/images/macos/provision/core/commonutils.sh
+++ b/images/macos/provision/core/commonutils.sh
@@ -56,8 +56,15 @@ for package in ${bcask_common_utils[@]}; do
     brew cask install $package
 done
 
-if ! is_HighSierra; then
+# Brew supports swiftlint only for Catalina and above
+if is_Catalina || is_BigSur; then
     brew install swiftlint
+fi
+
+if is_Mojave; then
+    swiftlintUrl=$(curl -s "https://api.github.com/repos/realm/SwiftLint/releases/latest" | jq -r '.assets[].browser_download_url | select(contains("SwiftLint.pkg"))')
+    download_with_retries $swiftlintUrl "/tmp" "SwiftLint.pkg"
+    sudo installer -pkg /tmp/SwiftLint.pkg -target /
 fi
 
 # Invoke bazel to download the latest bazel version via bazelisk

--- a/images/macos/provision/core/swiftlint.sh
+++ b/images/macos/provision/core/swiftlint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e -o pipefail
 
+source ~/utils/utils.sh
+
 echo "Install SwiftLint"
 swiftlintUrl=$(curl -s "https://api.github.com/repos/realm/SwiftLint/releases/latest" | jq -r '.assets[].browser_download_url | select(contains("SwiftLint.pkg"))')
 download_with_retries $swiftlintUrl "/tmp" "SwiftLint.pkg"

--- a/images/macos/provision/core/swiftlint.sh
+++ b/images/macos/provision/core/swiftlint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e -o pipefail
+
+echo "Install SwiftLint"
+swiftlintUrl=$(curl -s "https://api.github.com/repos/realm/SwiftLint/releases/latest" | jq -r '.assets[].browser_download_url | select(contains("SwiftLint.pkg"))')
+download_with_retries $swiftlintUrl "/tmp" "SwiftLint.pkg"
+sudo installer -pkg /tmp/SwiftLint.pkg -target /
+rm -rf /tmp/SwiftLint.pkg

--- a/images/macos/templates/macOS-10.13.json
+++ b/images/macos/templates/macOS-10.13.json
@@ -126,9 +126,9 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "pause_before": "30s",
             "scripts": [
+                "./provision/core/xcode-clt.sh",
                 "./provision/core/homebrew.sh",
                 "./provision/core/powershell.sh",
-                "./provision/core/xcode-clt.sh",
                 "./provision/core/dotnet.sh",
                 "./provision/core/python.sh",
                 "./provision/core/azcopy.sh",

--- a/images/macos/templates/macOS-10.14.json
+++ b/images/macos/templates/macOS-10.14.json
@@ -126,9 +126,9 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "pause_before": "30s",
             "scripts": [
+                "./provision/core/xcode-clt.sh",
                 "./provision/core/homebrew.sh",
                 "./provision/core/powershell.sh",
-                "./provision/core/xcode-clt.sh",
                 "./provision/core/dotnet.sh",
                 "./provision/core/python.sh",
                 "./provision/core/azcopy.sh",
@@ -159,6 +159,7 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "scripts": [
                 "./provision/core/commonutils.sh",
+                "./provision/core/swiftlint.sh",
                 "./provision/core/openjdk.sh",
                 "./provision/core/php.sh",
                 "./provision/core/aws.sh",

--- a/images/macos/templates/macOS-10.15.json
+++ b/images/macos/templates/macOS-10.15.json
@@ -127,9 +127,9 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "pause_before": "30s",
             "scripts": [
+                "./provision/core/xcode-clt.sh",
                 "./provision/core/homebrew.sh",
                 "./provision/core/powershell.sh",
-                "./provision/core/xcode-clt.sh",
                 "./provision/core/dotnet.sh",
                 "./provision/core/python.sh",
                 "./provision/core/azcopy.sh",
@@ -160,6 +160,7 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "scripts": [
                 "./provision/core/commonutils.sh",
+                "./provision/core/swiftlint.sh",
                 "./provision/core/openjdk.sh",
                 "./provision/core/php.sh",
                 "./provision/core/aws.sh",

--- a/images/macos/templates/macOS-11.0.json
+++ b/images/macos/templates/macOS-11.0.json
@@ -127,9 +127,9 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "pause_before": "30s",
             "scripts": [
+                "./provision/core/xcode-clt.sh",
                 "./provision/core/homebrew.sh",
                 "./provision/core/powershell.sh",
-                "./provision/core/xcode-clt.sh",
                 "./provision/core/dotnet.sh",
                 "./provision/core/python.sh",
                 "./provision/core/azcopy.sh",
@@ -160,6 +160,7 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "scripts": [
                 "./provision/core/commonutils.sh",
+                "./provision/core/swiftlint.sh",
                 "./provision/core/openjdk.sh",
                 "./provision/core/php.sh",
                 "./provision/core/aws.sh",


### PR DESCRIPTION
# Description
[Swiftlint brew formulae](https://formulae.brew.sh/formula/swiftlint) requires Xcode >= 11.4 to build the package yet the latest one we have on Mojave is 11.3.1.
This PR adds swiftlint installation from the latest release from https://github.com/realm/SwiftLint/releases for all macOS except High Sierra since it's not supported.
As an addition, xcode-clt installation script reverted to invoke before homebrew.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1620

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
