### PR TITLE
Caching docker images for .Net 5

### DIFF
--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -204,7 +204,11 @@
             "node:12",
             "node:10-alpine",
             "node:12-alpine",
-            "ubuntu:14.04"
+            "ubuntu:14.04",
+            "mcr.microsoft.com/dotnet/sdk:5.0-buster-slim",
+            "mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim",
+            "mcr.microsoft.com/dotnet/runtime:5.0-buster-slim",
+            "mcr.microsoft.com/dotnet/runtime-deps:5.0-buster-slim"
         ]
     },
     "pipx": [

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -304,7 +304,10 @@
             "mcr.microsoft.com/windows/nanoserver:1809",
             "mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2019",
             "mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019",
-            "microsoft/aspnetcore-build:1.0-2.0"
+            "microsoft/aspnetcore-build:1.0-2.0",
+            "mcr.microsoft.com/dotnet/sdk:5.0-nanoserver-1809",
+            "mcr.microsoft.com/dotnet/aspnet:5.0-nanoserver-1809",
+            "mcr.microsoft.com/dotnet/runtime:5.0-nanoserver-1809"
         ]
     },
     "pipx": [


### PR DESCRIPTION
# Description
Added the .Net 5 docker images to be pre-cached in windows-2019 and ubuntu-2004.

Ubuntu-2004:
mcr.microsoft.com/dotnet/sdk:5.0-buster-slim - Used to build .Net 5 applications
mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim - Used to run ASP.Net 5 applications
mcr.microsoft.com/dotnet/runtime:5.0-buster-slim - Used to run .Net 5 applications
mcr.microsoft.com/dotnet/runtime-deps:5.0-buster-slim - Used to run self-contained .Net 5 applications

Windows-2019:
mcr.microsoft.com/dotnet/sdk:5.0-nanoserver-1809 - Used to build .Net 5 applications
mcr.microsoft.com/dotnet/aspnet:5.0-nanoserver-1809 - Used to run ASP.Net 5 applications
mcr.microsoft.com/dotnet/runtime:5.0-nanoserver-1809 - Used to run .Net 5 applications

Couple of notes:
- I chose to list out each of the images, I could have just included the sdk image which will pull down the others as part of it.  But by listing each one it makes sure that the tests check for them all, and that the software report lists them all.
- I chose to use the more specific tags instead of the "5.0" tag (which also would work), to make it more obvious in the software report what OS the container images are based off of (until I did this PR I didn't realize that when you pull down the exact same image+tag on a windows host vs a linux host you actually get different images - I think this makes it clearer for others like me)
- There is no runtime-deps image for windows because the nanoserver base image includes all the runtime dependencies needed (unlike debian)
- I only updated the windows-2019/ubuntu-2004 images because I'm assuming if you're developing against the latest and greatest .Net version, you're probably using the latest and greatest build server image too (happy to update and test the other images if desired)

#### Related issue:
#2784 

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
