### PR TITLE
[Ubuntu] Add MSBuild to software report

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -61,6 +61,14 @@ function Get-MonoVersion {
     return "Mono $monoVersion"
 }
 
+function Get-MsbuildVersion {
+    $msbuildVersion = msbuild -version | Select-Object -Last 1
+    $result = Select-String -Path (Get-Command msbuild).Source -Pattern "msbuild"
+    $result -match "(?<path>\/\S*\.dll)" | Out-Null
+    $msbuildPath = $Matches.path
+    return "MSBuild $msbuildVersion (from $msbuildPath)"
+}
+
 function Get-NodeVersion {
     $nodeVersion = $(node --version).Substring(1)
     return "Node $nodeVersion"

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -43,6 +43,7 @@ $markdown += New-MDList -Style Unordered -Lines (@(
         (Get-ClangFormatVersions),
         (Get-ErlangVersion),
         (Get-MonoVersion),
+        (Get-MsbuildVersion),
         (Get-NodeVersion),
         (Get-PerlVersion),
         (Get-PythonVersion),

--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -150,6 +150,10 @@ Describe "Mono" {
         "mono --version" | Should -ReturnZeroExitCode
     }
 
+    It "msbuild" {
+        "msbuild -version" | Should -ReturnZeroExitCode
+    }
+
     It "nuget" {
         "nuget" | Should -ReturnZeroExitCode
     }


### PR DESCRIPTION
# Description
We don't provide information about the MSBuild version even though it comes along with Mono.
Sample output:
![image](https://user-images.githubusercontent.com/48208649/115242363-75ae7d00-a12a-11eb-96b7-c2909d54dc3b.png)

#### Related issue:
https://github.com/actions/virtual-environments/issues/3148

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
