### PR TITLE
[Ubuntu] Switch image generation to Standard_D4s_v4 VM size

### DIFF
--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -16,7 +16,7 @@
         "imagedata_file": "/imagegeneration/imagedata.json",
         "installer_script_folder": "/imagegeneration/installers",
         "helper_script_folder": "/imagegeneration/helpers",
-        "vm_size": "Standard_DS2_v2",
+        "vm_size": "Standard_D4s_v4",
         "capture_name_prefix": "packer",
         "image_version": "dev",
         "image_os": "ubuntu16",

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -16,7 +16,7 @@
         "imagedata_file": "/imagegeneration/imagedata.json",
         "installer_script_folder": "/imagegeneration/installers",
         "helper_script_folder": "/imagegeneration/helpers",
-        "vm_size": "Standard_DS2_v2",
+        "vm_size": "Standard_D4s_v4",
         "capture_name_prefix": "packer",
         "image_version": "dev",
         "image_os": "ubuntu18",

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -16,7 +16,7 @@
         "imagedata_file": "/imagegeneration/imagedata.json",
         "installer_script_folder": "/imagegeneration/installers",
         "helper_script_folder": "/imagegeneration/helpers",
-        "vm_size": "Standard_DS2_v2",
+        "vm_size": "Standard_D4s_v4",
         "capture_name_prefix": "packer",
         "image_version": "dev",
         "image_os": "ubuntu20",


### PR DESCRIPTION
# Description
We've investigated image generation using different VM sizes and the results are quite promising with Standard_D4s_v4 VM size (4cpu, 16Gb Ram, no temporary storage)  — build time decreased from 3.40-3.50 to 3 hours for Ubuntu 18.
The price shouldn't increase much:
Standard_D4s_v4 for 3h — $1.22
Standard_DS2_v2 for 4h — $1.01

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1595

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
