### PR TITLE
[Windows] Replace '+' to '-' in java path

### DIFF
--- a/images/win/scripts/Installers/Install-JavaTools.ps1
+++ b/images/win/scripts/Installers/Install-JavaTools.ps1
@@ -61,7 +61,8 @@ function Install-JavaFromAdoptOpenJDK {
         -and $_.binary.image_type -eq "jdk"
     }
     $downloadUrl = $asset.binary.package.link
-    $fullJavaVersion = $asset.version.semver
+    # We have to replace '+' sign in the version to '-' due to the issue with incorrect path in Android builds https://github.com/actions/virtual-environments/issues/3014
+    $fullJavaVersion = $asset.version.semver -replace '\+', '-'
 
     # Download and extract java binaries to temporary folder
     $archivePath = Start-DownloadWithRetry -Url $downloadUrl -Name $([IO.Path]::GetFileName($downloadUrl))

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Java.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Java.psm1
@@ -9,7 +9,9 @@ function Get-JavaVersions {
     return $javaVersions | Sort-Object $sortRules | ForEach-Object {
         $javaPath = $_.Value
         # Take semver from the java path
-        $version = (Split-Path $javaPath) -replace "\w:\\.*\\"
+        # The path contains - sign in the version number instead of '+' due to the issue, need to substitute it back https://github.com/actions/virtual-environments/issues/3014
+        $versionInPath = (Split-Path $javaPath) -replace "\w:\\.*\\"
+        $version = $versionInPath -replace '-', '+'
         $defaultPostfix = ($javaPath -eq $defaultJavaPath) ? " (default)" : ""
 
         [PSCustomObject] @{

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Java.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Java.psm1
@@ -16,7 +16,7 @@ function Get-JavaVersions {
 
         [PSCustomObject] @{
             "Version" = $version + $defaultPostfix
-            "Vendor" = "AdoptOpenJDK"
+            "Vendor" = "Adopt OpenJDK"
             "Environment Variable" = $_.Name
         }
     }

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Java.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Java.psm1
@@ -9,7 +9,7 @@ function Get-JavaVersions {
     return $javaVersions | Sort-Object $sortRules | ForEach-Object {
         $javaPath = $_.Value
         # Take semver from the java path
-        # The path contains - sign in the version number instead of '+' due to the issue, need to substitute it back https://github.com/actions/virtual-environments/issues/3014
+        # The path contains '-' sign in the version number instead of '+' due to the following issue, need to substitute it back https://github.com/actions/virtual-environments/issues/3014
         $versionInPath = (Split-Path $javaPath) -replace "\w:\\.*\\"
         $version = $versionInPath -replace '-', '+'
         $defaultPostfix = ($javaPath -eq $defaultJavaPath) ? " (default)" : ""


### PR DESCRIPTION
# Description
It turned out that the java path shouldn't contain the '+' sign, Android builds can't find such paths.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3014

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
