### PR TITLE
[Ubuntu] Install the latest two versions of GHC

### DIFF
--- a/images/linux/scripts/installers/haskell.sh
+++ b/images/linux/scripts/installers/haskell.sh
@@ -13,7 +13,7 @@ apt-get install -y software-properties-common
 add-apt-repository -y ppa:hvr/ghc
 apt-get update
 
-# Get 3 latest Haskell Major.Minor versions
+# Get 2 latest Haskell Major.Minor versions
 allGhcVersions=$(apt-cache search "^ghc-" | grep -Po '(\d*\.){2}\d*' | sort --unique --version-sort)
 ghcMajorMinorVersions=$(echo "$allGhcVersions" | cut -d "." -f 1,2 | sort --unique --version-sort | tail -2)
 

--- a/images/linux/scripts/installers/haskell.sh
+++ b/images/linux/scripts/installers/haskell.sh
@@ -15,7 +15,7 @@ apt-get update
 
 # Get 3 latest Haskell Major.Minor versions
 allGhcVersions=$(apt-cache search "^ghc-" | grep -Po '(\d*\.){2}\d*' | sort --unique --version-sort)
-ghcMajorMinorVersions=$(echo "$allGhcVersions" | cut -d "." -f 1,2 | sort --unique --version-sort | tail -3)
+ghcMajorMinorVersions=$(echo "$allGhcVersions" | cut -d "." -f 1,2 | sort --unique --version-sort | tail -2)
 
 for version in $ghcMajorMinorVersions; do
     # Get latest patch version for given Major.Minor one (ex. 8.6.5 for 8.6) and install it

--- a/images/linux/scripts/tests/Haskell.Tests.ps1
+++ b/images/linux/scripts/tests/Haskell.Tests.ps1
@@ -7,7 +7,7 @@ Describe "Haskell" {
 
     It "GHC directory contains three version of GHC" -TestCases $testCase {
         param ([object] $GHCVersions)
-        $GHCVersions.Count | Should -Be 3
+        $GHCVersions.Count | Should -Be 2
     }
 
     $testCases = $GHCVersions | ForEach-Object { @{ GHCPath = "${_}/bin/ghc"} }

--- a/images/linux/scripts/tests/Haskell.Tests.ps1
+++ b/images/linux/scripts/tests/Haskell.Tests.ps1
@@ -5,7 +5,7 @@ Describe "Haskell" {
     
     $testCase = @{ GHCVersions = $GHCVersions }
 
-    It "GHC directory contains three version of GHC" -TestCases $testCase {
+    It "GHC directory contains two version of GHC" -TestCases $testCase {
         param ([object] $GHCVersions)
         $GHCVersions.Count | Should -Be 2
     }


### PR DESCRIPTION
# Description
Сurrently, we install the latest 3 versions of GHC on Ubuntu images. We need to change installation policy and install only two versions due to lack of free space.

#### Related issue: [#1803](https://github.com/actions/virtual-environments-internal/issues/1803)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
