### PR TITLE
[Ubuntu] Move Az modules to the PowerShell Tools section

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -242,11 +242,6 @@ $markdown += New-MDList -Style Unordered -Lines @(
     (Get-DotNetCoreSdkVersions)
 )
 
-$markdown += New-MDHeader "Az Module" -Level 3
-$markdown += New-MDList -Style Unordered -Lines @(
-    (Get-AzModuleVersions)
-)
-
 $markdown += New-MDHeader "Databases" -Level 3
 $markdown += New-MDList -Style Unordered -Lines (@(
     (Get-PostgreSqlVersion),
@@ -270,7 +265,10 @@ $markdown += New-MDList -Lines (Get-PowershellVersion) -Style Unordered
 
 $markdown += New-MDHeader "PowerShell Modules" -Level 4
 $markdown += Get-PowerShellModules | New-MDTable
-$markdown += New-MDNewLine
+$markdown += New-MDHeader "Az PowerShell Modules" -Level 4
+$markdown += New-MDList -Style Unordered -Lines @(
+    (Get-AzModuleVersions)
+)
 
 $markdown += Build-WebServersSection
 

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -265,6 +265,7 @@ $markdown += New-MDList -Lines (Get-PowershellVersion) -Style Unordered
 
 $markdown += New-MDHeader "PowerShell Modules" -Level 4
 $markdown += Get-PowerShellModules | New-MDTable
+$markdown += New-MDNewLine
 $markdown += New-MDHeader "Az PowerShell Modules" -Level 4
 $markdown += New-MDList -Style Unordered -Lines @(
     (Get-AzModuleVersions)


### PR DESCRIPTION
# Description
Az **PowerShell** modules should be in the PowerShell Tools section of the docs.

#### Related issue:
n\a

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
