### PR TITLE
[Ubuntu] Install yarn from npm

### DIFF
--- a/images/linux/scripts/installers/nodejs.sh
+++ b/images/linux/scripts/installers/nodejs.sh
@@ -32,12 +32,4 @@ ln -s /usr/local/bin/vercel /usr/local/bin/now
 
 rm -rf ~/n
 
-# Install Yarn repository and key
-curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-apt-get update
-
-# Install yarn
-apt-get install -y --no-install-recommends yarn
-
 invoke_tests "Node" "Node.js"

--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -296,6 +296,10 @@
         {
             "name": "netlify-cli",
             "command": "netlify"
+        },
+        {
+            "name": "yarn",
+            "command": "yarn"
         }
     ]
 }

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -303,6 +303,10 @@
         {
             "name": "netlify-cli",
             "command": "netlify"
+        },
+        {
+            "name": "yarn",
+            "command": "yarn"
         }
     ]
 }

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -309,6 +309,10 @@
         {
             "name": "lerna",
             "command": "lerna"
+        },
+        {
+            "name": "yarn",
+            "command": "yarn"
         }
     ]
 }


### PR DESCRIPTION
# Description
In scope of this pull request we switch installation of yarn from `apt` to `npm install -g yarn`.

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/1959

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
