### PR TITLE
[macOS] Add SwiftFormat for all macOS versions except HS

### DIFF
--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -459,6 +459,11 @@ function Get-StackVersion {
     return "Stack $stackVersion"
 }
 
+function Get-SwiftFormatVersion {
+    $swiftFormatVersion = Run-Command "swiftformat --version"
+    return "SwiftFormat $swiftFormatVersion"
+}
+
 function Get-YamllintVersion {
     $yamllintVersion = Run-Command "yamllint --version"
     return $yamllintVersion

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -164,7 +164,8 @@ if( -not $os.IsHighSierra) {
         (Get-GHCupVersion),
         (Get-GHCVersion),
         (Get-CabalVersion),
-        (Get-StackVersion)
+        (Get-StackVersion),
+        (Get-SwiftFormatVersion)
     )
 }
 

--- a/images/macos/tests/BasicTools.Tests.ps1
+++ b/images/macos/tests/BasicTools.Tests.ps1
@@ -18,6 +18,12 @@ Describe "Subversion" {
     }
 }
 
+Describe "SwiftFormat" {
+    It "SwiftFormat" {
+        "swiftformat --version" | Should -ReturnZeroExitCode
+    }
+}
+
 Describe "Go" {
     It "Go" {
         "go version" | Should -ReturnZeroExitCode

--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -251,6 +251,7 @@
             "parallel",
             "perl",
             "subversion",
+            "swiftformat",
             "xctool",
             "zstd"
         ],

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -203,6 +203,7 @@
             "parallel",
             "perl",
             "subversion",
+            "swiftformat",
             "xctool",
             "zstd"
         ],

--- a/images/macos/toolsets/toolset-11.0.json
+++ b/images/macos/toolsets/toolset-11.0.json
@@ -135,6 +135,7 @@
             "packer",
             "perl",
             "subversion",
+            "swiftformat",
             "zstd"
         ],
         "cask_packages": [


### PR DESCRIPTION
# Description
SwiftFormat goes above and beyond what you might expect from a code formatter. In addition to adjusting white space it can insert or remove implicit self, remove redundant parentheses, and correct many other deviations from the standard Swift idioms.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3166

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
