### PR TITLE
[macOS] Add all Go symlinks for version 1.15

### DIFF
--- a/images/macos/provision/core/commonutils.sh
+++ b/images/macos/provision/core/commonutils.sh
@@ -19,8 +19,8 @@ if is_Less_Catalina; then
     echo "export USE_BAZEL_VERSION=${USE_BAZEL_VERSION}" >> "${HOME}/.bashrc"
 fi
 
-# Create a symlink for Go 1.15 to preserve backward compatibility
-ln -sf $(brew --prefix go@1.15)/bin/go /usr/local/bin/go
+# Create symlinks for Go 1.15 to preserve backward compatibility
+ln -sf $(brew --prefix go@1.15)/bin/* /usr/local/bin/
 
 # Invoke bazel to download bazel version via bazelisk
 bazel


### PR DESCRIPTION
# Description
Brew formula for the latest go adds all the binaries from Go's bin directory (go and gofmt), we need to do the same for 1.15

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1882

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
