### PR TITLE
[macOS] brew --cask option fix.

### DIFF
--- a/images/macos/provision/core/audiodevice.sh
+++ b/images/macos/provision/core/audiodevice.sh
@@ -2,7 +2,7 @@
 source ~/utils/invoke-tests.sh
 
 echo "install soundflower"
-brew cask install soundflower
+brew install --cask soundflower
 
 echo "install switchaudio-osx"
 brew install switchaudio-osx

--- a/images/macos/provision/core/aws.sh
+++ b/images/macos/provision/core/aws.sh
@@ -13,6 +13,6 @@ brew tap aws/tap
 brew install aws-sam-cli
 
 echo "Install aws cli session manager"
-brew cask install session-manager-plugin
+brew install --cask session-manager-plugin
 
 invoke_tests "Common" "AWS"

--- a/images/macos/provision/core/chrome.sh
+++ b/images/macos/provision/core/chrome.sh
@@ -6,7 +6,7 @@ echo "Installing Chrome..."
 brew_cask_install_ignoring_sha256 "google-chrome"
 
 echo "Installing Chrome Driver"
-brew cask install chromedriver
+brew install --cask chromedriver
 
 echo "Installing Selenium"
 brew install selenium-server-standalone

--- a/images/macos/provision/core/commonutils.sh
+++ b/images/macos/provision/core/commonutils.sh
@@ -53,7 +53,7 @@ fi
 
 for package in ${bcask_common_utils[@]}; do
     echo "Install $package"
-    brew cask install $package
+    brew install --cask $package
 done
 
 # Invoke bazel to download the latest bazel version via bazelisk

--- a/images/macos/provision/core/edge.sh
+++ b/images/macos/provision/core/edge.sh
@@ -3,7 +3,7 @@ source ~/utils/utils.sh
 source ~/utils/invoke-tests.sh
 
 echo "Installing Microsoft Edge..."
-brew cask install microsoft-edge
+brew install --cask microsoft-edge
 
 EDGE_INSTALLATION_PATH="/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"
 EDGE_VERSION=$("$EDGE_INSTALLATION_PATH" --version | cut -d' ' -f 3)

--- a/images/macos/provision/core/firefox.sh
+++ b/images/macos/provision/core/firefox.sh
@@ -2,7 +2,7 @@
 source ~/utils/invoke-tests.sh
 
 echo "Installing Firefox..."
-brew cask install firefox
+brew install --cask firefox
 
 echo "Installing Geckodriver..."
 brew install geckodriver

--- a/images/macos/provision/core/homebrew.sh
+++ b/images/macos/provision/core/homebrew.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e -o pipefail
-source ~/utils/utils.sh
 
 echo "Installing Homebrew..."
 HOMEBREW_INSTALL_URL="https://raw.githubusercontent.com/Homebrew/install/master/install.sh"
@@ -8,10 +7,8 @@ HOMEBREW_INSTALL_URL="https://raw.githubusercontent.com/Homebrew/install/master/
 echo "Disabling Homebrew analytics..."
 brew analytics off
 
-if ! is_HighSierra; then
-echo "Installing curl..."
+echo "Installing the latest curl..."
 brew install curl
-fi
 
 echo "Installing wget..."
 brew install wget

--- a/images/macos/provision/core/homebrew.sh
+++ b/images/macos/provision/core/homebrew.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -e -o pipefail
+source ~/utils/utils.sh
 
 echo "Installing Homebrew..."
 HOMEBREW_INSTALL_URL="https://raw.githubusercontent.com/Homebrew/install/master/install.sh"
@@ -7,8 +8,10 @@ HOMEBREW_INSTALL_URL="https://raw.githubusercontent.com/Homebrew/install/master/
 echo "Disabling Homebrew analytics..."
 brew analytics off
 
-echo "Installing the latest curl..."
+if ! is_HighSierra; then
+echo "Installing curl..."
 brew install curl
+fi
 
 echo "Installing wget..."
 brew install wget

--- a/images/macos/provision/core/openjdk.sh
+++ b/images/macos/provision/core/openjdk.sh
@@ -37,7 +37,7 @@ do
     if [[ $JAVA_VERSION == "7" ]]; then
         installAzulJDK "https://cdn.azul.com/zulu/bin/zulu7.42.0.51-ca-jdk7.0.285-macosx_x64.dmg"
     else
-        brew cask install "adoptopenjdk${JAVA_VERSION}"
+        brew install --cask "adoptopenjdk${JAVA_VERSION}"
     fi
     createEnvironmentVariable "JAVA_HOME_${JAVA_VERSION}_X64" $JAVA_VERSION
 done

--- a/images/macos/provision/core/powershell.sh
+++ b/images/macos/provision/core/powershell.sh
@@ -7,7 +7,7 @@ echo Installing Azure CLI...
 brew install azure-cli
 
 echo Installing PowerShell...
-brew cask install powershell
+brew install --cask powershell
 
 # A dummy call of `az` to initialize ~/.azure directory before the modules are installed
 az -v

--- a/images/macos/provision/utils/utils.sh
+++ b/images/macos/provision/utils/utils.sh
@@ -104,7 +104,7 @@ brew_cask_install_ignoring_sha256() {
     chmod a+w "$CASK_DIR/$TOOL_NAME.rb"
     SHA=$(grep "sha256" "$CASK_DIR/$TOOL_NAME.rb" | awk '{print $2}')
     sed -i '' "s/$SHA/:no_check/" "$CASK_DIR/$TOOL_NAME.rb"
-    brew cask install $TOOL_NAME
+    brew install --cask $TOOL_NAME
     pushd $CASK_DIR
     git checkout HEAD -- "$TOOL_NAME.rb"
     popd


### PR DESCRIPTION
# Description
Improvement
Brew changed cask installation to the following mode:

`brew install --cask`

in the build logs, it can be observed:

`Error: Calling brew cask install is disabled! Use brew install [--cask] instead.`

#### Related issue:
1629
## Check list
- [+] Related issue / work item is attached
- [+] Tests are written (if applicable)

