### PR TITLE
Fix linter fails

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Lint Code Base
         uses: github/super-linter@v3


### PR DESCRIPTION
# Description
Improvement

Linter started to fail recently with
```
You are not currently on a branch.
Please specify which branch you want to merge with.
See git-pull(1) for details.

    git pull <remote> <branch>
```

The fix is borrowed from https://github.com/github/super-linter/issues/1397#issuecomment-805249812    
    
#### Related issue: https://github.com/actions/virtual-environments-internal/issues/1953

## Check list
- [x] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
