### PR TITLE
Turn off macOS 10.13 scheduled daily builds

### DIFF
--- a/images.CI/macos/azure-pipelines/macos1013.yml
+++ b/images.CI/macos/azure-pipelines/macos1013.yml
@@ -1,11 +1,4 @@
 name: macOS-10.13_$(date:yyyyMMdd)$(rev:.r)_unstable
-schedules:
-- cron: "0 0 * * *"
-  displayName: Daily
-  branches:
-    include:
-    - main
-  always: true
 
 trigger: none
 pr:


### PR DESCRIPTION
# Description
Turning off macOS 10.13 scheduled build because we stop deploying it on regular basis, only per request.

HS is out of support for a lot of tools and its update is almost always a bit of pain, so given its usage, we are stopping its regular updates.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: n\a

## Check list
- [n\a ] Related issue / work item is attached
- [n\a ] Tests are written (if applicable)
- [n\a] Documentation is updated (if applicable)
- [n\a ] Changes are tested and related VM images are successfully generated
