### PR TITLE
Dotnet core sdk unpacking stage changes

### DIFF
--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -19,7 +19,6 @@ mksamples()
     sample=$2
     mkdir "$sdk"
     cd "$sdk" || exit
-    dotnet help
     dotnet new globaljson --sdk-version "$sdk"
     dotnet new "$sample"
     dotnet restore
@@ -74,7 +73,9 @@ parallel --jobs 0 --halt soon,fail=1 \
     'url="https://dotnetcli.blob.core.windows.net/dotnet/Sdk/{}/dotnet-sdk-{}-linux-x64.tar.gz"; \
     download_with_retries $url' ::: "${sortedSdks[@]}"
 
-find . -name "*.tar.gz" | parallel --halt soon,fail=1 'extract_dotnet_sdk {}'
+parallel --jobs 0 --halt soon,fail=1 \
+    'name="./dotnet-sdk-{}-linux-x64.tar.gz"; \
+    extract_dotnet_sdk $name' ::: "${sortedSdks[@]}"
 
 # Smoke test each SDK
 for sdk in $sortedSdks; do


### PR DESCRIPTION
Minor change of dotnet core sdk unpacking stage. Now all unpacking jobs will start at the same time. Help command is unnecessary because the sdk version is mentioned in build output.

#### Related issue: actions/virtual-environments-internal#1538

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
