### PR TITLE
[Ubuntu] Invoke chromium test after installation

### DIFF
--- a/images/linux/scripts/helpers/Tests.Helpers.psm1
+++ b/images/linux/scripts/helpers/Tests.Helpers.psm1
@@ -36,7 +36,7 @@ function Invoke-PesterTests {
     $ErrorActionPreference = $backupErrorActionPreference
 
     # Fail in case if no tests are run
-    if (-not ($results -and ($results.FailedCount -eq 0) -and ($results.PassedCount -gt 0))) {
+    if (-not ($results -and ($results.FailedCount -eq 0) -and ($results.PassedCount -ge 0))) {
         $results
         throw "Test run has failed"
     }

--- a/images/linux/scripts/helpers/Tests.Helpers.psm1
+++ b/images/linux/scripts/helpers/Tests.Helpers.psm1
@@ -36,7 +36,7 @@ function Invoke-PesterTests {
     $ErrorActionPreference = $backupErrorActionPreference
 
     # Fail in case if no tests are run
-    if (-not ($results -and ($results.FailedCount -eq 0) -and ($results.PassedCount -ge 0))) {
+    if (-not ($results -and ($results.FailedCount -eq 0) -and (($results.PassedCount + $results.SkippedCount) -gt 0))) {
         $results
         throw "Test run has failed"
     }

--- a/images/linux/scripts/installers/basic.sh
+++ b/images/linux/scripts/installers/basic.sh
@@ -13,3 +13,4 @@ for package in $common_packages $cmd_packages; do
 done
 
 invoke_tests "Apt"
+invoke_tests "Browsers" "Chromium"


### PR DESCRIPTION
# Description
Looks like we missed the test in the previous PR https://github.com/actions/virtual-environments/pull/2463 The test should be executed after the installation as well as at the end of the build.
This PR also fixes the case when all tests are skipped because conditions were not met.

#### Related issue:
n\a

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
