### PR TITLE
Remove M2_HOME from linux images

### DIFF
--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -50,7 +50,6 @@ curl -sL https://www-eu.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-mave
 unzip -d /usr/share maven.zip
 rm maven.zip
 ln -s /usr/share/apache-maven-3.6.3/bin/mvn /usr/bin/mvn
-echo "M2_HOME=/usr/share/apache-maven-3.6.3" | tee -a /etc/environment
 
 # Install Gradle
 # This script downloads the latest HTML list of releases at https://gradle.org/releases/.


### PR DESCRIPTION
# Description
 Improvement
 
 Since Maven 3.5.0, environment variable M2_HOME is not used/supported anymore:
https://maven.apache.org/docs/3.5.0/release-notes.html#overview-about-the-changes

#### Related issue: https://github.com/actions/virtual-environments/issues/2534

## Check list
- [x] Related issue / work item is attached
- [x] Changes are tested and related VM images are successfully generated
