### PR TITLE
[Ubuntu] Change minimumFreeSpaceMB 16000 -> 15000

### DIFF
--- a/images/linux/scripts/installers/validate-disk-space.sh
+++ b/images/linux/scripts/installers/validate-disk-space.sh
@@ -5,7 +5,7 @@
 ################################################################################
 
 availableSpaceMB=$(df / -hm | sed 1d | awk '{ print $4}')
-minimumFreeSpaceMB=16000
+minimumFreeSpaceMB=15000
 
 echo "Available disk space: $availableSpaceMB MB"
 


### PR DESCRIPTION
# Description
The GitHub-hosted runners  should have at least 14GB of disk space available: change minimumFreeSpaceMB 16000 -> 15000

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
