### PR TITLE
Reverted dotnet sdk extraction in parallel

### DIFF
--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -73,9 +73,7 @@ parallel --jobs 0 --halt soon,fail=1 \
     'url="https://dotnetcli.blob.core.windows.net/dotnet/Sdk/{}/dotnet-sdk-{}-linux-x64.tar.gz"; \
     download_with_retries $url' ::: "${sortedSdks[@]}"
 
-parallel --jobs 0 --halt soon,fail=1 \
-    'name="./dotnet-sdk-{}-linux-x64.tar.gz"; \
-    extract_dotnet_sdk $name' ::: "${sortedSdks[@]}"
+find . -name "*.tar.gz" | parallel --halt soon,fail=1 'extract_dotnet_sdk {}'
 
 # Smoke test each SDK
 for sdk in $sortedSdks; do


### PR DESCRIPTION
# Description
Reverted [dotnet sdk exctraction in parallel](https://github.com/actions/virtual-environments/commit/ba0809214be7bd66a26465734c9f77a951e73db8) 

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
