### PR TITLE
Remove GOROOT on Windows images

### DIFF
--- a/images/win/scripts/Installers/Configure-Toolset.ps1
+++ b/images/win/scripts/Installers/Configure-Toolset.ps1
@@ -42,7 +42,6 @@ $toolsEnvironmentVariables = @{
         pathTemplates = @(
             "{0}\bin"
         )
-        defaultVariable = "GOROOT"
         variableTemplate = "GOROOT_{0}_{1}_X64"
     }
 }


### PR DESCRIPTION
Improvement

The GOROOT environment variable is mostly deprecated, and no setup requires it.
The problem with hardcoding a GOROOT is that if any other go tool is in use (for example, because one compiled Go tip), the environment variable will override its autodetected GOROOT.

#### Related issue: https://github.com/actions/virtual-environments/issues/2655

## Check list
- [x] Related issue / work item is attached
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
