### PR TITLE
Replace the microsoft/aspnetcore-build Docker image with mcr.microsof…

### DIFF
--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -255,7 +255,7 @@
             "mcr.microsoft.com/windows/nanoserver:10.0.14393.953",
             "mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2016",
             "mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2016",
-            "microsoft/aspnetcore-build:1.0-2.0"
+            "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2016"
         ]
     },
     "pipx": [

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -303,7 +303,7 @@
             "mcr.microsoft.com/windows/nanoserver:1809",
             "mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2019",
             "mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019",
-            "microsoft/aspnetcore-build:1.0-2.0"
+            "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019"
         ]
     },
     "pipx": [


### PR DESCRIPTION
…t.com/dotnet/framework/sdk

# Description
 Improvement

Size: less by 800Mb

The microsoft/aspnetcore-build:1.0-2.0 image is two year old and is not supported. The mcr.microsoft.com/dotnet/framework/sdk images have replaced the microsoft/aspnetcore-build images

#### Related issue: https://github.com/actions/virtual-environments/issues/2962

## Check list
- [x] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
