### PR TITLE
[Windows] Remove boost from the images

### DIFF
--- a/images/win/scripts/Installers/Configure-Toolset.ps1
+++ b/images/win/scripts/Installers/Configure-Toolset.ps1
@@ -35,9 +35,6 @@ $toolsEnvironmentVariables = @{
             "{0}\Scripts"
         )
     }
-    Boost = @{
-        variableTemplate = "BOOST_ROOT_{0}_{1}_{2}"
-    }
     go = @{
         pathTemplates = @(
             "{0}\bin"
@@ -46,7 +43,7 @@ $toolsEnvironmentVariables = @{
     }
 }
 
-$toolsToConfigure = @("Python", "Boost", "Go")
+$toolsToConfigure = @("Python", "Go")
 $tools = Get-ToolsetContent | Select-Object -ExpandProperty toolcache `
                             | Where-Object { $toolsToConfigure -contains $_.name }
 

--- a/images/win/scripts/SoftwareReport/SoftwareReport.CachedTools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.CachedTools.psm1
@@ -1,38 +1,3 @@
-function Get-BoostMarkdown
-{
-    $Name = "Boost"
-    $ToolInstances = Get-CachedToolInstances -Name $Name
-    foreach ($Instance in $ToolInstances)
-    {
-        $VersionEnvVar = $Instance.Version.replace(".", "_")
-        $Instance."Environment Variable" = "BOOST_ROOT_${VersionEnvVar}"
-    }
-
-    $Content = $ToolInstances | New-MDTable -Columns ([ordered]@{
-        Version = "left";
-        Architecture = "left";
-        "Environment Variable" = "left"
-    })
-    $Content += New-MDHeader "Notes:" -Level 5
-    $Content += @'
-```
-1. Environment variable "BOOST_ROOT" is not set by default.
-   Please make sure you set this variable value to proper value
-   from table above depending on the Boost version you are using.
-2. If Boost was built using the boost-cmake project or from Boost 1.70.0
-   on it provides a package configuration file for use with find_package's config mode.
-   This module looks for the package configuration file called BoostConfig.cmake or boost-config.cmake
-   and stores the result in CACHE entry "Boost_DIR". If found, the package configuration file
-   is loaded and this module returns with no further action.
-   See documentation of the Boost CMake package configuration for details on what it provides.
-   Set Boost_NO_BOOST_CMAKE to ON, to disable the search for boost-cmake.
-   Link: https://cmake.org/cmake/help/latest/module/FindBoost.html
-```
-'@
-
-    return Build-MarkdownElement -Head $Name -Content $Content
-}
-
 function Get-GoMarkdown
 {
     $Name = "Go"
@@ -106,7 +71,6 @@ function Get-PyPyMarkdown
 function Build-CachedToolsMarkdown
 {
     $markdown = ""
-    $markdown += Get-BoostMarkdown
     $markdown += Get-GoMarkdown
     $markdown += Get-NodeMarkdown
     $markdown += Get-PythonMarkdown

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Helpers.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Helpers.psm1
@@ -65,14 +65,6 @@ function Get-CachedToolInstances
         [string]$instanceInfo.Path = Join-Path -Path $toolPath -ChildPath $version.Name
         [string]$instanceInfo.Version = $version.Name
 
-        ### Temporary workaround. Currently Boost instances don't have architecture subfolders.
-        if ($Name -eq "Boost")
-        {
-            [string]$instanceInfo.Architecture = "x64, x86"
-            $toolInstances += $instanceInfo
-            continue
-        }
-
         # Get all architectures for current version
         [array]$instanceInfo.Architecture_Array = Get-ChildItem $version.FullName -Name -Directory | Where-Object { $_ -match "^x[0-9]{2}$" }
         [string]$instanceInfo.Architecture = $instanceInfo.Architecture_Array -Join ", "

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -75,16 +75,6 @@
                 "1.16.*"
             ],
             "default": "1.15.*"
-        },
-        {
-            "name": "Boost",
-            "url" : "https://raw.githubusercontent.com/actions/boost-versions/main/versions-manifest.json",
-            "arch": "x86_64",
-            "platform" : "win32",
-            "toolset": "msvc14.1",
-            "versions": [
-                "1.72.0"
-            ]
         }
     ],
     "powershellModules": [

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -75,16 +75,6 @@
                 "1.16.*"
             ],
             "default": "1.15.*"
-        },
-        {
-            "name": "Boost",
-            "url" : "https://raw.githubusercontent.com/actions/boost-versions/main/versions-manifest.json",
-            "arch": "x86_64",
-            "platform" : "win32",
-            "toolset": "msvc14.2",
-            "versions": [
-                "1.72.0"
-            ]
         }
     ],
     "powershellModules": [


### PR DESCRIPTION
# Description
We are going to deprecate Boost due to lack of free space on images, maintenance concerns and low popularity.

#### Related issue:
https://github.com/actions/virtual-environments/issues/2667

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
