### PR TITLE
[macOS] Stick to go 1.15

### DIFF
--- a/images/macos/provision/configuration/environment/bashrc
+++ b/images/macos/provision/configuration/environment/bashrc
@@ -16,7 +16,6 @@ export RUNNER_TOOL_CACHE=$HOME/hostedtoolcache
 
 export PATH=/Library/Frameworks/Mono.framework/Versions/Current/Commands:$PATH
 export PATH=$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools:$ANDROID_NDK_HOME:$PATH
-export PATH=/usr/local/go/bin:$PATH
 export PATH=/usr/local/bin:/usr/local/sbin:~/bin:~/.yarn/bin:$PATH
 export PATH="/usr/local/opt/curl/bin:$PATH"
 export PATH="/usr/local/opt/ruby@2.7/bin:$PATH"

--- a/images/macos/provision/core/commonutils.sh
+++ b/images/macos/provision/core/commonutils.sh
@@ -19,6 +19,9 @@ if is_Less_Catalina; then
     echo "export USE_BAZEL_VERSION=${USE_BAZEL_VERSION}" >> "${HOME}/.bashrc"
 fi
 
+# Create a symlink for Go 1.15 to preserve backward compatibility
+ln -sf $(brew --prefix go@1.15)/bin/go /usr/local/bin/go
+
 # Invoke bazel to download bazel version via bazelisk
 bazel
 

--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -242,7 +242,7 @@
             "gh",
             "gnupg",
             "gnu-tar",
-            "go",
+            "go@1.15",
             "helm",
             "libpq",
             "llvm",

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -187,7 +187,7 @@
             "gh",
             "gnupg",
             "gnu-tar",
-            "go",
+            "go@1.15",
             "helm",
             "libpq",
             "llvm",

--- a/images/macos/toolsets/toolset-11.0.json
+++ b/images/macos/toolsets/toolset-11.0.json
@@ -120,7 +120,7 @@
             "gh",
             "gnupg",
             "gnu-tar",
-            "go",
+            "go@1.15",
             "helm",
             "libpq",
             "llvm",


### PR DESCRIPTION
# Description
Go 1.16 contains a lot of breaking changes, we should avoid setting it as the default one at least for a few next weeks.
it also turned out that we don't need to export `/usr/local/go/bin` directory as brew's go installed by another path.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1882

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
