### PR TITLE
[Windows] Stick to azure-cli 2.18

### DIFF
--- a/images/win/scripts/Installers/Install-AzureCli.ps1
+++ b/images/win/scripts/Installers/Install-AzureCli.ps1
@@ -4,7 +4,7 @@
 ################################################################################
 
 # Stick to 2.18.0 since 2.19 contains a bug https://github.com/Azure/azure-cli/issues/16908
-Choco-Install -PackageName azure-cli --version 2.18.0
+Choco-Install -PackageName azure-cli -ArgumentList "--version=2.18.0"
 
 $AzureCliExtensionPath = Join-Path $Env:CommonProgramFiles 'AzureCliExtensionDirectory'
 New-Item -ItemType "directory" -Path $AzureCliExtensionPath

--- a/images/win/scripts/Installers/Install-AzureCli.ps1
+++ b/images/win/scripts/Installers/Install-AzureCli.ps1
@@ -3,7 +3,8 @@
 ##  Desc:  Install Azure CLI
 ################################################################################
 
-Choco-Install -PackageName azure-cli
+# Stick to 2.18.0 since 2.19 contains a bug https://github.com/Azure/azure-cli/issues/16908
+Choco-Install -PackageName azure-cli --version 2.18.0
 
 $AzureCliExtensionPath = Join-Path $Env:CommonProgramFiles 'AzureCliExtensionDirectory'
 New-Item -ItemType "directory" -Path $AzureCliExtensionPath


### PR DESCRIPTION
# Description
2.19 has a bug, which can cause a lot of issues for customers.
https://github.com/Azure/azure-cli/issues/16908

#### Related issue:
n\a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
