### PR TITLE
Update PyPy to 7.3.4 on Windows (change platform format)

### DIFF
--- a/images/win/scripts/Installers/Install-PyPy.ps1
+++ b/images/win/scripts/Installers/Install-PyPy.ps1
@@ -89,7 +89,9 @@ foreach($pypyTool in $pypyTools)
     foreach($pypyVersion in $pypyTool.versions)
     {
         # Query latest PyPy version
-        $filter = '{0}{1}-v\d+\.\d+\.\d+-{2}.zip' -f $pypyTool.name, $pypyVersion, $pypyTool.platform
+        # PyPy 3.6 is not updated anymore and win32 should be used
+        $platform = if ($pypyVersion -like "3.6*") { "win32" } else { $pypyTool.platform }
+        $filter = '{0}{1}-v\d+\.\d+\.\d+-{2}.zip' -f $pypyTool.name, $pypyVersion, $platform
         $latestMajorPyPyVersion = $pypyVersions | Where-Object {$_.name -match $filter} | Select-Object -First 1
 
         if ($latestMajorPyPyVersion)

--- a/images/win/scripts/SoftwareReport/SoftwareReport.CachedTools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.CachedTools.psm1
@@ -52,9 +52,6 @@ function Get-PyPyMarkdown
     {
         $Instance."PyPy Version" = @()
         $Instance."Python Version" = $Instance.Version
-        # PyPy x64 is installed but it is placed in x86 folder
-        # to keep backward compatibility with tasks
-        $Instance."Architecture" = "x64"
         foreach ($Arch in $Instance.Architecture_Array)
         {
             $pythonExePath = Join-Path $Instance.Path $Arch | Join-Path -ChildPath "python.exe"
@@ -64,7 +61,6 @@ function Get-PyPyMarkdown
 
     $Content = $ToolInstances | New-MDTable -Columns ([ordered]@{
         "Python Version" = "left";
-        Architecture = "left";
         "PyPy Version" = "left"
     })
 

--- a/images/win/scripts/SoftwareReport/SoftwareReport.CachedTools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.CachedTools.psm1
@@ -52,6 +52,9 @@ function Get-PyPyMarkdown
     {
         $Instance."PyPy Version" = @()
         $Instance."Python Version" = $Instance.Version
+        # PyPy x64 is installed but it is placed in x86 folder
+        # to keep backward compatibility with tasks
+        $Instance."Architecture" = "x64"
         foreach ($Arch in $Instance.Architecture_Array)
         {
             $pythonExePath = Join-Path $Instance.Path $Arch | Join-Path -ChildPath "python.exe"

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -45,7 +45,7 @@
         {
             "name": "PyPy",
             "arch": "x86",
-            "platform" : "win32",
+            "platform" : "win64",
             "versions": [
                 "2.7",
                 "3.6",

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -45,7 +45,7 @@
         {
             "name": "PyPy",
             "arch": "x86",
-            "platform" : "win32",
+            "platform" : "win64",
             "versions": [
                 "2.7",
                 "3.6",


### PR DESCRIPTION
# Description
Starting PyPy 7.3.4, the format of versions was changed:
- platform: `win32` -> `win64`
- arch: `x86` -> `x64`

We need to fix it. We will download versions with win64 platform but will continue to install it to the `x86` folder. Otherwise, we will break tasks: UsePython (ADO), setup-python (GA)

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
