### PR TITLE
[macOS] Increase kern.maxfilesperproc to 65536

### DIFF
--- a/images/macos/provision/configuration/max-files.sh
+++ b/images/macos/provision/configuration/max-files.sh
@@ -17,7 +17,7 @@ cat > "${Launch_Daemons}/limit.maxfiles.plist" << EOF
       <string>launchctl</string>
       <string>limit</string>
       <string>maxfiles</string>
-      <string>52428</string>
+      <string>65536</string>
       <string>524288</string>
     </array>
     <key>RunAtLoad</key>


### PR DESCRIPTION
# Description
Issue: `Error: ENFILE: file table overflow, open`
Changes:  Increase kern.maxfilesperproc to 65536

#### Related issue:
https://github.com/actions/virtual-environments/issues/2842

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
