### PR TITLE
[Windows] Fix haskell tests for version 9

### DIFF
--- a/images/win/scripts/Installers/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/Initialize-VM.ps1
@@ -132,6 +132,10 @@ if (Test-IsWin19) {
     Choco-Install -PackageName vcredist2010
 }
 
+# Initialize environmental variable ChocolateyToolsLocation by invoking choco Get-ToolsLocation function
+Import-Module "$env:ChocolateyInstall\helpers\chocolateyInstaller.psm1" -Force
+Get-ToolsLocation
+
 # Expand disk size of OS drive
 $driveLetter = "C"
 $size = Get-PartitionSupportedSize -DriveLetter $driveLetter

--- a/images/win/scripts/Installers/Install-Haskell.ps1
+++ b/images/win/scripts/Installers/Install-Haskell.ps1
@@ -19,6 +19,12 @@ ForEach ($version in $VersionsList)
 $DefaultGhcVersion = $VersionsList | Select-Object -Last 1
 $DefaultGhcShortVersion = ([version]$DefaultGhcVersion).ToString(3)
 $DefaultGhcPath = Join-Path $env:ChocolateyInstall "lib\ghc.$DefaultGhcVersion\tools\ghc-$DefaultGhcShortVersion\bin"
+# Starting from version 9 haskell installation directory is $env:ChocolateyToolsLocation instead of $env:ChocolateyInstall\lib
+if ($ghcVersion -notmatch "^[0-8]\.\d+.*")
+{
+    $DefaultGhcPath = Join-Path $env:ChocolateyToolsLocation "ghc-$DefaultGhcShortVersion\bin"
+}
+
 Add-MachinePathItem -PathItem $DefaultGhcPath
 
 Write-Host "Installing cabal..."

--- a/images/win/scripts/Tests/Haskell.Tests.ps1
+++ b/images/win/scripts/Tests/Haskell.Tests.ps1
@@ -11,10 +11,16 @@ Describe "Haskell" {
     $ghcTestCases = $ghcVersionList | ForEach-Object {
         $ghcVersion = $_
         $ghcShortVersion = ([version]$ghcVersion).ToString(3)
+        $binGhcPath = Join-Path $chocoPackagesPath "ghc.$ghcVersion\tools\ghc-$ghcShortVersion\bin\ghc.exe"
+        # Starting from version 9 haskell installation directory is $env:ChocolateyToolsLocation instead of $env:ChocolateyInstall\lib
+        if ($ghcVersion -notmatch "^[0-8]\.\d+.*")
+        {
+            $binGhcPath = Join-Path $env:ChocolateyToolsLocation "ghc-$ghcShortVersion\bin\ghc.exe"
+        }
         @{
             ghcVersion = $ghcVersion
             ghcShortVersion = $ghcShortVersion
-            binGhcPath = Join-Path $chocoPackagesPath "ghc.$ghcVersion\tools\ghc-$ghcShortVersion\bin\ghc.exe"
+            binGhcPath = $binGhcPath
         }
     }
 


### PR DESCRIPTION
# Description
Starting from version 9 Haskell installation directory is `$env:ChocolateyToolsLocation` instead of `$env:ChocolateyInstall\lib`. By default `$env:ChocolateyToolsLocation` is not initialized and any choco script using it fall back to the `C:\Tools` directory, however, we can explicitly set this variable to the same`C:\Tools` path by calling the `Get-ToolsLocation` function: https://github.com/chocolatey/choco/blob/b6f49599536f77a204a1009d31185218fc8aee7c/src/chocolatey.resources/helpers/functions/Get-ToolsLocation.ps1#L87
This enables us to use the variable in all further build steps.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1904

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
