### PR TITLE
[Windows] use github release for Azure Cli

### DIFF
--- a/images/win/scripts/Installers/Install-AzureCli.ps1
+++ b/images/win/scripts/Installers/Install-AzureCli.ps1
@@ -3,11 +3,15 @@
 ##  Desc:  Install Azure CLI
 ################################################################################
 
-Choco-Install -PackageName azure-cli
+Write-Host "Install the latest Azure CLI release"
+$assets = Invoke-RestMethod -Uri 'https://api.github.com/repos/Azure/azure-cli/releases/latest'
+$azCliUrl = $assets.assets.browser_download_url
+$azCliName = [IO.Path]::GetFileName($azCliUrl)
+Install-Binary -Url $azCliUrl -Name $azCliName -ArgumentList ("/qn", "/norestart")
 
-$AzureCliExtensionPath = Join-Path $Env:CommonProgramFiles 'AzureCliExtensionDirectory'
-New-Item -ItemType "directory" -Path $AzureCliExtensionPath
+$azureCliExtensionPath = Join-Path $Env:CommonProgramFiles 'AzureCliExtensionDirectory'
+$null = New-Item -ItemType "Directory" -Path $azureCliExtensionPath
 
-[Environment]::SetEnvironmentVariable("AZURE_EXTENSION_DIR", $AzureCliExtensionPath, [System.EnvironmentVariableTarget]::Machine)
+[Environment]::SetEnvironmentVariable("AZURE_EXTENSION_DIR", $azureCliExtensionPath, [System.EnvironmentVariableTarget]::Machine)
 
 Invoke-PesterTests -TestFile "CLI.Tools" -TestName "Azure CLI"


### PR DESCRIPTION
# Description
Use a msi package to install the latest Azure Cli release from github source

#### Related issue:
[Windows] Fix Azure Cli installation #1974

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
