### PR TITLE
[Windows] Zstd add support archive with the parent folder

### DIFF
--- a/images/win/scripts/Installers/Install-Zstd.ps1
+++ b/images/win/scripts/Installers/Install-Zstd.ps1
@@ -10,8 +10,15 @@ $zstdArchivePath = Start-DownloadWithRetry -Url $zstdLatest -Name "zstd-win64.zi
 
 $toolPath = "C:\tools"
 $zstdPath = Join-Path $toolPath zstd
-Extract-7Zip -Path $zstdArchivePath -DestinationPath $toolPath
-Move-Item -Path "${zstdPath}*" -Destination $zstdPath
+$zstdParentName = [IO.Path]::GetFileNameWithoutExtension($zstdLatest)
+$filesInArchive = 7z l $zstdArchivePath | Out-String
+
+if ($filesInArchive.Contains($zstdParentName)) {
+    Extract-7Zip -Path $zstdArchivePath -DestinationPath $toolPath
+    Move-Item -Path "${zstdPath}*" -Destination $zstdPath
+} else {
+    Extract-7Zip -Path $zstdArchivePath -DestinationPath $zstdPath
+}
 
 # Add zstd-win64 to PATH
 Add-MachinePathItem $zstdPath


### PR DESCRIPTION
# Description
The new archive of zstd was repacked without parent folder - https://github.com/facebook/zstd/issues/2532

#### Related issue:
https://github.com/actions/virtual-environments/issues/2858

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
