### PR TITLE
[Windows] Add Apache and Nginx

### DIFF
--- a/images/win/scripts/Installers/Install-Apache.ps1
+++ b/images/win/scripts/Installers/Install-Apache.ps1
@@ -1,0 +1,21 @@
+################################################################################
+##  File:  Install-Apache.ps1
+##  Desc:  Install Apache HTTP Server
+################################################################################
+
+# Stop w3svc service
+Stop-Service -Name w3svc | Out-Null
+
+# Install latest apache in chocolatey
+$installDir = "C:\tools"
+Choco-Install -PackageName apache-httpd -ArgumentList "--force", "--params", "/installLocation:$installDir /port:80"
+
+# Stop and disable Apache service
+Stop-Service -Name Apache
+Set-Service Apache -StartupType Disabled
+
+# Start w3svc service
+Start-Service -Name w3svc | Out-Null
+
+# Invoke Pester Tests
+Invoke-PesterTests -TestFile "Apache"

--- a/images/win/scripts/Installers/Install-Nginx.ps1
+++ b/images/win/scripts/Installers/Install-Nginx.ps1
@@ -1,0 +1,21 @@
+################################################################################
+##  File:  Install-Nginx.ps1
+##  Desc:  Install Nginx
+################################################################################
+
+# Stop w3svc service
+Stop-Service -Name w3svc | Out-Null
+
+# Install latest nginx in chocolatey
+$installDir = "C:\tools"
+Choco-Install -PackageName nginx -ArgumentList "--force", "--params", "/installLocation:$installDir /port:80"
+
+# Stop and disable Nginx service
+Stop-Service -Name nginx
+Set-Service nginx -StartupType Disabled
+
+# Start w3svc service
+Start-Service -Name w3svc | Out-Null
+
+# Invoke Pester Tests
+Invoke-PesterTests -TestFile "Nginx"

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -7,6 +7,7 @@ Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Databases.psm1") -Disable
 Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Helpers.psm1") -DisableNameChecking
 Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Tools.psm1") -DisableNameChecking
 Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Java.psm1") -DisableNameChecking
+Import-Module (Join-Path $PSScriptRoot "SoftwareReport.WebServers.psm1") -DisableNameChecking
 Import-Module (Join-Path $PSScriptRoot "SoftwareReport.VisualStudio.psm1") -DisableNameChecking
 
 $markdown = ""
@@ -194,6 +195,8 @@ $markdown += New-MDList -Style Unordered -Lines (@(
     ) | Sort-Object
 )
 $markdown += New-MDNewLine
