### PR TITLE
[macOS] Get vs4mac version from stable manifest json

### DIFF
--- a/images/macos/provision/core/vsmac.sh
+++ b/images/macos/provision/core/vsmac.sh
@@ -4,7 +4,7 @@ source ~/utils/xamarin-utils.sh
 
 VSMAC_VERSION=$(get_toolset_value '.xamarin.vsmac')
 if [ $VSMAC_VERSION == "latest" ]; then
-    VSMAC_VERSION=$(curl https://formulae.brew.sh/api/cask/visual-studio.json 2>/dev/null | jq .version | tr -d \")
+    VSMAC_VERSION=$(curl -L "http://aka.ms/manifest/stable" | jq -r ".items[] | select(.genericName==\"VisualStudioMac\").version")
 fi
 VSMAC_DOWNLOAD_URL=$(buildVSMacDownloadUrl $VSMAC_VERSION)
 


### PR DESCRIPTION
# Description
There is a json file available by http://aka.ms/manifest/stable that contains the data about stable VS4mac and xamarin versions. We can use it to get the latest vs4mac version instead of greping brew formula, which is not updated regularly

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1907

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
