### PR TITLE
[Ubuntu] Updating release file pattern for Kitware/CMake

### DIFF
--- a/images/linux/scripts/installers/cmake.sh
+++ b/images/linux/scripts/installers/cmake.sh
@@ -11,7 +11,7 @@ if command -v cmake; then
 else
 	json=$(curl -s "https://api.github.com/repos/Kitware/CMake/releases")
 	latest_tag=$(echo $json | jq -r '.[] | select(.prerelease==false).tag_name' | sort --unique --version-sort | tail -1)
-	sh_url=$(echo $json | jq -r ".[] | select(.tag_name==\"${latest_tag}\").assets[].browser_download_url | select(endswith(\"linux-x86_64.sh\"))")
+	sh_url=$(echo $json | jq -r ".[] | select(.tag_name==\"${latest_tag}\").assets[].browser_download_url | select(endswith(\"inux-x86_64.sh\"))")
 	curl -sL ${sh_url} -o cmakeinstall.sh \
 	&& chmod +x cmakeinstall.sh \
 	&& ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir \

--- a/images/linux/scripts/installers/cmake.sh
+++ b/images/linux/scripts/installers/cmake.sh
@@ -11,7 +11,7 @@ if command -v cmake; then
 else
 	json=$(curl -s "https://api.github.com/repos/Kitware/CMake/releases")
 	latest_tag=$(echo $json | jq -r '.[] | select(.prerelease==false).tag_name' | sort --unique --version-sort | tail -1)
-	sh_url=$(echo $json | jq -r ".[] | select(.tag_name==\"${latest_tag}\").assets[].browser_download_url | select(endswith(\"Linux-x86_64.sh\"))")
+	sh_url=$(echo $json | jq -r ".[] | select(.tag_name==\"${latest_tag}\").assets[].browser_download_url | select(endswith(\"linux-x86_64.sh\"))")
 	curl -sL ${sh_url} -o cmakeinstall.sh \
 	&& chmod +x cmakeinstall.sh \
 	&& ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir \

--- a/images/linux/scripts/installers/cmake.sh
+++ b/images/linux/scripts/installers/cmake.sh
@@ -10,7 +10,7 @@ if command -v cmake; then
     echo "cmake is already installed"
 else
 	json=$(curl -s "https://api.github.com/repos/Kitware/CMake/releases")
-	latest_tag=$(echo $json | jq -r '.[] | select(.prerelease==false).tag_name' | sort --unique --version-sort | tail -1)
+	latest_tag=$(echo $json | jq -r '.[] | select(.prerelease==false).tag_name' | sort --unique --version-sort | grep -v "rc" | tail -1)
 	sh_url=$(echo $json | jq -r ".[] | select(.tag_name==\"${latest_tag}\").assets[].browser_download_url | select(endswith(\"inux-x86_64.sh\"))")
 	curl -sL ${sh_url} -o cmakeinstall.sh \
 	&& chmod +x cmakeinstall.sh \


### PR DESCRIPTION
# Description
This change fixes to install cmake.

https://github.com/actions/virtual-environments/pull/2714 has added an install script for [Kitware/CMake](https://github.com/Kitware/CMake).
But this script failed in installing process.

Because Kitware/CMake changed the name of assets after 3.20.0-rc that is the latest release (not pre-release).
e.g) `cmake-3.19.5-Linux-x86_64.sh` to `cmake-3.20.0-rc1-linux-x86_64.sh`

So, this Pull Request changes the pattern of assets. 

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
    - not applicable
- [ ] Documentation is updated (if applicable)
    - not applicable
- [x] Changes are tested and related VM images are successfully generated
