### PR TITLE
Add instructions of how to use the Postgres database on Linux

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Databases.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Databases.psm1
@@ -38,6 +38,27 @@ function Build-MySQLSection {
     return $output
 }
 
+function Build-PostgreSqlSection {
+    $output = ""
+
+    $output += New-MDHeader "PostgreSql" -Level 4
+    $output += New-MDList -Style Unordered -Lines @(
+        (Get-PostgreSqlVersion ),
+        "PostgreSql Server (user:root password:root)"
+    )
+    $output += New-MDCode -Lines @(@"
+        To create the root user and enable the service, use the following commands:
+        sudo systemctl start postgresql.service
+        echo "create user root password 'root';" > /tmp/create_user.sql
+        echo "ALTER ROLE root WITH CREATEDB;" >> /tmp/create_user.sql
+        sudo su postgres -c "psql --file=/tmp/create_user.sql"
+        sudo su postgres -c "createdb root"
+"@
+    )
+
+    return $output
+}
+
 function Build-MSSQLToolsSection {
     $output = ""
 

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -232,12 +232,12 @@ $markdown += New-MDList -Style Unordered -Lines @(
 
 $markdown += New-MDHeader "Databases" -Level 3
 $markdown += New-MDList -Style Unordered -Lines (@(
-    (Get-PostgreSqlVersion),
     (Get-MongoDbVersion),
     (Get-SqliteVersion)
     ) | Sort-Object
 )
 
+$markdown += Build-PostgreSqlSection
 $markdown += Build-MySQLSection
 $markdown += Build-MSSQLToolsSection
 


### PR DESCRIPTION
# Description

This PR adds instructions on how to set up the Postgres database that is installed in Linux images.

Maybe there is a simpler/better way to do it, but this is the best I could do! 

Another alternative would be changing `images/linux/scripts/installers/postgresql.sh` to create a user `root` with password `root`, similar to MySql. Please, let me know if you think this approach is better!

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
