### PR TITLE
[Ubuntu] Add locked flag to cargo install

### DIFF
--- a/images/linux/scripts/installers/rust.sh
+++ b/images/linux/scripts/installers/rust.sh
@@ -17,9 +17,7 @@ source $CARGO_HOME/env
 
 # Install common tools
 rustup component add rustfmt clippy
-cargo install bindgen cbindgen
-cargo install cargo-audit
-cargo install cargo-outdated
+cargo install --locked bindgen cbindgen cargo-audit cargo-outdated
 
 # Permissions
 chmod -R 777 $(dirname $RUSTUP_HOME)


### PR DESCRIPTION
# Description
It turned out that `cargo install` ignores the `Cargo.lock` file by default, which leads to unpredictable installation failures due to broken dependencies. The recent one affected us as well https://github.com/rust-lang/cargo/issues/9101
To avoid such surprises `--locked` flag can be used.
PS: A huge related thread for reference https://github.com/rust-lang/cargo/issues/7169

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1737

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
