### PR TITLE
[Ubuntu] Do not import Az.Account module on Ubuntu 18.04

### DIFF
--- a/images/linux/scripts/installers/containers.sh
+++ b/images/linux/scripts/installers/containers.sh
@@ -17,11 +17,6 @@ apt-get -qq -y install ${install_packages[@]}
 mkdir -p /etc/containers
 echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | tee /etc/containers/registries.conf
 
-if isUbuntu18; then
-    # Remote error from secret service: org.freedesktop.DBus.Error.ServiceUnknown: The name org.freedesktop.secrets was not provided by any .service files
-    apt-get remove dbus-user-session
-fi
-
 if isUbuntu18 || isUbuntu20 ; then
     invoke_tests "Tools" "Containers"
 fi

--- a/images/linux/scripts/installers/containers.sh
+++ b/images/linux/scripts/installers/containers.sh
@@ -17,6 +17,11 @@ apt-get -qq -y install ${install_packages[@]}
 mkdir -p /etc/containers
 echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | tee /etc/containers/registries.conf
 
+if isUbuntu18; then
+    # Remote error from secret service: org.freedesktop.DBus.Error.ServiceUnknown: The name org.freedesktop.secrets was not provided by any .service files
+    apt-get remove dbus-user-session
+fi
+
 if isUbuntu18 || isUbuntu20 ; then
     invoke_tests "Tools" "Containers"
 fi

--- a/images/linux/scripts/installers/containers.sh
+++ b/images/linux/scripts/installers/containers.sh
@@ -17,6 +17,4 @@ apt-get -qq -y install ${install_packages[@]}
 mkdir -p /etc/containers
 echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | tee /etc/containers/registries.conf
 
-if isUbuntu18 || isUbuntu20 ; then
-    invoke_tests "Tools" "Containers"
-fi
+invoke_tests "Tools" "Containers"

--- a/images/linux/scripts/installers/containers.sh
+++ b/images/linux/scripts/installers/containers.sh
@@ -4,8 +4,6 @@
 ##  Desc:  Installs container tools: podman, buildah and skopeo onto the image
 ################################################################################
 
-source $HELPER_SCRIPTS/os.sh
-
 # Install podman, buildah, scopeo container's tools
 install_packages=(podman buildah skopeo)
 source /etc/os-release

--- a/images/linux/scripts/tests/PowerShellModules.Tests.ps1
+++ b/images/linux/scripts/tests/PowerShellModules.Tests.ps1
@@ -70,7 +70,7 @@ Describe "AzureModules" {
                         $moduleVersion = (Get-Module -ListAvailable -Name $moduleName).Version.ToString()
                         $moduleVersion | Should -Match $moduleDefault
                 }
-            }  
+            }
         }
     }
 }


### PR DESCRIPTION
# Description
After installing `dbus-user-session` package on Ubuntu 18.04 ,` Import-Module Az.Accounts` has returned `** Message: 17:43:58.624: Remote error from secret service: org.freedesktop.DBus.Error.ServiceUnknown: The name org.freedesktop.secrets was not provided by any .service` files which has broken our CI due to writing to the stderr.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1831

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
