### PR TITLE
[Windows] Add missing Cbindgen version output in README

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -132,6 +132,7 @@ $markdown += New-MDList -Style Unordered -Lines (@(
     (Get-BindgenVersion),
     (Get-CargoAuditVersion),
     (Get-CargoOutdatedVersion),
+    (Get-CbindgenVersion),
     "Rustfmt $(Get-RustfmtVersion)",
     "Clippy $(Get-RustClippyVersion)"
     ) | Sort-Object


### PR DESCRIPTION
# Description
Add back missing Cbindgen version output in README back that was accidentally removed in scope of [this](https://github.com/actions/virtual-environments/pull/2422/files#diff-0f0deef55edf9ac41fe9db1cd386e44aac4536569e49e147e8fdc52457ca8dedL127) PR.

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
