### PR TITLE
[macOS] Add apache and nginx

### DIFF
--- a/images/macos/provision/core/apache.sh
+++ b/images/macos/provision/core/apache.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e -o pipefail
+
+brew install httpd
+sudo sed -Ei '' 's/Listen .*/Listen 80/' $(brew --prefix)/etc/httpd/httpd.conf
+
+invoke_tests "WebServers" "Apache"

--- a/images/macos/provision/core/nginx.sh
+++ b/images/macos/provision/core/nginx.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e -o pipefail
+
+brew install nginx
+sudo sed -Ei '' 's/listen.*/listen 80;/' $(brew --prefix)/etc/nginx/nginx.conf
+
+invoke_tests "WebServers" "Nginx"

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -14,6 +14,7 @@ Import-Module "$PSScriptRoot/SoftwareReport.Java.psm1" -DisableNameChecking
 Import-Module "$PSScriptRoot/SoftwareReport.Xamarin.psm1" -DisableNameChecking
 Import-Module "$PSScriptRoot/SoftwareReport.Toolcache.psm1" -DisableNameChecking
 Import-Module "$PSScriptRoot/SoftwareReport.Browsers.psm1" -DisableNameChecking
+Import-Module "$PSScriptRoot/SoftwareReport.WebServers.psm1" -DisableNameChecking
 Import-Module "$PSScriptRoot/../helpers/SoftwareReport.Helpers.psm1"
 Import-Module "$PSScriptRoot/../helpers/Common.Helpers.psm1"
 Import-Module "$PSScriptRoot/../helpers/Xcode.Helpers.psm1"
@@ -218,6 +219,11 @@ $markdown += New-MDList -Lines (Get-PowershellVersion) -Style Unordered
 $markdown += New-MDHeader "PowerShell Modules" -Level 4
 $markdown += Get-PowerShellModules | New-MDTable
 $markdown += New-MDNewLine
+
+# Web Servers
+if ($os.IsHigherThanMojave) {
+    $markdown += Build-WebServersSection
+}
 
 # Xamarin section
 $markdown += New-MDHeader "Xamarin" -Level 3

--- a/images/macos/software-report/SoftwareReport.WebServers.psm1
+++ b/images/macos/software-report/SoftwareReport.WebServers.psm1
@@ -7,8 +7,8 @@ function Get-ApacheVersion {
     return [PsCustomObject]@{
         "Name" = $name
         "Version" = $version
-        "ServiceStatus" = $serviceStatus
         "ConfigFile" = $configFile
+        "ServiceStatus" = $serviceStatus
         "ListenPort" = $port
     }
 }
@@ -22,11 +22,12 @@ function Get-NginxVersion {
     return [PsCustomObject]@{
         "Name" = $name
         "Version" = $version
-        "ServiceStatus" = $serviceStatus
         "ConfigFile" = $configFile
+        "ServiceStatus" = $serviceStatus
         "ListenPort" = $port
     }
 }
+
 function Build-WebServersSection {
     $output = ""
     $output += New-MDHeader "Web Servers" -Level 3

--- a/images/macos/software-report/SoftwareReport.WebServers.psm1
+++ b/images/macos/software-report/SoftwareReport.WebServers.psm1
@@ -35,7 +35,8 @@ function Build-WebServersSection {
         (Get-ApacheVersion),
         (Get-NginxVersion)
     ) | Sort-Object Name | New-MDTable
-    
+
+    $output += New-MDNewLine
     $output += New-MDHeader "Notes:" -Level 5
     $output += @'
 ```
@@ -49,5 +50,7 @@ function Build-WebServersSection {
     brew services stop "$service"
 ```
 '@
+
+    $output += New-MDNewLine
     return $output
 }

