### PR TITLE
[macOS] Update default Perl

### DIFF
--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -164,7 +164,7 @@ function Get-NodeVersion {
 }
 
 function Get-PerlVersion {
-    $version = Run-Command "perl -e 'print substr($^V,1)'"
+    $version = Run-Command "perl -e 'print substr(`$^V,1)'"
     return "Perl $version"
 }
 

--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -163,6 +163,11 @@ function Get-NodeVersion {
     return "Node.js $nodeVersion"
 }
 
+function Get-PerlVersion {
+    $version = Run-Command "perl -e 'print substr($^V,1)'"
+    return "Perl $version"
+}
+
 function Get-PythonVersion {
     $pythonVersion = Run-Command "python --version"
     return $pythonVersion

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -48,6 +48,7 @@ $markdown += New-MDList -Style Unordered -Lines @(
     (Get-NodeVersion),
     (Get-NVMVersion),
     (Get-NVMNodeVersionList),
+    (Get-PerlVersion),
     (Get-PythonVersion),
     (Get-Python3Version),
     (Get-RubyVersion),

--- a/images/macos/tests/Common.Tests.ps1
+++ b/images/macos/tests/Common.Tests.ps1
@@ -81,6 +81,10 @@ Describe "CommonUtils" {
         "packer --version" | Should -ReturnZeroExitCode
     }
 
+    It "Perl" {
+        "perl -e 'print substr($^V,1)'" | Should -ReturnZeroExitCode
+    }
+
     It "Helm" {
         "helm version --short" | Should -ReturnZeroExitCode
     }
@@ -121,10 +125,6 @@ Describe "CommonUtils" {
         "julia --version" | Should -ReturnZeroExitCode
     }
 
-    It "virtualbox" -Skip:($os.IsBigSur) {
-        "vboxmanage -v" | Should -ReturnZeroExitCode
-    }
-
     It "jq" {
         "jq --version" | Should -ReturnZeroExitCode
     }
@@ -139,6 +139,10 @@ Describe "CommonUtils" {
 
     It "vagrant" -Skip:($os.IsBigSur) {
         "vagrant --version" | Should -ReturnZeroExitCode
+    }
+
+    It "virtualbox" -Skip:($os.IsBigSur) {
+        "vboxmanage -v" | Should -ReturnZeroExitCode
     }
 
     It "xctool" -Skip:($os.IsBigSur) {

--- a/images/macos/toolsets/toolset-10.13.json
+++ b/images/macos/toolsets/toolset-10.13.json
@@ -203,32 +203,33 @@
     ],
     "brew": {
         "common_packages": [
-            "carthage",
-            "cmake",
-            "subversion",
-            "go",
-            "gnupg",
-            "llvm",
-            "libpq",
-            "zstd",
-            "packer",
-            "helm",
             "aliyun-cli",
-            "bazelisk",
-            "gh",
-            "p7zip",
             "ant",
             "aria2",
-            "gnu-tar",
-            "xctool",
             "bats",
-            "parallel"
+            "bazelisk",
+            "carthage",
+            "cmake",
+            "gh",
+            "gnupg",
+            "gnu-tar",
+            "go",
+            "helm",
+            "libpq",
+            "llvm",
+            "p7zip",
+            "packer",
+            "parallel",
+            "perl",
+            "subversion",
+            "xctool",
+            "zstd"
         ],
         "cask_packages": [
             "julia",
-            "virtualbox",
+            "r",
             "vagrant",
-            "r"
+            "virtualbox"
         ]
     },
     "toolcache": [

--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -226,32 +226,33 @@
     ],
     "brew": {
         "common_packages": [
-            "carthage",
-            "cmake",
-            "subversion",
-            "go",
-            "gnupg",
-            "llvm",
-            "libpq",
-            "zstd",
-            "packer",
-            "helm",
             "aliyun-cli",
-            "bazelisk",
-            "gh",
-            "p7zip",
             "ant",
             "aria2",
-            "gnu-tar",
-            "xctool",
             "bats",
-            "parallel"
+            "bazelisk",
+            "carthage",
+            "cmake",
+            "gh",
+            "gnupg",
+            "gnu-tar",
+            "go",
+            "helm",
+            "libpq",
+            "llvm",
+            "p7zip",
+            "packer",
+            "parallel",
+            "perl",
+            "subversion",
+            "xctool",
+            "zstd"
         ],
         "cask_packages": [
             "julia",
-            "virtualbox",
+            "r",
             "vagrant",
-            "r"
+            "virtualbox"
         ]
     },
     "toolcache": [

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -163,32 +163,33 @@
     ],
     "brew": {
         "common_packages": [
-            "carthage",
-            "cmake",
-            "subversion",
-            "go",
-            "gnupg",
-            "llvm",
-            "libpq",
-            "zstd",
-            "packer",
-            "helm",
             "aliyun-cli",
-            "bazelisk",
-            "gh",
-            "p7zip",
             "ant",
             "aria2",
-            "gnu-tar",
-            "xctool",
             "bats",
-            "parallel"
+            "bazelisk",
+            "carthage",
+            "cmake",
+            "gh",
+            "gnupg",
+            "gnu-tar",
+            "go",
+            "helm",
+            "libpq",
+            "llvm",
+            "p7zip",
+            "packer",
+            "parallel",
+            "perl",
+            "subversion",
+            "xctool",
+            "zstd"
         ],
         "cask_packages": [
             "julia",
-            "virtualbox",
+            "r",
             "vagrant",
-            "r"
+            "virtualbox"
         ]
     },
     "toolcache": [

--- a/images/macos/toolsets/toolset-11.0.json
+++ b/images/macos/toolsets/toolset-11.0.json
@@ -96,23 +96,24 @@
     ],
     "brew": {
         "common_packages": [
-            "carthage",
-            "cmake",
-            "subversion",
-            "go",
-            "gnupg",
-            "llvm",
-            "libpq",
-            "zstd",
-            "packer",
-            "helm",
             "aliyun-cli",
-            "bazelisk",
-            "gh",
-            "p7zip",
             "ant",
             "aria2",
-            "gnu-tar"
+            "bazelisk",
+            "carthage",
+            "cmake",
+            "gh",
+            "gnupg",
+            "gnu-tar",
+            "go",
+            "helm",
+            "libpq",
+            "llvm",
+            "p7zip",
+            "packer",
+            "perl",
+            "subversion",
+            "zstd"
         ],
         "cask_packages": [
             "julia"


### PR DESCRIPTION
# Description
Previously, we updated a perl package as a dependency of the subversion package. The new version of the subversion doesn't depend on on the perl package that's why the perl package was downgraded.
`Installing dependencies for subversion: apr, apr-util, lz4, perl and utf8proc`

macOS 10.15 Version: 20201212.1
`Perl 5.32.0`

macOS 10.15 Version: 20210110.1
`Perl 5.18.4`

#### Related issue:
https://github.com/actions/virtual-environments/issues/2477

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
