### PR TITLE
[Ubuntu] Don't create symlinks for PyPy 7.3.4

### DIFF
--- a/images/linux/scripts/installers/pypy.sh
+++ b/images/linux/scripts/installers/pypy.sh
@@ -56,8 +56,9 @@ function InstallPyPy
     echo "Create additional symlinks (Required for UsePythonVersion Azure DevOps task)"
     cd $PYPY_TOOLCACHE_VERSION_ARCH_PATH/bin
 
-    ln -s $PYPY_MAJOR $PYTHON_MAJOR
-    ln -s $PYTHON_MAJOR python
+    # Starting from PyPy 7.3.4 these links are already included in the package
+    [ -f ./$PYTHON_MAJOR ] || ln -s $PYPY_MAJOR $PYTHON_MAJOR
+    [ -f ./python ] || ln -s $PYTHON_MAJOR python
 
     chmod +x ./python ./$PYTHON_MAJOR
 


### PR DESCRIPTION
# Description
Starting from PyPy 7.3.4 symlinks for python3 and python3 are already included in the package — there is no need to create them.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2033

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
