### PR TITLE
[Ubuntu] Fix variable name in releaseUrl

### DIFF
--- a/images/linux/scripts/installers/preimagedata.sh
+++ b/images/linux/scripts/installers/preimagedata.sh
@@ -8,17 +8,17 @@ github_url="https://github.com/actions/virtual-environments/blob"
 
 if [[ "$image_label" =~ "ubuntu-20" ]]; then
     software_url="${github_url}/ubuntu20/${image_version}/images/linux/Ubuntu2004-README.md"
-    releaseUrl="https://github.com/actions/virtual-environments/releases/tag/ubuntu20%2F${imageVersion}"
+    releaseUrl="https://github.com/actions/virtual-environments/releases/tag/ubuntu20%2F${image_version}"
 fi
 
 if [[ "$image_label" =~ "ubuntu-18" ]]; then
     software_url="${github_url}/ubuntu18/${image_version}/images/linux/Ubuntu1804-README.md"
-    releaseUrl="https://github.com/actions/virtual-environments/releases/tag/ubuntu18%2F${imageVersion}"
+    releaseUrl="https://github.com/actions/virtual-environments/releases/tag/ubuntu18%2F${image_version}"
 fi
 
 if [[ "$image_label" =~ "ubuntu-16" ]]; then
     software_url="${github_url}/ubuntu16/${image_version}/images/linux/Ubuntu1604-README.md"
-    releaseUrl="https://github.com/actions/virtual-environments/releases/tag/ubuntu16%2F${imageVersion}"
+    releaseUrl="https://github.com/actions/virtual-environments/releases/tag/ubuntu16%2F${image_version}"
 fi
 
 cat <<EOF > $imagedata_file


### PR DESCRIPTION
# Description
The variable name is wrong — should be `image_version` instead of `imageVersion`.
Thanks @jsoref for noticing it.

#### Related issue:
https://github.com/actions/virtual-environments/pull/2783

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
