### PR TITLE
[Ubuntu] Remove stale go_default and go_versions params

### DIFF
--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -20,9 +20,7 @@
         "capture_name_prefix": "packer",
         "image_version": "dev",
         "image_os": "ubuntu20",
-        "run_validation_diskspace": "false",
-        "go_default": "1.14",
-        "go_versions": "1.14"
+        "run_validation_diskspace": "false"
     },
     "sensitive-variables": [
         "client_secret"


### PR DESCRIPTION
# Description
Remove stale `go_default` and `go_versions` params in a packer config.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
