### PR TITLE
Remove PyPy symlink workaround from Windows images

### DIFF
--- a/images/win/scripts/Installers/Install-PyPy.ps1
+++ b/images/win/scripts/Installers/Install-PyPy.ps1
@@ -67,15 +67,6 @@ function Install-PyPy
             exit 1
         }
 
-        # https://github.com/actions/setup-python/blob/master/src/find-python.ts
-        # https://github.com/microsoft/azure-pipelines-tasks/blob/master/Tasks/UsePythonVersionV0/usepythonversion.ts
-        #  // For PyPy, Windows uses 'bin', not 'Scripts'.
-        # const _binDir = path.join(installDir, 'bin');
-        # PyPy v7.3.1 or higher creates only Scripts folder therefore to preserve back compatibility with UsePythonVersionV0 task
-        # We should create a Scripts -> bin symlink
-        Write-Host "Symbolic link created for '$pypyArchPath\Scripts' <<===>> '$pypyArchPath\bin'"
-        New-Item -Path "$pypyArchPath\bin" -ItemType SymbolicLink -Value "$pypyArchPath\Scripts" | Out-Null
-
         Write-Host "Create complete file"
         New-Item -ItemType File -Path $pypyVersionPath -Name "$architecture.complete" | Out-Null
     }


### PR DESCRIPTION
# Improvement 

Currently, our images contains hack - symlink for PyPy on Windows: https://github.com/actions/virtual-environments/blob/main/images/win/scripts/Installers/Install-PyPy.ps1#L77

Some time ago we have modified actions/setup-python and UsePython and we don't need this hack anymore. It can be safety removed from images

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/1843

## Check list
- [x] Related issue / work item is attached
- [x] Changes are tested and related VM images are successfully generated
