### PR TITLE
[Windows] Add workaround to download docker images from another endpoint

### DIFF
--- a/images/win/scripts/Installers/Update-DockerImages.ps1
+++ b/images/win/scripts/Installers/Update-DockerImages.ps1
@@ -16,9 +16,14 @@ function DockerPull {
     }
 }
 
+# Temporary replace ip for download server to the more stable one
+Copy-Item -Path "$env:windir\System32\drivers\etc\hosts" -Destination "C:\hosts_backup" -Verbose
+"40.71.10.214 mcr.microsoft.com" >> "$env:windir\System32\drivers\etc\hosts"
+
 $dockerToolset = (Get-ToolsetContent).docker
 foreach($dockerImage in $dockerToolset.images) {
   DockerPull $dockerImage
 }
 
+Move-Item -Path "C:\hosts_backup" -Destination "$env:windir\System32\drivers\etc\hosts" -Force -Verbose
 Invoke-PesterTests -TestFile "Docker" -TestName "DockerImages"


### PR DESCRIPTION
# Description
We've faced intermittent docker images download failures from mcr.microsoft.com docker registry in west us2 azure region — after several retries the whole process ended with unexpected EOF:
```
2021-01-30T00:24:08.4376780Z     vhd: bd091f41e44c: Retrying in 7 seconds
2021-01-30T00:24:09.5598137Z     vhd: bd091f41e44c: Retrying in 6 seconds
2021-01-30T00:24:10.5462171Z     vhd: bd091f41e44c: Retrying in 5 seconds
2021-01-30T00:24:11.5227268Z     vhd: bd091f41e44c: Retrying in 4 seconds
2021-01-30T00:24:14.9258966Z     vhd: bd091f41e44c: Retrying in 3 seconds
2021-01-30T00:24:14.9261333Z     vhd: bd091f41e44c: Retrying in 2 seconds
2021-01-30T00:24:14.9267194Z     vhd: bd091f41e44c: Retrying in 1 second
2021-01-30T00:24:25.2014841Z     vhd: unexpected EOF
2021-01-30T00:24:25.2019153Z     vhd: Docker pull failed with a non-zero exit code
```

This PR temporarily changes the endpoint to the east us one until we figure out the root cause.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1763

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
