### PR TITLE
Haskell - Fixed version checking

### DIFF
--- a/images/win/scripts/Installers/Install-Haskell.ps1
+++ b/images/win/scripts/Installers/Install-Haskell.ps1
@@ -4,15 +4,15 @@
 ################################################################################
 
 # Get 3 latest versions of GHC
-[Version[]] $ChocoVersionsOutput = & choco search ghc --allversions | Where-Object { $_.StartsWith("ghc ") -and $_ -match "Approved"} | ForEach-Object { [regex]::matches($_, "\d+(\.\d+){2,}").value }
-$MajorMinorGroups = $ChocoVersionsOutput | Sort-Object -Descending | Group-Object { $_.ToString(2) } | Select-Object -First 3
+[Version[]] $ChocoVersionsOutput = & choco search ghc --allversions | Where-Object { $_.StartsWith('ghc ') -and $_ -match 'Approved' } | ForEach-Object { [regex]::matches($_, '\d+(\.\d+){2,}').value }
+$MajorMinorGroups = $ChocoVersionsOutput | Group-Object { $_.ToString(2) } | Sort-Object Name -Descending | Select-Object -First 3
 $VersionsList = $MajorMinorGroups | ForEach-Object { $_.Group | Select-Object -First 1 } | Sort-Object
 
 # The latest version will be installed as a default
 ForEach ($version in $VersionsList)
 {
     Write-Host "Installing ghc $version..."
-    Choco-Install -PackageName ghc -ArgumentList "--version", $version, "-m"
+    Choco-Install -PackageName ghc -ArgumentList '--version', $version, '-m'
 }
 
 # Add default version of GHC to path, because choco formula updates path on user level
@@ -20,14 +20,14 @@ $DefaultGhcVersion = $VersionsList | Select-Object -Last 1
 $DefaultGhcShortVersion = ([version]$DefaultGhcVersion).ToString(3)
 $DefaultGhcPath = Join-Path $env:ChocolateyInstall "lib\ghc.$DefaultGhcVersion\tools\ghc-$DefaultGhcShortVersion\bin"
 # Starting from version 9 haskell installation directory is $env:ChocolateyToolsLocation instead of $env:ChocolateyInstall\lib
-if ($ghcVersion -notmatch "^[0-8]\.\d+.*")
+if ($DefaultGhcShortVersion -notmatch '^[0-8]\.\d+.*')
 {
     $DefaultGhcPath = Join-Path $env:ChocolateyToolsLocation "ghc-$DefaultGhcShortVersion\bin"
 }
 
 Add-MachinePathItem -PathItem $DefaultGhcPath
 
-Write-Host "Installing cabal..."
+Write-Host 'Installing cabal...'
 Choco-Install -PackageName cabal
 
-Invoke-PesterTests -TestFile "Haskell"
+Invoke-PesterTests -TestFile 'Haskell'


### PR DESCRIPTION
The haskell installation broke the flow.

It was due to versioning wasn't sorted correct thus different machines had different version outcome.
One VM showed version 9 as the newest version, another VM only got version 8 and another VM only showed version 7 even though version 9 and version 8 was retrieved from Chocolatey.

When it tested on version against version 9, it tested against a variable which wasn't defined.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [X] Changes are tested and related VM images are successfully generated
