### PR TITLE
[macOS] suppress pipefail pgrep exit code

### DIFF
--- a/images/macos/provision/core/edge.sh
+++ b/images/macos/provision/core/edge.sh
@@ -44,7 +44,7 @@ do
 done
 
 echo "kill autoupdate process"
-ps -ef | grep [M]icrosoft | awk '{print $2}' | sudo xargs kill -9
+pgrep [M]icrosoft | sudo xargs kill -9 || true
 echo "remove autupdate service"
 sudo launchctl remove com.microsoft.autoupdate.helper
 


### PR DESCRIPTION
# Description
set -o pipefail This setting prevents errors in a pipeline from being masked. If any command in a pipeline fails, that return code will be used as the return code of the whole pipeline. By default, the pipeline's return code is that of the last command - even if it succeeds.

E.g:

```
$ ps -ef | grep [M]icrosoft | awk '{print $2}' | sudo xargs kill -9 || echo "ExitCode: $?"
ExitCode: 1
```

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2077

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
