### PR TITLE
[Windows] Switch to android ndk 21 from the latest one (22.0.7026061)

### DIFF
--- a/images/win/scripts/Installers/Update-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Update-AndroidSDK.ps1
@@ -77,6 +77,10 @@ Install-AndroidSDKPackages -AndroidSDKManagerPath $sdkManager `
 
 # Android NDK root path.
 $ndkRoot = "$sdkRoot\ndk-bundle"
+# This changes were added due to incompatibility with android ndk-bundle (ndk;22.0.7026061).
+# Link issue virtual-environments: https://github.com/actions/virtual-environments/issues/2481
+# Link issue xamarin-android: https://github.com/xamarin/xamarin-android/issues/5526
+New-Item -Path $ndkRoot -ItemType SymbolicLink -Value "$sdkRoot\ndk\21.3.6528147"
 
 if (Test-Path $ndkRoot) {
     setx ANDROID_HOME $sdkRoot /M

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -163,7 +163,7 @@
             "cmake;3.6.4111459",
             "cmake;3.10.2.4988404",
             "patcher;v4",
-            "ndk-bundle",
+            "ndk;21.3.6528147",
             "cmdline-tools;latest"
         ]
     },

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -163,7 +163,7 @@
             "cmake;3.6.4111459",
             "cmake;3.10.2.4988404",
             "patcher;v4",
-            "ndk-bundle",
+            "ndk;21.3.6528147",
             "cmdline-tools;latest"
         ]
     },


### PR DESCRIPTION
# Description
In scope of this pull request we add logic to switch latest ndk-bundle to the 21 due to the issue with android-xamarin.

#### Related issue: https://github.com/actions/virtual-environments/issues/2481
#### Related issue in xamarin-android: https://github.com/xamarin/xamarin-android/issues/5526

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
