### PR TITLE
[Ubuntu] get julia version from julialang.org

### DIFF
--- a/images/linux/scripts/installers/julia.sh
+++ b/images/linux/scripts/installers/julia.sh
@@ -4,6 +4,9 @@
 ##  Desc:  Installs Julia, and adds Julia to the path
 ################################################################################
 
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/install.sh
+
 # get the latest julia version
 json=$(curl --silent "https://julialang-s3.julialang.org/bin/versions.json")
 julia_version=$(echo $json | jq -r '.[].files[] | select(.triplet=="x86_64-linux-gnu" and (.version | contains("-") | not)).version' | sort -V | tail -n1)

--- a/images/linux/scripts/installers/julia.sh
+++ b/images/linux/scripts/installers/julia.sh
@@ -8,7 +8,7 @@
 source $HELPER_SCRIPTS/install.sh
 
 # get the latest julia version
-json=$(curl --silent "https://julialang-s3.julialang.org/bin/versions.json")
+json=$(curl -sL "https://julialang-s3.julialang.org/bin/versions.json")
 julia_version=$(echo $json | jq -r '.[].files[] | select(.triplet=="x86_64-linux-gnu" and (.version | contains("-") | not)).version' | sort -V | tail -n1)
 
 # download julia archive

--- a/images/linux/scripts/installers/julia.sh
+++ b/images/linux/scripts/installers/julia.sh
@@ -4,24 +4,21 @@
 ##  Desc:  Installs Julia, and adds Julia to the path
 ################################################################################
 
-# This function fetches the latest Julia release from the GitHub API
-# Based on https://gist.github.com/lukechilds/a83e1d7127b78fef38c2914c4ececc3c
-function GetLatestJuliaRelease () {
-    curl --silent "https://api.github.com/repos/julialang/julia/releases/latest" |
-    grep '"tag_name":' |
-    sed -E 's/.*"([^"]+)".*/\1/' |
-    sed 's/v//' # remove v prefix
-}
+# get the latest julia version
+json=$(curl --silent "https://julialang-s3.julialang.org/bin/versions.json")
+julia_version=$(echo $json | jq -r '.[].files[] | select(.triplet=="x86_64-linux-gnu" and (.version | contains("-") | not)).version' | sort -V | tail -n1)
 
-juliaVersion="$(GetLatestJuliaRelease)"
-juliaMajorAndMinorVersion="$(cut -d. -f1,2 <<< $juliaVersion)"
-juliaInstallationPath="/usr/local/julia$juliaVersion"
+# download julia archive
+julia_tar_url=$(echo $json | jq -r ".[].files[].url | select(endswith(\"julia-${julia_version}-linux-x86_64.tar.gz\"))")
+julia_tar_name="julia-${julia_version}-linux-x86_64.tar.gz"
+download_with_retries $julia_tar_url "/tmp" "${julia_tar_name}"
 
-curl -sL "https://julialang-s3.julialang.org/bin/linux/x64/$juliaMajorAndMinorVersion/julia-$juliaVersion-linux-x86_64.tar.gz" -o "julia-$juliaVersion-linux-x86_64.tar.gz"
-mkdir -p "$juliaInstallationPath"
-tar -C "$juliaInstallationPath" -xzf "julia-$juliaVersion-linux-x86_64.tar.gz" --strip-components=1
-rm "julia-$juliaVersion-linux-x86_64.tar.gz"
-
-ln -s "$juliaInstallationPath/bin/julia" /usr/bin/julia
+# extract files and make symlink
+julia_tar_tmp="/tmp/${julia_tar_name}"
+julia_installation_path="/usr/local/julia${julia_version}"
+mkdir -p "${julia_installation_path}"
+tar -C "${julia_installation_path}" -xzf "${julia_tar_tmp}" --strip-components=1
+ln -s "${julia_installation_path}/bin/julia" /usr/bin/julia
+rm "${julia_tar_tmp}"
 
 invoke_tests "Tools" "Julia"


### PR DESCRIPTION
# Description
Sometimes the latest release of julia from github is not available to download from `https://julialang-s3.julialang.org` site.  Use official repo `https://julialang-s3.julialang.org/bin/versions.json` json to parse the latest available julia archive.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1957

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
