### PR TITLE
[Ubuntu] Disabled .NET warmup 

### DIFF
--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -12,21 +12,6 @@ source $HELPER_SCRIPTS/os.sh
 LATEST_DOTNET_PACKAGES=$(get_toolset_value '.dotnet.aptPackages[]')
 DOTNET_VERSIONS=$(get_toolset_value '.dotnet.versions[]')
 
-mksamples()
-{
-    sdk=$1
-    sample=$2
-    mkdir "$sdk"
-    cd "$sdk" || exit
-    dotnet new globaljson --sdk-version "$sdk"
-    dotnet new "$sample"
-    dotnet restore
-    dotnet build
-    set +e
-    cd .. || exit
-    rm -rf "$sdk"
-}
-
 # Disable telemetry
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 
@@ -73,16 +58,6 @@ parallel --jobs 0 --halt soon,fail=1 \
     download_with_retries $url' ::: "${sortedSdks[@]}"
 
 find . -name "*.tar.gz" | parallel --halt soon,fail=1 'extract_dotnet_sdk {}'
-
-# Smoke test each SDK
-for sdk in $sortedSdks; do
-    mksamples "$sdk" "console"
-    mksamples "$sdk" "mstest"
-    mksamples "$sdk" "xunit"
-    mksamples "$sdk" "web"
-    mksamples "$sdk" "mvc"
-    mksamples "$sdk" "webapi"
-done
 
 # NuGetFallbackFolder at /usr/share/dotnet/sdk/NuGetFallbackFolder is warmed up by smoke test
 # Additional FTE will just copy to ~/.dotnet/NuGet which provides no benefit on a fungible machine


### PR DESCRIPTION
# Description

We have investigated and found out that installation of .NET is hugest bottleneck in image-generation of  Ubuntu. The Ubuntu `dotnetcore-sdk.sh` installation script takes 1h20m (the total time of image-generation is 3h30m). 

There are two reasons for it:

1. We install a lot of .NET versions: 2.1, 3.1, 5.0 on Ubuntu
2. We run a huge validation after installation that takes the most of the time

On Ubuntu, we run the following code for every version:
```
    dotnet new globaljson --sdk-version "$sdk"
    dotnet new "$sample"
    dotnet restore
    dotnet build
```

In scope of the investigation ([Speed up .NET installation process](https://github.com/actions/virtual-environments/discussions/2367)) we decided to remove warmup stage  , since there are no performance benefits at all. 

Platform | Downloading and installation time with warmup | Downloading and installation time without warmup
-- | -- | --
Ubuntu | 1h40m | 15m


#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1988

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
