### PR TITLE
[Windows] Increase GDIProcessHandleQuota value to 20000

### DIFF
--- a/images/win/scripts/Installers/Configure-GDIProcessHandleQuota.ps1
+++ b/images/win/scripts/Installers/Configure-GDIProcessHandleQuota.ps1
@@ -1,0 +1,9 @@
+# https://docs.microsoft.com/en-us/windows/win32/sysinfo/gdi-objects
+# This value can be set to a number between 256 and 65,536
+
+$defaultValue = 20000
+Write-Host "Set the GDIProcessHandleQuota value to $defaultValue"
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Windows" -Name GDIProcessHandleQuota -Value $defaultValue
+Set-ItemProperty -Path "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows NT\CurrentVersion\Windows" -Name GDIProcessHandleQuota -Value $defaultValue
+
+Invoke-PesterTests -TestFile "WindowsFeatures" -TestName "GDIProcessHandleQuota"

--- a/images/win/scripts/Tests/WindowsFeatures.Tests.ps1
+++ b/images/win/scripts/Tests/WindowsFeatures.Tests.ps1
@@ -57,3 +57,12 @@ Describe "DynamicPorts" {
         $udpPorts | Should -BeNullOrEmpty
     }
 }
+
+Describe "GDIProcessHandleQuota" {
+    It "The GDIProcessHandleQuota value is 20000" {
+        $regPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Windows"
+        $regPath32 = "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows NT\CurrentVersion\Windows"
+        (Get-ItemProperty $regPath).GDIProcessHandleQuota | Should -BeExactly 20000
+        (Get-ItemProperty $regPath32).GDIProcessHandleQuota | Should -BeExactly 20000
+    }
+}

--- a/images/win/windows2016.json
+++ b/images/win/windows2016.json
@@ -329,6 +329,7 @@
             "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1",
                 "{{ template_dir }}/scripts/Installers/Configure-DynamicPort.ps1",
+                "{{ template_dir }}/scripts/Installers/Configure-GDIProcessHandleQuota.ps1",
                 "{{ template_dir }}/scripts/Installers/Configure-Shell.ps1"
             ],
             "elevated_user": "{{user `install_user`}}",

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -322,6 +322,7 @@
             "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1",
                 "{{ template_dir }}/scripts/Installers/Configure-DynamicPort.ps1",
+                "{{ template_dir }}/scripts/Installers/Configure-GDIProcessHandleQuota.ps1",
                 "{{ template_dir }}/scripts/Installers/Configure-Shell.ps1"
             ],
             "elevated_user": "{{user `install_user`}}",


### PR DESCRIPTION
# Description
Increase `GDIProcessHandleQuota` value to 20000:

```
PS > testlimit64.exe -g

Testlimit v5.24 - test Windows limits
Copyright (C) 2012-2015 Mark Russinovich
Sysinternals - www.sysinternals.com

Process ID: 6648

Creating GDI objects...
Created 20000 GDI objects totalling 19 KB. Lasterror: 0

PS C> & "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\ResGen.exe" icons.resx icons.resources
Read in 4001 resources from "icons.resx"
Writing resource file...  Done.
```

#### Related issue:
https://github.com/actions/virtual-environments/issues/2740

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
