### PR TITLE
[Ubuntu] Fix PyPy version pattern to pick up beta versions

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.CachedTools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.CachedTools.psm1
@@ -13,7 +13,7 @@ function Get-ToolcachePyPyVersions {
     Get-ChildItem -Path $toolcachePath -Name | Sort-Object { [Version] $_ } | ForEach-Object {
         $pypyRootPath = Join-Path $toolcachePath $_ "x64"
         [string]$pypyVersionOutput = & "$pypyRootPath/bin/python" -c "import sys;print(sys.version)"
-        $pypyVersionOutput -match "^([\d\.]+) \(.+\) \[PyPy ([\d\.]+) .+]$" | Out-Null
+        $pypyVersionOutput -match "^([\d\.]+) \(.+\) \[PyPy ([\d\.]+\S*) .+]$" | Out-Null
         return "{0} [PyPy {1}]" -f $Matches[1], $Matches[2]
     }
 }


### PR DESCRIPTION
# Description
PyPy based on python 3.7.9 is still in beta state so the version output is `PyPy 7.3.3-beta0`, which is currently not acceptable by regex pattern and thus we've got the wrong version in the docs.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1859

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
