### PR TITLE
Add Android Command Line tools for MacOS images

### DIFF
--- a/images/macos/provision/core/android-toolsets.sh
+++ b/images/macos/provision/core/android-toolsets.sh
@@ -24,6 +24,7 @@ ANDROID_PLATFORM=($(get_toolset_value '.android.platform_min_version'))
 ANDROID_BUILD_TOOL=($(get_toolset_value '.android.build_tools_min_version'))
 ANDROID_EXTRA_LIST=($(get_toolset_value '.android."extra-list"[]'))
 ANDROID_ADDON_LIST=($(get_toolset_value '.android."addon-list"[]'))
+ANDROID_ADDITIONAL_TOOLS=($(get_toolset_value '.android."additional-tools"[]'))
 
 # Get the latest command line tools from https://developer.android.com/studio/index.html
 # Release note: https://developer.android.com/studio/releases/sdk-tools.html
@@ -92,6 +93,12 @@ for addon_name in "${ANDROID_ADDON_LIST[@]}"
 do
     echo "Installing add-on $addon_name ..."
     echo y | $SDKMANAGER "add-ons;$addon_name"
+done
+
+for tool_name in "${ANDROID_ADDITIONAL_TOOLS[@]}"
+do
+    echo "Installing additional tool $tool_name ..."
+    echo y | $SDKMANAGER "$tool_name"
 done
 
 popd

--- a/images/macos/software-report/SoftwareReport.Android.psm1
+++ b/images/macos/software-report/SoftwareReport.Android.psm1
@@ -51,6 +51,10 @@ function Build-AndroidTable {
             "Version" = Get-AndroidBuildToolVersions -PackageInfo $packageInfo
         },
         @{
+            "Package" = "Android Command Line Tools"
+            "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android SDK Command-line Tools"
+        },
+        @{
             "Package" = "Android SDK Platform-Tools"
             "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android SDK Platform-Tools"
         },

--- a/images/macos/tests/Android.Tests.ps1
+++ b/images/macos/tests/Android.Tests.ps1
@@ -27,7 +27,8 @@ Describe "Android" {
         $platforms,
         $buildTools,
         (Get-ToolsetValue "android.extra-list" | ForEach-Object { "extras/${_}" }),
-        (Get-ToolsetValue "android.addon-list" | ForEach-Object { "add-ons/${_}" })
+        (Get-ToolsetValue "android.addon-list" | ForEach-Object { "add-ons/${_}" }),
+        (Get-ToolsetValue "android.additional-tools")
     ) | ForEach-Object { $_ }
 
     BeforeAll {

--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -209,6 +209,9 @@
         ],
         "addon-list": [
             "addon-google_apis-google-24", "addon-google_apis-google-23", "addon-google_apis-google-22", "addon-google_apis-google-21"
+        ],
+        "additional-tools": [
+            "cmdline-tools;latest"
         ]
     },
     "powershellModules": [

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -139,6 +139,9 @@
         ],
         "addon-list": [
             "addon-google_apis-google-24", "addon-google_apis-google-23", "addon-google_apis-google-22", "addon-google_apis-google-21"
+        ],
+        "additional-tools": [
+            "cmdline-tools;latest"
         ]
     },
     "powershellModules": [

--- a/images/macos/toolsets/toolset-11.0.json
+++ b/images/macos/toolsets/toolset-11.0.json
@@ -72,7 +72,10 @@
         "extra-list": [
             "android;m2repository", "google;m2repository", "google;google_play_services", "intel;Hardware_Accelerated_Execution_Manager"
         ],
-        "addon-list": []
+        "addon-list": [],
+        "additional-tools": [
+            "cmdline-tools;latest"
+        ]
     },
     "powershellModules": [
         {


### PR DESCRIPTION
# Description
New tool 

size:  100Mb
time: 30 secs

Virtual environments currently installs Android "SDK Tools", which is deprecated: https://developer.android.com/studio/releases/sdk-tools

Google suggests using the new "cmdline-tools" package instead:
https://developer.android.com/studio/command-line

#### Related issue: https://github.com/actions/virtual-environments/issues/2252

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
