### PR TITLE
Install Android Command Line tools on Windows images

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -43,6 +43,10 @@ function Build-AndroidTable {
             "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android SDK Tools"
         },
         @{
+            "Package" = "Android Command Line Tools"
+            "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android SDK Command-line Tools"
+        },
+        @{
             "Package" = "Android SDK Platforms"
             "Version" = Get-AndroidPlatformVersions -PackageInfo $packageInfo
         },

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -161,7 +161,8 @@
             "cmake;3.6.4111459",
             "cmake;3.10.2.4988404",
             "patcher;v4",
-            "ndk-bundle"
+            "ndk-bundle",
+            "cmdline-tools;latest"
         ]
     },
     "visualStudio": {

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -161,7 +161,8 @@
             "cmake;3.6.4111459",
             "cmake;3.10.2.4988404",
             "patcher;v4",
-            "ndk-bundle"
+            "ndk-bundle",
+            "cmdline-tools;latest"
         ]
     },
     "visualStudio": {


### PR DESCRIPTION
# Description
New tool 

size:  100Mb
time: 30 secs

Virtual environments currently installs Android "SDK Tools", which is deprecated: https://developer.android.com/studio/releases/sdk-tools

Google suggests using the new "cmdline-tools" package instead:
https://developer.android.com/studio/command-line

#### Related issue: https://github.com/actions/virtual-environments/issues/2252

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
