### PR TITLE
fix: Report correct Erlang version, fix Erlang tests

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -34,8 +34,9 @@ function Get-ClangVersions {
 }
 
 function Get-ErlangVersion {
-    $version = (erl -eval 'erlang:display(erlang:system_info(version)), halt().' -noshell).Trim('"')
-    return "Erlang $version"
+    $erlangVersion = (erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), ''OTP_VERSION''])), io:fwrite(Version), halt().' -noshell)
+    $shellVersion = (erl -eval 'erlang:display(erlang:system_info(version)), halt().' -noshell).Trim('"')
+    return "Erlang $erlangVersion (Eshell $shellVersion)"
 }
 
 function Get-MonoVersion {

--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -110,15 +110,15 @@ Describe "Cmake" {
 }
 
 Describe "erlang" {
-    $testCases = @("erl", "erlc", "rebar3") | ForEach-Object { @{ErlangCommand = $_} }
+    $testCases = @("erl -version", "erlc -v", "rebar3 -v") | ForEach-Object { @{ErlangCommand = $_} }
 
     It "erlang <ErlangCommand>" -TestCases $testCases {
         param (
             [string] $ErlangCommand
         )
 
-        "$ErlangCommand -v" | Should -ReturnZeroExitCode
-    }   
+        "$ErlangCommand" | Should -ReturnZeroExitCode
+    }
 }
 
 Describe "gcc" {


### PR DESCRIPTION
# Description

SoftwareReport collects wrong version for Erlang, it reports Eshell version rather than Erlang itself.
reference: https://stackoverflow.com/questions/9560815/how-to-get-erlangs-release-version-number-from-a-shell
2nd answer

`erl` doesn't have `-v` flag, only `-version`
`erlc` `-v` flag is for verbose output
`rebar3` reports it's version with flag `-v`
Reverting back the erlang test logic to test it via `command -v` as it breaks during packer build.
reference: http://erlang.org/doc/man/erl.html

#### Related issue: #3061

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
