### PR TITLE
[Ubuntu] Remove google-cloud-sdk repo

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -95,7 +95,8 @@ function Get-GitFTPVersion {
 }
 
 function Get-GoogleCloudSDKVersion {
-    return "$(gcloud --version | Select-Object -First 1)"
+    $aptSourceRepo = Get-AptSourceRepository -PackageName "google-cloud-sdk"
+    return "$(gcloud --version | Select-Object -First 1) (apt source repository: $aptSourceRepo)"
 }
 
 function Get-HavegedVersion {

--- a/images/linux/scripts/installers/google-cloud-sdk.sh
+++ b/images/linux/scripts/installers/google-cloud-sdk.sh
@@ -4,10 +4,19 @@
 ##  Desc:  Installs the Google Cloud SDK
 ################################################################################
 
+REPO_URL="https://packages.cloud.google.com/apt"
+
 # Install the Google Cloud SDK
-echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] $REPO_URL cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 sudo apt-get update -y
 sudo apt-get install -y google-cloud-sdk
+
+# remove apt
+rm /etc/apt/sources.list.d/google-cloud-sdk.list
+rm /usr/share/keyrings/cloud.google.gpg /usr/share/keyrings/cloud.google.gpg~
+
+# add repo to the apt-sources.txt
+echo "google-cloud-sdk $REPO_URL" >> $HELPER_SCRIPTS/apt-sources.txt
 
 invoke_tests "CLI.Tools" "Google Cloud SDK"


### PR DESCRIPTION
# Description
- Remove packages.cloud.google.com/apt (Google Cloud SDK)

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2073

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
