### PR TITLE
ANDROID_NDK_ROOT and ANDROID_NDK_HOME environment variables should be preset

### DIFF
--- a/images/linux/scripts/installers/android.sh
+++ b/images/linux/scripts/installers/android.sh
@@ -27,10 +27,15 @@ function filter_components_by_version {
 # Set env variable for SDK Root (https://developer.android.com/studio/command-line/variables)
 ANDROID_ROOT=/usr/local/lib/android
 ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
+ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
 echo "ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT}" | tee -a /etc/environment
 
 # ANDROID_HOME is deprecated, but older versions of Gradle rely on it
 echo "ANDROID_HOME=${ANDROID_SDK_ROOT}" | tee -a /etc/environment
+
+# Set env variables for NDK Root
+echo "ANDROID_NDK_HOME=${ANDROID_NDK_ROOT}" | tee -a /etc/environment
+echo "ANDROID_NDK_ROOT=${ANDROID_NDK_ROOT}" | tee -a /etc/environment
 
 # Create android sdk directory
 mkdir -p ${ANDROID_SDK_ROOT}

--- a/images/macos/provision/configuration/environment/bashrc
+++ b/images/macos/provision/configuration/environment/bashrc
@@ -5,6 +5,7 @@ export LANG=en_US.UTF-8
 export ANDROID_HOME=${HOME}/Library/Android/sdk
 export ANDROID_SDK_ROOT=${HOME}/Library/Android/sdk
 export ANDROID_NDK_HOME=${ANDROID_HOME}/ndk-bundle
+export ANDROID_NDK_ROOT=${ANDROID_HOME}/ndk-bundle
 
 export NUNIT_BASE_PATH=/Library/Developer/nunit
 export NUNIT3_PATH=/Library/Developer/nunit/3.6.0

--- a/images/win/scripts/Installers/Update-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Update-AndroidSDK.ps1
@@ -83,6 +83,7 @@ if (Test-Path $ndkRoot) {
     setx ANDROID_SDK_ROOT $sdkRoot /M
     setx ANDROID_NDK_HOME $ndkRoot /M
     setx ANDROID_NDK_PATH $ndkRoot /M
+    setx ANDROID_NDK_ROOT $ndkRoot /M
     (Get-Content -Encoding UTF8 "${ndkRoot}\ndk-build.cmd").replace('%~dp0\build\ndk-build.cmd','"%~dp0\build\ndk-build.cmd"')|Set-Content -Encoding UTF8 "${ndkRoot}\ndk-build.cmd"
 } else {
     Write-Host "NDK is not installed at path $ndk_root"


### PR DESCRIPTION
# Description
Added ANDROID_NDK_HOME and ANDROID_NDK_ROOT to the all images

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:
#2426 
## Check list
- [x] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
