### PR TITLE
[Ubuntu] Migrate missing tools tests to Pester

### DIFF
--- a/images/linux/scripts/installers/7-zip.sh
+++ b/images/linux/scripts/installers/7-zip.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs 7-zip
 ################################################################################
 
-
 # Install 7-Zip
 apt-get update -y
 apt-get install -y p7zip p7zip-full p7zip-rar

--- a/images/linux/scripts/installers/aliyun-cli.sh
+++ b/images/linux/scripts/installers/aliyun-cli.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs Alibaba Cloud CLI
 ################################################################################
 
-
 # Install Alibaba Cloud CLI
 URL=$(curl -s https://api.github.com/repos/aliyun/aliyun-cli/releases/latest | jq -r '.assets[].browser_download_url | select(contains("aliyun-cli-linux"))')
 wget -P /tmp $URL

--- a/images/linux/scripts/installers/aws-sam-cli.sh
+++ b/images/linux/scripts/installers/aws-sam-cli.sh
@@ -5,7 +5,6 @@
 ##         Requires Python >=3.6, must be run as non-root user after toolset installation
 ################################################################################
 
-
 # Download latest aws sam cli sources
 TarballUrl=$(curl -s https://api.github.com/repos/aws/aws-sam-cli/releases/latest | jq -r '.tarball_url')
 TarballPath="/tmp/aws-sam-cli.tar.gz"

--- a/images/linux/scripts/installers/azcopy.sh
+++ b/images/linux/scripts/installers/azcopy.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs AzCopy
 ################################################################################
 
-
 # Install AzCopy7
 wget -O azcopy.tar.gz https://aka.ms/downloadazcopylinux64
 tar -xf azcopy.tar.gz

--- a/images/linux/scripts/installers/azure-cli.sh
+++ b/images/linux/scripts/installers/azure-cli.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installed Azure CLI (az)
 ################################################################################
 
-
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 

--- a/images/linux/scripts/installers/azure-devops-cli.sh
+++ b/images/linux/scripts/installers/azure-devops-cli.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installed Azure DevOps CLI (az devops)
 ################################################################################
 
-
 # AZURE_EXTENSION_DIR shell variable defines where modules are installed
 # https://docs.microsoft.com/en-us/cli/azure/azure-cli-extensions-overview
 export AZURE_EXTENSION_DIR=/opt/az/azcliextensions

--- a/images/linux/scripts/installers/bazel.sh
+++ b/images/linux/scripts/installers/bazel.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs Bazel and Bazelisk (A user-friendly launcher for Bazel)
 ################################################################################
 
-
 # Install bazel
 curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
 echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list

--- a/images/linux/scripts/installers/cmake.sh
+++ b/images/linux/scripts/installers/cmake.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs CMake
 ################################################################################
 
-
 # Test to see if the software in question is already installed, if not install it
 echo "Checking to see if the installer script has already been run"
 if command -v cmake; then

--- a/images/linux/scripts/installers/containers.sh
+++ b/images/linux/scripts/installers/containers.sh
@@ -15,11 +15,4 @@ apt-get -qq -y install ${install_packages[@]}
 mkdir -p /etc/containers
 echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | tee /etc/containers/registries.conf
 
-# Check that tools are installed properly
-echo "Testing to make sure that script performed as expected, and basic scenarios work" 
-for cmd in ${install_packages[@]}; do 
-    if ! command -v $cmd; then 
-        echo "$cmd was not installed" 
-        exit 1 
-    fi 
-done
+invoke_tests "Tools" "Containers"

--- a/images/linux/scripts/installers/containers.sh
+++ b/images/linux/scripts/installers/containers.sh
@@ -4,6 +4,8 @@
 ##  Desc:  Installs container tools: podman, buildah and skopeo onto the image
 ################################################################################
 
+source $HELPER_SCRIPTS/os.sh
+
 # Install podman, buildah, scopeo container's tools
 install_packages=(podman buildah skopeo)
 source /etc/os-release
@@ -15,4 +17,6 @@ apt-get -qq -y install ${install_packages[@]}
 mkdir -p /etc/containers
 echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | tee /etc/containers/registries.conf
 
-invoke_tests "Tools" "Containers"
+if isUbuntu18 || isUbuntu20 ; then
+    invoke_tests "Tools" "Containers"
+fi

--- a/images/linux/scripts/installers/docker-compose.sh
+++ b/images/linux/scripts/installers/docker-compose.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs Docker Compose
 ################################################################################
 
-
 # Install latest docker-compose from releases
 URL=$(curl -s https://api.github.com/repos/docker/compose/releases/latest | jq -r '.assets[].browser_download_url | select(contains("docker-compose-Linux-x86_64"))' | head -1)
 curl -L $URL -o /usr/local/bin/docker-compose

--- a/images/linux/scripts/installers/erlang.sh
+++ b/images/linux/scripts/installers/erlang.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs erlang
 ################################################################################
 
-
 source_list=/etc/apt/sources.list.d/eslerlang.list
 
 # Install Erlang

--- a/images/linux/scripts/installers/github-cli.sh
+++ b/images/linux/scripts/installers/github-cli.sh
@@ -5,7 +5,6 @@
 ##         Must be run as non-root user after homebrew
 ################################################################################
 
-
 # Install GitHub CLI
 url=$(curl -s https://api.github.com/repos/cli/cli/releases/latest | jq -r '.assets[].browser_download_url|select(contains("linux") and contains("amd64") and contains(".deb"))')
 wget $url

--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs google-chrome  and chromedriver
 ################################################################################
 
-
 LSB_RELEASE=$(lsb_release -rs)
 
 wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -

--- a/images/linux/scripts/installers/google-cloud-sdk.sh
+++ b/images/linux/scripts/installers/google-cloud-sdk.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs the Google Cloud SDK
 ################################################################################
 
-
 # Install the Google Cloud SDK
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -

--- a/images/linux/scripts/installers/heroku.sh
+++ b/images/linux/scripts/installers/heroku.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs Heroku CLI
 ################################################################################
 
-
 # Install Heroku CLI
 curl https://cli-assets.heroku.com/install-ubuntu.sh | sh
 

--- a/images/linux/scripts/installers/hhvm.sh
+++ b/images/linux/scripts/installers/hhvm.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs hhvm
 ################################################################################
 
-
 apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
 add-apt-repository https://dl.hhvm.com/ubuntu
 apt-get update

--- a/images/linux/scripts/installers/julia.sh
+++ b/images/linux/scripts/installers/julia.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs Julia, and adds Julia to the path
 ################################################################################
 
-
 # This function fetches the latest Julia release from the GitHub API
 # Based on https://gist.github.com/lukechilds/a83e1d7127b78fef38c2914c4ececc3c
 function GetLatestJuliaRelease () {

--- a/images/linux/scripts/installers/kubernetes-tools.sh
+++ b/images/linux/scripts/installers/kubernetes-tools.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs kubectl, helm, kustomize
 ################################################################################
 
-
 # Install KIND
 URL=$(curl -s https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r '.assets[].browser_download_url | select(contains("kind-linux-amd64"))')
 curl -L -o /usr/local/bin/kind $URL

--- a/images/linux/scripts/installers/leiningen.sh
+++ b/images/linux/scripts/installers/leiningen.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs Leiningen
 ################################################################################
 
-
 LEIN_BIN=/usr/local/bin/lein
 curl -s https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein > $LEIN_BIN
 chmod 0755 $LEIN_BIN

--- a/images/linux/scripts/installers/mercurial.sh
+++ b/images/linux/scripts/installers/mercurial.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs Mercurial
 ################################################################################
 
-
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/os.sh
 

--- a/images/linux/scripts/installers/miniconda.sh
+++ b/images/linux/scripts/installers/miniconda.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs miniconda
 ################################################################################
 
-
 # Install Miniconda
 curl -sL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh \
     && chmod +x miniconda.sh \

--- a/images/linux/scripts/installers/mono.sh
+++ b/images/linux/scripts/installers/mono.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs Mono
 ################################################################################
 
-
 LSB_CODENAME=$(lsb_release -cs)
 
 # Test to see if the software in question is already installed, if not install it

--- a/images/linux/scripts/installers/mssql-cmd-tools.sh
+++ b/images/linux/scripts/installers/mssql-cmd-tools.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Install MS SQL Server client tools (https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-setup-tools?view=sql-server-2017)
 ################################################################################
 
-
 export ACCEPT_EULA=Y
 
 apt-get update

--- a/images/linux/scripts/installers/netlify.sh
+++ b/images/linux/scripts/installers/netlify.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs the Netlify CLI
 ################################################################################
 
-
 # Install the Netlify CLI
 npm i -g netlify-cli
 

--- a/images/linux/scripts/installers/nodejs.sh
+++ b/images/linux/scripts/installers/nodejs.sh
@@ -20,11 +20,4 @@ apt-get update
 # Install yarn
 apt-get install -y --no-install-recommends yarn
 
-# Run tests to determine that the software installed as expected
-echo "Testing to make sure that script performed as expected, and basic scenarios work"
-for cmd in node grunt gulp webpack parcel yarn newman; do
-    if ! command -v $cmd; then
-        echo "$cmd was not installed"
-        exit 1
-    fi
-done
+invoke_tests "Tools" "NodeJS"

--- a/images/linux/scripts/installers/nodejs.sh
+++ b/images/linux/scripts/installers/nodejs.sh
@@ -20,4 +20,4 @@ apt-get update
 # Install yarn
 apt-get install -y --no-install-recommends yarn
 
-invoke_tests "Tools" "NodeJS"
+invoke_tests "Tools" "Node.js"

--- a/images/linux/scripts/installers/nvm.sh
+++ b/images/linux/scripts/installers/nvm.sh
@@ -12,10 +12,7 @@ echo 'export NVM_DIR=$HOME/.nvm' | tee -a /etc/skel/.bash_profile
 echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm' | tee -a /etc/skel/.bash_profile
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
-if ! command -v nvm; then
-    echo "nvm was not installed"
-    exit 1
-fi
+invoke_tests "Tools" "nvm"
 
 # set system node.js as default one
 nvm alias default system

--- a/images/linux/scripts/installers/packer.sh
+++ b/images/linux/scripts/installers/packer.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs packer
 ################################################################################
 
-
 # Install Packer
 PACKER_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/packer | jq -r .current_version)
 curl -LO "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip"

--- a/images/linux/scripts/installers/phantomjs.sh
+++ b/images/linux/scripts/installers/phantomjs.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs PhantomJS
 ################################################################################
 
-
 # Install PhantomJS
 apt-get install -y chrpath libssl-dev libxft-dev libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev
 PHANTOM_JS=phantomjs-2.1.1-linux-x86_64

--- a/images/linux/scripts/installers/pipx-packages.sh
+++ b/images/linux/scripts/installers/pipx-packages.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Install tools via pipx
 ################################################################################
 
-
 export PATH="$PATH:/opt/pipx_bin"
 
 toolset="$INSTALLER_SCRIPT_FOLDER/toolset.json"

--- a/images/linux/scripts/installers/pollinate.sh
+++ b/images/linux/scripts/installers/pollinate.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs Pollinate
 ################################################################################
 
-
 # Install Pollinate
 apt-get install -y --no-install-recommends pollinate
 

--- a/images/linux/scripts/installers/powershellcore.sh
+++ b/images/linux/scripts/installers/powershellcore.sh
@@ -6,5 +6,3 @@
 
 # Install Powershell
 apt-get install -y powershell
-
-invoke_tests "Tools" "PowerShell Core"

--- a/images/linux/scripts/installers/powershellcore.sh
+++ b/images/linux/scripts/installers/powershellcore.sh
@@ -6,3 +6,5 @@
 
 # Install Powershell
 apt-get install -y powershell
+
+invoke_tests "Tools" "PowerShell Core"

--- a/images/linux/scripts/installers/powershellcore.sh
+++ b/images/linux/scripts/installers/powershellcore.sh
@@ -6,10 +6,3 @@
 
 # Install Powershell
 apt-get install -y powershell
-
-# Run tests to determine that the software installed as expected
-echo "Testing to make sure that script performed as expected, and basic scenarios work"
-if ! command -v pwsh; then
-    echo "pwsh was not installed"
-    exit 1
-fi

--- a/images/linux/scripts/installers/python.sh
+++ b/images/linux/scripts/installers/python.sh
@@ -40,11 +40,4 @@ if isUbuntu18 || isUbuntu20 ; then
     fi
 fi
 
-# Run tests to determine that the software installed as expected
-echo "Testing to make sure that script performed as expected, and basic scenarios work"
-for cmd in python pip python3 pip3; do
-    if ! command -v $cmd; then
-        echo "$cmd was not installed or not found on PATH"
-        exit 1
-    fi
-done
+invoke_tests "Tools" "Python"

--- a/images/linux/scripts/installers/rndgenerator.sh
+++ b/images/linux/scripts/installers/rndgenerator.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Install random number generator
 ################################################################################
 
-
 # Install haveged
 apt-get -y install haveged
 

--- a/images/linux/scripts/installers/sbt.sh
+++ b/images/linux/scripts/installers/sbt.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs sbt
 ################################################################################
 
-
 # Install sbt
 # https://www.scala-sbt.org/1.x/docs/Installing-sbt-on-Linux.html
 echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list

--- a/images/linux/scripts/installers/selenium.sh
+++ b/images/linux/scripts/installers/selenium.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs selenium server
 ################################################################################
 
-
 # Determine latest selenium standalone server version
 SELENIUM_LATEST_VERSION_URL=https://api.github.com/repos/SeleniumHQ/selenium/releases/latest
 SELENIUM_VERSION=$(curl $SELENIUM_LATEST_VERSION_URL | jq '.name' | tr -d '"' | cut -d ' ' -f 2)

--- a/images/linux/scripts/installers/subversion.sh
+++ b/images/linux/scripts/installers/subversion.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs Subversion client
 ################################################################################
 
-
 # Install Subversion
 apt-get install -y --no-install-recommends subversion
 

--- a/images/linux/scripts/installers/swig.sh
+++ b/images/linux/scripts/installers/swig.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -e
 
-
 # Install Swig
 sudo apt-get install -y swig
 

--- a/images/linux/scripts/installers/terraform.sh
+++ b/images/linux/scripts/installers/terraform.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs terraform
 ################################################################################
 
-
 # Install Terraform
 TERRAFORM_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r .current_version)
 curl -LO "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"

--- a/images/linux/scripts/installers/vercel.sh
+++ b/images/linux/scripts/installers/vercel.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs the Vercel CLI
 ################################################################################
 
-
 # Install the Vercel CLI
 npm i -g vercel
 

--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -344,3 +344,45 @@ Describe "Haveged" {
         "systemctl status haveged  | grep 'active (running)'" | Should -ReturnZeroExitCode
     }
 }
+
+Describe "Containers" {
+    $testCases = @("podman", "buildah", "skopeo") | ForEach-Object { @{ContainerCommand = $_} }
+
+    It "<ContainerCommand>" -TestCases $testCases {
+        param (
+            [string] $ContainerCommand
+        )
+
+        "$ContainerCommand -v" | Should -ReturnZeroExitCode
+    }   
+}
+
+Describe "NodeJS" {
+    $testCases = @("node", "grunt", "gulp", "webpack", "parcel", "yarn", "newman") | ForEach-Object { @{NodeCommand = $_} }
+
+    It "<NodeCommand>" -TestCases $testCases {
+        param (
+            [string] $NodeCommand
+        )
+
+        "$NodeCommand --version" | Should -ReturnZeroExitCode
+    }   
+}
+
+Describe "nvm" {
+    It "nvm" {
+        "nvm --version" | Should -ReturnZeroExitCode
+    }
+}
+
+Describe "Python" {
+    $testCases = @("python", "pip", "python3", "pip3") | ForEach-Object { @{PythonCommand = $_} }
+
+    It "<PythonCommand>" -TestCases $testCases {
+        param (
+            [string] $PythonCommand
+        )
+
+        "$PythonCommand --version" | Should -ReturnZeroExitCode
+    }   
+}

--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -357,7 +357,7 @@ Describe "Containers" {
     }   
 }
 
-Describe "NodeJS" {
+Describe "Node.js" {
     $testCases = @("node", "grunt", "gulp", "webpack", "parcel", "yarn", "newman") | ForEach-Object { @{NodeCommand = $_} }
 
     It "<NodeCommand>" -TestCases $testCases {
@@ -371,7 +371,7 @@ Describe "NodeJS" {
 
 Describe "nvm" {
     It "nvm" {
-        "nvm --version" | Should -ReturnZeroExitCode
+        "source /etc/skel/.nvm/nvm.sh && nvm --version" | Should -ReturnZeroExitCode
     }
 }
 

--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -335,7 +335,7 @@ Describe "Haveged" {
     }
 }
 
-Describe "Containers" {
+Describe "Containers" -Skip:(Test-IsUbuntu16) {
     $testCases = @("podman", "buildah", "skopeo") | ForEach-Object { @{ContainerCommand = $_} }
 
     It "<ContainerCommand>" -TestCases $testCases {

--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -83,16 +83,6 @@ Describe "Docker-compose" {
     }
 }
 
-Describe "PowerShell Core" {
-    It "pwsh" {
-        "pwsh --version" | Should -ReturnZeroExitCode
-    }
-
-    It "Execute 2+2 command" {
-        pwsh -Command "2+2" | Should -BeExactly 4
-    }
-}
-
 Describe "Ansible" {
     It "Ansible" {
         "ansible --version" | Should -ReturnZeroExitCode


### PR DESCRIPTION
# Description
In scope of this PR we are migrating missing tools tests to Pester and removing test for powershellcore.
 
List of tools:
`containers.sh`
`nodejs.sh`
`nvm.sh`
`powershellcore.sh`
`python.sh`

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
