### PR TITLE
feat: Return `apt` packages with their installed versions

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -295,10 +295,20 @@ function Get-CachedDockerImagesTableData {
 }
 
 function Get-AptPackages {
-    $toolsetJson = Get-ToolsetContent
-    $apt = $toolsetJson.apt
-    $pkgs = ($apt.common_packages + $apt.cmd_packages | Sort-Object) -join ", "
-    return $pkgs
+    $apt = (Get-ToolsetContent).Apt
+    $output = @()
+    ForEach ($pkg in ($apt.common_packages + $apt.cmd_packages)) {
+        $version = $(dpkg-query -W -f '${Version}' $pkg)
+        if ($Null -eq $version) {
+            $version = $(dpkg-query -W -f '${Version}' "$pkg*")
+        }
+
+        $output += [PSCustomObject] @{
+            Name    = $pkg
+            Version = $version
+        }
+    }
+    return ($output | Sort-Object Name)
 }
 
 function Get-PipxVersion {

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -286,6 +286,6 @@ $markdown += Get-CachedDockerImagesTableData | New-MDTable
 $markdown += New-MDNewLine
 
 $markdown += New-MDHeader "Installed apt packages" -Level 3
-$markdown += New-MDList -Style Unordered -Lines @(Get-AptPackages)
+$markdown += Get-AptPackages | New-MDTable
 
 $markdown | Out-File -FilePath "${OutputDirectory}/Ubuntu-Readme.md"


### PR DESCRIPTION
Change list to table and print package version corresponding to the tool.
This will allow to see which versions of `apt` tools are installed in current image.