### PR TITLE
Rework bazel installation to avoid using apt repos

### DIFF
--- a/images/linux/scripts/installers/bazel.sh
+++ b/images/linux/scripts/installers/bazel.sh
@@ -6,16 +6,10 @@
 
 source $HELPER_SCRIPTS/install.sh
 
-# Install bazel
-bazelVersion=$(curl -s -L "https://api.github.com/repos/bazelbuild/bazel/releases" | jq -r '.[] | select(.prerelease==false).name' | sort --unique --version-sort | grep -ve "-.*" | tail -1)
-download_with_retries "https://github.com/bazelbuild/bazel/releases/download/${bazelVersion}/bazel-${bazelVersion}-installer-linux-x86_64.sh" "/tmp" "bazel-installer.sh"
-chmod +x /tmp/bazel-installer.sh
-sudo /tmp/bazel-installer.sh
+# Install bazelisk
+npm install -g @bazel/bazelisk
 
-bazeliskVersion=$(curl -s -L "https://api.github.com/repos/bazelbuild/bazelisk/releases" | jq -r '.[] | select(.prerelease==false).name' | sort --unique --version-sort | grep -ve "-.*" | tail -1)
-
-download_with_retries "https://github.com/bazelbuild/bazelisk/releases/download/${bazeliskVersion}/bazelisk-linux-amd64" "/tmp" "bazelisk"
-chmod +x /tmp/bazelisk
-sudo mv /tmp/bazelisk /usr/local/bin
+# run bazelisk once in order to instal /usr/local/bin/bazel binary
+bazelisk
 
 invoke_tests "Tools" "Bazel"

--- a/images/linux/scripts/installers/bazel.sh
+++ b/images/linux/scripts/installers/bazel.sh
@@ -12,4 +12,10 @@ download_with_retries "https://github.com/bazelbuild/bazel/releases/download/${b
 chmod +x /tmp/bazel-installer.sh
 sudo /tmp/bazel-installer.sh
 
+bazeliskVersion=$(curl -s -L "https://api.github.com/repos/bazelbuild/bazelisk/releases" | jq -r '.[] | select(.prerelease==false).name' | sort --unique --version-sort | grep -ve "-.*" | tail -1)
+
+download_with_retries "https://github.com/bazelbuild/bazelisk/releases/download/${bazeliskVersion}/bazelisk-linux-amd64" "/tmp" "bazelisk"
+chmod +x /tmp/bazelisk
+sudo mv /tmp/bazelisk /usr/local/bin
+
 invoke_tests "Tools" "Bazel"

--- a/images/linux/scripts/installers/bazel.sh
+++ b/images/linux/scripts/installers/bazel.sh
@@ -4,13 +4,12 @@
 ##  Desc:  Installs Bazel and Bazelisk (A user-friendly launcher for Bazel)
 ################################################################################
 
-# Install bazel
-curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
-echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-apt-get update -y
-apt-get install -y bazel
+source $HELPER_SCRIPTS/install.sh
 
-# Install bazelisk
-npm install -g @bazel/bazelisk
+# Install bazel
+bazelVersion=$(curl -s -L "https://api.github.com/repos/bazelbuild/bazel/releases" | jq -r '.[] | select(.prerelease==false).name' | sort --unique --version-sort | grep -ve "-.*" | tail -1)
+download_with_retries "https://github.com/bazelbuild/bazel/releases/download/${bazelVersion}/bazel-${bazelVersion}-installer-linux-x86_64.sh" "/tmp" "bazel-installer.sh"
+chmod +x /tmp/bazel-installer.sh
+sudo /tmp/bazel-installer.sh
 
 invoke_tests "Tools" "Bazel"


### PR DESCRIPTION
# Description
Improvement

bazel can be installed from git, it is one of recommend method https://docs.bazel.build/versions/master/install-ubuntu.html#install-with-installer-ubuntu

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/1962

## Check list
- [x] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
