### PR TITLE
[Windows] set ascii encoding - C:\shells\msys2bash.cmd

### DIFF
--- a/images/win/scripts/Installers/Configure-Shell.ps1
+++ b/images/win/scripts/Installers/Configure-Shell.ps1
@@ -10,7 +10,7 @@ IF NOT DEFINED MSYS2_PATH_TYPE set MSYS2_PATH_TYPE=strict
 IF NOT DEFINED MSYSTEM set MSYSTEM=mingw64
 set CHERE_INVOKING=1
 C:\msys64\usr\bin\bash.exe -leo pipefail %*
-'@ | Out-File -FilePath "$shellPath\msys2bash.cmd"
+'@ | Out-File -FilePath "$shellPath\msys2bash.cmd" -Encoding ascii
 
 # gitbash <--> C:\Program Files\Git\bin\bash.exe
 New-Item -ItemType SymbolicLink -Path "$shellPath\gitbash.exe" -Target "$env:ProgramFiles\Git\bin\bash.exe" | Out-Null


### PR DESCRIPTION
# Description
Set the default encoding for C:\shells\msys2bash.cmd is ascii.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3085

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
