### PR TITLE
Revert "[Windows] Add workaround to download docker images from another endpoint"

### DIFF
--- a/images/win/scripts/Installers/Update-DockerImages.ps1
+++ b/images/win/scripts/Installers/Update-DockerImages.ps1
@@ -16,14 +16,9 @@ function DockerPull {
     }
 }
 
-# Temporary replace ip for download server to the more stable one
-Copy-Item -Path "$env:windir\System32\drivers\etc\hosts" -Destination "C:\hosts_backup" -Verbose
-"40.71.10.214 mcr.microsoft.com" >> "$env:windir\System32\drivers\etc\hosts"
-
 $dockerToolset = (Get-ToolsetContent).docker
 foreach($dockerImage in $dockerToolset.images) {
   DockerPull $dockerImage
 }
 
-Move-Item -Path "C:\hosts_backup" -Destination "$env:windir\System32\drivers\etc\hosts" -Force -Verbose
 Invoke-PesterTests -TestFile "Docker" -TestName "DockerImages"


### PR DESCRIPTION
The issue is resolved from the MCR side, we can get rid of the workaround.