--- a/images/macos/software-report/SoftwareReport.WebServers.psm1
+++ b/images/macos/software-report/SoftwareReport.WebServers.psm1
@@ -1,0 +1,52 @@
+function Get-ApacheVersion {
+    $name = "httpd"
+    $port = 80
+    $version = brew list $name --versions | Take-Part -Part 1
+    $serviceStatus = (brew services list) -match $name | Take-Part -Part 1
+    $configFile = "$(brew --prefix)/etc/httpd/httpd.conf"
+    return [PsCustomObject]@{
+        "Name" = $name
+        "Version" = $version
+        "ServiceStatus" = $serviceStatus
+        "ConfigFile" = $configFile
+        "ListenPort" = $port
+    }
+}
+
+function Get-NginxVersion {
+    $name = "nginx"
+    $port = 80
+    $version = brew list $name --versions | Take-Part -Part 1
+    $serviceStatus = (brew services list) -match $name | Take-Part -Part 1
+    $configFile = "$(brew --prefix)/etc/nginx/nginx.conf"
+    return [PsCustomObject]@{
+        "Name" = $name
+        "Version" = $version
+        "ServiceStatus" = $serviceStatus
+        "ConfigFile" = $configFile
+        "ListenPort" = $port
+    }
+}
+function Build-WebServersSection {
+    $output = ""
+    $output += New-MDHeader "Web Servers" -Level 3
+    $output += @(
+        (Get-ApacheVersion),
+        (Get-NginxVersion)
+    ) | Sort-Object Name | New-MDTable
+    
+    $output += New-MDHeader "Notes:" -Level 5
+    $output += @'
+```
+    1. Start the service formula immediately
+    brew services start $service
+    2. List all managed services
+    brew services list | grep $service
+    3. Port 80 availability check
+    sudo lsof -i :80 | grep LISTEN
+    4. Stop the service formula immediately
+    brew services stop "$service"
+```
+'@
+    return $output
+}

--- a/images/macos/software-report/SoftwareReport.WebServers.psm1
+++ b/images/macos/software-report/SoftwareReport.WebServers.psm1
@@ -37,20 +37,5 @@ function Build-WebServersSection {
     ) | Sort-Object Name | New-MDTable
 
     $output += New-MDNewLine
-    $output += New-MDHeader "Notes:" -Level 5
-    $output += @'
-```
-    1. Start the service formula immediately
-    brew services start $service
-    2. List all managed services
-    brew services list | grep $service
-    3. Port 80 availability check
-    sudo lsof -i :80 | grep LISTEN
-    4. Stop the service formula immediately
-    brew services stop "$service"
-```
-'@
-
-    $output += New-MDNewLine
     return $output
 }

--- a/images/macos/templates/macOS-10.15.json
+++ b/images/macos/templates/macOS-10.15.json
@@ -174,6 +174,8 @@
                 "./provision/core/xamarin-android-ndk.sh",
                 "./provision/core/vsmac.sh",
                 "./provision/core/nvm.sh",
+                "./provision/core/apache.sh",
+                "./provision/core/nginx.sh",
                 "./provision/core/postgresql.sh",
                 "./provision/core/mongodb.sh",
                 "./provision/core/audiodevice.sh",

--- a/images/macos/templates/macOS-11.0.json
+++ b/images/macos/templates/macOS-11.0.json
@@ -173,6 +173,8 @@
                 "./provision/core/xamarin.sh",
                 "./provision/core/vsmac.sh",
                 "./provision/core/nvm.sh",
+                "./provision/core/apache.sh",
+                "./provision/core/nginx.sh",
                 "./provision/core/postgresql.sh",
                 "./provision/core/mongodb.sh",
                 "./provision/core/vcpkg.sh",

--- a/images/macos/tests/WebServers.Tests.ps1
+++ b/images/macos/tests/WebServers.Tests.ps1
@@ -1,0 +1,19 @@
+Describe "Apache" {
+    It "Apache CLI" {
+        "httpd -v" | Should -ReturnZeroExitCode
+    }
+
+    It "Apache Service" {
+        brew services list | Out-String | Should -Match "httpd\s+stopped"
+    }
+}
+
+Describe "Nginx" {
+    It "Nginx CLI" {
+        "nginx -v" | Should -ReturnZeroExitCode
+    }
+
+    It "Nginx Service" {
+        brew services list | Out-String | Should -Match "nginx\s+stopped"
+    }
+}


### PR DESCRIPTION
# Description
### Web Servers
| Name  | Version  | ConfigFile                      | ServiceStatus | ListenPort |
| ----- | -------- | ------------------------------- | ------------- | ---------- |
| httpd | 2.4.46_2 | /usr/local/etc/httpd/httpd.conf | stopped       | 80         |
| nginx | 1.19.6   | /usr/local/etc/nginx/nginx.conf | stopped       | 80         |
##### Notes:
```
    1. Start the service formula immediately
    brew services start $service
    2. List all managed services
    brew services list | grep $service
    3. Port 80 availability check
    sudo lsof -i :80 | grep LISTEN
    4. Stop the service formula immediately
    brew services stop "$service"
```

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1713

## Check list
- [X] Related issue / work item is attached
- [X] Tests are written (if applicable)
- [X] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
