### PR TITLE
Change Android SDK root

### DIFF
--- a/images/win/scripts/Installers/Update-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Update-AndroidSDK.ps1
@@ -19,15 +19,17 @@
 $base64Content = "UEsDBBQAAAAAAKJeN06amkPzKgAAACoAAAAhAAAAbGljZW5zZXMvYW5kcm9pZC1nb29nbGV0di1saWNlbnNlDQpmYzk0NmU4ZjIzMWYzZTMxNTliZjBiN2M2NTVjOTI0Y2IyZTM4MzMwUEsDBBQAAAAIAKBrN05E+YSqQwAAAFQAAAAcAAAAbGljZW5zZXMvYW5kcm9pZC1zZGstbGljZW5zZQXByREAIQgEwP9WmYsjhxgOKJN/CNs9vmdOQ2zdRw2dxQnWjqQ/3oIgXQM9vqUiwkiX8ljWea4ZlCF3xTo1pz6w+wdQSwMEFAAAAAAAxV43TpECY7AqAAAAKgAAACQAAABsaWNlbnNlcy9hbmRyb2lkLXNkay1wcmV2aWV3LWxpY2Vuc2UNCjUwNDY2N2Y0YzBkZTdhZjFhMDZkZTlmNGIxNzI3Yjg0MzUxZjI5MTBQSwMEFAAAAAAAzF43TpOr0CgqAAAAKgAAABsAAABsaWNlbnNlcy9nb29nbGUtZ2RrLWxpY2Vuc2UNCjMzYjZhMmI2NDYwN2YxMWI3NTlmMzIwZWY5ZGZmNGFlNWM0N2Q5N2FQSwMEFAAAAAAAz143TqxN4xEqAAAAKgAAACQAAABsaWNlbnNlcy9pbnRlbC1hbmRyb2lkLWV4dHJhLWxpY2Vuc2UNCmQ5NzVmNzUxNjk4YTc3YjY2MmYxMjU0ZGRiZWVkMzkwMWU5NzZmNWFQSwMEFAAAAAAA0l43Tu2ee/8qAAAAKgAAACYAAABsaWNlbnNlcy9taXBzLWFuZHJvaWQtc3lzaW1hZ2UtbGljZW5zZQ0KNjNkNzAzZjU2OTJmZDg5MWQ1YWNhY2ZiZDhlMDlmNDBmYzk3NjEwNVBLAQIUABQAAAAAAKJeN06amkPzKgAAACoAAAAhAAAAAAAAAAEAIAAAAAAAAABsaWNlbnNlcy9hbmRyb2lkLWdvb2dsZXR2LWxpY2Vuc2VQSwECFAAUAAAACACgazdORPmEqkMAAABUAAAAHAAAAAAAAAABACAAAABpAAAAbGljZW5zZXMvYW5kcm9pZC1zZGstbGljZW5zZVBLAQIUABQAAAAAAMVeN06RAmOwKgAAACoAAAAkAAAAAAAAAAEAIAAAAOYAAABsaWNlbnNlcy9hbmRyb2lkLXNkay1wcmV2aWV3LWxpY2Vuc2VQSwECFAAUAAAAAADMXjdOk6vQKCoAAAAqAAAAGwAAAAAAAAABACAAAABSAQAAbGljZW5zZXMvZ29vZ2xlLWdkay1saWNlbnNlUEsBAhQAFAAAAAAAz143TqxN4xEqAAAAKgAAACQAAAAAAAAAAQAgAAAAtQEAAGxpY2Vuc2VzL2ludGVsLWFuZHJvaWQtZXh0cmEtbGljZW5zZVBLAQIUABQAAAAAANJeN07tnnv/KgAAACoAAAAmAAAAAAAAAAEAIAAAACECAABsaWNlbnNlcy9taXBzLWFuZHJvaWQtc3lzaW1hZ2UtbGljZW5zZVBLBQYAAAAABgAGANoBAACPAgAAAAA="
 $content = [System.Convert]::FromBase64String($base64Content)
 Set-Content -Path .\android-sdk-licenses.zip -Value $content -Encoding Byte
-Expand-Archive -Path .\android-sdk-licenses.zip -DestinationPath 'C:\Program Files (x86)\Android\android-sdk' -Force
+$sdkInstallRoot = "C:\Program Files (x86)\Android\android-sdk"
+$sdkRoot = "C:\Android\android-sdk"
+Expand-Archive -Path .\android-sdk-licenses.zip -DestinationPath $sdkInstallRoot -Force
+New-Item -Path "C:\Android" -ItemType Directory
+New-Item -Path "$sdkRoot" -ItemType SymbolicLink -Value "$sdkInstallRoot"
 
 # run the updates.
 # keep newer versions in descending order
 
 # Get android content from toolset
 $androidToolset = (Get-ToolsetContent).android
-
-$sdkRoot = "C:\Program Files (x86)\Android\android-sdk"
 $sdkManager = "$sdkRoot\tools\bin\sdkmanager.bat"
 
 & $sdkManager --sdk_root=$sdkRoot "platform-tools"
@@ -74,7 +76,7 @@ Install-AndroidSDKPackages -AndroidSDKManagerPath $sdkManager `
                           -AndroidPackages $androidToolset.additional_tools
 
 # Android NDK root path.
-$ndkRoot = "C:\Program Files (x86)\Android\android-sdk\ndk-bundle"
+$ndkRoot = "$sdkRoot\ndk-bundle"
 
 if (Test-Path $ndkRoot) {
     setx ANDROID_HOME $sdkRoot /M


### PR DESCRIPTION
# Description
 Improvement

Create a hardlink `C:\Android\android-sdk` pointing to `C:\Program Files (x86)\Android\android-sdk` and set `ANDROID_SDK_ROOT` to `C:\Android\android-sdk`

Problem to solve:

ANDROID_NDK_PATH / HOME should not contain spaces. Otherwise, the script C:\Program Files (x86)\Android\android-sdk\ndk-bundle\ndk-build.cmd gives an error

```
 'C:\Program' is not recognized as an internal or external command,
operable program or batch file.
```
changing just ndk-build.cmd is not (nearly) enough. We depend on all the compiler wrapper scripts in ./toolchains/llvm/prebuilt/windows-x86_64/bin/<architecture>-clang*.cmd being capable of handling spaces, and have not gone beyond checking what else might break.


#### Related issue: https://github.com/actions/virtual-environments/issues/1122

## Check list
- [x] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
