### PR TITLE
[Ubuntu] Remove Android SDK Platforms and Build-tools that are less than version 23

### DIFF
--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -85,8 +85,8 @@
         ]
     },
     "android": {
-        "platform_min_version": "10",
-        "build_tools_min_version": "19.1.0",
+        "platform_min_version": "23",
+        "build_tools_min_version": "23.0.1",
         "extra_list": [
             "android;m2repository",
             "google;m2repository",

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -85,8 +85,8 @@
         ]
     },
     "android": {
-        "platform_min_version": "17",
-        "build_tools_min_version": "19.1.0",
+        "platform_min_version": "23",
+        "build_tools_min_version": "23.0.1",
         "extra_list": [
             "android;m2repository",
             "google;m2repository",


### PR DESCRIPTION
# Description
We are going to deprecate old Android SDK Platforms and Build-tools due to a lack of free space on Ubuntu images.
Build tools version 23.0.0 marked as obsolete so the first available version will be 23.0.1

#### Related issue:
https://github.com/actions/virtual-environments/issues/2673

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
