### PR TITLE
Update README with new macOS 11.0 status

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ For general questions about using the virtual environments or writing your Actio
 | Windows Server 2019 | `windows-latest` or `windows-2019` | [windows-2019] | [![](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=windows-2019&badge=1)](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=windows-2019&redirect=1)
 | Windows Server 2016 | `windows-2016` | [windows-2016] | [![](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=windows-2016&badge=1)](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=windows-2016&redirect=1)
 ```
-The MacOS 11.0 virtual environment is currently provided as a preview only.
-The "macos-latest" YAML workflow label still uses the MacOS 10.15 virtual environment.
+The macOS 11.0 virtual environment is currently provided as a private preview only.
+The "macos-latest" YAML workflow label still uses the macOS 10.15 virtual environment.
 ```
 
 ***What images are available for GitHub Actions and Azure DevOps?***


### PR DESCRIPTION
# Description
Updated README to indicate macOS 11.0 is in private preview.

#### Related issue: https://github.com/actions/virtual-environments/issues/2486

## Check list
- [n/a] Related issue / work item is attached
- [n/a] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [n/a] Changes are tested and related VM images are successfully generated
