### PR TITLE
[Ubuntu] Preload `libgsl-dev` from APT repo

### DIFF
--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -134,6 +134,7 @@
             "libcurl3",
             "libgbm-dev",
             "libgconf-2-4",
+            "libgsl-dev",
             "libgtk-3-0",
             "libicu55",
             "libsecret-1-dev",

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -130,6 +130,7 @@
             "libcurl3",
             "libgbm-dev",
             "libgconf-2-4",
+            "libgsl-dev",
             "libgtk-3-0",
             "libsecret-1-dev",
             "libsqlite3-dev",

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -103,6 +103,7 @@
             "libcurl4",
             "libgbm-dev",
             "libgconf-2-4",
+            "libgsl-dev",
             "libgtk-3-0",
             "libsecret-1-dev",
             "libsqlite3-dev",


### PR DESCRIPTION
# Description

Install `libgsl-dev` from Ubuntu APT repository. `libgsl23` is a dependency (binary package) so no need to install separately.

#### Related issue: #2356

## Check list

- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
