### PR TITLE
[Ubuntu] Add python-setuptools package to Ubuntu 16 & 18 toolset files

### DIFF
--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -152,6 +152,7 @@
             "p7zip-rar",
             "p7zip",
             "pkg-config",
+            "python-setuptools",
             "rpm",
             "texinfo",
             "tk",

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -146,6 +146,7 @@
             "openssh-client",
             "p7zip-rar",
             "pkg-config",
+            "python-setuptools",
             "rpm",
             "texinfo",
             "tk",


### PR DESCRIPTION
# Description
Previously the package was installed during the ansible tool installation, but we've changed the way for ansible installation and this package does not exist on Ubuntu 18 anymore. 
This PR explicitly adds the package by specifying it in the toolset file for Ubuntu 16 & 18 since the package is for python2, which is not presented on Ubuntu 20 image.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3069

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
