### PR TITLE
[Ubuntu] Add clang-format to the readme

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -38,6 +38,7 @@ function Get-ClangTool {
 
     return $clangVersions -Join ", "
 }
+
 function Get-ClangVersions {
     $clangVersions = Get-ClangTool -ToolName "clang"
     return "Clang " + $clangVersions

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -23,14 +23,26 @@ function Get-FortranVersions {
 function Get-ClangVersions {
     $clangVersions = @()
     $result = Get-CommandResult "apt list --installed" -Multiline
+
     $clangVersions = $result.Output | Where-Object { $_ -match "^clang-\d+"} | ForEach-Object {
         $clangCommand = ($_ -Split "/")[0]
         Invoke-Expression "$clangCommand --version" | Where-Object { $_ -match "clang version" } | ForEach-Object {
             $_ -match "clang version (?<version>\d+\.\d+\.\d+)-" | Out-Null
             $Matches.version
+            }
+        } | Sort-Object {[Version]$_}
+    $clangVersions = "Clang " + ($clangVersions -Join ", ")
+
+    $clangFormatVersions = $result.Output | Where-Object { $_ -match "^clang-format-\d+"} | ForEach-Object {
+        $clangCommand = ($_ -Split "/")[0]
+        Invoke-Expression "$clangCommand --version" | Where-Object { $_ -match "clang-format version" } | ForEach-Object {
+            $_ -match "clang-format version (?<version>\d+\.\d+\.\d+)-" | Out-Null
+            $Matches.version
         }
     } | Sort-Object {[Version]$_}
-    return "Clang " + ($clangVersions -Join ", ")
+    $clangFormatVersions = "Clang-format " + ($clangFormatVersions -Join ", ")
+
+    return "$clangVersions`n$clangFormatVersions"
 }
 
 function Get-ErlangVersion {

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -20,7 +20,7 @@ function Get-FortranVersions {
     return "GNU Fortran " + ($fortranVersions -Join ", ")
 }
 
-function Get-ClangTool {
+function Get-ClangToolVersions {
     param (
         [Parameter(Mandatory = $true)]
         [string] $ToolName,
@@ -28,7 +28,7 @@ function Get-ClangTool {
     )
 
     $result = Get-CommandResult "apt list --installed" -Multiline
-    $clangVersions = $result.Output | Where-Object { $_ -match "^${ToolName}-\d+"} | ForEach-Object {
+    $toolVersions = $result.Output | Where-Object { $_ -match "^${ToolName}-\d+"} | ForEach-Object {
         $clangCommand = ($_ -Split "/")[0]
         Invoke-Expression "$clangCommand --version" | Where-Object { $_ -match "${ToolName} version" } | ForEach-Object {
             $_ -match "${ToolName} version (?<version>${VersionPattern}" | Out-Null
@@ -36,16 +36,16 @@ function Get-ClangTool {
             }
         } | Sort-Object {[Version]$_}
 
-    return $clangVersions -Join ", "
+    return $toolVersions -Join ", "
 }
 
 function Get-ClangVersions {
-    $clangVersions = Get-ClangTool -ToolName "clang"
+    $clangVersions = Get-ClangToolVersions -ToolName "clang"
     return "Clang " + $clangVersions
 }
 
 function Get-ClangFormatVersions {
-    $clangFormatVersions = Get-ClangTool -ToolName "clang-format"
+    $clangFormatVersions = Get-ClangToolVersions -ToolName "clang-format"
     return "Clang-format " + $clangFormatVersions
 }
 

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -40,6 +40,7 @@ $markdown += New-MDList -Style Unordered -Lines (@(
         (Get-CPPVersions),
         (Get-FortranVersions),
         (Get-ClangVersions),
+        (Get-ClangFormatVersions),
         (Get-ErlangVersion),
         (Get-MonoVersion),
         (Get-NodeVersion),


### PR DESCRIPTION
# Description
We install clang-format along with the clang but don't mention it in the readme.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3053

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
