### PR TITLE
[Windows] Add --no-progress flag to choco install

### DIFF
--- a/images/win/scripts/ImageHelpers/ChocoHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/ChocoHelpers.ps1
@@ -12,7 +12,7 @@ function Choco-Install {
         while($true)
         {
             Write-Host "Running [#$count]: choco install $packageName -y $argumentList"
-            choco install $packageName -y @argumentList
+            choco install $packageName -y @argumentList --no-progress
 
             $pkg = choco list --localonly $packageName --exact --all --limitoutput
             if ($pkg) {


### PR DESCRIPTION
# Description
There are a lot of logs regarding the packages download process, we can get rid of it using the choco `--no-progress` flag to improve readability.
![image](https://user-images.githubusercontent.com/48208649/115698847-bd711680-a36d-11eb-96c9-194fd1ecdc67.png)

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2109

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
