### PR TITLE
Add cleanup logic for the packer os disk

### DIFF
--- a/images.CI/linux-and-win/azure-pipelines/image-generation.yml
+++ b/images.CI/linux-and-win/azure-pipelines/image-generation.yml
@@ -92,8 +92,9 @@ jobs:
       targetType: filePath
       filePath: ./images.CI/linux-and-win/cleanup.ps1
       arguments: -ResourcesNamePrefix $(Build.BuildId) `
+                     -Image ${{ parameters.image_type }} `
+                     -StorageAccount $(AZURE_STORAGE_ACCOUNT) `
+                     -SubscriptionId $(AZURE_SUBSCRIPTION) `
                      -ClientId $(CLIENT_ID) `
                      -ClientSecret $(CLIENT_SECRET) `
-                     -Image ${{ parameters.image_type }} `
-                     -SubscriptionId $(AZURE_SUBSCRIPTION) `
                      -TenantId $(AZURE_TENANT)

--- a/images.CI/linux-and-win/cleanup.ps1
+++ b/images.CI/linux-and-win/cleanup.ps1
@@ -1,6 +1,7 @@
 param(
     [String] [Parameter (Mandatory=$true)] $Image,
     [String] [Parameter (Mandatory=$true)] $ResourcesNamePrefix,
+    [String] [Parameter (Mandatory=$true)] $StorageAccount,
     [String] [Parameter (Mandatory=$true)] $ClientId,
     [String] [Parameter (Mandatory=$true)] $ClientSecret,
     [String] [Parameter (Mandatory=$true)] $SubscriptionId,
@@ -13,9 +14,13 @@ $TempResourceGroupName = "${ResourcesNamePrefix}_${Image}"
 
 $groupExist = az group exists --name $TempResourceGroupName --subscription $SubscriptionId
 if ($groupExist -eq "true") {
+    $osDiskName = az group deployment list --resource-group $TempResourceGroupName --query "[].properties.parameters.osDiskName.value" -o tsv
     Write-Host "Found a match, deleting temporary files"
     az group delete --name $TempResourceGroupName --subscription $SubscriptionId --yes | Out-Null
-    Write-Host "Temporary group was deleted succesfully" -ForegroundColor Green
+    Write-Host "Temporary group was deleted succesfully"
+    Write-Host "Deleting OS disk"
+    az storage remove --account-name $StorageAccount -c "images" -n "$osDiskName.vhd" | Out-Null
+    Write-Host "OS disk deleted"
 } else {
     Write-Host "No temporary groups found"
 }


### PR DESCRIPTION
# Description

Currently, our cleanup script only deletes the temporary resource group and VM created by the packer, however, it doesn't touch os disk, thus the vhd file remains in the storage account.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/1908

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
