### PR TITLE
[Image.CI] Suppress output from Set/Stop/Move-VM cmdlets

### DIFF
--- a/images.CI/macos/move-vm.ps1
+++ b/images.CI/macos/move-vm.ps1
@@ -65,9 +65,9 @@ $vm = Get-VM $VMName
 if ($env:AGENT_JOBSTATUS -eq 'Failed') {
     try {
         if($vm.PowerState -ne "PoweredOff") {
-            Stop-VM -VM $vm -Confirm:$false -ErrorAction Stop
+            Stop-VM -VM $vm -Confirm:$false -ErrorAction Stop | Out-Null
         }
-        Set-VM -VM $vm -Name "${VMName}_failed" -Confirm:$false -ErrorAction Stop
+        Set-VM -VM $vm -Name "${VMName}_failed" -Confirm:$false -ErrorAction Stop | Out-Null
         Write-Host "VM has been successfully powered off and renamed to [${VMName}_failed]"
     } catch {
         Write-Host "##vso[task.LogIssue type=error;]Failed to power off and rename VM '$VMName'"
@@ -75,7 +75,7 @@ if ($env:AGENT_JOBSTATUS -eq 'Failed') {
 }
 
 try {
-    Move-VM -Vm $vm -Datastore $TargetDataStore -ErrorAction Stop
+    Move-VM -Vm $vm -Datastore $TargetDataStore -ErrorAction Stop | Out-Null
     Write-Host "VM has been moved successfully to target datastore '$TargetDataStore'"
 } catch {
     Write-Host "##vso[task.LogIssue type=error;]Failed to move VM '$VMName' to target datastore '$TargetDataStore'"
@@ -84,7 +84,7 @@ try {
 try {
     if ($VMName -notmatch "10.13") {
         Write-Host "Change CPU count to $CpuCount, cores count to $CoresPerSocketCount, amount of RAM to $Memory"
-        $vm | Set-VM -NumCPU $CpuCount -CoresPerSocket $CoresPerSocketCount -MemoryMB $Memory -Confirm:$false -ErrorAction Stop
+        $vm | Set-VM -NumCPU $CpuCount -CoresPerSocket $CoresPerSocketCount -MemoryMB $Memory -Confirm:$false -ErrorAction Stop | Out-Null
     }
 } catch {
     Write-Host "##vso[task.LogIssue type=error;]Failed to change specs for VM '$VMName'"


### PR DESCRIPTION
# Description
Current output contains unnecessary info:
```
Name                 PowerState Num CPUs MemoryGB
----                 ---------- -------- --------
macOS-10.15_2021011… PoweredOff 10       24.000
macOS-10.15_2021011… PoweredOff 10       24.000
VM has been successfully powered off and renamed to [macOS-10.15_20210114.10_unstable.1_failed]
macOS-10.15_2021011… PoweredOff 10       24.000
VM has been moved successfully to target datastore 'ds-image'
Change CPU count to 3, cores count to 3, amount of RAM to 14336
macOS-10.15_2021011… PoweredOff 3        14.000
```


## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
