### PR TITLE
[Ubuntu] Fix package name output in Pipx test

### DIFF
--- a/images/linux/scripts/tests/Common.Tests.ps1
+++ b/images/linux/scripts/tests/Common.Tests.ps1
@@ -40,7 +40,7 @@ Describe "Swift" {
 }
 
 Describe "PipxPackages" -Skip:(Test-IsUbuntu16) {
-    [array]$testCases = (Get-ToolsetContent).pipx | ForEach-Object { @{cmd = $_.cmd} }
+    [array]$testCases = (Get-ToolsetContent).pipx | ForEach-Object { @{package=$_.package; cmd = $_.cmd} }
 
     It "<package>" -TestCases $testCases {
         "$cmd --version" | Should -ReturnZeroExitCode


### PR DESCRIPTION
# Description
Currently the output doesn't contain list of pipx packages in the PipxPackages test.
```
azure-arm: Describing PipxPackages
    azure-arm:   [+]  63ms (59ms|3ms)
    azure-arm:   [+]  172ms (171ms|1ms)
    azure-arm:   [+]  324ms (322ms|2ms)
```

