### PR TITLE
[Ubuntu] Remove apt source for podman, buildah and skopeo

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -34,17 +34,20 @@ function Get-CodeQLBundleVersion {
 
 function Get-PodManVersion {
     $podmanVersion = podman --version | Take-OutputPart -Part 2
-    return "Podman $podmanVersion"
+    $aptSourceRepo = Get-AptSourceRepository -PackageName "containers"
+    return "Podman $podmanVersion (apt source repository: $aptSourceRepo)"
 }
 
 function Get-BuildahVersion {
     $buildahVersion = buildah --version | Take-OutputPart -Part 2
-    return "Buildah $buildahVersion"
+    $aptSourceRepo = Get-AptSourceRepository -PackageName "containers"
+    return "Buildah $buildahVersion (apt source repository: $aptSourceRepo)"
 }
 
 function Get-SkopeoVersion {
     $skopeoVersion = skopeo --version | Take-OutputPart -Part 2
-    return "Skopeo $skopeoVersion"
+    $aptSourceRepo = Get-AptSourceRepository -PackageName "containers"
+    return "Skopeo $skopeoVersion (apt source repository: $aptSourceRepo)"
 }
 
 function Get-CMakeVersion {

--- a/images/linux/scripts/installers/containers.sh
+++ b/images/linux/scripts/installers/containers.sh
@@ -7,20 +7,24 @@
 source $HELPER_SCRIPTS/os.sh
 
 install_packages=(podman buildah skopeo)
+REPO_URL="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable"
 
 # Install podman, buildah, scopeo container's tools (on Ubuntu20 these tools can be installed without adding new repository)
+source /etc/os-release
+sh -c "echo 'deb ${REPO_URL}/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
+wget -qnv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key -O Release.key
+apt-key add Release.key
+apt-get update -qq
+apt-get -qq -y install ${install_packages[@]}
+mkdir -p /etc/containers
+echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | tee /etc/containers/registries.conf
+
+# We can safely remove source repo on Ubuntu20
 if isUbuntu20 ; then
-    apt-get -y update
-    apt-get -qq -y install ${install_packages[@]}
-else
-    source /etc/os-release
-    sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-    wget -qnv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key -O Release.key
-    apt-key add Release.key
-    apt-get update -qq
-    apt-get -qq -y install ${install_packages[@]}
-    mkdir -p /etc/containers
-    echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | tee /etc/containers/registries.conf
+    rm /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
 fi
+
+# Document source repo
+echo "containers $REPO_URL" >> $HELPER_SCRIPTS/apt-sources.txt
 
 invoke_tests "Tools" "Containers"

--- a/images/linux/scripts/installers/containers.sh
+++ b/images/linux/scripts/installers/containers.sh
@@ -4,6 +4,8 @@
 ##  Desc:  Installs container tools: podman, buildah and skopeo onto the image
 ################################################################################
 
+source $HELPER_SCRIPTS/os.sh
+
 # Install podman, buildah, scopeo container's tools
 install_packages=(podman buildah skopeo)
 source /etc/os-release
@@ -14,5 +16,9 @@ apt-get update -qq
 apt-get -qq -y install ${install_packages[@]}
 mkdir -p /etc/containers
 echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | tee /etc/containers/registries.conf
+
+if isUbuntu20 ; then
+    rm /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+fi
 
 invoke_tests "Tools" "Containers"

--- a/images/linux/scripts/installers/containers.sh
+++ b/images/linux/scripts/installers/containers.sh
@@ -19,10 +19,8 @@ apt-get -qq -y install ${install_packages[@]}
 mkdir -p /etc/containers
 echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | tee /etc/containers/registries.conf
 
-# We can safely remove source repo on Ubuntu20
-if isUbuntu20 ; then
-    rm /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-fi
+# Remove source repo
+rm /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
 
 # Document source repo
 echo "containers $REPO_URL" >> $HELPER_SCRIPTS/apt-sources.txt

--- a/images/linux/scripts/installers/containers.sh
+++ b/images/linux/scripts/installers/containers.sh
@@ -6,19 +6,21 @@
 
 source $HELPER_SCRIPTS/os.sh
 
-# Install podman, buildah, scopeo container's tools
 install_packages=(podman buildah skopeo)
-source /etc/os-release
-sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key -O Release.key
-apt-key add Release.key
-apt-get update -qq
-apt-get -qq -y install ${install_packages[@]}
-mkdir -p /etc/containers
-echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | tee /etc/containers/registries.conf
 
+# Install podman, buildah, scopeo container's tools (on Ubuntu20 these tools can be installed without adding new repository)
 if isUbuntu20 ; then
-    rm /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+    apt-get -y update
+    apt-get -qq -y install ${install_packages[@]}
+else
+    source /etc/os-release
+    sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
+    wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key -O Release.key
+    apt-key add Release.key
+    apt-get update -qq
+    apt-get -qq -y install ${install_packages[@]}
+    mkdir -p /etc/containers
+    echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | tee /etc/containers/registries.conf
 fi
 
 invoke_tests "Tools" "Containers"


### PR DESCRIPTION
# Description
In scope of this PR we are simplifying `podman`, `buildah `and `skopeo` installation on `ubuntu20`. As for `ubuntu16` and `ubuntu18` we have to use current installation approach.

#### Related issue: [#1960](https://github.com/actions/virtual-environments-internal/issues/1960)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
