### PR TITLE
Update the cached Docker images

### DIFF
--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -203,19 +203,20 @@
     },
     "docker": {
         "images": [
-            "alpine:3.7",
-            "alpine:3.8",
-            "alpine:3.9",
-            "alpine:3.10",
+            "alpine:3.11",
+            "alpine:3.12",
+            "alpine:3.13",
             "buildpack-deps:stretch",
             "buildpack-deps:buster",
-            "debian:8",
             "debian:9",
+            "debian:10",
             "node:10",
             "node:12",
             "node:10-alpine",
             "node:12-alpine",
-            "ubuntu:14.04"
+            "ubuntu:16.04",
+            "ubuntu:18.04",
+            "ubuntu:20.04"
         ]
     },
     "dotnet": {

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -196,19 +196,20 @@
     },
     "docker": {
         "images": [
-            "alpine:3.7",
-            "alpine:3.8",
-            "alpine:3.9",
-            "alpine:3.10",
+            "alpine:3.11",
+            "alpine:3.12",
+            "alpine:3.13",
             "buildpack-deps:stretch",
             "buildpack-deps:buster",
-            "debian:8",
             "debian:9",
+            "debian:10",
             "node:10",
             "node:12",
             "node:10-alpine",
             "node:12-alpine",
-            "ubuntu:14.04"
+            "ubuntu:16.04",
+            "ubuntu:18.04",
+            "ubuntu:20.04"
         ]
     },
     "pipx": [

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -196,19 +196,20 @@
     },
     "docker": {
         "images": [
-            "alpine:3.7",
-            "alpine:3.8",
-            "alpine:3.9",
-            "alpine:3.10",
+            "alpine:3.11",
+            "alpine:3.12",
+            "alpine:3.13",
             "buildpack-deps:stretch",
             "buildpack-deps:buster",
-            "debian:8",
             "debian:9",
+            "debian:10",
             "node:10",
             "node:12",
             "node:10-alpine",
             "node:12-alpine",
-            "ubuntu:14.04"
+            "ubuntu:16.04",
+            "ubuntu:18.04",
+            "ubuntu:20.04"
         ]
     },
     "pipx": [


### PR DESCRIPTION
# Description
 Improvement

Some cached OS images have reached EOL and need to be updates

Required size: 50Mb

#### Related issue: https://github.com/actions/virtual-environments/issues/2963

## Check list
- [x] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
