### PR TITLE
Use the value from toolset visualStudio.edition when locating VSIXInstaller

### DIFF
--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -220,12 +220,14 @@ function Install-VsixExtension
     $argumentList = ('/quiet', "`"$FilePath`"")
 
     Write-Host "Starting Install $Name..."
+    $toolset = Get-ToolsetContent
+    $vsEdition = $toolset.visualStudio.edition
     try
     {
         #There are 2 types of packages at the moment - exe and vsix
         if ($Name -match "vsix")
         {
-            $process = Start-Process -FilePath "C:\Program Files (x86)\Microsoft Visual Studio\$VSversion\Enterprise\Common7\IDE\VSIXInstaller.exe" -ArgumentList $argumentList -Wait -PassThru
+            $process = Start-Process -FilePath "C:\Program Files (x86)\Microsoft Visual Studio\$VSversion\${vsEdition}\Common7\IDE\VSIXInstaller.exe" -ArgumentList $argumentList -Wait -PassThru
         }
         else
         {

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -220,8 +220,7 @@ function Install-VsixExtension
     $argumentList = ('/quiet', "`"$FilePath`"")
 
     Write-Host "Starting Install $Name..."
-    $toolset = Get-ToolsetContent
-    $vsEdition = $toolset.visualStudio.edition
+    $vsEdition = (Get-ToolsetContent).visualStudio.edition
     try
     {
         #There are 2 types of packages at the moment - exe and vsix


### PR DESCRIPTION
Previously it was hardwired to "Enterprise".

# Description
Bug fixing.

The VS version is specified in the toolset.json instead of hardwiring it to "Enterprise".

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
