### PR TITLE
[macOS] Fix Android tests to work with platform version S and remove Cmake 3.6

### DIFF
--- a/images/macos/provision/core/android-toolsets.sh
+++ b/images/macos/provision/core/android-toolsets.sh
@@ -69,9 +69,6 @@ echo "84831b9409646a918e30573bab4c9c91346d8abd" >> $ANDROID_HOME/licenses/androi
 echo "Installing latest tools & platform tools..."
 echo y | $SDKMANAGER "tools" "platform-tools"
 
-echo "Installing latest CMake..."
-echo y | $SDKMANAGER "cmake;3.6.4111459"
-
 echo "Installing latest ndk..."
 ndkLtsLatest=$(get_full_ndk_version  $ANDROID_NDK_MAJOR_LTS)
 ndkLatest=$(get_full_ndk_version  $ANDROID_NDK_MAJOR_LATEST)

--- a/images/macos/provision/core/dotnet.sh
+++ b/images/macos/provision/core/dotnet.sh
@@ -12,7 +12,7 @@ export DOTNET_CLI_TELEMETRY_OPTOUT=1
 
 # Download installer from dot.net and keep it locally
 DOTNET_INSTALL_SCRIPT="https://dotnet.microsoft.com/download/dotnet-core/scripts/v1/dotnet-install.sh"
-curl -o "dotnet-install.sh" "$DOTNET_INSTALL_SCRIPT"
+curl -L -o "dotnet-install.sh" "$DOTNET_INSTALL_SCRIPT"
 chmod +x ./dotnet-install.sh
 
 ARGS_LIST=()

--- a/images/macos/tests/Android.Tests.ps1
+++ b/images/macos/tests/Android.Tests.ps1
@@ -13,13 +13,14 @@ Describe "Android" {
     $ndkLatestFullVersion = (Get-ChildItem "$env:ANDROID_HOME/ndk/$ndkLatestVersion.*" | Select-Object -Last 1).Name
     $ndkLtsFullVersion = (Get-ChildItem "$env:ANDROID_HOME/ndk/$ndkLtsVersion.*" | Select-Object -Last 1).Name
 
-    $platforms = (($androidSdkManagerPackages | Where-Object { "$_".StartsWith("platforms;") }) -replace 'platforms;', '' |
-    Where-Object { [int]$_.Split("-")[1] -ge $platformMinVersion } | Sort-Object { [int]$_.Split("-")[1] } -Unique |
-    ForEach-Object { "platforms/${_}" })
+    $platformVersionsList = ($androidSdkManagerPackages | Where-Object { "$_".StartsWith("platforms;") }) -replace 'platforms;android-', ''
+    $platformNumericList = $platformVersionsList | Where-Object { $_ -match "\d+" } | Where-Object { [int]$_ -ge $platformMinVersion } | Sort-Object -Unique
+    $platformLetterList = $platformVersionsList | Where-Object { $_ -match "\D+" } | Sort-Object -Unique
+    $platforms = $platformNumericList + $platformLetterList | ForEach-Object { "platforms/android-${_}" }
 
-    $buildTools = (($androidSdkManagerPackages | Where-Object { "$_".StartsWith("build-tools;") }) -replace 'build-tools;', '' |
-    Where-Object { [version]$_ -ge $buildToolsMinVersion } | Sort-Object { [version]$_ } -Unique |
-    ForEach-Object { "build-tools/${_}" })
+    $buildToolsList = ($androidSdkManagerPackages | Where-Object { "$_".StartsWith("build-tools;") }) -replace 'build-tools;', ''
+    $buildTools = $buildToolsList | Where-Object { $_ -match "\d+(\.\d+){2,}$"} | Where-Object { [version]$_ -ge $buildToolsMinVersion } | Sort-Object -Unique |
+    ForEach-Object { "build-tools/${_}" }
 
     $androidPackages = @(
         "tools",

--- a/images/macos/toolsets/toolset-10.13.json
+++ b/images/macos/toolsets/toolset-10.13.json
@@ -190,6 +190,9 @@
         "addon-list": [
             "addon-google_apis-google-24", "addon-google_apis-google-23", "addon-google_apis-google-22", "addon-google_apis-google-21"
         ],
+        "additional-tools": [
+            "cmake;3.10.2.4988404"
+        ],
         "ndk": {
             "lts": "21",
             "latest": "22"

--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -211,6 +211,7 @@
             "addon-google_apis-google-24", "addon-google_apis-google-23", "addon-google_apis-google-22", "addon-google_apis-google-21"
         ],
         "additional-tools": [
+            "cmake;3.10.2.4988404",
             "cmdline-tools;latest"
         ],
         "ndk": {

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -156,6 +156,7 @@
             "addon-google_apis-google-24", "addon-google_apis-google-23", "addon-google_apis-google-22", "addon-google_apis-google-21"
         ],
         "additional-tools": [
+            "cmake;3.10.2.4988404",
             "cmdline-tools;latest"
         ],
         "ndk": {

--- a/images/macos/toolsets/toolset-11.0.json
+++ b/images/macos/toolsets/toolset-11.0.json
@@ -90,6 +90,7 @@
         ],
         "addon-list": [],
         "additional-tools": [
+            "cmake;3.10.2.4988404",
             "cmdline-tools;latest"
         ],
         "ndk": {


### PR DESCRIPTION
# Description

1. There is a new Android platform called **S** that breaks our test script since we rely on numbers only:
`System.Management.Automation.PSInvalidCastException: Cannot convert value "S" to type "System.Int32"`
Also, we don't install the RC version of build tools, yet we didn't make an exclusion in tests for that case either.

2. Cmake 3.6 is not available through SDK manager anymore, we need to switch to 3.10

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1858

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
