### PR TITLE
[Ubuntu] Add ACCEPT_EULA=Y env var

### DIFF
--- a/images/linux/scripts/installers/configure-environment.sh
+++ b/images/linux/scripts/installers/configure-environment.sh
@@ -1,10 +1,13 @@
 #!/bin/bash -e
 
-#Set ImageVersion and ImageOS env variables
+# Set ImageVersion and ImageOS env variables
 echo ImageVersion=$IMAGE_VERSION | tee -a /etc/environment
 echo ImageOS=$IMAGE_OS | tee -a /etc/environment
 
-# Create a file to store user-related global environment variables 
+# Set the ACCEPT_EULA variable to Y value to confirm your acceptance of the End-User Licensing Agreement
+echo ACCEPT_EULA=Y | tee -a /etc/environment
+
+# Create a file to store user-related global environment variables
 touch /etc/profile.d/env_vars.sh
 # Set BASH_ENV variable pointed to the file with user-related global environment variables for non-interactive sessions
 echo "BASH_ENV=/etc/profile.d/env_vars.sh" | tee -a /etc/environment


### PR DESCRIPTION
# Description
https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-configure-environment-variables?view=sql-server-ver15

Environment variable | Description
-- | --
ACCEPT_EULA | Set the ACCEPT_EULA variable to any value to confirm your acceptance of the End-User Licensing Agreement. Required setting for the SQL Server image.

#### Related issue:
https://github.com/actions/virtual-environments/issues/2904

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
