### PR TITLE
fix: emoji support in Chrome on Ubuntu

### DIFF
--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -9,7 +9,7 @@ LSB_RELEASE=$(lsb_release -rs)
 wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
 echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list
 apt-get update
-apt-get install -y google-chrome-stable
+apt-get install -y google-chrome-stable fonts-noto-color-emoji
 echo "CHROME_BIN=/usr/bin/google-chrome" | tee -a /etc/environment
 
 CHROME_VERSION=$(google-chrome --product-version)

--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -9,7 +9,7 @@ LSB_RELEASE=$(lsb_release -rs)
 wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
 echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list
 apt-get update
-apt-get install -y google-chrome-stable fonts-noto-color-emoji
+apt-get install -y google-chrome-stable
 echo "CHROME_BIN=/usr/bin/google-chrome" | tee -a /etc/environment
 
 CHROME_VERSION=$(google-chrome --product-version)

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -117,6 +117,7 @@
             "dnsutils",
             "dpkg",
             "fakeroot",
+            "fonts-noto-color-emoji",
             "gnupg2",
             "imagemagick",
             "iproute2",


### PR DESCRIPTION
# Description

Currently, Chrome isn't able to render emojis properly. It's annoying when using browser testing tools taking screenshots of the changes such as [Symfony Panther](https://github.com/symfony/panther) (maintainer here), or [Cypress](https://docs.cypress.io/guides/guides/screenshots-and-videos.html).

Adding the `fonts-noto-color-emoji` font fixes the problem.

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
