### PR TITLE
Set HOMEBREW_NO_AUTO_UPDATE and HOMEBREW_NO_INSTALL_CLEANUP

### DIFF
--- a/images/linux/scripts/installers/homebrew.sh
+++ b/images/linux/scripts/installers/homebrew.sh
@@ -18,6 +18,8 @@ brew shellenv|grep 'export HOMEBREW'|sed -E 's/^export (.*);$/\1/' | sudo tee -a
 # add brew executables locations to PATH
 brew_path=$(brew shellenv|grep  '^export PATH' |sed -E 's/^export PATH="([^$]+)\$.*/\1/')
 prependEtcEnvironmentPath "$brew_path"
+setEtcEnvironmentVariable HOMEBREW_NO_AUTO_UPDATE 1
+setEtcEnvironmentVariable HOMEBREW_NO_INSTALL_CLEANUP 1
 
 # Validate the installation ad hoc
 echo "Validate the installation reloading /etc/environment"

--- a/images/linux/scripts/installers/homebrew.sh
+++ b/images/linux/scripts/installers/homebrew.sh
@@ -19,7 +19,7 @@ brew shellenv|grep 'export HOMEBREW'|sed -E 's/^export (.*);$/\1/' | sudo tee -a
 brew_path=$(brew shellenv|grep  '^export PATH' |sed -E 's/^export PATH="([^$]+)\$.*/\1/')
 prependEtcEnvironmentPath "$brew_path"
 setEtcEnvironmentVariable HOMEBREW_NO_AUTO_UPDATE 1
-setEtcEnvironmentVariable HOMEBREW_NO_INSTALL_CLEANUP 1
+setEtcEnvironmentVariable HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS 3650
 
 # Validate the installation ad hoc
 echo "Validate the installation reloading /etc/environment"


### PR DESCRIPTION
# Description
Improvement

Since update and cleanup are invoked in the CI environment each time, the installation process using brew is very slow. However, these are generally not needed in CI environments and we can disable them using the following environment variables:

 * HOMEBREW_NO_AUTO_UPDATE
 * HOMEBREW_NO_INSTALL_CLEANUP

#### Related issue: https://github.com/actions/virtual-environments/issues/2466

## Check list
- [x] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
