### PR TITLE
Replace dpkg with apt

### DIFF
--- a/images/linux/scripts/installers/aws.sh
+++ b/images/linux/scripts/installers/aws.sh
@@ -25,6 +25,6 @@ if isUbuntu16 || isUbuntu18 ; then
 fi
 
 curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
-sudo dpkg -i session-manager-plugin.deb
+sudo apt install ./session-manager-plugin.deb
 
 invoke_tests "CLI.Tools" "AWS"


### PR DESCRIPTION
# Description
Improvement?  

We have apt mocks to retry in case of  errors, but there's no one for dpkg utility. 


#### Related issue: https://github.com/actions/virtual-environments-internal/issues/1634

## Check list
- [x] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
