### PR TITLE
[Windows] Install vcredist 2010 using direct links

### DIFF
--- a/images/win/scripts/Installers/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/Initialize-VM.ps1
@@ -129,7 +129,13 @@ if (Test-IsWin16) {
 
 if (Test-IsWin19) {
     # Install vcredist2010
-    Choco-Install -PackageName vcredist2010
+    $Vc2010x86Name = "vcredist_x86.exe"
+    $Vc2010x86URI = "https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/${Vc2010x86Name}"
+    $Vc2010x64Name = "vcredist_x64.exe"
+    $Vc2010x64URI = "https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/${Vc2010x64Name}"
+    $ArgumentList = ("/install", "/quiet", "/norestart")
+    Install-Binary -Url $Vc2010x86URI -Name $Vc2010x86Name -ArgumentList $ArgumentList
+    Install-Binary -Url $Vc2010x64URI -Name $Vc2010x64Name -ArgumentList $ArgumentList
 }
 
 # Initialize environmental variable ChocolateyToolsLocation by invoking choco Get-ToolsLocation function


### PR DESCRIPTION
# Description
`Choco-Install -PackageName vcredist2010` started to fail because the links to vcredist2010 in `chocolateyInstall.ps1` are not valid anymore. We need this package since it provides msvcr100.dll — https://github.com/actions/virtual-environments/pull/1427
This PR adds vcredist2010 installation from the direct links, which were taken from https://www.microsoft.com/en-us/download/details.aspx?id=26999

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2098

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
