### PR TITLE
[macOS] Fix packer output for version 1.7.1

### DIFF
--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -293,7 +293,9 @@ function Get-SVNVersion {
 }
 
 function Get-PackerVersion {
-    $packerVersion = Run-Command "packer --version"
+    # Packer 1.7.1 has a bug and outputs version to stderr instead of stdout https://github.com/hashicorp/packer/issues/10855
+    $result = Run-Command -Command "packer --version"
+    $packerVersion = [regex]::matches($result, "(\d+.){2}\d+").Value
     return "Packer $packerVersion"
 }
 


### PR DESCRIPTION
# Description
Packer 1.7.1 has a bug and outputs version to stderr instead of stdout https://github.com/hashicorp/packer/issues/10855
This PR changes `Get-PackerVersion` function to retrieve only the version regex match. 

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2013

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
