### PR TITLE
Upgrade Android SDK tools from deprecated "SDK Tools" to new "Command Line Tools"

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -49,6 +49,10 @@ function Build-AndroidTable {
             "Version" = Get-AndroidBuildToolVersions -PackageInfo $packageInfo
         },
         @{
+            "Package" = "Android Command Line Tools"
+            "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android Command Line Tools"
+        },
+        @{
             "Package" = "Android emulator"
             "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android Emulator"
         },

--- a/images/linux/scripts/installers/android.sh
+++ b/images/linux/scripts/installers/android.sh
@@ -73,6 +73,8 @@ availableBuildTools=$(echo ${allBuildTools[@]//*rc[0-9]/})
 filter_components_by_version $minimumPlatformVersion "${availablePlatforms[@]}"
 filter_components_by_version $minimumBuildToolVersion "${availableBuildTools[@]}"
 
+components+=" cmdline-tools;latest"
+
 echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager ${components[@]}
 
 # Add required permissions

--- a/images/macos/provision/core/android-toolsets.sh
+++ b/images/macos/provision/core/android-toolsets.sh
@@ -73,6 +73,7 @@ filter_components_by_version $ANDROID_PLATFORM "${availablePlatforms[@]}"
 allBuildTools=($(${ANDROID_HOME}/tools/bin/sdkmanager --list --include_obsolete | grep "build-tools;" | cut -d"|" -f 1 | sort -u))
 availableBuildTools=$(echo ${allBuildTools[@]//*rc[0-9]/})
 filter_components_by_version $ANDROID_BUILD_TOOL "${availableBuildTools[@]}"
+components+=" cmdline-tools;latest"
 
 echo "y" | ${ANDROID_HOME}/tools/bin/sdkmanager ${components[@]}
 

--- a/images/macos/software-report/SoftwareReport.Android.psm1
+++ b/images/macos/software-report/SoftwareReport.Android.psm1
@@ -51,6 +51,10 @@ function Build-AndroidTable {
             "Version" = Get-AndroidBuildToolVersions -PackageInfo $packageInfo
         },
         @{
+            "Package" = "Android Command Line Tools"
+            "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android SDK Command-line Tools"
+        },
+        @{
             "Package" = "Android SDK Platform-Tools"
             "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android SDK Platform-Tools"
         },

--- a/images/macos/tests/Android.Tests.ps1
+++ b/images/macos/tests/Android.Tests.ps1
@@ -57,6 +57,17 @@ Describe "Android" {
         }
     }
 
+    Context "Android command line tools" {
+        It "Latest command line tools are installed" {
+            $cmdlineTools = "apkanalyzer", "avdmanager", "lint", "screenshot2", "sdkmanager"
+
+            $cmdlineTools | ForEach-Object {
+                $toolPath = Join-Path $ANDROID_SDK_DIR "cmdline-tools" "latest" "bin" $_
+                $toolPath | Should -Exist
+            }
+        }
+    }
+
     Context "NDK toolchains" -Skip:($os.IsBigSur) {
         $testCases = $androidNdkToolchains | ForEach-Object { @{AndroidNdkToolchain = $_} }
 

--- a/images/win/scripts/Installers/Update-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Update-AndroidSDK.ps1
@@ -51,6 +51,9 @@ $buildToolsList = Get-AndroidPackagesByVersion -AndroidPackages $androidPackages
                   -Delimiter ";" `
                   -Index 1
 
+# cmdline-tools
+$cmdlineToolsList = ,"cmdline-tools;latest"
+
 Install-AndroidSDKPackages -AndroidSDKManagerPath $sdkManager `
                           -AndroidSDKRootPath $sdkRoot `
                           -AndroidPackages $platformList
@@ -58,6 +61,10 @@ Install-AndroidSDKPackages -AndroidSDKManagerPath $sdkManager `
 Install-AndroidSDKPackages -AndroidSDKManagerPath $sdkManager `
                           -AndroidSDKRootPath $sdkRoot `
                           -AndroidPackages $buildToolsList
+
+Install-AndroidSDKPackages -AndroidSDKManagerPath $sdkManager `
+                          -AndroidSDKRootPath $sdkRoot `
+                          -AndroidPackages $cmdlineToolsList
 
 Install-AndroidSDKPackages -AndroidSDKManagerPath $sdkManager `
                           -AndroidSDKRootPath $sdkRoot `

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -43,6 +43,10 @@ function Build-AndroidTable {
             "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android SDK Tools"
         },
         @{
+            "Package" = "Android Command Line Tools"
+            "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android SDK Command-line Tools"
+        },
+        @{
             "Package" = "Android SDK Platforms"
             "Version" = Get-AndroidPlatformVersions -PackageInfo $packageInfo
         },

--- a/images/win/scripts/Tests/Android.Tests.ps1
+++ b/images/win/scripts/Tests/Android.Tests.ps1
@@ -55,7 +55,7 @@ Describe "Android SDK" {
 
     It "Latest command line tools are installed" {
         $cmdlineTools = "apkanalyzer.bat", "avdmanager.bat", "lint.bat", "screenshot2.bat", "sdkmanager.bat"
-
+        $sdkRoot=$Env:ANDROID_SDK_ROOT
         $cmdlineTools | ForEach-Object {
             "$sdkRoot\cmdline-tools\latest\bin\$_" | Should -Exist
         }

--- a/images/win/scripts/Tests/Android.Tests.ps1
+++ b/images/win/scripts/Tests/Android.Tests.ps1
@@ -53,6 +53,14 @@ Describe "Android SDK" {
         "$installedPackages" | Should -Match "$buildToolsVersion"
     }
 
+    It "Latest command line tools are installed" {
+        $cmdlineTools = "apkanalyzer.bat", "avdmanager.bat", "lint.bat", "screenshot2.bat", "sdkmanager.bat"
+
+        $cmdlineTools | ForEach-Object {
+            "$sdkRoot\cmdline-tools\latest\bin\$_" | Should -Exist
+        }
+    }
+
     if (Test-IsWin19) {
         It "Extra package <extraPackage> is installed" -TestCases $extraPackagesTestCases {
             "$installedPackages" | Should -Match "extras;$extraPackage"


### PR DESCRIPTION
# Description
New tool 

size:  100Mb
time: 30 secs

Virtual environments currently installs Android "SDK Tools", which is deprecated: https://developer.android.com/studio/releases/sdk-tools

Google suggests using the new "cmdline-tools" package instead:
https://developer.android.com/studio/command-line

#### Related issue: https://github.com/actions/virtual-environments/issues/2252

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
