### PR TITLE
[Ubuntu] Revert $BASH_ENV variable

### DIFF
--- a/images/linux/scripts/installers/configure-environment.sh
+++ b/images/linux/scripts/installers/configure-environment.sh
@@ -7,14 +7,9 @@ echo ImageOS=$IMAGE_OS | tee -a /etc/environment
 # Set the ACCEPT_EULA variable to Y value to confirm your acceptance of the End-User Licensing Agreement
 echo ACCEPT_EULA=Y | tee -a /etc/environment
 
-# Create a file to store user-related global environment variables
-touch /etc/profile.d/env_vars.sh
-# Set BASH_ENV variable pointed to the file with user-related global environment variables for non-interactive sessions
-echo "BASH_ENV=/etc/profile.d/env_vars.sh" | tee -a /etc/environment
-
 # This directory is supposed to be created in $HOME and owned by user(https://github.com/actions/virtual-environments/issues/491)
 mkdir -p /etc/skel/.config/configstore
-echo 'export XDG_CONFIG_HOME=$HOME/.config' | tee -a /etc/profile.d/env_vars.sh
+echo 'export XDG_CONFIG_HOME=$HOME/.config' | tee -a /etc/skel/.bashrc
 
 # Change waagent entries to use /mnt for swapfile
 sed -i 's/ResourceDisk.Format=n/ResourceDisk.Format=y/g' /etc/waagent.conf

--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -89,6 +89,7 @@ done
 setEtcEnvironmentVariable DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1
 setEtcEnvironmentVariable DOTNET_NOLOGO 1
 setEtcEnvironmentVariable DOTNET_MULTILEVEL_LOOKUP 0
-echo 'export PATH=$PATH:$HOME/.dotnet/tools' | tee -a /etc/profile.d/env_vars.sh
+prependEtcEnvironmentPath /home/runner/.dotnet/tools
+echo 'export PATH="$PATH:$HOME/.dotnet/tools"' | tee -a /etc/skel/.bashrc
 
 invoke_tests "DotnetSDK"

--- a/images/linux/scripts/installers/nvm.sh
+++ b/images/linux/scripts/installers/nvm.sh
@@ -8,7 +8,7 @@ export NVM_DIR="/etc/skel/.nvm"
 mkdir $NVM_DIR
 VERSION=$(curl -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r '.tag_name')
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$VERSION/install.sh | bash
-echo 'export NVM_DIR=$HOME/.nvm' | tee -a /etc/profile.d/env_vars.sh
+echo 'export NVM_DIR=$HOME/.nvm' | tee -a /etc/skel/.bash_profile
 echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm' | tee -a /etc/skel/.bash_profile
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 

--- a/images/linux/scripts/installers/php.sh
+++ b/images/linux/scripts/installers/php.sh
@@ -87,8 +87,12 @@ php composer-setup.php
 sudo mv composer.phar /usr/bin/composer
 php -r "unlink('composer-setup.php');"
 
+# Update /etc/environment
+prependEtcEnvironmentPath /home/runner/.config/composer/vendor/bin
+
+
 # Add composer bin folder to path
-echo 'export PATH=$PATH:$HOME/.config/composer/vendor/bin' | tee -a /etc/profile.d/env_vars.sh
+echo 'export PATH="$PATH:$HOME/.config/composer/vendor/bin"' >> /etc/skel/.bashrc
 
 #Create composer folder for user to preserve folder permissions
 mkdir -p /etc/skel/.composer

--- a/images/linux/scripts/installers/python.sh
+++ b/images/linux/scripts/installers/python.sh
@@ -41,6 +41,6 @@ if isUbuntu18 || isUbuntu20 ; then
 fi
 
 # Adding this dir to PATH will make installed pip commands are immediately available.
-echo 'export PATH=$PATH:$HOME/.local/bin' | tee -a /etc/profile.d/env_vars.sh
+echo 'export PATH="$PATH:$HOME/.local/bin"' | tee -a /etc/skel/.bashrc
 
 invoke_tests "Tools" "Python"


### PR DESCRIPTION
# Description
It turned out that $BASH_ENV causes some issues since updated PATH is not propagated to other shells like pwsh.
Reverts https://github.com/actions/virtual-environments/pull/2826

#### Related issue:
https://github.com/actions/virtual-environments/issues/2978

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
