### PR TITLE
[Ubuntu] update apt.mock with additional lock error.

### DIFF
--- a/images/linux/scripts/base/apt-mock.sh
+++ b/images/linux/scripts/base/apt-mock.sh
@@ -32,6 +32,9 @@ while [ \$i -le 30 ];do
   elif grep -q 'Temporary failure in name resolution' \$err;then
     # It looks like DNS is not updated with random generated hostname yet
     retry=true
+  elif grep -q 'dpkg frontend is locked by another process' \$err;then
+    # dpkg process is busy by another process
+    retry=true
   fi
 
   rm \$err


### PR DESCRIPTION
# Description
Improvement
There was error during Ubuntu built:

`==> azure-arm: dpkg: error: dpkg frontend is locked by another process`

I've added the error to apt.mock to retry in case of re-occurance.

#### Related issue:
---

## Check list
- [-] Related issue / work item is attached
- [-] Tests are written (if applicable)
