### PR TITLE
[macOS] Add Xcode 12.5 to Big Sur

### DIFF
--- a/images/macos/toolsets/toolset-11.0.json
+++ b/images/macos/toolsets/toolset-11.0.json
@@ -2,6 +2,7 @@
     "xcode": {
         "default": "12.3",
         "versions": [
+            { "link": "12.5", "version": "12.5.0"},
             { "link": "12.4", "version": "12.4.0"},
             { "link": "12.3", "version": "12.3.0"},
             { "link": "12.2", "version": "12.2.0" },


### PR DESCRIPTION
# Description
Xcode 12.5 has been released and it requires macOS Big Sur 😩
https://developer.apple.com/documentation/xcode-release-notes/xcode-12_5-beta-release-notes

#### Related issue:
n\a

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
