### PR TITLE
[Windows] Fix hub installation

### DIFF
--- a/images/win/scripts/Installers/Install-Git.ps1
+++ b/images/win/scripts/Installers/Install-Git.ps1
@@ -31,7 +31,7 @@ Install-Binary  -Url $downloadUrl `
                     "/o:EnableSymlinks=Enabled", `
                     "/COMPONENTS=gitlfs")
 
-# Install hub with --ignore-dependencies option to avoid to prevent the installation of the git package
+# Install hub with --ignore-dependencies option to prevent the installation of the git package
 Choco-Install -PackageName hub -ArgumentList "--ignore-dependencies"
 
 # Disable GCM machine-wide

--- a/images/win/scripts/Installers/Install-Git.ps1
+++ b/images/win/scripts/Installers/Install-Git.ps1
@@ -31,7 +31,7 @@ Install-Binary  -Url $downloadUrl `
                     "/o:EnableSymlinks=Enabled", `
                     "/COMPONENTS=gitlfs")
 
-# Install hub with --ignore-dependencies option to prevent the installation of the git package
+# Install hub with --ignore-dependencies option to prevent the installation of the git package. See details in https://github.com/actions/virtual-environments/issues/2375
 Choco-Install -PackageName hub -ArgumentList "--ignore-dependencies"
 
 # Disable GCM machine-wide

--- a/images/win/scripts/Installers/Install-Git.ps1
+++ b/images/win/scripts/Installers/Install-Git.ps1
@@ -31,6 +31,7 @@ Install-Binary  -Url $downloadUrl `
                     "/o:EnableSymlinks=Enabled", `
                     "/COMPONENTS=gitlfs")
 
+# Install hub with --ignore-dependencies option to avoid to prevent the installation of the git package
 Choco-Install -PackageName hub -ArgumentList "--ignore-dependencies"
 
 # Disable GCM machine-wide

--- a/images/win/scripts/Installers/Install-Git.ps1
+++ b/images/win/scripts/Installers/Install-Git.ps1
@@ -31,7 +31,7 @@ Install-Binary  -Url $downloadUrl `
                     "/o:EnableSymlinks=Enabled", `
                     "/COMPONENTS=gitlfs")
 
-Choco-Install -PackageName hub
+Choco-Install -PackageName hub -ArgumentList "--ignore-dependencies"
 
 # Disable GCM machine-wide
 [Environment]::SetEnvironmentVariable("GCM_INTERACTIVE", "Never", [System.EnvironmentVariableTarget]::Machine)


### PR DESCRIPTION
# Description
In scope of this PR we are adding `--ignore-dependencies` option during the installation of hub, because Git for Windows is installed twice in current approach: once explicitly using the binary installer, and again using Chocolatey as a dependency of hub.

#### Related issue: [#2375](https://github.com/actions/virtual-environments/issues/2375) 

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
