### PR TITLE
[macOS] Change go in the HS toolset to 1.15

### DIFF
--- a/images/macos/toolsets/toolset-10.13.json
+++ b/images/macos/toolsets/toolset-10.13.json
@@ -221,7 +221,7 @@
             "gh",
             "gnupg",
             "gnu-tar",
-            "go",
+            "go@1.15",
             "helm",
             "libpq",
             "llvm",


### PR DESCRIPTION
# Description
Go 1.16 contains a lot of breaking changes, we should avoid setting it as the default one. We have previously done it for all macOS versions except HS here https://github.com/actions/virtual-environments/pull/2795

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2046

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
