### PR TITLE
[Windows] Fix packer output for version 1.7.1

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -112,7 +112,10 @@ function Get-OpenSSLVersion {
 }
 
 function Get-PackerVersion {
-    return "Packer $(packer --version)"
+    # Packer 1.7.1 has a bug and outputs version to stderr instead of stdout https://github.com/hashicorp/packer/issues/10855
+    ($(cmd /c "packer --version 2>&1") | Out-String) -match "(?<version>(\d+.){2}\d+)" | Out-Null
+    $packerVersion = $Matches.Version
+    return "Packer $packerVersion"
 }
 
 function Get-PulumiVersion {


### PR DESCRIPTION
# Description
Packer 1.7.1 has a bug and outputs version to stderr instead of stdout https://github.com/hashicorp/packer/issues/10855
This PR changes the `Get-PackerVersion` function to retrieve the version regardless of the output stream. 

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2013

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
