### PR TITLE
[macOS] Improve select-datastore script

### DIFF
--- a/images.CI/macos/select-datastore.ps1
+++ b/images.CI/macos/select-datastore.ps1
@@ -79,7 +79,7 @@ function Select-DataStore {
     # Wait for 60 seconds to check if any other tags are assigned to the same datastore
     Start-Sleep -Seconds 60
     # Take only first 2 tags, all the others will go to the next round
-    $tagAssignments = (Get-TagAssignment -Entity $buildDatastore).Tag.Name | Select-Object -First 2
+    $tagAssignments = (Get-TagAssignment -Entity $buildDatastore).Tag.Name | Select-Object -Last 1
     $isAllow = $tagAssignments -contains $VMName
 
     if ($isAllow)

--- a/images.CI/macos/select-datastore.ps1
+++ b/images.CI/macos/select-datastore.ps1
@@ -78,7 +78,7 @@ function Select-DataStore {
 
     # Wait for 60 seconds to check if any other tags are assigned to the same datastore
     Start-Sleep -Seconds 60
-    # Take only first 2 tags, all the others will go to the next round
+    # Take the last tag (Last in, first out), all the others will go to the next round
     $tagAssignments = (Get-TagAssignment -Entity $buildDatastore).Tag.Name | Select-Object -Last 1
     $isAllow = $tagAssignments -contains $VMName
 


### PR DESCRIPTION
# Description
It seems that currently, select-datastore script doesn't work properly because sometimes 2 simultaneous builds run on the same host even though all the other hosts are free. We changed the logic a bit to follow "last in first out" approach, it should help us in this case.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1864

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
