### PR TITLE
[Ubuntu] suppress wget's progress bar in swift.sh script

### DIFF
--- a/images/linux/scripts/installers/swift.sh
+++ b/images/linux/scripts/installers/swift.sh
@@ -4,14 +4,18 @@
 ##  Desc:  Installs Swift
 ################################################################################
 
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/install.sh
 
 # Install
 image_label="$(lsb_release -rs)"
 swift_version=$(curl -s -L -N https://swift.org/download|awk -F"[ <]" '/id="swift-/ {print $4; exit}')
 
-wget -P /tmp https://swift.org/builds/swift-$swift_version-release/ubuntu${image_label//./}/swift-$swift_version-RELEASE/swift-$swift_version-RELEASE-ubuntu$image_label.tar.gz
+swift_tar_name="swift-$swift_version-RELEASE-ubuntu$image_label.tar.gz"
+swift_tar_url="https://swift.org/builds/swift-$swift_version-release/ubuntu${image_label//./}/swift-$swift_version-RELEASE/$swift_tar_name"
+download_with_retries $swift_tar_url "/tmp" "$swift_tar_name"
 
-tar xzf /tmp/swift-$swift_version-RELEASE-ubuntu$image_label.tar.gz
+tar xzf /tmp/$swift_tar_name
 mv swift-$swift_version-RELEASE-ubuntu$image_label /usr/share/swift
 
 SWIFT_PATH="/usr/share/swift/usr/bin"


### PR DESCRIPTION
# Description
We shouldn't keep wget's downloading progress in a packer log and use the download_with_retries helper function .

e.g
https://github.visualstudio.com/virtual-environments/_build/results?buildId=103242&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=5431112d-2b61-5a5f-7042-ef698f761043

lines: 19747 - 11700 = 8047