### PR TITLE
[Ubuntu] Fix packer output for version 1.7.1

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -157,7 +157,10 @@ function Get-NvmVersion {
 }
 
 function Get-PackerVersion {
-    return "Packer $(packer --version)"
+    # Packer 1.7.1 has a bug and outputs version to stderr instead of stdout https://github.com/hashicorp/packer/issues/10855
+    $result = (Get-CommandResult -Command "packer --version").Output
+    $packerVersion = [regex]::matches($result, "(\d+.){2}\d+").Value
+    return "Packer $packerVersion"
 }
 
 function Get-PhantomJSVersion {


### PR DESCRIPTION
# Description
Packer 1.7.1 has a bug and outputs version to stderr instead of stdout https://github.com/hashicorp/packer/issues/10855
This PR changes `Get-PackerVersion` function to retrieve the version regardless of the output stream. 

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2013

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
