### PR TITLE
[macOS] Remove nvm aliases and old node versions.

### DIFF
--- a/images/macos/provision/core/nvm.sh
+++ b/images/macos/provision/core/nvm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e -o pipefail
 ###########################################################################
-# The script installs node version manager with node versions 6,8,10 and 12
+# The script installs node version manager with node versions 10,12 and 14
 #
 ###########################################################################
 source ~/utils/utils.sh
@@ -11,9 +11,12 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$VERSION/install.sh | bash
 if [ $? -eq 0 ]; then
         . ~/.bashrc
         nvm --version
-        nvm install lts/dubnium # 10.x
-        nvm install lts/erbium # 12.x
-        nvm install v14 # 14.x
+        nodeVersions=("v10" "v12" "v14")
+        for version in ${nodeVersions[@]}
+        do
+                nvm install $version
+        done
+
         # set system node as default
         nvm alias default system
 else

--- a/images/macos/provision/core/nvm.sh
+++ b/images/macos/provision/core/nvm.sh
@@ -11,18 +11,9 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$VERSION/install.sh | bash
 if [ $? -eq 0 ]; then
         . ~/.bashrc
         nvm --version
-        nvm install lts/boron # 6.x
-        nvm install lts/carbon # 8.x
         nvm install lts/dubnium # 10.x
         nvm install lts/erbium # 12.x
-        nvm install v13 # 13.x
         nvm install v14 # 14.x
-        nvm alias node6 lts/boron
-        nvm alias node8 lts/carbon
-        nvm alias node10 lts/dubnium
-        nvm alias node12 lts/erbium
-        nvm alias node13 v13
-        nvm alias node14 v14
         # set system node as default
         nvm alias default system
 else

--- a/images/macos/tests/Node.Tests.ps1
+++ b/images/macos/tests/Node.Tests.ps1
@@ -38,7 +38,7 @@ Describe "nvm" {
     }
 
     Context "nvm versions" {
-        $NVM_VERSIONS = @(6, 8, 10, 12)
+        $NVM_VERSIONS = @(10, 12, 14)
         $testCases = $NVM_VERSIONS | ForEach-Object { @{NvmVersion = $_} }
 
         It "<NvmVersion>" -TestCases $testCases {


### PR DESCRIPTION
# Description
In scope of this pull request we deprecate some old node versions from nvm and remove nvm node aliases.

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/1689

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
