### PR TITLE
[Windows] Fix Android tests to work with platform version S and remove Cmake 3.6

### DIFF
--- a/images/win/scripts/Installers/Update-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Update-AndroidSDK.ps1
@@ -39,11 +39,14 @@ $androidPackages = Get-AndroidPackages -AndroidSDKManagerPath $sdkManager
 
 # platforms
 [int]$platformMinVersion = $androidToolset.platform_min_version
-$platformList = Get-AndroidPackagesByVersion -AndroidPackages $androidPackages `
+$platformListByVersion = Get-AndroidPackagesByVersion -AndroidPackages $androidPackages `
                 -PrefixPackageName "platforms;" `
                 -MinimumVersion $platformMinVersion `
                 -Delimiter "-" `
                 -Index 1
+$platformListByName = Get-AndroidPackagesByName -AndroidPackages $androidPackages `
+                -PrefixPackageName "platforms;" | Where-Object {$_ -match "-\D+$"}
+$platformList = $platformListByVersion + $platformListByName
 
 # build-tools
 [version]$buildToolsMinVersion = $androidToolset.build_tools_min_version

--- a/images/win/scripts/Tests/Android.Tests.ps1
+++ b/images/win/scripts/Tests/Android.Tests.ps1
@@ -10,11 +10,14 @@ Describe "Android SDK" {
 
     $platformTestCases = @()
     [int]$platformMinVersion = $androidToolset.platform_min_version
-    $platformList = Get-AndroidPackagesByVersion -AndroidPackages $androidPackages `
+    $platformListByVersion = Get-AndroidPackagesByVersion -AndroidPackages $androidPackages `
                     -PrefixPackageName "platforms;" `
                     -MinimumVersion $platformMinVersion `
                     -Delimiter "-" `
                     -Index 1
+    $platformListByName = Get-AndroidPackagesByName -AndroidPackages $androidPackages `
+                    -PrefixPackageName "platforms;" | Where-Object {$_ -match "-\D+$"}
+    $platformList = $platformListByVersion + $platformListByName 
     $platformList | ForEach-Object {
         $platformTestCases += @{ platformVersion = $_; installedPackages = $androidInstalledPackages }
     }

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -163,7 +163,6 @@
             "addon-google_apis-google-21"
         ],
         "additional_tools": [
-            "cmake;3.6.4111459",
             "cmake;3.10.2.4988404",
             "patcher;v4",
             "cmdline-tools;latest"

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -163,7 +163,6 @@
             "addon-google_apis-google-21"
         ],
         "additional_tools": [
-            "cmake;3.6.4111459",
             "cmake;3.10.2.4988404",
             "patcher;v4",
             "cmdline-tools;latest"


### PR DESCRIPTION
# Description
There is a new Android platform called S that breaks our test script since we rely on numbers only:
`System.Management.Automation.PSInvalidCastException: Cannot convert value "S" to type "System.Int32"`

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1858
## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
