### PR TITLE
remove M2_HOME from windows images

### DIFF
--- a/images/win/scripts/Installers/Install-JavaTools.ps1
+++ b/images/win/scripts/Installers/Install-JavaTools.ps1
@@ -95,7 +95,6 @@ $m2_repo = 'C:\ProgramData\m2'
 New-Item -Path $m2_repo -ItemType Directory -Force
 
 setx M2 $m2 /M
-setx M2_HOME $m2_home /M
 setx M2_REPO $m2_repo /M
 setx MAVEN_OPTS $maven_opts /M
 


### PR DESCRIPTION
Improvement

Since Maven 3.5.0, environment variable M2_HOME is not used/supported anymore:
https://maven.apache.org/docs/3.5.0/release-notes.html#overview-about-the-changes

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/1829

## Check list
- [x] Related issue / work item is attached
- [x] Changes are tested and related VM images are successfully generated
