### PR TITLE
[macOS] Get rid of invoke_tests imports

### DIFF
--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -24,3 +24,7 @@ sudo "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1176 885
 curl https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer --output $HOME/AppleWWDRCAG3.cer --silent
 sudo security add-trusted-cert -d -r unspecified -k /Library/Keychains/System.keychain $HOME/AppleWWDRCAG3.cer
 rm $HOME/AppleWWDRCAG3.cer
+
+# Create symlink for tests running
+chmod +x ~/utils/invoke-tests.sh
+ln -s ~/utils/invoke-tests.sh /usr/local/bin/invoke_tests

--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -27,7 +27,7 @@ rm $HOME/AppleWWDRCAG3.cer
 
 # Create symlink for tests running
 if [ ! -d "/usr/local/bin" ];then
-    sudo mkdir -p /usr/local/bin
+    sudo mkdir -p -m 775 /usr/local/bin
     sudo chown $USER:admin /usr/local/bin
 fi
 chmod +x $HOME/utils/invoke-tests.sh

--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -28,6 +28,7 @@ rm $HOME/AppleWWDRCAG3.cer
 # Create symlink for tests running
 if [ ! -d "/usr/local/bin" ];then
     sudo mkdir -p /usr/local/bin
+    sudo chown $USER:admin /usr/local/bin
 fi
 chmod +x $HOME/utils/invoke-tests.sh
 sudo ln -s $HOME/utils/invoke-tests.sh /usr/local/bin/invoke_tests

--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -26,5 +26,8 @@ sudo security add-trusted-cert -d -r unspecified -k /Library/Keychains/System.ke
 rm $HOME/AppleWWDRCAG3.cer
 
 # Create symlink for tests running
-chmod +x ~/utils/invoke-tests.sh
-sudo ln -s ~/utils/invoke-tests.sh /usr/bin/invoke_tests
+if [ ! -d "/usr/local/bin" ];then
+    sudo mkdir -p /usr/local/bin
+fi
+chmod +x $HOME/utils/invoke-tests.sh
+sudo ln -s $HOME/utils/invoke-tests.sh /usr/local/bin/invoke_tests

--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -27,4 +27,4 @@ rm $HOME/AppleWWDRCAG3.cer
 
 # Create symlink for tests running
 chmod +x ~/utils/invoke-tests.sh
-sudo ln -s ~/utils/invoke-tests.sh /usr/local/bin/invoke_tests
+sudo ln -s ~/utils/invoke-tests.sh /usr/bin/invoke_tests

--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -27,4 +27,4 @@ rm $HOME/AppleWWDRCAG3.cer
 
 # Create symlink for tests running
 chmod +x ~/utils/invoke-tests.sh
-ln -s ~/utils/invoke-tests.sh /usr/local/bin/invoke_tests
+sudo ln -s ~/utils/invoke-tests.sh /usr/local/bin/invoke_tests

