### PR TITLE
[Ubuntu] Fix `setEtcEnvironmentVariable` function

### DIFF
--- a/images/linux/scripts/helpers/etc-environment.sh
+++ b/images/linux/scripts/helpers/etc-environment.sh
@@ -18,7 +18,7 @@ function addEtcEnvironmentVariable {
     variable_name="$1"
     variable_value="$2"
 
-    echo "$variable_name=\"$variable_value\"" | sudo tee -a /etc/environment
+    echo "$variable_name=$variable_value" | sudo tee -a /etc/environment
 }
 
 function replaceEtcEnvironmentVariable {

--- a/images/linux/scripts/installers/python.sh
+++ b/images/linux/scripts/installers/python.sh
@@ -29,8 +29,8 @@ if isUbuntu18 || isUbuntu20 ; then
     python3 -m pipx ensurepath
 
     # Update /etc/environment
-    setEtcEnvironmentVariable "PIPX_BIN_DIR" $PIPX_BIN_DIR
-    setEtcEnvironmentVariable "PIPX_HOME" $PIPX_HOME
+    echo "PIPX_BIN_DIR=$PIPX_BIN_DIR" | tee -a /etc/environment
+    echo "PIPX_HOME=$PIPX_HOME" | tee -a /etc/environment
     prependEtcEnvironmentPath $PIPX_BIN_DIR
 
     # Test pipx

--- a/images/linux/scripts/installers/python.sh
+++ b/images/linux/scripts/installers/python.sh
@@ -29,8 +29,8 @@ if isUbuntu18 || isUbuntu20 ; then
     python3 -m pipx ensurepath
 
     # Update /etc/environment
-    echo "PIPX_BIN_DIR=$PIPX_BIN_DIR" | tee -a /etc/environment
-    echo "PIPX_HOME=$PIPX_HOME" | tee -a /etc/environment
+    setEtcEnvironmentVariable "PIPX_BIN_DIR" $PIPX_BIN_DIR
+    setEtcEnvironmentVariable "PIPX_HOME" $PIPX_HOME
     prependEtcEnvironmentPath $PIPX_BIN_DIR
 
     # Test pipx


### PR DESCRIPTION
Function `setEtcEnvironmentVariable` adds new variable value with quotes. It cause incorrect installation for new packages via pipx on Ubuntu.

Example of installation a new package: https://buildcanary.visualstudio.com/PipelineCanary/_build/results?buildId=1314837&view=logs&j=2666b424-a65e-5d07-a841-d60507eedf54&t=30f8b51d-c83a-54b4-a539-070a66f8e560

Also, `pipx list` command not shows already installed packages.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
