### PR TITLE
Add missed Rust tools to the documentation for Win

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -47,7 +47,7 @@ function Get-RustupVersion {
      return $version
 }
 
-function Get-CargoVersion {
+function Get-RustCargoVersion {
      $version = [regex]::matches($(cargo --version), "\d+\.\d+\.\d+").Value
      return $version
 }
@@ -67,7 +67,7 @@ function Get-RustfmtVersion {
      return $version
 }
 
-function Get-ClippyVersion {
+function Get-RustClippyVersion {
      $version = [regex]::matches($(cargo clippy  --version), "\d+\.\d+\.\d+").Value
      return $version
 }

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -52,11 +52,6 @@ function Get-RustCargoVersion {
      return $version
 }
 
-function Get-RustDocVersion {
-     $version = [regex]::matches($(rustdoc --version), "\d+\.\d+\.\d+").Value
-     return $version
-}
-
 function Get-RustdocVersion {
      $version = [regex]::matches($(rustdoc --version), "\d+\.\d+\.\d+").Value
      return $version

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -42,6 +42,36 @@ function Get-RustVersion {
     return $rustVersion
 }
 
+function Get-RustupVersion {
+     $version = [regex]::matches($(rustup --version), "\d+\.\d+\.\d+").Value
+     return $version
+}
+
+function Get-CargoVersion {
+     $version = [regex]::matches($(cargo --version), "\d+\.\d+\.\d+").Value
+     return $version
+}
+
+function Get-RustDocVersion {
+     $version = [regex]::matches($(rustdoc --version), "\d+\.\d+\.\d+").Value
+     return $version
+}
+
+function Get-RustdocVersion {
+     $version = [regex]::matches($(rustdoc --version), "\d+\.\d+\.\d+").Value
+     return $version
+}
+
+function Get-RustfmtVersion {
+     $version = [regex]::matches($(rustfmt --version), "\d+\.\d+\.\d+").Value
+     return $version
+}
+
+function Get-ClippyVersion {
+     $version = [regex]::matches($(cargo clippy  --version), "\d+\.\d+\.\d+").Value
+     return $version
+}
+
 function Get-BindgenVersion {
     return bindgen --version
 }

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -118,17 +118,17 @@ $markdown += New-MDHeader "Rust Tools" -Level 3
 $markdown += New-MDList -Style Unordered -Lines @(
     "Rust $(Get-RustVersion)",
     "Rustup $(Get-RustupVersion)",
-    "Cargo $(Get-CargoVersion)",
-    "Rustdoc $(Get-RustdocVersion)",
-    "Rustfmt $(Get-RustfmtVersion)",
-    "Clippy $(Get-ClippyVersion)"
+    "Cargo $(Get-RustCargoVersion)",
+    "Rustdoc $(Get-RustdocVersion)"
 )
 $markdown += New-MDHeader "Packages" -Level 4
 $markdown += New-MDList -Style Unordered -Lines @(
     (Get-BindgenVersion),
     (Get-CbindgenVersion),
     (Get-CargoAuditVersion),
-    (Get-CargoOutdatedVersion)
+    (Get-CargoOutdatedVersion),
+    "Rustfmt $(Get-RustfmtVersion)",
+    "Clippy $(Get-RustClippyVersion)"
 )
 
 $markdown += New-MDHeader "Browsers and webdrivers" -Level 3

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -116,7 +116,12 @@ $markdown += New-MDList -Style Unordered -Lines @(
 
 $markdown += New-MDHeader "Rust Tools" -Level 3
 $markdown += New-MDList -Style Unordered -Lines @(
-    "Rust $(Get-RustVersion)"
+    "Rust $(Get-RustVersion)",
+    "Rustup $(Get-RustupVersion)",
+    "Cargo $(Get-CargoVersion)",
+    "Rustdoc $(Get-RustdocVersion)",
+    "Rustfmt $(Get-RustfmtVersion)",
+    "Clippy $(Get-ClippyVersion)"
 )
 $markdown += New-MDHeader "Packages" -Level 4
 $markdown += New-MDList -Style Unordered -Lines @(


### PR DESCRIPTION
# Description
Improvement

Here is a list with missed Rust tools in the documentation:

rustdoc
cargo
rustfmt
clippy

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/1643

## Check list
- [x] Related issue / work item is attached
- [x] Changes are tested and related VM images are successfully generated
