### PR TITLE
Remove GOROOT on linux images

### DIFF
--- a/images/linux/scripts/installers/Configure-Toolset.ps1
+++ b/images/linux/scripts/installers/Configure-Toolset.ps1
@@ -44,7 +44,6 @@ $toolsEnvironment = @{
     }
     go = @{
         command = "ln -s {0}/bin/* /usr/bin/"
-        defaultVariable = "GOROOT"
         variableTemplate = "GOROOT_{0}_{1}_X64"
     }
 }


### PR DESCRIPTION
# Description
 Improvement

The GOROOT environment variable is mostly deprecated, and no setup requires it. 
The problem with hardcoding a GOROOT is that if any other go tool is in use (for example, because one compiled Go tip), the environment variable will override its autodetected GOROOT.

#### Related issue: https://github.com/actions/virtual-environments/issues/2655

## Check list
- [x] Related issue / work item is attached
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
