### PR TITLE
[Ubuntu] use pipx to install ansible

### DIFF
--- a/images/linux/scripts/installers/ansible.sh
+++ b/images/linux/scripts/installers/ansible.sh
@@ -4,6 +4,8 @@
 ##  Desc:  Installs Ansible
 ################################################################################
 
+# this script is used only on Ubuntu 16.04
+# for Ubuntu 18.04 and 20.04 we use pipx ansible-base package
 # Install latest Ansible
 add-apt-repository ppa:ansible/ansible
 apt-get update

--- a/images/linux/scripts/installers/ansible.sh
+++ b/images/linux/scripts/installers/ansible.sh
@@ -4,16 +4,9 @@
 ##  Desc:  Installs Ansible
 ################################################################################
 
-# Source the helpers for use with the script
-source $HELPER_SCRIPTS/os.sh
-
-# ppa:ansible/ansible doesn't contain packages for Ubuntu20.04
-if isUbuntu16 || isUbuntu18 ; then
-    add-apt-repository ppa:ansible/ansible
-    apt-get update
-fi
-
 # Install latest Ansible
+add-apt-repository ppa:ansible/ansible
+apt-get update
 apt-get install -y --no-install-recommends ansible
 
 invoke_tests "Tools" "Ansible"

--- a/images/linux/scripts/tests/Common.Tests.ps1
+++ b/images/linux/scripts/tests/Common.Tests.ps1
@@ -43,6 +43,6 @@ Describe "PipxPackages" -Skip:(Test-IsUbuntu16) {
     [array]$testCases = (Get-ToolsetContent).pipx | ForEach-Object { @{cmd = $_.cmd} }
 
     It "<package>" -TestCases $testCases {
-        "$cmd  --version" | Should -ReturnZeroExitCode
+        "$cmd --version" | Should -ReturnZeroExitCode
     }
 }

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -224,6 +224,10 @@
         {
             "package": "aws-sam-cli",
             "cmd": "sam"
+        },
+        {
+            "package": "ansible-base",
+            "cmd": "ansible"
         }
     ],
     "dotnet": {

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -217,6 +217,10 @@
         {
             "package": "aws-sam-cli",
             "cmd": "sam"
+        },
+        {
+            "package": "ansible-base",
+            "cmd": "ansible"
         }
     ],
     "dotnet": {

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -188,7 +188,6 @@
         {
             "type": "shell",
             "scripts": [
-                "{{template_dir}}/scripts/installers/ansible.sh",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
                 "{{template_dir}}/scripts/installers/azure-cli.sh",
                 "{{template_dir}}/scripts/installers/azure-devops-cli.sh",

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -188,7 +188,6 @@
         {
             "type": "shell",
             "scripts": [
-                "{{template_dir}}/scripts/installers/ansible.sh",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
                 "{{template_dir}}/scripts/installers/azure-cli.sh",
                 "{{template_dir}}/scripts/installers/azure-devops-cli.sh",


### PR DESCRIPTION
# Description
- use pipx to install ansible on Ubuntu 18.04/20.04
- remove ppa:ansible/ansible on Ubuntu 18.04

#### Related issue:
https://github.com/actions/virtual-environments/issues/3001

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
