### PR TITLE
[Ubuntu] Remove boost from the images

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.CachedTools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.CachedTools.psm1
@@ -41,43 +41,8 @@ function Build-GoEnvironmentTable {
     }
 }
 
-function Get-ToolcacheBoostVersions {
-    $Name = "Boost"
-    $toolcachePath = Join-Path $env:AGENT_TOOLSDIRECTORY "boost"
-    if (-not (Test-Path $toolcachePath)) {
-        return @()
-    }
-
-    $BoostVersions = Get-ChildItem $toolcachePath -Name | Sort-Object { [Version]$_ }
-    $ToolInstances = $BoostVersions | ForEach-Object {
-        $VersionEnvVar = $_.replace(".", "_")
-        return @{
-            Version = $_
-            Architecture = "x64"
-            "Environment Variable" = "BOOST_ROOT_${VersionEnvVar}"
-
-        }
-    }
-    $Content = $ToolInstances | New-MDTable -Columns ([ordered]@{
-        Version = "left";
-        Architecture = "left";
-        "Environment Variable" = "left"
-    })
-
-    $markdown = ""
-
-    if ($Content.Count -gt 0) {
-        $markdown += New-MDHeader $Name -Level 4
-        $markdown += New-MDParagraph -Lines $Content
-    }
-
-    return $markdown
-}
-
 function Build-CachedToolsSection {
     $output = ""
-
-    $output += Get-ToolcacheBoostVersions
 
     $output += New-MDHeader "Go" -Level 4
     $output += New-MDList -Lines (Get-ToolcacheGoVersions) -Style Unordered

--- a/images/linux/scripts/helpers/SoftwareReport.Helpers.psm1
+++ b/images/linux/scripts/helpers/SoftwareReport.Helpers.psm1
@@ -80,14 +80,6 @@ function Get-CachedToolInstances
         [string]$instanceInfo.Path = Join-Path -Path $toolPath -ChildPath $version.Name
         [string]$instanceInfo.Version = $version.Name
 
-        ### Temporary workaround. Currently Boost instances don't have architecture subfolders.
-        if ($Name -eq "Boost")
-        {
-            [string]$instanceInfo.Architecture = "x64, x86"
-            $toolInstances += $instanceInfo
-            continue
-        }
-
         # Get all architectures for current version
         [array]$instanceInfo.Architecture_Array = Get-ChildItem $version.FullName -Name -Directory | Where-Object { $_ -match "^x[0-9]{2}$" }
         [string]$instanceInfo.Architecture = $instanceInfo.Architecture_Array -Join ", "

--- a/images/linux/scripts/installers/Configure-Toolset.ps1
+++ b/images/linux/scripts/installers/Configure-Toolset.ps1
@@ -39,9 +39,6 @@ $ErrorActionPreference = "Stop"
 
 Write-Host "Configure toolset tools environment..."
 $toolsEnvironment = @{
-    boost = @{
-        variableTemplate = "BOOST_ROOT_{0}_{1}_{2}"
-    }
     go = @{
         command = "ln -s {0}/bin/* /usr/bin/"
         variableTemplate = "GOROOT_{0}_{1}_X64"

--- a/images/linux/scripts/installers/Install-Toolset.ps1
+++ b/images/linux/scripts/installers/Install-Toolset.ps1
@@ -28,7 +28,7 @@ $ErrorActionPreference = "Stop"
 
 # Get toolset content
 $toolset = Get-Content -Path "$env:INSTALLER_SCRIPT_FOLDER/toolset.json" -Raw
-$toolsToInstall = @("Python", "Node", "Boost", "Go")
+$toolsToInstall = @("Python", "Node", "Go")
 
 $tools = ConvertFrom-Json -InputObject $toolset | Select-Object -ExpandProperty toolcache | Where-Object {$ToolsToInstall -contains $_.Name}
 

--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -48,16 +48,6 @@
             "default": "1.15.*"
         },
         {
-            "name": "boost",
-            "url" : "https://raw.githubusercontent.com/actions/boost-versions/main/versions-manifest.json",
-            "platform" : "linux",
-            "platform_version": "16.04",
-            "arch": "x64",
-            "versions": [
-                "1.72.0"
-            ]
-        },
-        {
             "name": "Ruby",
             "platform_version": "16.04",
             "arch": "x64",

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -48,16 +48,6 @@
             "default": "1.15.*"
         },
         {
-            "name": "boost",
-            "url" : "https://raw.githubusercontent.com/actions/boost-versions/main/versions-manifest.json",
-            "platform" : "linux",
-            "platform_version": "18.04",
-            "arch": "x64",
-            "versions": [
-                "1.72.0"
-            ]
-        },
-        {
             "name": "Ruby",
             "platform_version": "18.04",
             "arch": "x64",


### PR DESCRIPTION
# Description
We are going to deprecate Boost due to lack of free space on images, maintenance concerns and low popularity.

#### Related issue:
https://github.com/actions/virtual-environments/issues/2667

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
