### PR TITLE
[macOS] Upgrade az powershell module from 4.8.0 to 5.7.0

### DIFF
--- a/images/macos/toolsets/toolset-10.13.json
+++ b/images/macos/toolsets/toolset-10.13.json
@@ -202,7 +202,7 @@
         {
             "name": "Az",
             "versions": [
-                "5.7.0"
+                "4.8.0"
             ]
         },
         {"name": "MarkdownPS"},

--- a/images/macos/toolsets/toolset-10.13.json
+++ b/images/macos/toolsets/toolset-10.13.json
@@ -202,7 +202,7 @@
         {
             "name": "Az",
             "versions": [
-                "4.8.0"
+                "5.7.0"
             ]
         },
         {"name": "MarkdownPS"},

--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -223,7 +223,7 @@
         {
             "name": "Az",
             "versions": [
-                "4.8.0"
+                "5.7.0"
             ]
         },
         {"name": "MarkdownPS"},

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -175,7 +175,7 @@
         {
             "name": "Az",
             "versions": [
-                "4.8.0"
+                "5.7.0"
             ]
         },
         {"name": "MarkdownPS"},

--- a/images/macos/toolsets/toolset-11.0.json
+++ b/images/macos/toolsets/toolset-11.0.json
@@ -109,7 +109,7 @@
         {
             "name": "Az",
             "versions": [
-                "4.8.0"
+                "5.7.0"
             ]
         },
         {"name": "MarkdownPS"},


### PR DESCRIPTION
# Description
Az modules is updated from 4.8.0 to 5.7.0

#### Related issue:
https://github.com/actions/virtual-environments/issues/3129

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
