### PR TITLE
[macOS] Switch to android ndk 21 from the latest one (22.0.7026061)

### DIFF
--- a/images/macos/provision/core/android-toolsets.sh
+++ b/images/macos/provision/core/android-toolsets.sh
@@ -66,7 +66,11 @@ echo "Installing latest CMake..."
 echo y | $SDKMANAGER "cmake;3.6.4111459"
 
 echo "Installing latest ndk..."
-echo y | $SDKMANAGER "ndk-bundle"
+echo y | $SDKMANAGER  "ndk;21.3.6528147"
+# This changes were added due to incompatibility with android ndk-bundle (ndk;22.0.7026061).
+# Link issue virtual-environments: https://github.com/actions/virtual-environments/issues/2481
+# Link issue xamarin-android: https://github.com/xamarin/xamarin-android/issues/5526
+ln -s $ANDROID_HOME/ndk/21.3.6528147 $ANDROID_HOME/ndk-bundle
 
 availablePlatforms=($(${ANDROID_HOME}/tools/bin/sdkmanager --list | grep "platforms;android-" | cut -d"|" -f 1 | sort -u))
 filter_components_by_version $ANDROID_PLATFORM "${availablePlatforms[@]}"


### PR DESCRIPTION
# Description
In scope of this pull request we add logic to switch latest ndk-bundle to the 21 due to the issue with android-xamarin.

#### Related issue: https://github.com/actions/virtual-environments/issues/2481
#### Related issue in xamarin-android: https://github.com/xamarin/xamarin-android/issues/5526

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
