### PR TITLE
[Ubuntu] Install 1.27.4 on ubuntu16/18

### DIFF
--- a/images/linux/scripts/installers/docker-compose.sh
+++ b/images/linux/scripts/installers/docker-compose.sh
@@ -8,6 +8,7 @@ source $HELPER_SCRIPTS/os.sh
 # Install latest docker-compose from releases
 URL=$(curl -s https://api.github.com/repos/docker/compose/releases/latest | jq -r '.assets[].browser_download_url | select(contains("docker-compose-Linux-x86_64"))' | head -1)
 if isUbuntu16 || isUbuntu18 ; then
+    # https://github.com/docker/compose/issues/8048
     URL="https://github.com/docker/compose/releases/download/1.27.4/docker-compose-Linux-x86_64"
 fi
 curl -L $URL -o /usr/local/bin/docker-compose

--- a/images/linux/scripts/installers/docker-compose.sh
+++ b/images/linux/scripts/installers/docker-compose.sh
@@ -3,9 +3,13 @@
 ##  File:  docker-compose.sh
 ##  Desc:  Installs Docker Compose
 ################################################################################
+source $HELPER_SCRIPTS/os.sh
 
 # Install latest docker-compose from releases
 URL=$(curl -s https://api.github.com/repos/docker/compose/releases/latest | jq -r '.assets[].browser_download_url | select(contains("docker-compose-Linux-x86_64"))' | head -1)
+if isUbuntu16 || isUbuntu18 ; then
+    URL="https://github.com/docker/compose/releases/download/1.27.4/docker-compose-Linux-x86_64"
+fi
 curl -L $URL -o /usr/local/bin/docker-compose
 chmod +x /usr/local/bin/docker-compose
 

--- a/images/linux/scripts/installers/docker-compose.sh
+++ b/images/linux/scripts/installers/docker-compose.sh
@@ -6,7 +6,7 @@
 source $HELPER_SCRIPTS/os.sh
 
 # Install latest docker-compose from releases
-URL=$(curl -s https://api.github.com/repos/docker/compose/releases/latest | jq -r '.assets[].browser_download_url | select(contains("docker-compose-Linux-x86_64"))' | head -1)
+URL=$(curl -s https://api.github.com/repos/docker/compose/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("docker-compose-Linux-x86_64"))')
 if isUbuntu16 || isUbuntu18 ; then
     # https://github.com/docker/compose/issues/8048
     URL="https://github.com/docker/compose/releases/download/1.27.4/docker-compose-Linux-x86_64"

--- a/images/linux/scripts/installers/oras-cli.sh
+++ b/images/linux/scripts/installers/oras-cli.sh
@@ -8,7 +8,7 @@ source $HELPER_SCRIPTS/install.sh
 
 # Determine latest ORAS CLI version
 ORAS_CLI_LATEST_VERSION_URL=https://api.github.com/repos/deislabs/oras/releases/latest
-ORAS_CLI_DOWNLOAD_URL=$(curl -s $ORAS_CLI_LATEST_VERSION_URL | jq -r '.assets[].browser_download_url | select(contains("linux_amd64.tar.gz"))')
+ORAS_CLI_DOWNLOAD_URL=$(curl -s $ORAS_CLI_LATEST_VERSION_URL | jq -r '.assets[].browser_download_url | select(endswith("linux_amd64.tar.gz"))')
 ORAS_CLI_ARCHIVE=$(basename $ORAS_CLI_DOWNLOAD_URL)
 
 # Install ORAS CLI


### PR DESCRIPTION
# Description
Install docker-compose 1.27.4 on ubuntu16/18 until the issue is resolved - https://github.com/docker/compose/issues/8048

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1711

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
