### PR TITLE
Add Android Command Line tools to Linux images

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -49,6 +49,10 @@ function Build-AndroidTable {
             "Version" = Get-AndroidBuildToolVersions -PackageInfo $packageInfo
         },
         @{
+            "Package" = "Android Command Line Tools"
+            "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android Command Line Tools"
+        },
+        @{
             "Package" = "Android emulator"
             "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android Emulator"
         },

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -50,7 +50,7 @@ function Build-AndroidTable {
         },
         @{
             "Package" = "Android Command Line Tools"
-            "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android Command Line Tools"
+            "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android SDK Command-line Tools"
         },
         @{
             "Package" = "Android emulator"

--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -93,7 +93,8 @@
             "cmake;3.10.2.4988404",
             "patcher;v4",
             "ndk-bundle",
-            "platform-tools"
+            "platform-tools",
+            "cmdline-tools;latest"
         ]
     },
     "powershellModules": [

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -89,7 +89,8 @@
             "cmake;3.10.2.4988404",
             "patcher;v4",
             "ndk-bundle",
-            "platform-tools"
+            "platform-tools",
+            "cmdline-tools;latest"
         ]
     },
     "powershellModules": [

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -72,7 +72,8 @@
             "cmake;3.10.2.4988404",
             "patcher;v4",
             "ndk-bundle",
-            "platform-tools"
+            "platform-tools",
+            "cmdline-tools;latest"
         ]
     },
     "powershellModules": [


### PR DESCRIPTION
# Description
New tool 

size:  100Mb
time: 30 secs

Virtual environments currently installs Android "SDK Tools", which is deprecated: https://developer.android.com/studio/releases/sdk-tools

Google suggests using the new "cmdline-tools" package instead:
https://developer.android.com/studio/command-line

#### Related issue: https://github.com/actions/virtual-environments/issues/2252

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
