### PR TITLE
[Windows] Clear local NuGet resources list in cache

### DIFF
--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -109,7 +109,7 @@ function RunPostInstallationSteps()
     Set-ItemProperty -Path "HKLM:\Software\Microsoft\Windows\CurrentVersion\Run" -Name "DOTNETUSERPATH" -Value $cmdDotNet
 
     # Clear list of local NuGet resources in temporary cache
-    Invoke-Expression "dotnet nuget locals all --clear"
+    dotnet nuget locals all --clear
 }
 
 InstallAllValidSdks

--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -107,6 +107,9 @@ function RunPostInstallationSteps()
 
     # Update Run key to run a script at logon
     Set-ItemProperty -Path "HKLM:\Software\Microsoft\Windows\CurrentVersion\Run" -Name "DOTNETUSERPATH" -Value $cmdDotNet
+
+    # Clear list of local NuGet resources in temporary cache
+    Invoke-Expression "dotnet nuget locals all --clear"
 }
 
 InstallAllValidSdks


### PR DESCRIPTION
Sometimes Dotnet application' builds are failed with error:
```
error NU1101: Unable to find package <package name>. No packages exist with this id in source(s): Microsoft Visual Studio Offline Packages
```
Nuget only looking for locally cached packages rather than using nuget.org.
Added clean-up NuGet resources list in cache after Dotnet installation.

[Link to NuGet resources cache documentation.](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-locals)

#### Related issue: [issue in setup-dotnet repository](https://github.com/actions/setup-dotnet/issues/155)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
