### PR TITLE
[Windows] Remove user-wide dotnet config

### DIFF
--- a/images/win/post-generation/Dotnet.ps1
+++ b/images/win/post-generation/Dotnet.ps1
@@ -6,3 +6,6 @@ if (-not $latestPath.Contains($dotnetPath))
     $latestPath = "$dotnetPath;$latestPath"
     [System.Environment]::SetEnvironmentVariable('PATH', $latestPath, [System.EnvironmentVariableTarget]::Machine)
 }
+
+# Delete empty nuget.config file to prevent the issue with downloading packages from nuget.org https://github.com/actions/virtual-environments/issues/3038
+Remove-Item $env:APPDATA\NuGet\NuGet.Config -Force


### PR DESCRIPTION
# Description
This PR should mitigate the issue when packages from NuGet.org are not resolved due to the empty user-wide nuget.config.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3038

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