+
+$markdown += Build-WebServerMarkdown
 
 $vs = Get-VisualStudioVersion
 $markdown += New-MDHeader "$($vs.Name)" -Level 3

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -196,7 +196,7 @@ $markdown += New-MDList -Style Unordered -Lines (@(
 )
 $markdown += New-MDNewLine
 
-$markdown += Build-WebServerMarkdown
+$markdown += Build-WebServersSection
 
 $vs = Get-VisualStudioVersion
 $markdown += New-MDHeader "$($vs.Name)" -Level 3

--- a/images/win/scripts/SoftwareReport/SoftwareReport.WebServers.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.WebServers.psm1
@@ -1,0 +1,65 @@
+function Get-ApachePath {
+    return Join-Path "C:\tools\" (Get-Item C:\tools\apache*).Name
+}
+
+function Get-NginxPath {
+    return Join-Path "C:\tools\" (Get-Item C:\tools\nginx*).Name
+}
+
+function Get-ApacheVersion {
+    $apacheBinPath = Join-Path (Get-ApachePath) "\bin\httpd"
+    (. $apacheBinPath -V | Select-String -Pattern "Apache/") -match "Apache/(?<version>\d+\.\d+\.\d+)" | Out-Null
+    return $Matches.Version
+}
+
+function Get-NginxVersion {
+    $nginxBinPath = Join-Path (Get-NginxPath) "\nginx"
+    (. $nginxBinPath -v 2>&1 | Select-String -Pattern "nginx/") -match "nginx/(?<version>\d+\.\d+\.\d+)" | Out-Null
+    return $Matches.Version
+}
+
+function Get-ApacheMarkdown
+{
+    $name = "Apache"
+    $apachePort = "80"
+    $apacheService = Get-Service -Name $name
+    $apacheVersion = Get-ApacheVersion
+    $apacheConfigFile = Join-Path (Get-ApachePath) "\conf\httpd.conf"
+    return [PSCustomObject]@{
+        Name = $name
+        Version = $apacheVersion
+        ConfigFile = $apacheConfigFile
+        ServiceName = $apacheService.Name
+        ServiceStatus = $apacheService.Status
+        ListenPort = $apachePort
+    }
+}
+
+function Get-NginxMarkdown
+{
+    $name = "Nginx"
+    $nginxPort = "80"
+    $nginxService = Get-Service -Name $name
+    $nginxVersion = Get-NginxVersion
+    $nginxConfigFile = Join-Path (Get-NginxPath) "\conf\nginx.conf"
+    return [PSCustomObject]@{
+        Name = $name
+        Version = $nginxVersion
+        ConfigFile = $nginxConfigFile
+        ServiceName = $nginxService.Name
+        ServiceStatus = $nginxService.Status
+        ListenPort = $nginxPort
+    }
+}
+
+function Build-WebServersSection {
+    $output = ""
+    $output += New-MDHeader "Web Servers" -Level 3
+    $output += @(
+    (Get-ApacheMarkdown),
+    (Get-NginxMarkdown)
+    ) | Sort-Object Name | New-MDTable
+
+    $output += New-MDNewLine
+    return $output
+}

--- a/images/win/scripts/Tests/Apache.Tests.ps1
+++ b/images/win/scripts/Tests/Apache.Tests.ps1
@@ -1,0 +1,25 @@
+Describe "Apache" {
+    Context "Path" {
+        It "Apache" {
+            $apachePath = Join-Path (Join-Path "C:\tools\" (Get-Item C:\tools\apache*).Name) "\bin\httpd"
+            ". $apachePath -V" | Should -ReturnZeroExitCode
+        }
+    }
+
+    Context "Service" {
+        $apacheService = Get-Service -Name Apache
+        $apacheServiceTests = @{
+            Name = $apacheService.Name
+            Status = $apacheService.Status
+            StartType = $apacheService.StartType
+        }
+
+        It "<Name> service is stopped" -TestCases $apacheServiceTests {
+            $Status | Should -Be "Stopped"
+        }
+
+        It "<Name> service is disabled" -TestCases $apacheServiceTests {
+            $StartType | Should -Be "Disabled"
+        }
+    }
+}

--- a/images/win/scripts/Tests/Apache.Tests.ps1
+++ b/images/win/scripts/Tests/Apache.Tests.ps1
@@ -2,7 +2,7 @@ Describe "Apache" {
     Context "Path" {
         It "Apache" {
             $apachePath = Join-Path (Join-Path "C:\tools\" (Get-Item C:\tools\apache*).Name) "\bin\httpd"
-            ". $apachePath -V" | Should -ReturnZeroExitCode
+            "$apachePath -V" | Should -ReturnZeroExitCode
         }
     }
 

--- a/images/win/scripts/Tests/Nginx.Tests.ps1
+++ b/images/win/scripts/Tests/Nginx.Tests.ps1
@@ -1,0 +1,25 @@
+Describe "Nginx" {
+    Context "Path" {
+        It "Nginx" {
+            $nginxPath = Join-Path (Join-Path "C:\tools\" (Get-Item C:\tools\nginx*).Name) "\nginx"
+            ". $nginxPath -v" | Should -ReturnZeroExitCode
+        }
+    }
+
+    Context "Service" {
+        $nginxService = Get-Service -Name nginx
+        $nginxServiceTests = @{
+            Name = $nginxService.Name
+            Status = $nginxService.Status
+            StartType = $nginxService.StartType
+        }
+
+        It "<Name> service is stopped" -TestCases $nginxServiceTests {
+            $Status | Should -Be "Stopped"
+        }
+
+        It "<Name> service is disabled" -TestCases $nginxServiceTests {
+            $StartType | Should -Be "Disabled"
+        }
+    }
+}

--- a/images/win/scripts/Tests/Nginx.Tests.ps1
+++ b/images/win/scripts/Tests/Nginx.Tests.ps1
@@ -2,7 +2,7 @@ Describe "Nginx" {
     Context "Path" {
         It "Nginx" {
             $nginxPath = Join-Path (Join-Path "C:\tools\" (Get-Item C:\tools\nginx*).Name) "\nginx"
-            ". $nginxPath -v" | Should -ReturnZeroExitCode
+            "$nginxPath -v" | Should -ReturnZeroExitCode
         }
     }
 

--- a/images/win/windows2016.json
+++ b/images/win/windows2016.json
@@ -244,7 +244,9 @@
                 "{{ template_dir }}/scripts/Installers/Install-Edge.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Firefox.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Selenium.ps1",
-                "{{ template_dir }}/scripts/Installers/Install-IEWebDriver.ps1"
+                "{{ template_dir }}/scripts/Installers/Install-IEWebDriver.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-Apache.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-Nginx.ps1"
             ]
         },
         {

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -248,7 +248,9 @@
                 "{{ template_dir }}/scripts/Installers/Install-Edge.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Firefox.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Selenium.ps1",
-                "{{ template_dir }}/scripts/Installers/Install-IEWebDriver.ps1"
+                "{{ template_dir }}/scripts/Installers/Install-IEWebDriver.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-Apache.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-Nginx.ps1"
             ]
         },
         {


### PR DESCRIPTION
# Description
New Tool
This PR adds `Apache` and `Nginx` to the Windows images.

### Web Servers
| Name   | Version | ConfigFile                            | ServiceName | ServiceStatus | ListenPort |
| ------ | ------- | ------------------------------------- | ----------- | ------------- | ---------- |
| Apache | 2.4.46  | C:\tools\Apache24\conf\httpd.conf       | Apache      | Stopped       | 80         |
| Nginx  | 1.19.6  | C:\tools\nginx-1.19.6\conf\nginx.conf | nginx       | Stopped       | 80         |

#### Related issue: #2501

## Check list
- [X] Related issue / work item is attached
- [X] Tests are written (if applicable)
- [X] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
