### PR TITLE
[Ubuntu] Add lerna to Ubuntu 20.04 docs

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -84,6 +84,11 @@ function Get-JuliaVersion {
     return "Julia $juliaVersion"
 }
 
+function Get-LernaVersion {
+    $version = lerna -v
+    return "Lerna $version"
+}
+
 function Get-HomebrewVersion {
     $result = Get-CommandResult "brew -v"
     $result.Output -match "Homebrew (?<version>\d+\.\d+\.\d+)" | Out-Null

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -77,13 +77,19 @@ $markdown += Build-PackageManagementEnvironmentTable | New-MDTable
 $markdown += New-MDNewLine
 
 $markdown += New-MDHeader "Project Management" -Level 3
-$markdown += New-MDList -Style Unordered -Lines (@(
-        (Get-AntVersion),
-        (Get-GradleVersion),
-        (Get-MavenVersion),
-        (Get-SbtVersion)
-        ) | Sort-Object
+$projectManagementList = @(
+    (Get-AntVersion),
+    (Get-GradleVersion),
+    (Get-MavenVersion),
+    (Get-SbtVersion)
 )
+
+if (Test-IsUbuntu20) {
+    $projectManagementList += @(
+        (Get-LernaVersion)
+    )
+}
+$markdown += New-MDList -Style Unordered -Lines ($projectManagementList | Sort-Object)
 
 $markdown += New-MDHeader "Tools" -Level 3
 $toolsList = @(


### PR DESCRIPTION
# Description
Add lerna to Ubuntu 20.04 docs.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1920

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
