### PR TITLE
Added escaping on clang report

### DIFF
--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -81,7 +81,7 @@ function Get-ClangLLVMVersion {
     $locationsList | Foreach-Object {
         (Run-Command "${_} --version" | Out-String) -match "(?<version>\d+\.\d+\.\d+)" | Out-Null
         $version = $Matches.version
-        "Clang/LLVM $version " + $(if(${_} -Match "brew") {"is available on ``${_}``"} else {"is default"})
+        "Clang/LLVM $version " + $(if(${_} -Match "brew") {"is available on ```'${_}`'``"} else {"is default"})
     }
 }
 


### PR DESCRIPTION
# Description
Clang MacOS  report string contains `$(brew --prefix llvm)/bin/clang` string that was not escaped

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: actions/virtual-environments-internal#1610

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
