### PR TITLE
[Ubuntu] Fix Android tests to work with platform version S and remove Cmake 3.6

### DIFF
--- a/images/linux/scripts/tests/Android.Tests.ps1
+++ b/images/linux/scripts/tests/Android.Tests.ps1
@@ -11,9 +11,8 @@ Describe "Android" {
     $platforms = $platformNumericList + $platformLetterList | ForEach-Object { "platforms/${_}" }
 
     $buildToolsList = ($androidSdkManagerPackages | Where-Object { "$_".StartsWith("build-tools;") }) -replace 'build-tools;', ''
-    $buildToolsNumericList = $buildToolsList | Where-Object { $_ -match "\d+(\.\d+){2,}$"} | Where-Object { [version]$_ -ge $buildToolsMinVersion } | Sort-Object -Unique
-    $buildToolsLetterList = $buildToolsList | Where-Object { $_ -match "\d+(\.\d+){2,}-\w+"} | Sort-Object -Unique
-    $buildTools = $buildToolsNumericList + $buildToolsLetterList | ForEach-Object { "build-tools/${_}" }
+    $buildTools = $buildToolsList | Where-Object { $_ -match "\d+(\.\d+){2,}$"} | Where-Object { [version]$_ -ge $buildToolsMinVersion } | Sort-Object -Unique |
+    ForEach-Object { "build-tools/${_}" }
 
     $androidPackages = @(
         $platforms,

--- a/images/linux/scripts/tests/Android.Tests.ps1
+++ b/images/linux/scripts/tests/Android.Tests.ps1
@@ -8,7 +8,7 @@ Describe "Android" {
     $platformVersionsList = ($androidSdkManagerPackages | Where-Object { "$_".StartsWith("platforms;") }) -replace 'platforms;android-', ''
     $platformNumericList = $platformVersionsList | Where-Object { $_ -match "\d+" } | Where-Object { [int]$_ -ge $platformMinVersion } | Sort-Object -Unique
     $platformLetterList = $platformVersionsList | Where-Object { $_ -match "\D+" } | Sort-Object -Unique
-    $platforms = $platformNumericList + $platformLetterList | ForEach-Object { "platforms/${_}" }
+    $platforms = $platformNumericList + $platformLetterList | ForEach-Object { "platforms/android-${_}" }
 
     $buildToolsList = ($androidSdkManagerPackages | Where-Object { "$_".StartsWith("build-tools;") }) -replace 'build-tools;', ''
     $buildTools = $buildToolsList | Where-Object { $_ -match "\d+(\.\d+){2,}$"} | Where-Object { [version]$_ -ge $buildToolsMinVersion } | Sort-Object -Unique |

--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -103,7 +103,6 @@
             "addon-google_apis-google-21"
         ],
         "additional_tools": [
-            "cmake;3.6.4111459",
             "cmake;3.10.2.4988404",
             "patcher;v4",
             "platform-tools",

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -99,7 +99,6 @@
             "addon-google_apis-google-21"
         ],
         "additional_tools": [
-            "cmake;3.6.4111459",
             "cmake;3.10.2.4988404",
             "patcher;v4",
             "platform-tools",


### PR DESCRIPTION
# Description

1. There is a new Android platform called **S** that breaks our test script since we rely on numbers only:
`System.Management.Automation.PSInvalidCastException: Cannot convert value "S" to type "System.Int32"`
Also, we don't install the RC version of build tools, yet we didn't make an exclusion in tests for that case either.

2. Cmake 3.6 is not available through SDK manager anymore, we need to switch to 3.10

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1858

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
