### PR TITLE
[Ubuntu] Get back Android NDK to the readme 

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -157,9 +157,6 @@ function Get-AndroidGoogleAPIsVersions {
 function Get-AndroidNDKVersions {
     $versions = @()
     $ndkFolderPath = Join-Path (Get-AndroidSDKRoot) "ndk"
-    Get-ChildItem -Path $ndkFolderPath | ForEach-Object {
-        $versions += $_.Name
-    }
-    
+    $versions = Get-ChildItem -Path $ndkFolderPath -Name
     return ($versions -Join "<br>")
 }

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -78,7 +78,7 @@ function Build-AndroidTable {
         },
         @{
             "Package" = "NDK"
-            "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "ndk-bundle"
+            "Version" = Get-AndroidNDKVersions
         },
         @{
             "Package" = "SDK Patch Applier v4"
@@ -154,3 +154,12 @@ function Get-AndroidGoogleAPIsVersions {
     return ($versions -Join "<br>")
 }
 
+function Get-AndroidNDKVersions {
+    $versions = @()
+    $ndkFolderPath = Join-Path (Get-AndroidSDKRoot) "ndk"
+    Get-ChildItem -Path $ndkFolderPath | ForEach-Object {
+        $versions += $_.Name
+    }
+    
+    return ($versions -Join "<br>")
+}

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -155,7 +155,6 @@ function Get-AndroidGoogleAPIsVersions {
 }
 
 function Get-AndroidNDKVersions {
-    $versions = @()
     $ndkFolderPath = Join-Path (Get-AndroidSDKRoot) "ndk"
     $versions = Get-ChildItem -Path $ndkFolderPath -Name
     return ($versions -Join "<br>")


### PR DESCRIPTION
# Description
There is no ndk section in the readme due to the latest changes (switching from ndk-bundle to separate ndk installation)

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1765

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
