### PR TITLE
Add missed Rust tools to the documentation for macOS

### DIFF
--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -24,9 +24,30 @@ function Get-RVersion {
     $rVersion = Run-Command "R --version | grep 'R version'" | Take-Part -Part 2
     return "R $rVersion"
 }
+
 function Get-RustVersion {
     $rustVersion = Run-Command "rustc --version" | Take-Part -Part 1
     return "Rust $rustVersion"
+}
+
+function Get-RustfmtVersion {
+    $version = Run-Command "rustfmt --version" | Take-Part -Part 1
+    return "Rustfmt $version"
+}
+
+function Get-RustdocVersion {
+    $version = Run-Command "rustdoc --version" | Take-Part -Part 1
+    return "Rustdoc $version"
+}
+
+function Get-CargoVersion {
+    $version = Run-Command "cargo --version" | Take-Part -Part 1
+    return "Cargo $version"
+}
+
+function Get-ClippyVersion {
+    $version = Run-Command "cargo clippy --version" | Take-Part -Part 1
+    return "Clippy $version"
 }
 
 function Get-Bindgen {

--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -40,12 +40,12 @@ function Get-RustdocVersion {
     return "Rustdoc $version"
 }
 
-function Get-CargoVersion {
+function Get-RustCargoVersion {
     $version = Run-Command "cargo --version" | Take-Part -Part 1
     return "Cargo $version"
 }
 
-function Get-ClippyVersion {
+function Get-RustClippyVersion {
     $version = Run-Command "cargo clippy --version" | Take-Part -Part 1
     return "Clippy $version"
 }

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -175,7 +175,11 @@ if ( -not $os.IsHighSierra) {
     $markdown += New-MDHeader "Rust Tools" -Level 3
     $markdown += New-MDList -Style Unordered -Lines @(
         (Get-RustVersion),
-        (Get-RustupVersion)
+        (Get-RustupVersion),
+        (Get-RustfmtVersion),
+        (Get-RustdocVersion),
+        (Get-CargoVersion),
+        (Get-ClippyVersion)
     )
     $markdown += New-MDHeader "Packages" -Level 4
     $markdown += New-MDList -Style Unordered -Lines @(

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -176,17 +176,17 @@ if ( -not $os.IsHighSierra) {
     $markdown += New-MDList -Style Unordered -Lines @(
         (Get-RustVersion),
         (Get-RustupVersion),
-        (Get-RustfmtVersion),
         (Get-RustdocVersion),
-        (Get-CargoVersion),
-        (Get-ClippyVersion)
+        (Get-RustCargoVersion)
     )
     $markdown += New-MDHeader "Packages" -Level 4
     $markdown += New-MDList -Style Unordered -Lines @(
         (Get-Bindgen),
         (Get-Cbindgen),
         (Get-Cargooutdated),
-        (Get-Cargoaudit)
+        (Get-Cargoaudit),
+        (Get-RustfmtVersion),
+        (Get-RustClippyVersion)
     )
 }
 


### PR DESCRIPTION
# Description
Improvement

Here is a list with missed Rust tools in the documentation:

rustdoc
cargo
rustfmt
clippy

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/1643

## Check list
- [x] Related issue / work item is attached
- [x] Changes are tested and related VM images are successfully generated
