### PR TITLE
[Ubuntu] Add net-tools

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -118,6 +118,7 @@ $toolsList = @(
     (Get-M4Version),
     (Get-HGVersion),
     (Get-MinikubeVersion),
+    (Get-NetToolsVersion),
     (Get-NewmanVersion),
     (Get-NvmVersion),
     (Get-PackerVersion),

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -174,6 +174,11 @@ function Get-MediainfoVersion {
     return "MediaInfo $mediainfoVersion"
 }
 
+function Get-NetToolsVersion {
+    $netToolsVersion = dpkg-query --showformat='${Version}' --show net-tools | Take-OutputPart -Part 0 -Delimiter "+"
+    return "net-tools $netToolsVersion"
+}
+
 function Get-NewmanVersion {
     return "Newman $(newman --version)"
 }

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -175,7 +175,7 @@ function Get-MediainfoVersion {
 }
 
 function Get-NetToolsVersion {
-    $netToolsVersion = dpkg-query --showformat='${Version}' --show net-tools | Take-OutputPart -Part 0 -Delimiter "+"
+    $netToolsVersion = dpkg-query --showformat='${Version}' --show net-tools | Take-OutputPart -Part 0 -Delimiter '-' | Take-OutputPart -Part 0 -Delimiter '+'
     return "net-tools $netToolsVersion"
 }
 

--- a/images/linux/scripts/tests/Apt.Tests.ps1
+++ b/images/linux/scripts/tests/Apt.Tests.ps1
@@ -34,6 +34,11 @@ Describe "Apt" {
             $toolName = "tr"
         }
 
+        if ($toolName -eq "net-tools")
+        {
+            $toolName = "netstat"
+        }
+
         (Get-Command -Name $toolName).CommandType | Should -BeExactly "Application"
     }
 }

--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -194,6 +194,7 @@
             "m4",
             "mediainfo",
             "netcat",
+            "net-tools",
             "p7zip-full",
             "parallel",
             "pass",

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -188,6 +188,7 @@
             "m4",
             "mediainfo",
             "netcat",
+            "net-tools",
             "parallel",
             "pass",
             "p7zip-full",

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -168,6 +168,7 @@
             "m4",
             "mediainfo",
             "netcat",
+            "net-tools",
             "p7zip-full",
             "parallel",
             "pass",


### PR DESCRIPTION
# Description
Install net-tools on Ubuntu 20.04

#### Related issue:
https://github.com/actions/virtual-environments/issues/2837

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
