### PR TITLE
[Ubuntu] Remove explicit npm installation

### DIFF
--- a/images/linux/scripts/installers/nodejs.sh
+++ b/images/linux/scripts/installers/nodejs.sh
@@ -9,7 +9,6 @@ curl -sL https://raw.githubusercontent.com/mklement0/n-install/stable/bin/n-inst
 ~/n/bin/n lts
 npm install -g grunt gulp n parcel-bundler typescript newman
 npm install -g --save-dev webpack webpack-cli
-npm install -g npm
 rm -rf ~/n
 
 # Install Yarn repository and key


### PR DESCRIPTION
# Description
We should avoid explicit npm installation and stick to the version which comes along with node js.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1789

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
