### PR TITLE
[Ubuntu] Add sshpass package

### DIFF
--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -190,6 +190,7 @@
             "sphinxsearch",
             "sqlite3",
             "ssh",
+            "sshpass",
             "subversion",
             "sudo",
             "swig",

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -184,6 +184,7 @@
             "sqlite3",
             "sphinxsearch",
             "ssh",
+            "sshpass",
             "subversion",
             "sudo",
             "swig",

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -184,6 +184,7 @@
             "sphinxsearch",
             "sqlite3",
             "ssh",
+            "sshpass",
             "subversion",
             "sudo",
             "swig",


### PR DESCRIPTION
# Description
After reworked ansible(https://github.com/actions/virtual-environments/pull/3015) installation we stop pre-install `sshpass` pkg.  We should revert this pkg.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3102

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
