### PR TITLE
[Ubuntu] Tiny fix for the environmental variables section in the docs

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -64,9 +64,6 @@ $packageManagementList = @(
         (Get-Pip3Version),
         (Get-VcpkgVersion)
 )
-$markdown += New-MDHeader "Environment variables" -Level 4
-$markdown += Build-PackageManagementEnvironmentTable | New-MDTable
-$markdown += New-MDNewLine
 
 if (-not (Test-IsUbuntu16)) {
     $packageManagementList += @(
@@ -75,6 +72,9 @@ if (-not (Test-IsUbuntu16)) {
 }
 
 $markdown += New-MDList -Style Unordered -Lines ($packageManagementList | Sort-Object)
+$markdown += New-MDHeader "Environment variables" -Level 4
+$markdown += Build-PackageManagementEnvironmentTable | New-MDTable
+$markdown += New-MDNewLine
 
 $markdown += New-MDHeader "Project Management" -Level 3
 $markdown += New-MDList -Style Unordered -Lines (@(
@@ -219,7 +219,6 @@ if (Test-IsUbuntu20) {
 }
 
 $markdown += New-MDList -Style Unordered -Lines $browsersAndDriversList
-$markdown += New-MDNewLine
 $markdown += New-MDHeader "Environment variables" -Level 4
 $markdown += Build-BrowserWebdriversEnvironmentTable | New-MDTable
 $markdown += New-MDNewLine


### PR DESCRIPTION
# Description
Package management environmental variables should be at the end of the section, not at the beginning as it's now.
No newline required in the browsers section.
The current output [can be found here](https://github.com/actions/virtual-environments/pull/2709/commits/35d3142b20038903355f723345c0b64a309e21bc)

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1833

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
