### PR TITLE
[Ubuntu] Fix empty password for mysql-server

### DIFF
--- a/images/linux/scripts/installers/mysql.sh
+++ b/images/linux/scripts/installers/mysql.sh
@@ -4,28 +4,15 @@
 ##  Desc:  Installs MySQL Client
 ################################################################################
 
-source $HELPER_SCRIPTS/os.sh
-
 export ACCEPT_EULA=Y
-
-if isUbuntu16 || isUbuntu18 ; then
-    apt-get install mysql-client -y
-fi
-
-if isUbuntu20 ; then
-    # Install mysql 8 for Ubuntu 20.
-
-    debconf-set-selections <<< 'mysql-apt-config mysql-apt-config/select-server select mysql-8.0'
-    package_version=$(curl https://dev.mysql.com/downloads/repo/apt/ 2> /dev/null | grep "\.deb" | awk -F "[()]" '{print $2}')
-    wget https://dev.mysql.com/get/$package_version
-    dpkg -i $package_version
-    apt update
-fi
 
 # Mysql setting up root password
 MYSQL_ROOT_PASSWORD=root
 echo "mysql-server mysql-server/root_password password $MYSQL_ROOT_PASSWORD" | debconf-set-selections
 echo "mysql-server mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD" | debconf-set-selections
+
+# Install MySQL Client
+apt-get install mysql-client -y
 
 # Install MySQL Server
 apt-get install -y mysql-server
@@ -36,3 +23,5 @@ apt install libmysqlclient-dev -y
 # Disable mysql.service
 systemctl is-active --quiet mysql.service && systemctl stop mysql.service
 systemctl disable mysql.service
+
+invoke_tests "Databases" "MySQL"

--- a/images/linux/scripts/tests/Databases.Tests.ps1
+++ b/images/linux/scripts/tests/Databases.Tests.ps1
@@ -22,7 +22,8 @@ Describe "MySQL" {
     }
 
     It "MySQL Service" {
-        "sudo systemctl start mysql" | Should -ReturnZeroExitCode 
+        "sudo systemctl start mysql" | Should -ReturnZeroExitCode
+        mysql -s -N -h localhost -uroot -proot -e "select count(*) from mysql.user where user='root' and authentication_string is null;" | Should -BeExactly 0
         "sudo mysql -vvv -e 'CREATE DATABASE smoke_test' -uroot -proot" | Should -ReturnZeroExitCode
         "sudo mysql -vvv -e 'DROP DATABASE smoke_test' -uroot -proot" | Should -ReturnZeroExitCode
         "sudo systemctl stop mysql" | Should -ReturnZeroExitCode 


### PR DESCRIPTION
# Description
Currently, password for user `root` is not set during mysql 8 installation on Ubuntu 20.04:
```
select host,user,authentication_string,plugin from mysql.user
--------------
+-----------+------------------+------------------------------------------------------------------------+-----------------------+
| host      | user             | authentication_string                                                  | plugin                |
+-----------+------------------+------------------------------------------------------------------------+-----------------------+
| localhost | mysql.infoschema | $A$005$THISISACOMBINATIONOFINVALIDSALTANDPASSWORDTHATMUSTNEVERBRBEUSED | caching_sha2_password |
| localhost | mysql.session    | $A$005$THISISACOMBINATIONOFINVALIDSALTANDPASSWORDTHATMUSTNEVERBRBEUSED | caching_sha2_password |
| localhost | mysql.sys        | $A$005$THISISACOMBINATIONOFINVALIDSALTANDPASSWORDTHATMUSTNEVERBRBEUSED | caching_sha2_password |
| localhost | root             |                                                                        | auth_socket           |
+-----------+------------------+------------------------------------------------------------------------+-----------------------+
```

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1662

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
