### PR TITLE
[macOS] Remove gradle test for init.d plugins

### DIFF
--- a/images/macos/tests/Java.Tests.ps1
+++ b/images/macos/tests/Java.Tests.ps1
@@ -66,10 +66,6 @@ Describe "Java" {
             It "Gradle is installed to /usr/local/bin" {
                 (Get-Command "gradle").Path | Should -BeExactly "/usr/local/bin/gradle"
             }
-        
-            It "Gradle is compatible with init.d plugins" {
-                "cd /tmp && gradle tasks" | Should -ReturnZeroExitCode
-            }
         }
     }
 }


### PR DESCRIPTION
# Description
Remove Gradle test for init.d plugins because executing Gradle tasks as part of an undefined build is not supported since Gradle 7.0

#### Related issue: [#2035](https://github.com/actions/virtual-environments-internal/issues/2035)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
