### PR TITLE
[macOS] Fix ndk output in readme for Big Sur

### DIFF
--- a/images/macos/software-report/SoftwareReport.Android.psm1
+++ b/images/macos/software-report/SoftwareReport.Android.psm1
@@ -179,10 +179,5 @@ function Get-AndroidNDKVersions {
         $versions += $_.Name
     }
 
-    $versions += $packageInfo | Where-Object { $_ -Match "ndk-bundle" } | ForEach-Object {
-        $packageInfoParts = Split-TableRowByColumns $_
-        return $packageInfoParts[1]
-    }
-
     return ($versions -Join "<br>")
 }

--- a/images/macos/software-report/SoftwareReport.Android.psm1
+++ b/images/macos/software-report/SoftwareReport.Android.psm1
@@ -84,7 +84,7 @@ function Build-AndroidTable {
         },
         @{
             "Package" = "NDK"
-            "Version" = Get-AndroidNDKVersions -PackageInfo $packageInfo
+            "Version" = Get-AndroidNDKVersions
         },
         @{
             "Package" = "SDK Patch Applier v4"
@@ -161,11 +161,6 @@ function Get-AndroidGoogleAPIsVersions {
 }
 
 function Get-AndroidNDKVersions {
-    param (
-        [Parameter(Mandatory)][AllowEmptyString()]
-        [string[]] $packageInfo
-    )
-
     $os = Get-OSVersion
     $versions = @()
 

--- a/images/macos/software-report/SoftwareReport.Android.psm1
+++ b/images/macos/software-report/SoftwareReport.Android.psm1
@@ -162,10 +162,10 @@ function Get-AndroidGoogleAPIsVersions {
 
 function Get-AndroidNDKVersions {
     $os = Get-OSVersion
-    $versions = @()
 
     if ($os.IsLessThanBigSur) {
         # Hardcode NDK 15 as a separate case since it is installed manually without sdk-manager (to none default location)
+        $versions = @()
         $versions += "15.2.4203891"
     }
 

--- a/images/macos/software-report/SoftwareReport.Android.psm1
+++ b/images/macos/software-report/SoftwareReport.Android.psm1
@@ -172,11 +172,11 @@ function Get-AndroidNDKVersions {
     if ($os.IsLessThanBigSur) {
         # Hardcode NDK 15 as a separate case since it is installed manually without sdk-manager (to none default location)
         $versions += "15.2.4203891"
+    }
 
-        $ndkFolderPath = Join-Path (Get-AndroidSDKRoot) "ndk"
-        Get-ChildItem -Path $ndkFolderPath | ForEach-Object {
-            $versions += $_.Name
-        }
+    $ndkFolderPath = Join-Path (Get-AndroidSDKRoot) "ndk"
+    Get-ChildItem -Path $ndkFolderPath | ForEach-Object {
+        $versions += $_.Name
     }
 
     $versions += $packageInfo | Where-Object { $_ -Match "ndk-bundle" } | ForEach-Object {

--- a/images/macos/software-report/SoftwareReport.Android.psm1
+++ b/images/macos/software-report/SoftwareReport.Android.psm1
@@ -170,9 +170,7 @@ function Get-AndroidNDKVersions {
     }
 
     $ndkFolderPath = Join-Path (Get-AndroidSDKRoot) "ndk"
-    Get-ChildItem -Path $ndkFolderPath | ForEach-Object {
-        $versions += $_.Name
-    }
+    $versions += Get-ChildItem -Path $ndkFolderPath -Name
 
     return ($versions -Join "<br>")
 }


### PR DESCRIPTION
# Description
Due to the wrong condition, NDK versions are not included in the Readme file.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1764

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
