### PR TITLE
[Ubuntu] Add acl package on Ubuntu 20.04

### DIFF
--- a/images/linux/scripts/tests/Apt.Tests.ps1
+++ b/images/linux/scripts/tests/Apt.Tests.ps1
@@ -9,6 +9,11 @@ Describe "Apt" {
     }
 
     It "<toolName> is available" -TestCases $testCases {
+        if ($toolName -eq "acl")
+        {
+            $toolName = "getfacl"
+        }
+
         if ($toolName -eq "p7zip-full")
         {
             $toolName = "p7zip"

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -156,6 +156,7 @@
             "zsync"
         ],
         "cmd_packages": [
+            "acl",
             "binutils",
             "bison",
             "brotli",


### PR DESCRIPTION
# Description
There is no pre-installed the acl package by default on Ubuntu 20.04 which we use during installation provisioner stage.
