### PR TITLE
[Ubuntu] Install the latest version of cmake

### DIFF
--- a/images/linux/scripts/installers/cmake.sh
+++ b/images/linux/scripts/installers/cmake.sh
@@ -9,8 +9,10 @@ echo "Checking to see if the installer script has already been run"
 if command -v cmake; then
     echo "cmake is already installed"
 else
-	url=$(curl -s https://api.github.com/repos/Kitware/CMake/releases/latest | jq -r '.assets[].browser_download_url | select(contains("Linux-x86_64.sh"))')
-	curl -sL ${url} -o cmakeinstall.sh \
+	json=$(curl -s "https://api.github.com/repos/Kitware/CMake/releases")
+	latest_tag=$(echo $json | jq -r '.[] | select(.prerelease==false).tag_name' | sort --unique --version-sort | tail -1)
+	sh_url=$(echo $json | jq -r ".[] | select(.tag_name==\"${latest_tag}\").assets[].browser_download_url | select(endswith(\"Linux-x86_64.sh\"))")
+	curl -sL ${sh_url} -o cmakeinstall.sh \
 	&& chmod +x cmakeinstall.sh \
 	&& ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir \
 	&& rm cmakeinstall.sh


### PR DESCRIPTION
# Description
Currently, we install the latest published version instead of the latest  release. To exclude rc versions from the output use a filter `.prerelease==false`


#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1834
## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
