### PR TITLE
[macOS] Default Xcode is set to Xcode 12.3 and default Xamarin bundle is changed to 6_12_5

### DIFF
--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -1,6 +1,6 @@
 {
     "xcode": {
-        "default": "12.2",
+        "default": "12.3",
         "versions": [
             { "link": "12.4", "version": "12.4.0"},
             { "link": "12.3", "version": "12.3.0"},
@@ -31,7 +31,7 @@
         "android-versions": [
             "11.1.0.26", "11.0.2.0", "10.3.1.4", "10.2.0.100", "10.1.3.7", "10.0.6.2"
         ],
-        "bundle-default": "6_12_4",
+        "bundle-default": "6_12_5",
         "bundles": [
             {
                 "symlink": "6_12_5",

--- a/images/macos/toolsets/toolset-11.0.json
+++ b/images/macos/toolsets/toolset-11.0.json
@@ -1,6 +1,6 @@
 {
     "xcode": {
-        "default": "12.2",
+        "default": "12.3",
         "versions": [
             { "link": "12.4", "version": "12.4.0"},
             { "link": "12.3", "version": "12.3.0"},
@@ -22,7 +22,7 @@
         "android-versions": [
             "11.1.0.26", "11.0.2.0"
         ],
-        "bundle-default": "6_12_4",
+        "bundle-default": "6_12_5",
         "bundles": [
             {
                 "symlink": "6_12_5",


### PR DESCRIPTION
# Description
Default Xcode is changed to 12.3, and default Xamarin bundle is changed to 6_12_5 which includes:
- Xamarin.iOS 14.8 
- Xamarin.Android 11.1
- Xamarin.Mac 7.2
- Mono 6.12

#### Related issue:
https://github.com/actions/virtual-environments/issues/2440

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
