### PR TITLE
feat(docker): authenticate using DockerHub credentials

### DIFF
--- a/images/linux/scripts/installers/docker-moby.sh
+++ b/images/linux/scripts/installers/docker-moby.sh
@@ -28,10 +28,21 @@ systemctl is-enabled --quiet docker.service || systemctl enable docker.service
 sleep 10
 docker info
 
+# If credentials are provided, attempt to log into Docker Hub
+# with a paid account to avoid Docker Hub's rate limit.
+if [ "${DOCKERHUB_LOGIN}" ] && [ "${DOCKERHUB_PASSWORD}" ]; then
+  docker login --username "${DOCKERHUB_LOGIN}" --password "${DOCKERHUB_PASSWORD}"
+fi
+
 # Pull images
 images=$(get_toolset_value '.docker.images[]')
 for image in $images; do
     docker pull "$image"
 done
+
+# Always attempt to logout so we do not leave our credentials on the built
+# image. Logout _should_ return a zero exit code even if no credentials were
+# stored from earlier.
+docker logout
 
 invoke_tests "Tools" "Docker"

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -20,7 +20,9 @@
         "capture_name_prefix": "packer",
         "image_version": "dev",
         "image_os": "ubuntu16",
-        "run_validation_diskspace": "false"
+        "run_validation_diskspace": "false",
+        "dockerhub_login": "{{env `DOCKERHUB_LOGIN`}}",
+        "dockerhub_password": "{{env `DOCKERHUB_PASSWORD`}}"
     },
     "sensitive-variables": [
         "client_secret"
@@ -169,6 +171,20 @@
         {
             "type": "shell",
             "scripts": [
+                "{{template_dir}}/scripts/installers/docker-compose.sh",
+                "{{template_dir}}/scripts/installers/docker-moby.sh"
+            ],
+            "environment_vars": [
+                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
+                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}",
+                "DOCKERHUB_LOGIN={{user `dockerhub_login`}}",
+                "DOCKERHUB_PASSWORD={{user `dockerhub_password`}}"
+            ],
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "scripts": [
                 "{{template_dir}}/scripts/installers/ansible.sh",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
                 "{{template_dir}}/scripts/installers/azure-cli.sh",
@@ -181,8 +197,6 @@
                 "{{template_dir}}/scripts/installers/swift.sh",
                 "{{template_dir}}/scripts/installers/cmake.sh",
                 "{{template_dir}}/scripts/installers/codeql-bundle.sh",
-                "{{template_dir}}/scripts/installers/docker-compose.sh",
-                "{{template_dir}}/scripts/installers/docker-moby.sh",
                 "{{template_dir}}/scripts/installers/dotnetcore-sdk.sh",
                 "{{template_dir}}/scripts/installers/erlang.sh",
                 "{{template_dir}}/scripts/installers/firefox.sh",

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -20,7 +20,9 @@
         "capture_name_prefix": "packer",
         "image_version": "dev",
         "image_os": "ubuntu18",
-        "run_validation_diskspace": "false"
+        "run_validation_diskspace": "false",
+        "dockerhub_login": "{{env `DOCKERHUB_LOGIN`}}",
+        "dockerhub_password": "{{env `DOCKERHUB_PASSWORD`}}"
     },
     "sensitive-variables": [
         "client_secret"
@@ -172,6 +174,20 @@
         {
             "type": "shell",
             "scripts": [
+                "{{template_dir}}/scripts/installers/docker-compose.sh",
+                "{{template_dir}}/scripts/installers/docker-moby.sh"
+            ],
+            "environment_vars": [
+                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
+                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}",
+                "DOCKERHUB_LOGIN={{user `dockerhub_login`}}",
+                "DOCKERHUB_PASSWORD={{user `dockerhub_password`}}"
+            ],
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "scripts": [
                 "{{template_dir}}/scripts/installers/ansible.sh",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
                 "{{template_dir}}/scripts/installers/azure-cli.sh",
@@ -184,8 +200,6 @@
                 "{{template_dir}}/scripts/installers/cmake.sh",
                 "{{template_dir}}/scripts/installers/codeql-bundle.sh",
                 "{{template_dir}}/scripts/installers/containers.sh",
-                "{{template_dir}}/scripts/installers/docker-compose.sh",
-                "{{template_dir}}/scripts/installers/docker-moby.sh",
                 "{{template_dir}}/scripts/installers/dotnetcore-sdk.sh",
                 "{{template_dir}}/scripts/installers/erlang.sh",
                 "{{template_dir}}/scripts/installers/firefox.sh",

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -20,7 +20,9 @@
         "capture_name_prefix": "packer",
         "image_version": "dev",
         "image_os": "ubuntu20",
-        "run_validation_diskspace": "false"
+        "run_validation_diskspace": "false",
+        "dockerhub_login": "{{env `DOCKERHUB_LOGIN`}}",
+        "dockerhub_password": "{{env `DOCKERHUB_PASSWORD`}}"
     },
     "sensitive-variables": [
         "client_secret"
@@ -172,6 +174,20 @@
         {
             "type": "shell",
             "scripts": [
+                "{{template_dir}}/scripts/installers/docker-compose.sh",
+                "{{template_dir}}/scripts/installers/docker-moby.sh"
+            ],
+            "environment_vars": [
+                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
+                "INSTALLER_SCRIPT_FOLDER={{user `installer_script_folder`}}",
+                "DOCKERHUB_LOGIN={{user `dockerhub_login`}}",
+                "DOCKERHUB_PASSWORD={{user `dockerhub_password`}}"
+            ],
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "scripts": [
                 "{{template_dir}}/scripts/installers/ansible.sh",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
                 "{{template_dir}}/scripts/installers/azure-cli.sh",
@@ -184,8 +200,6 @@
                 "{{template_dir}}/scripts/installers/cmake.sh",
                 "{{template_dir}}/scripts/installers/codeql-bundle.sh",
                 "{{template_dir}}/scripts/installers/containers.sh",
-                "{{template_dir}}/scripts/installers/docker-compose.sh",
-                "{{template_dir}}/scripts/installers/docker-moby.sh",
                 "{{template_dir}}/scripts/installers/dotnetcore-sdk.sh",
                 "{{template_dir}}/scripts/installers/erlang.sh",
                 "{{template_dir}}/scripts/installers/firefox.sh",


### PR DESCRIPTION
Ubuntu builds, by default, pull images anonymously from the
official DockerHub. DockerHub rate limits requests from
anonymous and unpaid accounts:
- https://docs.docker.com/docker-hub/download-rate-limit/

When those rate limits are reached the Packer build will
fail with an error indicated the rate limit has been
reached.

Add support for providing credentials for a paid
account that can be used by the Docker setup steps to
authenticate when pulling images from DockerHub, thereby
avoiding the rate limit.

Related to #2094