### PR TITLE
[macOS] install geckodriver from binaries for 10.13

### DIFF
--- a/images/macos/provision/core/firefox.sh
+++ b/images/macos/provision/core/firefox.sh
@@ -10,7 +10,7 @@ if ! is_HighSierra; then
     brew_smart_install "geckodriver"
     geckoPath="$(brew --prefix geckodriver)/bin"
 else
-    geckoVersion=$(curl https://formulae.brew.sh/api/formula/geckodriver.json 2>/dev/null | jq .versions.stable | tr -d \")
+    geckoVersion=$(curl https://formulae.brew.sh/api/formula/geckodriver.json 2>/dev/null | jq -r .versions.stable)
     geckoUrl="https://github.com/mozilla/geckodriver/releases/download/v${geckoVersion}/geckodriver-v${geckoVersion}-macos.tar.gz"
     download_with_retries $geckoUrl "/tmp" "geckodriver.tar.gz"
     geckoPath="/usr/local/bin"

--- a/images/macos/provision/core/firefox.sh
+++ b/images/macos/provision/core/firefox.sh
@@ -10,8 +10,7 @@ if ! is_HighSierra; then
     brew_smart_install "geckodriver"
     geckoPath="$(brew --prefix geckodriver)/bin"
 else
-    geckoVersion=$(curl https://formulae.brew.sh/api/formula/geckodriver.json 2>/dev/null | jq -r .versions.stable)
-    geckoUrl="https://github.com/mozilla/geckodriver/releases/download/v${geckoVersion}/geckodriver-v${geckoVersion}-macos.tar.gz"
+    geckoUrl="$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("macos.tar.gz"))')"
     download_with_retries $geckoUrl "/tmp" "geckodriver.tar.gz"
     geckoPath="/usr/local/bin"
     tar -xzf /tmp/geckodriver.tar.gz -C $geckoPath

--- a/images/macos/provision/core/firefox.sh
+++ b/images/macos/provision/core/firefox.sh
@@ -4,10 +4,19 @@ source ~/utils/utils.sh
 echo "Installing Firefox..."
 brew install --cask firefox
 
-echo "Installing Geckodriver..."
-brew_smart_install "geckodriver"
-
-echo "Add GECKOWEBDRIVER to bashrc..."
-echo "export GECKOWEBDRIVER=$(brew --prefix geckodriver)/bin" >> "${HOME}/.bashrc"
+# High Sierra builds driver from sources and it takes about 2 hours, it's much faster to download the binary directly
+if ! is_HighSierra; then
+    echo "Installing Geckodriver..."
+    brew_smart_install "geckodriver"
+    echo "Add GECKOWEBDRIVER to bashrc..."
+    echo "export GECKOWEBDRIVER=$(brew --prefix geckodriver)/bin" >> "${HOME}/.bashrc"
+else
+    geckoVersion=$(curl https://formulae.brew.sh/api/formula/geckodriver.json 2>/dev/null | jq .versions.stable | tr -d \")
+    geckorUrl="https://github.com/mozilla/geckodriver/releases/download/v${geckoVersion}/geckodriver-v${geckoVersion}-macos.tar.gz"
+    download_with_retries $geckorUrl "/tmp" "geckodriver.tar.gz"
+    tar -xzf /tmp/geckodriver.tar.gz -C /usr/local/bin
+    echo "Add GECKOWEBDRIVER to bashrc..."
+    echo "export GECKOWEBDRIVER=$(which geckodriver)" >> "${HOME}/.bashrc"
+fi
 
 invoke_tests "Browsers" "Firefox"

--- a/images/macos/provision/core/firefox.sh
+++ b/images/macos/provision/core/firefox.sh
@@ -4,7 +4,7 @@ source ~/utils/utils.sh
 echo "Installing Firefox..."
 brew install --cask firefox
 
-# High Sierra builds driver from sources and it takes about 2 hours, it's much faster to download the binary directly
+# High Sierra builds driver from sources, and it takes about 2 hours. It's much faster to download the binary directly
 if ! is_HighSierra; then
     echo "Installing Geckodriver..."
     brew_smart_install "geckodriver"

--- a/images/macos/provision/core/firefox.sh
+++ b/images/macos/provision/core/firefox.sh
@@ -11,8 +11,8 @@ if ! is_HighSierra; then
     geckoPath="$(brew --prefix geckodriver)/bin"
 else
     geckoVersion=$(curl https://formulae.brew.sh/api/formula/geckodriver.json 2>/dev/null | jq .versions.stable | tr -d \")
-    geckorUrl="https://github.com/mozilla/geckodriver/releases/download/v${geckoVersion}/geckodriver-v${geckoVersion}-macos.tar.gz"
-    download_with_retries $geckorUrl "/tmp" "geckodriver.tar.gz"
+    geckoUrl="https://github.com/mozilla/geckodriver/releases/download/v${geckoVersion}/geckodriver-v${geckoVersion}-macos.tar.gz"
+    download_with_retries $geckoUrl "/tmp" "geckodriver.tar.gz"
     geckoPath="/usr/local/bin"
     tar -xzf /tmp/geckodriver.tar.gz -C $geckoPath
 fi

--- a/images/macos/provision/core/firefox.sh
+++ b/images/macos/provision/core/firefox.sh
@@ -8,15 +8,16 @@ brew install --cask firefox
 if ! is_HighSierra; then
     echo "Installing Geckodriver..."
     brew_smart_install "geckodriver"
-    echo "Add GECKOWEBDRIVER to bashrc..."
-    echo "export GECKOWEBDRIVER=$(brew --prefix geckodriver)/bin" >> "${HOME}/.bashrc"
+    geckoPath="$(brew --prefix geckodriver)/bin"
 else
     geckoVersion=$(curl https://formulae.brew.sh/api/formula/geckodriver.json 2>/dev/null | jq .versions.stable | tr -d \")
     geckorUrl="https://github.com/mozilla/geckodriver/releases/download/v${geckoVersion}/geckodriver-v${geckoVersion}-macos.tar.gz"
     download_with_retries $geckorUrl "/tmp" "geckodriver.tar.gz"
-    tar -xzf /tmp/geckodriver.tar.gz -C /usr/local/bin
-    echo "Add GECKOWEBDRIVER to bashrc..."
-    echo "export GECKOWEBDRIVER=$(which geckodriver)" >> "${HOME}/.bashrc"
+    geckoPath="/usr/local/bin"
+    tar -xzf /tmp/geckodriver.tar.gz -C $geckoPath
 fi
+
+echo "Add GECKOWEBDRIVER to bashrc..."
+echo "export GECKOWEBDRIVER=${geckoPath}" >> "${HOME}/.bashrc"
 
 invoke_tests "Browsers" "Firefox"


### PR DESCRIPTION
# Description
Geckodriver brew formula has a build-time only dependency "rust", which can't be built on High Sierra at the moment. Moreover, building rust takes about 1.5h instead of a few seconds to download and untar the binary.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1740

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