--- a/images/macos/provision/configuration/finalize-vm.sh
+++ b/images/macos/provision/configuration/finalize-vm.sh
@@ -37,3 +37,6 @@ sudo rm -rf ~/utils ~/image-generation /tmp/*
 sudo mdutil -E /
 sudo log stream | grep -q -E 'mds.*Released.*BackgroundTask' || true
 echo "Indexing completed"
+
+# delete symlink for tests running
+sudo rm -f /usr/local/bin/invoke_tests

--- a/images/macos/provision/configuration/finalize-vm.sh
+++ b/images/macos/provision/configuration/finalize-vm.sh
@@ -39,4 +39,4 @@ sudo log stream | grep -q -E 'mds.*Released.*BackgroundTask' || true
 echo "Indexing completed"
 
 # delete symlink for tests running
-sudo rm -f /usr/local/bin/invoke_tests
+sudo rm -f /usr/bin/invoke_tests

--- a/images/macos/provision/configuration/finalize-vm.sh
+++ b/images/macos/provision/configuration/finalize-vm.sh
@@ -39,4 +39,4 @@ sudo log stream | grep -q -E 'mds.*Released.*BackgroundTask' || true
 echo "Indexing completed"
 
 # delete symlink for tests running
-sudo rm -f /usr/bin/invoke_tests
+sudo rm -f /usr/local/bin/invoke_tests

--- a/images/macos/provision/core/android-toolsets.sh
+++ b/images/macos/provision/core/android-toolsets.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
-source ~/utils/invoke-tests.sh
 
 function filter_components_by_version {
     minimumVersion=$1

--- a/images/macos/provision/core/audiodevice.sh
+++ b/images/macos/provision/core/audiodevice.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e -o pipefail
-source ~/utils/invoke-tests.sh
 source ~/utils/utils.sh
 
 echo "install soundflower"

--- a/images/macos/provision/core/aws.sh
+++ b/images/macos/provision/core/aws.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -e -o pipefail
-
 source ~/utils/utils.sh
-source ~/utils/invoke-tests.sh
 
 echo Installing aws...
 AWS_CLI_URL="https://awscli.amazonaws.com/AWSCLIV2.pkg"

--- a/images/macos/provision/core/azcopy.sh
+++ b/images/macos/provision/core/azcopy.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -e -o pipefail
-
 source ~/utils/utils.sh
-source ~/utils/invoke-tests.sh
 
 AZCOPY_DOWNLOAD_URL="https://aka.ms/downloadazcopy-v10-mac"
 

--- a/images/macos/provision/core/chrome.sh
+++ b/images/macos/provision/core/chrome.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
-source ~/utils/invoke-tests.sh
 
 echo "Installing Chrome..."
 brew_cask_install_ignoring_sha256 "google-chrome"

--- a/images/macos/provision/core/cocoapods.sh
+++ b/images/macos/provision/core/cocoapods.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e -o pipefail
-source ~/utils/invoke-tests.sh
 
 # Setup the Cocoapods
 echo "Installing Cocoapods..."

--- a/images/macos/provision/core/commonutils.sh
+++ b/images/macos/provision/core/commonutils.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
-source ~/utils/invoke-tests.sh
 
 common_packages=$(get_toolset_value '.brew.common_packages[]')
 for package in $common_packages; do

--- a/images/macos/provision/core/dotnet.sh
+++ b/images/macos/provision/core/dotnet.sh
@@ -6,9 +6,7 @@
 # https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script
 #
 ###########################################################################
-
 source ~/utils/utils.sh
-source ~/utils/invoke-tests.sh
 
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 
@@ -56,7 +54,6 @@ if [ $(dotnet --list-sdks | wc -l) -lt "1" ]; then
 fi
 
 echo 'export PATH="$PATH:$HOME/.dotnet/tools"' >> "$HOME/.bashrc"
-
 echo "Dotnet operations have been completed successfully..."
 
 invoke_tests "Common" ".NET"

--- a/images/macos/provision/core/edge.sh
+++ b/images/macos/provision/core/edge.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
-source ~/utils/invoke-tests.sh
 
 echo "Installing Microsoft Edge..."
 brew install --cask microsoft-edge

--- a/images/macos/provision/core/firefox.sh
+++ b/images/macos/provision/core/firefox.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e -o pipefail
-source ~/utils/invoke-tests.sh
 source ~/utils/utils.sh
 
 echo "Installing Firefox..."

--- a/images/macos/provision/core/gcc.sh
+++ b/images/macos/provision/core/gcc.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
-source ~/utils/invoke-tests.sh
 
 echo "Installing GCC@8 using homebrew..."
 brew_smart_install "gcc@8"

--- a/images/macos/provision/core/git.sh
+++ b/images/macos/provision/core/git.sh
@@ -1,6 +1,4 @@
 #!/bin/bash -e -o pipefail
-source ~/utils/invoke-tests.sh
-
 source ~/utils/utils.sh
 
 echo Installing Git...

--- a/images/macos/provision/core/haskell.sh
+++ b/images/macos/provision/core/haskell.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e -o pipefail
-source ~/utils/invoke-tests.sh
 
 curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
 export PATH="$HOME/.ghcup/bin:$PATH"

--- a/images/macos/provision/core/miniconda.sh
+++ b/images/macos/provision/core/miniconda.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e -o pipefail
-source ~/utils/invoke-tests.sh
 
 MINICONDA_INSTALLER="/tmp/miniconda.sh"
 curl -sL https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o $MINICONDA_INSTALLER

--- a/images/macos/provision/core/mongodb.sh
+++ b/images/macos/provision/core/mongodb.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
-source ~/utils/invoke-tests.sh
 
 # MongoDB object-value database
 # installs last version of MongoDB Community Edition

--- a/images/macos/provision/core/node.sh
+++ b/images/macos/provision/core/node.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e -o pipefail
-source ~/utils/invoke-tests.sh
 source ~/utils/utils.sh
 
 node_modules=(

--- a/images/macos/provision/core/nvm.sh
+++ b/images/macos/provision/core/nvm.sh
@@ -4,7 +4,6 @@
 #
 ###########################################################################
 source ~/utils/utils.sh
-source ~/utils/invoke-tests.sh
 
 VERSION=$(curl -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r '.tag_name')
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$VERSION/install.sh | bash

--- a/images/macos/provision/core/openjdk.sh
+++ b/images/macos/provision/core/openjdk.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -e -o pipefail
-
 source ~/utils/utils.sh
-source ~/utils/invoke-tests.sh
 
 installAzulJDK() {
     local URL=$1

--- a/images/macos/provision/core/openssl.sh
+++ b/images/macos/provision/core/openssl.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
-source ~/utils/invoke-tests.sh
 
 echo "Install latest openssl"
 brew_smart_install "openssl"

--- a/images/macos/provision/core/php.sh
+++ b/images/macos/provision/core/php.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
-source ~/utils/invoke-tests.sh
 
 echo Installing PHP
 brew_smart_install "php"

--- a/images/macos/provision/core/pipx-packages.sh
+++ b/images/macos/provision/core/pipx-packages.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
-source ~/utils/invoke-tests.sh
 
 export PATH="$PATH:/opt/pipx_bin"
 

--- a/images/macos/provision/core/postgresql.sh
+++ b/images/macos/provision/core/postgresql.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
-source ~/utils/invoke-tests.sh
 
 #Install latest version of postgresql
 brew_smart_install "postgres"

--- a/images/macos/provision/core/powershell.sh
+++ b/images/macos/provision/core/powershell.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -e -o pipefail
-
 source ~/utils/utils.sh
-source ~/utils/invoke-tests.sh
 
 echo Installing Azure CLI...
 brew_smart_install "azure-cli"

--- a/images/macos/provision/core/python.sh
+++ b/images/macos/provision/core/python.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e -o pipefail
-source ~/utils/invoke-tests.sh
 source ~/utils/utils.sh
 
 echo "Installing Python Tooling"

--- a/images/macos/provision/core/ruby.sh
+++ b/images/macos/provision/core/ruby.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e -o pipefail
-source ~/utils/invoke-tests.sh
 source ~/utils/utils.sh
 
 echo Installing Ruby...

--- a/images/macos/provision/core/rubygem.sh
+++ b/images/macos/provision/core/rubygem.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e -o pipefail
-source ~/utils/invoke-tests.sh
 source ~/utils/utils.sh
 
 echo Updating RubyGems...

--- a/images/macos/provision/core/rust.sh
+++ b/images/macos/provision/core/rust.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
-source ~/utils/invoke-tests.sh
 
 echo Installing Rustup...
 brew_smart_install "rustup-init"

--- a/images/macos/provision/core/stack.sh
+++ b/images/macos/provision/core/stack.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e -o pipefail
-source ~/utils/invoke-tests.sh
 source ~/utils/utils.sh
 
 echo "Get the latest Stack version..."

--- a/images/macos/provision/core/swiftlint.sh
+++ b/images/macos/provision/core/swiftlint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e -o pipefail
-source ~/utils/invoke-tests.sh
 source ~/utils/utils.sh
 
 echo "Install SwiftLint"

--- a/images/macos/provision/core/vcpkg.sh
+++ b/images/macos/provision/core/vcpkg.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e -o pipefail
-source ~/utils/invoke-tests.sh
 source ~/utils/utils.sh
 
 # Set env variable for vcpkg

--- a/images/macos/provision/core/vsmac.sh
+++ b/images/macos/provision/core/vsmac.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
 source ~/utils/xamarin-utils.sh
-source ~/utils/invoke-tests.sh
 
 VSMAC_VERSION=$(get_toolset_value '.xamarin.vsmac')
 if [ $VSMAC_VERSION == "latest" ]; then
@@ -28,4 +27,3 @@ sudo hdiutil detach "$TMPMOUNT"
 sudo rm -rf "$TMPMOUNT"
 
 invoke_tests "Common" "VSMac"
-

--- a/images/macos/provision/core/xamarin-android-ndk.sh
+++ b/images/macos/provision/core/xamarin-android-ndk.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e -o pipefail
-source ~/utils/invoke-tests.sh
 source ~/utils/utils.sh
 
 ANDROID_HOME=$HOME/Library/Android/sdk

--- a/images/macos/provision/core/xamarin.sh
+++ b/images/macos/provision/core/xamarin.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e -o pipefail
-source ~/utils/invoke-tests.sh
 source ~/utils/utils.sh
 source ~/utils/xamarin-utils.sh
 

--- a/images/macos/provision/utils/invoke-tests.sh
+++ b/images/macos/provision/utils/invoke-tests.sh
@@ -1,8 +1,5 @@
 #!/bin/bash -e -o pipefail
 
-local TEST_FILE="$1"
-local TEST_NAME="$2"
-
 source $HOME/.bashrc
 pwsh -Command "Import-Module '$HOME/image-generation/helpers/Tests.Helpers.psm1' -DisableNameChecking
-        Invoke-PesterTests -TestFile \"$TEST_FILE\" -TestName \"$TEST_NAME\""
+        Invoke-PesterTests -TestFile \"$1\" -TestName \"$2\""

--- a/images/macos/provision/utils/invoke-tests.sh
+++ b/images/macos/provision/utils/invoke-tests.sh
@@ -1,10 +1,8 @@
 #!/bin/bash -e -o pipefail
 
-invoke_tests() {
-    local TEST_FILE="$1"
-    local TEST_NAME="$2"
+local TEST_FILE="$1"
+local TEST_NAME="$2"
 
-    source $HOME/.bashrc
-    pwsh -Command "Import-Module '$HOME/image-generation/helpers/Tests.Helpers.psm1' -DisableNameChecking
+source $HOME/.bashrc
+pwsh -Command "Import-Module '$HOME/image-generation/helpers/Tests.Helpers.psm1' -DisableNameChecking
         Invoke-PesterTests -TestFile \"$TEST_FILE\" -TestName \"$TEST_NAME\""
-}


### PR DESCRIPTION
# Description
Add "invoke-test" function to PATH and get rid of imports in every file.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1668

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
