### PR TITLE
openssl php extension fix

### DIFF
--- a/images/win/scripts/Installers/Install-PHP.ps1
+++ b/images/win/scripts/Installers/Install-PHP.ps1
@@ -11,7 +11,7 @@ Choco-Install -PackageName php -ArgumentList "--force", "--params", "/InstallDir
 Choco-Install -PackageName composer -ArgumentList "--ia", "/DEV=$installDir /PHP=$installDir"
 
 # update path to extensions and enable curl and mbstring extensions, and enable php openssl extensions.
-((Get-Content -path $installDir\php.ini -Raw) -replace ';extension=curl','extension=curl' -replace ';extension=mbstring','extension=mbstring' -replace ';extension_dir = "ext"','extension_dir = "ext"' -replace 'extension=";php_openssl.dll"','extension_dir = "php_openssl.dll"') | Set-Content -Path $installDir\php.ini
+((Get-Content -path $installDir\php.ini -Raw) -replace ';extension=curl','extension=curl' -replace ';extension=mbstring','extension=mbstring' -replace ';extension_dir = "ext"','extension_dir = "ext"' -replace ';extension=openssl','extension=openssl') | Set-Content -Path $installDir\php.ini
 
 # Set the PHPROOT environment variable.
 setx PHPROOT $installDir /M


### PR DESCRIPTION
# Description
Openssl extension installation on Windows do not use correct string replacements. 
Currently no string that contains "php_openssl.dll" can be found at php.ini and also documentation says that 

> "The syntax used in previous PHP versions ('extension=<ext>.so' and 'extension='php_<ext>.dll') is supported for legacy reasons and may be deprecated in a future PHP major version. So, when it is possible, please move to the new ('extension=<ext>) syntax"

so `extension=openssl` should be used instead.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: actions/virtual-environments#2436

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
