### PR TITLE
Update documentation for post-deployment scripts.

### DIFF
--- a/help/CreateImageAndAzureResources.md
+++ b/help/CreateImageAndAzureResources.md
@@ -158,6 +158,6 @@ The scripts are copied to the VHD during the image generation process to the fol
 - **Choco.ps1** - contains dummy command to cleanup orphaned packages to avoid initial delay for future choco commands
 - **Dotnet.ps1** - adds `$env:USERPROFILE\.dotnet\tools` directory to the PATH
 - **InternetExplorerConfiguration** - turns off the Internet Explorer Enhanced Security feature
-- **Msys2FirstLaunch.ps1** - creates user profile at the first launch to avoid delays on the first MSYS start
+- **Msys2FirstLaunch.ps1** - initializes bash user profile in MSYS2
 - **RustJunction.ps1** - creates Rust junction points to cargo and rustup folders
 - **VSConfiguration.ps1** - performs initial Visual Studio configuration

--- a/help/CreateImageAndAzureResources.md
+++ b/help/CreateImageAndAzureResources.md
@@ -124,3 +124,22 @@ Generated tool versions and details can be found in related projects:
 - [Go](https://github.com/actions/go-versions)
 - [Node](https://github.com/actions/node-versions)
 - [Boost](https://github.com/actions/boost-versions)
+
+### Post-generation scripts
+Scripts for setting up some specific configuration after packer build procedure are placed in `post-generation` folder. These scripts are intended to apply configuration which cannot be covered during packer build procedure. Scripts are required, since packer build and default agent users are not the same and some specific configuration should be applied after build process under agent's user.
+
+Detailed description for the scripts:
+
+#### Ubuntu
+- **cleanup-logs.sh** - wipes all log files, which were generated during build procedure
+- **environment-variables.sh** - replaces `$HOME` with the default user's home directory for environmental variables related to the default user home directory
+- **homebrew-permissions.sh** - resets brew repository directory to make the brew clean after rights change for /home directory
+- **rust-permissions.sh** - fixes permissions for the Rust folder. Detailed issue explanation is avaliable by [the link](https://github.com/actions/virtual-environments/issues/572).
+
+#### Windows
+- **Choco.ps1** - contains dummy command to cleanup orphaned packages to avoid initial delay for future choco commands
+- **Dotnet.ps1** - adds `$env:USERPROFILE\.dotnet\tools` direcort to the PATH
+- **InternetExplorerConfiguration** - turns off the Internet Explorer Enhanced Security feature
+- **Msys2FirstLaunch.ps1** - creates user profile at the first launch
+- **RustJunction.ps1** - creates Rust junction points to cargo and rustup folders
+- **VSConfiguration** - performs initial Visual Studio configuration

--- a/help/CreateImageAndAzureResources.md
+++ b/help/CreateImageAndAzureResources.md
@@ -126,14 +126,13 @@ Generated tool versions and details can be found in related projects:
 - [Boost](https://github.com/actions/boost-versions)
 
 ### Post-generation scripts
-### Post-generation scripts
 The user, created during the image generation, does not exist in the result VHD hence some configuration files related to the user's home directory need to be changed as well as the file permissions for some directories. Scripts for that are located in the `post-generation` folder in the repository:
-- Windows https://github.com/actions/virtual-environments/tree/main/images/win/post-generation
-- Linux https://github.com/actions/virtual-environments/tree/main/images/linux/post-generation
+- Windows: https://github.com/actions/virtual-environments/tree/main/images/win/post-generation
+- Linux: https://github.com/actions/virtual-environments/tree/main/images/linux/post-generation
 
 The scripts are copied to the VHD during the image generation process to the following paths:
-- Windows `C:\post-generation`
-- Linux  `/opt/post-generation` 
+- Windows: `C:\post-generation`
+- Linux:  `/opt/post-generation` 
 
 #### Running scripts
 

--- a/help/CreateImageAndAzureResources.md
+++ b/help/CreateImageAndAzureResources.md
@@ -132,24 +132,24 @@ The scripts are copied to the virtual machines during the packer build to `/opt/
 
 #### Running scripts
 
-- **Ubuntu**
+##### Ubuntu
 
         find /opt/post-generation -mindepth 1 -maxdepth 1 -type f -name '*.sh' -exec bash {} \;
 
-- **Windows**
+##### Windows
 
         Get-ChildItem C:\post-generation -Filter *.ps1 | ForEach-Object { & $_.FullName }
 
 #### Script details
 
-- **Ubuntu**
+##### Ubuntu
 
 - **cleanup-logs.sh** - removes all build process logs from the machine
 - **environment-variables.sh** - replaces `$HOME` with the default user's home directory for environmental variables related to the default user home directory
 - **homebrew-permissions.sh** - changes brew repository folder owner to make the brew clean after changing permissions for `/home` directory
 - **rust-permissions.sh** - fixes permissions for the Rust folder. Detailed issue explanation is provided in [virtual-environments/issues/572](https://github.com/actions/virtual-environments/issues/572).
 
-- **Windows**
+##### Windows
 
 - **Choco.ps1** - contains dummy command to cleanup orphaned packages to avoid initial delay for future choco commands
 - **Dotnet.ps1** - adds `$env:USERPROFILE\.dotnet\tools` directory to the PATH

--- a/help/CreateImageAndAzureResources.md
+++ b/help/CreateImageAndAzureResources.md
@@ -126,20 +126,32 @@ Generated tool versions and details can be found in related projects:
 - [Boost](https://github.com/actions/boost-versions)
 
 ### Post-generation scripts
-Scripts for setting up some specific configuration after packer build procedure are placed in `post-generation` folder. These scripts are intended to apply configuration which cannot be covered during packer build procedure. Scripts are required, since packer build and default agent users are not the same and some specific configuration should be applied after build process under agent's user.
+Extra configuration should be applied after packer build process, because packer build user and default agent's user are not the same. These configuration scripts are located in the `post-generation` folder. 
+
+The scripts are copied to the virtual machines during the packer build and can be found in the `/opt/post-generation` directory for Ubuntu and `C:\post-generation` directory for Windows images.
+
+In order to run all post-generation scripts it is possible to use the following commands:
+
+- **Ubuntu**
+
+        for i in $(find /opt/post-generation -mindepth 1 -maxdepth 1 -type f -name '*.sh'); do bash "$script"; done
+
+- **Windows**
+
+        Get-ChildItem C:\post-generation -Filter *.ps1 | ForEach-Object { $_.FullName }
 
 Detailed description for the scripts:
 
 #### Ubuntu
-- **cleanup-logs.sh** - wipes all log files, which were generated during build procedure
+- **cleanup-logs.sh** - removes all build process logs from the machine
 - **environment-variables.sh** - replaces `$HOME` with the default user's home directory for environmental variables related to the default user home directory
-- **homebrew-permissions.sh** - resets brew repository directory to make the brew clean after rights change for /home directory
-- **rust-permissions.sh** - fixes permissions for the Rust folder. Detailed issue explanation is avaliable by [the link](https://github.com/actions/virtual-environments/issues/572).
+- **homebrew-permissions.sh** - changes brew repository folder owner to make the brew clean after changing permissions for `/home` directory
+- **rust-permissions.sh** - fixes permissions for the Rust folder. Detailed issue explanation is provided in [virtual-environments/issues/572](https://github.com/actions/virtual-environments/issues/572).
 
 #### Windows
 - **Choco.ps1** - contains dummy command to cleanup orphaned packages to avoid initial delay for future choco commands
-- **Dotnet.ps1** - adds `$env:USERPROFILE\.dotnet\tools` direcort to the PATH
+- **Dotnet.ps1** - adds `$env:USERPROFILE\.dotnet\tools` directory to the PATH
 - **InternetExplorerConfiguration** - turns off the Internet Explorer Enhanced Security feature
 - **Msys2FirstLaunch.ps1** - creates user profile at the first launch
 - **RustJunction.ps1** - creates Rust junction points to cargo and rustup folders
-- **VSConfiguration** - performs initial Visual Studio configuration
+- **VSConfiguration.ps1** - performs initial Visual Studio configuration

--- a/help/CreateImageAndAzureResources.md
+++ b/help/CreateImageAndAzureResources.md
@@ -132,23 +132,25 @@ The scripts are copied to the virtual machines during the packer build to `/opt/
 
 #### Running scripts
 
-#### Ubuntu
+- **Ubuntu**
 
         find /opt/post-generation -mindepth 1 -maxdepth 1 -type f -name '*.sh' -exec bash {} \;
 
-#### Windows
+- **Windows**
 
         Get-ChildItem C:\post-generation -Filter *.ps1 | ForEach-Object { & $_.FullName }
 
 #### Script details
 
-#### Ubuntu
+- **Ubuntu**
+
 - **cleanup-logs.sh** - removes all build process logs from the machine
 - **environment-variables.sh** - replaces `$HOME` with the default user's home directory for environmental variables related to the default user home directory
 - **homebrew-permissions.sh** - changes brew repository folder owner to make the brew clean after changing permissions for `/home` directory
 - **rust-permissions.sh** - fixes permissions for the Rust folder. Detailed issue explanation is provided in [virtual-environments/issues/572](https://github.com/actions/virtual-environments/issues/572).
 
-#### Windows
+- **Windows**
+
 - **Choco.ps1** - contains dummy command to cleanup orphaned packages to avoid initial delay for future choco commands
 - **Dotnet.ps1** - adds `$env:USERPROFILE\.dotnet\tools` directory to the PATH
 - **InternetExplorerConfiguration** - turns off the Internet Explorer Enhanced Security feature

--- a/help/CreateImageAndAzureResources.md
+++ b/help/CreateImageAndAzureResources.md
@@ -128,9 +128,9 @@ Generated tool versions and details can be found in related projects:
 ### Post-generation scripts
 Extra configuration should be applied after packer build process, because packer build user and default agent's user are not the same. These configuration scripts are located in the `post-generation` folder. 
 
-The scripts are copied to the virtual machines during the packer build and can be found in the `/opt/post-generation` directory for Ubuntu and `C:\post-generation` directory for Windows images.
+The scripts are copied to the virtual machines during the packer build to `/opt/post-generation` directory for Ubuntu and to `C:\post-generation` directory for Windows images.
 
-In order to run all post-generation scripts it is possible to use the following commands:
+Use the following commands to run these scripts::
 
 - **Ubuntu**
 
@@ -140,7 +140,7 @@ In order to run all post-generation scripts it is possible to use the following 
 
         Get-ChildItem C:\post-generation -Filter *.ps1 | ForEach-Object { $_.FullName }
 
-Detailed description for the scripts:
+Scripts detailed description:
 
 #### Ubuntu
 - **cleanup-logs.sh** - removes all build process logs from the machine

--- a/help/CreateImageAndAzureResources.md
+++ b/help/CreateImageAndAzureResources.md
@@ -131,7 +131,9 @@ The user, created during the image generation, does not exist in the result VHD 
 - Windows https://github.com/actions/virtual-environments/tree/main/images/win/post-generation
 - Linux https://github.com/actions/virtual-environments/tree/main/images/linux/post-generation
 
-The scripts are copied to the virtual machines during the packer build to `/opt/post-generation` directory for Ubuntu and to `C:\post-generation` directory for Windows images.
+The scripts are copied to the VHD during the image generation process to the following paths:
+- Windows `C:\post-generation`
+- Linux  `/opt/post-generation` 
 
 #### Running scripts
 

--- a/help/CreateImageAndAzureResources.md
+++ b/help/CreateImageAndAzureResources.md
@@ -132,13 +132,13 @@ The scripts are copied to the virtual machines during the packer build to `/opt/
 
 Use the following commands to run these scripts::
 
-- **Ubuntu**
+#### Ubuntu
 
-        for i in $(find /opt/post-generation -mindepth 1 -maxdepth 1 -type f -name '*.sh'); do bash "$script"; done
+        find /opt/post-generation -mindepth 1 -maxdepth 1 -type f -name '*.sh' -exec bash {} \;
 
-- **Windows**
+#### Windows
 
-        Get-ChildItem C:\post-generation -Filter *.ps1 | ForEach-Object { $_.FullName }
+        Get-ChildItem C:\post-generation -Filter *.ps1 | ForEach-Object { & $_.FullName }
 
 Scripts detailed description:
 

--- a/help/CreateImageAndAzureResources.md
+++ b/help/CreateImageAndAzureResources.md
@@ -126,7 +126,10 @@ Generated tool versions and details can be found in related projects:
 - [Boost](https://github.com/actions/boost-versions)
 
 ### Post-generation scripts
-Extra configuration should be applied after packer build process, because packer build user and default agent's user are not the same. These configuration scripts are located in the `post-generation` folder. 
+### Post-generation scripts
+The user, created during the image generation, does not exist in the result VHD hence some configuration files related to the user's home directory need to be changed as well as the file permissions for some directories. Scripts for that are located in the `post-generation` folder in the repository:
+- Windows https://github.com/actions/virtual-environments/tree/main/images/win/post-generation
+- Linux https://github.com/actions/virtual-environments/tree/main/images/linux/post-generation
 
 The scripts are copied to the virtual machines during the packer build to `/opt/post-generation` directory for Ubuntu and to `C:\post-generation` directory for Windows images.
 

--- a/help/CreateImageAndAzureResources.md
+++ b/help/CreateImageAndAzureResources.md
@@ -130,7 +130,7 @@ Extra configuration should be applied after packer build process, because packer
 
 The scripts are copied to the virtual machines during the packer build to `/opt/post-generation` directory for Ubuntu and to `C:\post-generation` directory for Windows images.
 
-Use the following commands to run these scripts::
+#### Running scripts
 
 #### Ubuntu
 

--- a/help/CreateImageAndAzureResources.md
+++ b/help/CreateImageAndAzureResources.md
@@ -140,7 +140,7 @@ The scripts are copied to the virtual machines during the packer build to `/opt/
 
         Get-ChildItem C:\post-generation -Filter *.ps1 | ForEach-Object { & $_.FullName }
 
-Scripts detailed description:
+#### Script details
 
 #### Ubuntu
 - **cleanup-logs.sh** - removes all build process logs from the machine

--- a/help/CreateImageAndAzureResources.md
+++ b/help/CreateImageAndAzureResources.md
@@ -158,6 +158,6 @@ The scripts are copied to the VHD during the image generation process to the fol
 - **Choco.ps1** - contains dummy command to cleanup orphaned packages to avoid initial delay for future choco commands
 - **Dotnet.ps1** - adds `$env:USERPROFILE\.dotnet\tools` directory to the PATH
 - **InternetExplorerConfiguration** - turns off the Internet Explorer Enhanced Security feature
-- **Msys2FirstLaunch.ps1** - creates user profile at the first launch
+- **Msys2FirstLaunch.ps1** - creates user profile at the first launch to avoid delays on the first MSYS start
 - **RustJunction.ps1** - creates Rust junction points to cargo and rustup folders
 - **VSConfiguration.ps1** - performs initial Visual Studio configuration


### PR DESCRIPTION
# Description
Improvement
There is no documentation for post-deployment scripts in our repository. Let's add some description for them.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1975

## Check list
- [+] Related issue / work item is attached
- [+] Documentation is updated (if applicable)
