### PR TITLE
[macOS] Rework Xamarin documentation

### DIFF
--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -236,17 +236,9 @@ $markdown += New-MDHeader "Xamarin" -Level 3
 $markdown += New-MDHeader "Visual Studio for Mac" -Level 4
 $markdown += New-MDList -Lines @(Get-VSMacVersion) -Style Unordered
 
-$markdown += New-MDHeader "Mono" -Level 4
-$markdown += New-MDList -Lines (Build-MonoList) -Style Unordered
-
-$markdown += New-MDHeader "Xamarin.iOS" -Level 4
-$markdown += New-MDList -Lines (Build-XamarinIOSList) -Style Unordered
-
-$markdown += New-MDHeader "Xamarin.Mac" -Level 4
-$markdown += New-MDList -Lines (Build-XamarinMacList) -Style Unordered
-
-$markdown += New-MDHeader "Xamarin.Android" -Level 4
-$markdown += New-MDList -Lines (Build-XamarinAndroidList) -Style Unordered
+$markdown += New-MDHeader "Xamarin bundles" -Level 4
+$markdown += Build-XamarinTable | New-MDTable
+$markdown += New-MDNewLine
 
 $markdown += New-MDHeader "Unit Test Framework" -Level 4
 $markdown += New-MDList -Lines @(Get-NUnitVersion) -Style Unordered

--- a/images/macos/software-report/SoftwareReport.Xamarin.psm1
+++ b/images/macos/software-report/SoftwareReport.Xamarin.psm1
@@ -1,7 +1,4 @@
-$sortRulesByVersion = @{
-    Expression = { [System.Version]::Parse($_) }
-    Descending = $true
-}
+Import-Module "$PSScriptRoot/../helpers/Common.Helpers.psm1"
 
 function Get-VSMacVersion {
     $plistPath = "/Applications/Visual Studio.app/Contents/Info.plist"
@@ -13,66 +10,23 @@ function Get-NUnitVersion {
     return "NUnit ${version}"
 }
 
-function Build-MonoList {
-    $monoVersionsPath = "/Library/Frameworks/Mono.framework/Versions"
-    $monoFolders = Get-ChildItemWithoutSymlinks $monoVersionsPath
+function Build-XamarinTable {
+    $xamarinBundles = Get-ToolsetValue "xamarin.bundles"
+    $defaultSymlink = Get-ToolsetValue "xamarin.bundle-default"
+    $sortRules = @{
+        Expression = { [System.String]::($_.symlink) }
+        Descending = $true
+    }
 
-    $monoVersionList = $monoFolders | ForEach-Object {
-        $versionFilePath = Join-Path $_.FullName "Version"
-        if (Test-Path $versionFilePath) {
-            return Get-Content -Raw $versionFilePath
+    return $xamarinBundles | Sort-Object $sortRules | ForEach-Object {
+        $defaultPostfix = ($_.symlink -eq $defaultSymlink ) ? " (default)" : ""
+        [PSCustomObject] @{
+            "symlink" = $_.symlink + $defaultPostfix 
+            "Xamarin.Mono" = $_.mono
+            "Xamarin.iOS" = $_.ios
+            "Xamarin.Mac" = $_.mac
+            "Xamarin.Android" = $_.android
         }
-
-        return $_.Name
-    } | ForEach-Object { $_.Trim() }
-
-    return $monoVersionList | Sort-Object -Property $sortRulesByVersion
+    }
 }
 
-function Build-XamarinIOSList {
-    $sdkVersionsPath = "/Library/Frameworks/Xamarin.iOS.framework/Versions"
-    $sdkFolders = Get-ChildItemWithoutSymlinks $sdkVersionsPath
-
-    $sdkVersionList = $sdkFolders | ForEach-Object {
-        $versionFilePath = Join-Path $_.FullName "Version"
-        if (Test-Path $versionFilePath) {
-            return Get-Content -Raw $versionFilePath
-        }
-
-        return $_.Name
-    } | ForEach-Object { $_.Trim() }
-
-    return $sdkVersionList | Sort-Object -Property $sortRulesByVersion
-}
-
-function Build-XamarinMacList {
-    $sdkVersionsPath = "/Library/Frameworks/Xamarin.Mac.framework/Versions"
-    $sdkFolders = Get-ChildItemWithoutSymlinks $sdkVersionsPath
-
-    $sdkVersionList = $sdkFolders | ForEach-Object {
-        $versionFilePath = Join-Path $_.FullName "Version"
-        if (Test-Path $versionFilePath) {
-            return Get-Content -Raw $versionFilePath
-        }
-
-        return $_.Name
-    } | ForEach-Object { $_.Trim() }
-
-    return $sdkVersionList | Sort-Object -Property $sortRulesByVersion
-}
-
-function Build-XamarinAndroidList {
-    $sdkVersionsPath = "/Library/Frameworks/Xamarin.Android.framework/Versions"
-    $sdkFolders = Get-ChildItemWithoutSymlinks $sdkVersionsPath
-
-    $sdkVersionList = $sdkFolders | ForEach-Object {
-        $versionFilePath = Join-Path $_.FullName "Version"
-        if (Test-Path $versionFilePath) {
-            return Get-Content -Raw $versionFilePath
-        }
-
-        return $_.Name
-    } | ForEach-Object { $_.Trim() }
-
-    return $sdkVersionList | Sort-Object -Property $sortRulesByVersion
-}

--- a/images/macos/software-report/SoftwareReport.Xamarin.psm1
+++ b/images/macos/software-report/SoftwareReport.Xamarin.psm1
@@ -16,12 +16,8 @@ function Build-XamarinTable {
     if ($defaultSymlink -eq "latest") {
         $defaultSymlink = $xamarinBundles[0].symlink
     }
-    $sortRules = @{
-        Expression = { [System.String]::($_.symlink) }
-        Descending = $true
-    }
 
-    return $xamarinBundles | Sort-Object $sortRules | ForEach-Object {
+    return $xamarinBundles | ForEach-Object {
         $defaultPostfix = ($_.symlink -eq $defaultSymlink ) ? " (default)" : ""
         [PSCustomObject] @{
             "symlink" = $_.symlink + $defaultPostfix 

--- a/images/macos/software-report/SoftwareReport.Xamarin.psm1
+++ b/images/macos/software-report/SoftwareReport.Xamarin.psm1
@@ -13,6 +13,9 @@ function Get-NUnitVersion {
 function Build-XamarinTable {
     $xamarinBundles = Get-ToolsetValue "xamarin.bundles"
     $defaultSymlink = Get-ToolsetValue "xamarin.bundle-default"
+    if ($defaultSymlink -eq "latest") {
+        $defaultSymlink = $xamarinBundles[0].symlink
+    }
     $sortRules = @{
         Expression = { [System.String]::($_.symlink) }
         Descending = $true


### PR DESCRIPTION
# Description
We've improved the documentation for Xamarin by adding the table containing Xamarin bundles and associated symlinks.

![image](https://user-images.githubusercontent.com/49442273/113675635-3d3b8780-96c4-11eb-9200-910239d455bf.png)


#### Related issue:
[Add information about default Xamarin / Mono to MacOS image documentation #1929](https://github.com/actions/virtual-environments-internal/issues/1929)
## Check list
- [x] Related issue / work item is attached
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
