### PR TITLE
[macOS] Create VM_ASSETS environment variable

### DIFF
--- a/images/macos/provision/configuration/environment/bashrc
+++ b/images/macos/provision/configuration/environment/bashrc
@@ -7,6 +7,8 @@ export ANDROID_SDK_ROOT=${HOME}/Library/Android/sdk
 export ANDROID_NDK_HOME=${ANDROID_HOME}/ndk-bundle
 export ANDROID_NDK_ROOT=${ANDROID_HOME}/ndk-bundle
 
+export VM_ASSETS=/usr/local/opt/$USER/scripts
+
 export NUNIT_BASE_PATH=/Library/Developer/nunit
 export NUNIT3_PATH=/Library/Developer/nunit/3.6.0
 

--- a/images/macos/provision/configuration/finalize-vm.sh
+++ b/images/macos/provision/configuration/finalize-vm.sh
@@ -22,6 +22,8 @@ mv $HOME/image-generation/assets/* /usr/local/opt/$USER/scripts
 
 find /usr/local/opt/$USER/scripts -type f -name "*\.sh" -exec chmod +x {} \;
 
+echo "export VM_ASSETS=/usr/local/opt/$USER/scripts" >> "$HOME/.bashrc"
+
 # Clean up npm cache which collected during image-generation
 # we have to do that here because `npm install` is run in a few different places during image-generation
 npm cache clean --force

--- a/images/macos/provision/configuration/finalize-vm.sh
+++ b/images/macos/provision/configuration/finalize-vm.sh
@@ -22,8 +22,6 @@ mv $HOME/image-generation/assets/* /usr/local/opt/$USER/scripts
 
 find /usr/local/opt/$USER/scripts -type f -name "*\.sh" -exec chmod +x {} \;
 
-echo "export VM_ASSETS=/usr/local/opt/$USER/scripts" >> "$HOME/.bashrc"
-
 # Clean up npm cache which collected during image-generation
 # we have to do that here because `npm install` is run in a few different places during image-generation
 npm cache clean --force


### PR DESCRIPTION
# Description
Added VM_ASSETS environment variable to point to the folder with vm_assets scripts, so that we can use this variable in official documentation without exposing `/usr/local/opt/runner/scripts`

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/2067

## Check list
- [x] Related issue / work item is attached
- [n\a] Tests are written (if applicable)
- [n\a] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
