### PR TITLE
[macOS] Add MSBuild to software report 

### DIFF
--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -156,6 +156,14 @@ function Get-PHPVersion {
     return $PHPVersion
 }
 
+function Get-MSBuildVersion {
+    $msbuildVersion = msbuild -version | Select-Object -Last 1
+    $result = Select-String -Path (Get-Command msbuild).Source -Pattern "msbuild"
+    $result -match "(?<path>\/\S*\.dll)" | Out-Null
+    $msbuildPath = $Matches.path
+    return "MSBuild $msbuildVersion (from $msbuildPath)"
+}
+
 function Get-NodeVersion {
     $nodeVersion = Run-Command "node --version"
     return "Node.js $nodeVersion"

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -32,6 +32,7 @@ $markdown += New-MDHeader "Installed Software" -Level 2
 $markdown += New-MDHeader "Language and Runtime" -Level 3
 $languageAndRuntimeList = @(
     (Get-BashVersion),
+    (Get-MSBuildVersion),
     (Get-NodeVersion),
     (Get-NVMVersion),
     (Get-NVMNodeVersionList),

--- a/images/macos/tests/Xamarin.Tests.ps1
+++ b/images/macos/tests/Xamarin.Tests.ps1
@@ -75,9 +75,13 @@ Describe "Mono" {
             }
         }
     }
+
+    It "MSBuild is available" {
+        "msbuild -version" | Should -ReturnZeroExitCode
+    }
 }
 
-Describe "Xamarin.iOS" {  
+Describe "Xamarin.iOS" {
     $XAMARIN_IOS_VERSIONS | ForEach-Object {
         Context "$_" {
             $XAMARIN_IOS_VERSIONS_PATH = "/Library/Frameworks/Xamarin.iOS.framework/Versions"


### PR DESCRIPTION
# Description
We don't provide information about the MSBuild version even though it comes along with Mono.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3148

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
