### PR TITLE
[Ubuntu] Remove Clang, GCC and Gfortran versions less than 9.x

### DIFF
--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -230,22 +230,17 @@
     },
     "clang": {
         "versions": [
-            "6.0",
-            "8",
             "9"
         ],
         "default_version": "9"
     },
     "gcc": {
         "versions": [
-            "g++-7",
-            "g++-8",
             "g++-9"
         ]
     },
     "gfortran": {
         "versions": [
-            "gfortran-8",
             "gfortran-9"
         ]
     },

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -233,23 +233,18 @@
     },
     "clang": {
         "versions": [
-            "6.0",
-            "8",
             "9"
         ],
         "default_version": "9"
     },
     "gcc": {
         "versions": [
-            "g++-7",
-            "g++-8",
             "g++-9",
             "g++-10"
         ]
     },
     "gfortran": {
         "versions": [
-            "gfortran-8",
             "gfortran-9",
             "gfortran-10"
         ]

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -234,7 +234,6 @@
     },
     "clang": {
         "versions": [
-            "8",
             "9",
             "10",
             "11"
@@ -243,15 +242,12 @@
     },
     "gcc": {
         "versions": [
-            "g++-7",
-            "g++-8",
             "g++-9",
             "g++-10"
         ]
     },
     "gfortran": {
         "versions": [
-            "gfortran-8",
             "gfortran-9",
             "gfortran-10"
         ]


### PR DESCRIPTION
# Description
We are going to deprecate these versions of the listed tools due to the lack of free space on Ubuntu images

#### Related issue:
https://github.com/actions/virtual-environments/issues/2950#

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
