### PR TITLE
[Ubuntu] Switch to android ndk 21 from the latest one (22.0.7026061)

### DIFF
--- a/images/linux/scripts/installers/android.sh
+++ b/images/linux/scripts/installers/android.sh
@@ -70,6 +70,11 @@ additional=$(get_toolset_value '.android.additional_tools[]')
 # Install the following SDKs and build tools, passing in "y" to accept licenses.
 components=( "${extras[@]}" "${addons[@]}" "${additional[@]}" )
 
+# This changes were added due to incompatibility with android ndk-bundle (ndk;22.0.7026061).
+# Link issue virtual-environments: https://github.com/actions/virtual-environments/issues/2481
+# Link issue xamarin-android: https://github.com/xamarin/xamarin-android/issues/5526
+ln -s $ANDROID_SDK_ROOT/ndk/21.3.6528147 $ANDROID_NDK_ROOT
+
 availablePlatforms=($(${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --list | sed -n '/Available Packages:/,/^$/p' | grep "platforms;android-" | cut -d"|" -f 1))
 allBuildTools=($(${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --list | grep "build-tools;" | cut -d"|" -f 1 | sort -u))
 availableBuildTools=$(echo ${allBuildTools[@]//*rc[0-9]/})

--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -106,7 +106,7 @@
             "cmake;3.6.4111459",
             "cmake;3.10.2.4988404",
             "patcher;v4",
-            "ndk-bundle",
+            "ndk;21.3.6528147",
             "platform-tools",
             "cmdline-tools;latest"
         ]

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -102,7 +102,7 @@
             "cmake;3.6.4111459",
             "cmake;3.10.2.4988404",
             "patcher;v4",
-            "ndk-bundle",
+            "ndk;21.3.6528147",
             "platform-tools",
             "cmdline-tools;latest"
         ]

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -85,7 +85,7 @@
         "additional_tools": [
             "cmake;3.10.2.4988404",
             "patcher;v4",
-            "ndk-bundle",
+            "ndk;21.3.6528147",
             "platform-tools",
             "cmdline-tools;latest"
         ]


### PR DESCRIPTION
# Description
In scope of this pull request we add logic to switch latest ndk-bundle to the 21 due to the issue with android-xamarin.

#### Related issue: https://github.com/actions/virtual-environments/issues/2481
#### Related issue in xamarin-android: https://github.com/xamarin/xamarin-android/issues/5526

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
