### PR TITLE
[Windows] Install vsix extensions using CDN endpoint

### DIFF
--- a/images/win/scripts/ImageHelpers/ImageHelpers.psm1
+++ b/images/win/scripts/ImageHelpers/ImageHelpers.psm1
@@ -21,6 +21,7 @@ Export-ModuleMember -Function @(
     'Stop-SvcWithErrHandling'
     'Set-SvcWithErrHandling'
     'Start-DownloadWithRetry'
+    'Get-VsixExtenstionFromMarketplace'
     'Install-VsixExtension'
     'Get-VSExtensionVersion'
     'Get-WinVersion'

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -213,13 +213,13 @@ function Get-VsixExtenstionFromMarketplace {
     $assetUri = $Matches.uri
     $request -match "`"Microsoft\.VisualStudio\.Services\.Payload\.FileName`":`"(?<filename>[^`"]*)" | Out-Null
     $fileName = $Matches.filename
-    $DownloadUri = $assetUri + "/" + $fileName
+    $downloadUri = $assetUri + "/" + $fileName
 
     return [PSCustomObject] @{
         "ExtensionName" = $ExtensionName
         "VsixId" = $vsixId
         "FileName" = $fileName
-        "DownloadUri" = $DownloadUri
+        "DownloadUri" = $downloadUri
     }
 }
 

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -198,6 +198,28 @@ function Start-DownloadWithRetry
     return $filePath
 }
 
+function Get-VsixExtenstionFromMarketplace {
+    Param
+    (
+        [string] $MarketplaceUri
+    )
+
+    $request = Invoke-WebRequest -Uri $MarketplaceUri -UseBasicParsing
+    $request -match "`"AssetUri`":`"(?<uri>[^`"]*)" | Out-Null
+    $assetUri = $Matches.uri
+    $request -match "`"Microsoft\.VisualStudio\.Services\.Payload\.FileName`":`"(?<filename>[^`"]*)" | Out-Null
+    $fileName = $Matches.filename
+    $request -match "VsixId`":`"(?<vsixid>[^`"]*)"
+    $vsixId = $Matches.vsixid
+    $cdnUri = $assetUri + "/" + $fileName
+
+    return [PSCustomObject] @{
+        "VsixId" = $vsixId
+        "FileName" = $fileName
+        "CdnUri" = $cdnUri
+    }
+}
+
 function Install-VsixExtension
 {
     Param

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -201,7 +201,8 @@ function Start-DownloadWithRetry
 function Get-VsixExtenstionFromMarketplace {
     Param
     (
-        [string] $MarketplaceUri
+        [string] $MarketplaceUri,
+        [string] $ExtensionName
     )
 
     $request = Invoke-WebRequest -Uri $MarketplaceUri -UseBasicParsing
@@ -214,6 +215,7 @@ function Get-VsixExtenstionFromMarketplace {
     $cdnUri = $assetUri + "/" + $fileName
 
     return [PSCustomObject] @{
+        "ExtensionName" = $ExtensionName
         "VsixId" = $vsixId
         "FileName" = $fileName
         "CdnUri" = $cdnUri

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -201,24 +201,25 @@ function Start-DownloadWithRetry
 function Get-VsixExtenstionFromMarketplace {
     Param
     (
-        [string] $MarketplaceUri,
-        [string] $ExtensionName
+        [string] $MarketplaceUri
     )
 
     $request = Invoke-WebRequest -Uri $MarketplaceUri -UseBasicParsing
+    $request -match "UniqueIdentifierValue`":`"(?<extensionname>[^`"]*)"
+    $ExtensionName = $Matches.extensionname
+    $request -match "VsixId`":`"(?<vsixid>[^`"]*)"
+    $vsixId = $Matches.vsixid
     $request -match "`"AssetUri`":`"(?<uri>[^`"]*)" | Out-Null
     $assetUri = $Matches.uri
     $request -match "`"Microsoft\.VisualStudio\.Services\.Payload\.FileName`":`"(?<filename>[^`"]*)" | Out-Null
     $fileName = $Matches.filename
-    $request -match "VsixId`":`"(?<vsixid>[^`"]*)"
-    $vsixId = $Matches.vsixid
-    $cdnUri = $assetUri + "/" + $fileName
+    $DownloadUri = $assetUri + "/" + $fileName
 
     return [PSCustomObject] @{
         "ExtensionName" = $ExtensionName
         "VsixId" = $vsixId
         "FileName" = $fileName
-        "CdnUri" = $cdnUri
+        "CdnUri" = $DownloadUri
     }
 }
 

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -205,9 +205,9 @@ function Get-VsixExtenstionFromMarketplace {
     )
 
     $request = Invoke-WebRequest -Uri $MarketplaceUri -UseBasicParsing
-    $request -match "UniqueIdentifierValue`":`"(?<extensionname>[^`"]*)"
-    $ExtensionName = $Matches.extensionname
-    $request -match "VsixId`":`"(?<vsixid>[^`"]*)"
+    $request -match "UniqueIdentifierValue`":`"(?<extensionname>[^`"]*)" | Out-Null
+    $extensionName = $Matches.extensionname
+    $request -match "VsixId`":`"(?<vsixid>[^`"]*)" | Out-Null
     $vsixId = $Matches.vsixid
     $request -match "`"AssetUri`":`"(?<uri>[^`"]*)" | Out-Null
     $assetUri = $Matches.uri
@@ -216,7 +216,7 @@ function Get-VsixExtenstionFromMarketplace {
     $downloadUri = $assetUri + "/" + $fileName
 
     return [PSCustomObject] @{
-        "ExtensionName" = $ExtensionName
+        "ExtensionName" = $extensionName
         "VsixId" = $vsixId
         "FileName" = $fileName
         "DownloadUri" = $downloadUri

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -219,7 +219,7 @@ function Get-VsixExtenstionFromMarketplace {
         "ExtensionName" = $ExtensionName
         "VsixId" = $vsixId
         "FileName" = $fileName
-        "CdnUri" = $DownloadUri
+        "DownloadUri" = $DownloadUri
     }
 }
 

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -201,17 +201,19 @@ function Start-DownloadWithRetry
 function Get-VsixExtenstionFromMarketplace {
     Param
     (
-        [string] $MarketplaceUri
+        [string] $ExtensionMarketPlaceName,
+        [string] $MarketplaceUri = "https://marketplace.visualstudio.com/items?itemName="
     )
 
-    $request = Invoke-WebRequest -Uri $MarketplaceUri -UseBasicParsing
-    $request -match "UniqueIdentifierValue`":`"(?<extensionname>[^`"]*)" | Out-Null
+    $extensionUri = $MarketplaceUri + $ExtensionMarketPlaceName
+    $request = Invoke-WebRequest -Uri $extensionUri -UseBasicParsing
+    $request -match 'UniqueIdentifierValue":"(?<extensionname>[^"]*)' | Out-Null
     $extensionName = $Matches.extensionname
-    $request -match "VsixId`":`"(?<vsixid>[^`"]*)" | Out-Null
+    $request -match 'VsixId":"(?<vsixid>[^"]*)' | Out-Null
     $vsixId = $Matches.vsixid
-    $request -match "`"AssetUri`":`"(?<uri>[^`"]*)" | Out-Null
+    $request -match 'AssetUri":"(?<uri>[^"]*)' | Out-Null
     $assetUri = $Matches.uri
-    $request -match "`"Microsoft\.VisualStudio\.Services\.Payload\.FileName`":`"(?<filename>[^`"]*)" | Out-Null
+    $request -match 'Microsoft\.VisualStudio\.Services\.Payload\.FileName":"(?<filename>[^"]*)' | Out-Null
     $fileName = $Matches.filename
     $downloadUri = $assetUri + "/" + $fileName
 

--- a/images/win/scripts/Installers/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/Initialize-VM.ps1
@@ -127,10 +127,10 @@ if (Test-IsWin16) {
     Choco-Install -PackageName vcredist140
 }
 
-if (Test-IsWin19) {
-    # Install vcredist2010
-    Choco-Install -PackageName vcredist2010
-}
+#if (Test-IsWin19) {
+#    # Install vcredist2010
+#    Choco-Install -PackageName vcredist2010
+#}
 
 # Initialize environmental variable ChocolateyToolsLocation by invoking choco Get-ToolsLocation function
 Import-Module "$env:ChocolateyInstall\helpers\chocolateyInstaller.psm1" -Force

--- a/images/win/scripts/Installers/Install-Vsix.ps1
+++ b/images/win/scripts/Installers/Install-Vsix.ps1
@@ -15,9 +15,11 @@ $vsixPackagesList | ForEach-Object {
     # Retrieve cdn endpoint to avoid HTTP error 429 https://github.com/actions/virtual-environments/issues/3074 
     $request = Invoke-WebRequest -Uri $_.url -UseBasicParsing
     $request -match "`"AssetUri`":`"(?<uri>https:\/\/\S*\.vsassets\.io\S*\/\d*)`""
-    $packageName = $_.name
-    $cdnUrl = $Matches.uri + "/" + $packageName
-    Install-VsixExtension -Url $cdnUrl -Name $packageName -VSversion $vsVersion
+    $assetUri = $Matches.uri
+    $request -match "`"Microsoft\.VisualStudio\.Services\.Payload\.FileName`":`"(?<filename>\S*\.(?:vsix|exe))`""
+    $fileName = $Matches.filename
+    $cdnUri = $assetUri + "/" + $fileName
+    Install-VsixExtension -Url $cdnUri -Name $fileName -VSversion $vsVersion
 }
 
 Invoke-PesterTests -TestFile "Vsix"

--- a/images/win/scripts/Installers/Install-Vsix.ps1
+++ b/images/win/scripts/Installers/Install-Vsix.ps1
@@ -13,7 +13,7 @@ if (-not $vsixPackagesList) {
 $vsVersion = $toolset.visualStudio.Version
 $vsixPackagesList | ForEach-Object {
     # Retrieve cdn endpoint to avoid HTTP error 429 https://github.com/actions/virtual-environments/issues/3074 
-    $vsixPackage = Get-VsixExtenstionFromMarketplace -MarketplaceUri $_.url
+    $vsixPackage = Get-VsixExtenstionFromMarketplace -MarketplaceUri $_.url -ExtensionName $_.name
     Install-VsixExtension -Url $vsixPackage.CdnUri -Name $vsixPackage.FileName -VSversion $vsVersion
 }
 

--- a/images/win/scripts/Installers/Install-Vsix.ps1
+++ b/images/win/scripts/Installers/Install-Vsix.ps1
@@ -12,7 +12,12 @@ if (-not $vsixPackagesList) {
 
 $vsVersion = $toolset.visualStudio.Version
 $vsixPackagesList | ForEach-Object {
-    Install-VsixExtension -Url $_.url -Name $_.name -VSversion $vsVersion
+    # Retrieve cdn endpoint to avoid HTTP error 429 https://github.com/actions/virtual-environments/issues/3074 
+    $request = Invoke-WebRequest -Uri $_.url -UseBasicParsing
+    $request -match "`"AssetUri`":`"(?<uri>https:\/\/\S*\.vsassets\.io\S*\/\d*)`""
+    $packageName = $_.name
+    $cdnUrl = $Matches.uri + "/" + $packageName
+    Install-VsixExtension -Url $cdnUrl -Name $packageName -VSversion $vsVersion
 }
 
 Invoke-PesterTests -TestFile "Vsix"

--- a/images/win/scripts/Installers/Install-Vsix.ps1
+++ b/images/win/scripts/Installers/Install-Vsix.ps1
@@ -13,7 +13,7 @@ if (-not $vsixPackagesList) {
 $vsVersion = $toolset.visualStudio.Version
 $vsixPackagesList | ForEach-Object {
     # Retrieve cdn endpoint to avoid HTTP error 429 https://github.com/actions/virtual-environments/issues/3074 
-    $vsixPackage = Get-VsixExtenstionFromMarketplace -MarketplaceUri $_.url
+    $vsixPackage = Get-VsixExtenstionFromMarketplace -ExtensionMarketPlaceName $_
     Install-VsixExtension -Url $vsixPackage.DownloadUri -Name $vsixPackage.FileName -VSversion $vsVersion
 }
 

--- a/images/win/scripts/Installers/Install-Vsix.ps1
+++ b/images/win/scripts/Installers/Install-Vsix.ps1
@@ -19,6 +19,7 @@ $vsixPackagesList | ForEach-Object {
     $request -match "`"Microsoft\.VisualStudio\.Services\.Payload\.FileName`":`"(?<filename>\S*\.(?:vsix|exe))`""
     $fileName = $Matches.filename
     $cdnUri = $assetUri + "/" + $fileName
+    Write-Host "Installing $fileName extension from $cdnUri"
     Install-VsixExtension -Url $cdnUri -Name $fileName -VSversion $vsVersion
 }
 

--- a/images/win/scripts/Installers/Install-Vsix.ps1
+++ b/images/win/scripts/Installers/Install-Vsix.ps1
@@ -13,14 +13,8 @@ if (-not $vsixPackagesList) {
 $vsVersion = $toolset.visualStudio.Version
 $vsixPackagesList | ForEach-Object {
     # Retrieve cdn endpoint to avoid HTTP error 429 https://github.com/actions/virtual-environments/issues/3074 
-    $request = Invoke-WebRequest -Uri $_.url -UseBasicParsing
-    $request -match "`"AssetUri`":`"(?<uri>https:\/\/\S*\.vsassets\.io\S*\/\d*)`""
-    $assetUri = $Matches.uri
-    $request -match "`"Microsoft\.VisualStudio\.Services\.Payload\.FileName`":`"(?<filename>\S*\.(?:vsix|exe))`""
-    $fileName = $Matches.filename
-    $cdnUri = $assetUri + "/" + $fileName
-    Write-Host "Installing $fileName extension from $cdnUri"
-    Install-VsixExtension -Url $cdnUri -Name $fileName -VSversion $vsVersion
+    $vsixPackage = Get-VsixExtenstionFromMarketplace -MarketplaceUri $_.url
+    Install-VsixExtension -Url $vsixPackage.CdnUri -Name $vsixPackage.FileName -VSversion $vsVersion
 }
 
 Invoke-PesterTests -TestFile "Vsix"

--- a/images/win/scripts/Installers/Install-Vsix.ps1
+++ b/images/win/scripts/Installers/Install-Vsix.ps1
@@ -13,8 +13,8 @@ if (-not $vsixPackagesList) {
 $vsVersion = $toolset.visualStudio.Version
 $vsixPackagesList | ForEach-Object {
     # Retrieve cdn endpoint to avoid HTTP error 429 https://github.com/actions/virtual-environments/issues/3074 
-    $vsixPackage = Get-VsixExtenstionFromMarketplace -MarketplaceUri $_.url -ExtensionName $_.name
-    Install-VsixExtension -Url $vsixPackage.CdnUri -Name $vsixPackage.FileName -VSversion $vsVersion
+    $vsixPackage = Get-VsixExtenstionFromMarketplace -MarketplaceUri $_.url
+    Install-VsixExtension -Url $vsixPackage.DownloadUri -Name $vsixPackage.FileName -VSversion $vsVersion
 }
 
 Invoke-PesterTests -TestFile "Vsix"

--- a/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
@@ -23,12 +23,15 @@ function Get-VisualStudioExtensions {
     # Additional vsixs
     $toolset = Get-ToolsetContent
     $vsixUrls = $toolset.visualStudio.vsix
-    $vsixs = $vsixUrls | ForEach-Object {
-        $vsix = Get-VsixExtenstionFromMarketplace -MarketplaceUri $_.url
-        $vsixVersion = (Get-VisualStudioPackages | Where-Object {$_.Id -match $vsix.VsixId -and $_.type -eq 'vsix'}).Version
-        @{
-            Package = $vsix.ExtensionName
-            Version = $vsixVersion
+    if ($vsixUrls)
+    {
+        $vsixs = $vsixUrls | ForEach-Object {
+            $vsix = Get-VsixExtenstionFromMarketplace -MarketplaceUri $_.url
+            $vsixVersion = (Get-VisualStudioPackages | Where-Object {$_.Id -match $vsix.VsixId -and $_.type -eq 'vsix'}).Version
+            @{
+                Package = $vsix.ExtensionName
+                Version = $vsixVersion
+            }
         }
     }
 

--- a/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
@@ -26,7 +26,7 @@ function Get-VisualStudioExtensions {
     if ($vsixUrls)
     {
         $vsixs = $vsixUrls | ForEach-Object {
-            $vsix = Get-VsixExtenstionFromMarketplace -MarketplaceUri $_.url
+            $vsix = Get-VsixExtenstionFromMarketplace -ExtensionMarketPlaceName $_
             $vsixVersion = (Get-VisualStudioPackages | Where-Object {$_.Id -match $vsix.VsixId -and $_.type -eq 'vsix'}).Version
             @{
                 Package = $vsix.ExtensionName

--- a/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
@@ -20,6 +20,18 @@ function Get-WDKVersion {
 }
 
 function Get-VisualStudioExtensions {
+    # Additional vsixs
+    $toolset = Get-ToolsetContent
+    $vsixUrls = $toolset.visualStudio.vsix
+    $vsixs = $vsixUrls | ForEach-Object {
+        $vsix = Get-VsixExtenstionFromMarketplace -MarketplaceUri $_.url
+        $vsixVersion = (Get-VisualStudioPackages | Where-Object {$_.Id -match $vsix.VsixId -and $_.type -eq 'vsix'}).Version
+        @{
+            Package = $vsix.ExtensionName
+            Version = $vsixVersion
+        }
+    }
+
     # Wix
     $vs = (Get-VisualStudioVersion).Name.Split()[-1]
     $wixPackageVersion = Get-WixVersion
@@ -29,18 +41,9 @@ function Get-VisualStudioExtensions {
     $wdkPackageVersion = Get-VSExtensionVersion -packageName 'Microsoft.Windows.DriverKit'
     $wdkExtensionVersion = Get-WDKVersion
 
-    # SSDT
-    $analysisPackageVersion = Get-VSExtensionVersion -packageName '04a86fc2-dbd5-4222-848e-911638e487fe'
-    $reportingPackageVersion = Get-VSExtensionVersion -packageName '717ad572-c4b7-435c-c166-c2969777f718'
-
-    $integrationPackageName = ($vs -match "2019") ? '851E7A09-7B2B-4F06-A15D-BABFCB26B970' : 'D1B09713-C12E-43CC-9EF4-6562298285AB'
-    $integrationPackageVersion = Get-VSExtensionVersion -packageName $integrationPackageName
-
     $extensions = @(
-        @{Package = 'SSDT Microsoft Analysis Services Projects'; Version = $analysisPackageVersion}
-        @{Package = 'SSDT SQL Server Integration Services Projects'; Version = $integrationPackageVersion}
-        @{Package = 'SSDT Microsoft Reporting Services Projects'; Version = $reportingPackageVersion}
-        @{Package = 'Windows Driver Kit'; Version = $wixPackageVersion}
+        $vsixs
+        @{Package = 'Windows Driver Kit'; Version = $wdkPackageVersion}
         @{Package = 'Windows Driver Kit Visual Studio Extension'; Version = $wdkExtensionVersion}
         @{Package = 'WIX Toolset'; Version = $wixPackageVersion}
         @{Package = "WIX Toolset Studio $vs Extension"; Version = $wixExtensionVersion}
@@ -48,5 +51,5 @@ function Get-VisualStudioExtensions {
 
     $extensions | Foreach-Object {
         [PSCustomObject]$_
-    } | Select-Object Package, Version
+    } | Select-Object Package, Version | Sort-Object Package
 }

--- a/images/win/scripts/Tests/Vsix.Tests.ps1
+++ b/images/win/scripts/Tests/Vsix.Tests.ps1
@@ -4,7 +4,7 @@ Describe "Vsix" {
 
     $allPackages = (Get-VSSetupInstance | Select-VsSetupInstance -Product *).Packages
     $testCases = $requiredVsixs | ForEach-Object {
-        $vsix = Get-VsixExtenstionFromMarketplace -MarketplaceUri $_.url
+        $vsix = Get-VsixExtenstionFromMarketplace -ExtensionMarketPlaceName $_
         @{
             VsixName = $vsix.ExtensionName
             VsixId = $vsix.VsixId

--- a/images/win/scripts/Tests/Vsix.Tests.ps1
+++ b/images/win/scripts/Tests/Vsix.Tests.ps1
@@ -12,7 +12,7 @@ Describe "Vsix" {
         }
     }
     if ($testCases.Count -gt 0) {
-        It "Extension <VsixName>" -TestCases $testCases {
+        It "Extension <VsixName> is installed" -TestCases $testCases {
             $objVsix = $AllPackages | Where-Object { $_.id -eq $VsixId }
             $objVsix | Should -Not -BeNullOrEmpty
         }

--- a/images/win/scripts/Tests/Vsix.Tests.ps1
+++ b/images/win/scripts/Tests/Vsix.Tests.ps1
@@ -4,14 +4,15 @@ Describe "Vsix" {
 
     $allPackages = (Get-VSSetupInstance | Select-VsSetupInstance -Product *).Packages
     $testCases = $requiredVsixs | ForEach-Object {
-        $vsixId = (Get-VsixExtenstionFromMarketplace -MarketplaceUri $_.url).VsixId
+        $vsix = Get-VsixExtenstionFromMarketplace -MarketplaceUri $_.url -ExtensionName $_.name
         @{
-            VsixId = $vsixId
+            VsixName = $vsix.ExtensionName
+            VsixId = $vsix.VsixId
             AllPackages = $allPackages
         }
     }
     if ($testCases.Count -gt 0) {
-        It "Extension <VsixId>" -TestCases $testCases {
+        It "Extension <VsixName>" -TestCases $testCases {
             $objVsix = $AllPackages | Where-Object { $_.id -eq $VsixId }
             $objVsix | Should -Not -BeNullOrEmpty
         }

--- a/images/win/scripts/Tests/Vsix.Tests.ps1
+++ b/images/win/scripts/Tests/Vsix.Tests.ps1
@@ -4,7 +4,7 @@ Describe "Vsix" {
 
     $allPackages = (Get-VSSetupInstance | Select-VsSetupInstance -Product *).Packages
     $testCases = $requiredVsixs | ForEach-Object {
-        $vsix = Get-VsixExtenstionFromMarketplace -MarketplaceUri $_.url -ExtensionName $_.name
+        $vsix = Get-VsixExtenstionFromMarketplace -MarketplaceUri $_.url
         @{
             VsixName = $vsix.ExtensionName
             VsixId = $vsix.VsixId

--- a/images/win/scripts/Tests/Vsix.Tests.ps1
+++ b/images/win/scripts/Tests/Vsix.Tests.ps1
@@ -3,7 +3,13 @@ Describe "Vsix" {
     $requiredVsixs = $toolset.visualStudio.vsix
 
     $allPackages = (Get-VSSetupInstance | Select-VsSetupInstance -Product *).Packages
-    $testCases = $requiredVsixs | ForEach-Object { @{ VsixId = $_.Id;  AllPackages = $allPackages }}
+    $testCases = $requiredVsixs | ForEach-Object {
+        $vsixId = (Get-VsixExtenstionFromMarketplace -MarketplaceUri $_.url).VsixId
+        @{
+            VsixId = $vsixId
+            AllPackages = $allPackages
+        }
+    }
     if ($testCases.Count -gt 0) {
         It "Extension <VsixId>" -TestCases $testCases {
             $objVsix = $AllPackages | Where-Object { $_.id -eq $VsixId }

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -270,21 +270,11 @@
             "Component.MDD.Linux.GCC.arm"
         ],
         "vsix": [
-            {
-                "url": "https://marketplace.visualstudio.com/items?itemName=ProBITools.MicrosoftAnalysisServicesModelingProjects"
-            },
-            {
-                "url": "https://marketplace.visualstudio.com/items?itemName=SSIS.SqlServerIntegrationServicesProjects"
-            },
-            {
-                "url": "https://marketplace.visualstudio.com/items?itemName=ProBITools.MicrosoftReportProjectsforVisualStudio"
-            },
-            {
-                "url": "https://marketplace.visualstudio.com/items?itemName=VisualStudioClient.MicrosoftVisualStudio2017InstallerProjects"
-            },
-            {
-                "url": "https://marketplace.visualstudio.com/items?itemName=ms-biztalk.BizTalk"
-            }
+            "ProBITools.MicrosoftAnalysisServicesModelingProjects",
+            "SSIS.SqlServerIntegrationServicesProjects",
+            "ProBITools.MicrosoftReportProjectsforVisualStudio",
+            "VisualStudioClient.MicrosoftVisualStudio2017InstallerProjects",
+            "ms-biztalk.BizTalk"
         ]
     },
     "docker": {

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -271,27 +271,22 @@
         ],
         "vsix": [
             {
-                "name": "Microsoft.DataTools.AnalysisServices.vsix",
                 "url": "https://marketplace.visualstudio.com/items?itemName=ProBITools.MicrosoftAnalysisServicesModelingProjects",
                 "id": "04a86fc2-dbd5-4222-848e-911638e487fe"
             },
             {
-                "name": "Microsoft.DataTools.IntegrationServices.exe",
                 "url": "https://marketplace.visualstudio.com/items?itemName=SSIS.SqlServerIntegrationServicesProjects",
                 "id": "851E7A09-7B2B-4F06-A15D-BABFCB26B970"
             },
             {
-                "name": "Microsoft.DataTools.ReportingServices.vsix",
                 "url": "https://marketplace.visualstudio.com/items?itemName=ProBITools.MicrosoftReportProjectsforVisualStudio",
                 "id": "717ad572-c4b7-435c-c166-c2969777f718"
             },
             {
-                "name": "Microsoft.VisualStudio.Installer.Projects.vsix",
                 "url": "https://marketplace.visualstudio.com/items?itemName=VisualStudioClient.MicrosoftVisualStudio2017InstallerProjects",
                 "id": "VSInstallerProjects"
             },
             {
-                "name": "BizTalkVsix.vsix",
                 "url": "https://marketplace.visualstudio.com/items?itemName=ms-biztalk.BizTalk",
                 "id": "BizTalkProjectSystem.BD1D0FA0-E48A-4270-995F-F110DD9F7838"
             }

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -271,24 +271,19 @@
         ],
         "vsix": [
             {
-                "url": "https://marketplace.visualstudio.com/items?itemName=ProBITools.MicrosoftAnalysisServicesModelingProjects",
-                "id": "04a86fc2-dbd5-4222-848e-911638e487fe"
+                "url": "https://marketplace.visualstudio.com/items?itemName=ProBITools.MicrosoftAnalysisServicesModelingProjects"
             },
             {
-                "url": "https://marketplace.visualstudio.com/items?itemName=SSIS.SqlServerIntegrationServicesProjects",
-                "id": "851E7A09-7B2B-4F06-A15D-BABFCB26B970"
+                "url": "https://marketplace.visualstudio.com/items?itemName=SSIS.SqlServerIntegrationServicesProjects"
             },
             {
-                "url": "https://marketplace.visualstudio.com/items?itemName=ProBITools.MicrosoftReportProjectsforVisualStudio",
-                "id": "717ad572-c4b7-435c-c166-c2969777f718"
+                "url": "https://marketplace.visualstudio.com/items?itemName=ProBITools.MicrosoftReportProjectsforVisualStudio"
             },
             {
-                "url": "https://marketplace.visualstudio.com/items?itemName=VisualStudioClient.MicrosoftVisualStudio2017InstallerProjects",
-                "id": "VSInstallerProjects"
+                "url": "https://marketplace.visualstudio.com/items?itemName=VisualStudioClient.MicrosoftVisualStudio2017InstallerProjects"
             },
             {
-                "url": "https://marketplace.visualstudio.com/items?itemName=ms-biztalk.BizTalk",
-                "id": "BizTalkProjectSystem.BD1D0FA0-E48A-4270-995F-F110DD9F7838"
+                "url": "https://marketplace.visualstudio.com/items?itemName=ms-biztalk.BizTalk"
             }
         ]
     },

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -272,27 +272,27 @@
         "vsix": [
             {
                 "name": "Microsoft.DataTools.AnalysisServices.vsix",
-                "url": "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ProBITools/vsextensions/MicrosoftAnalysisServicesModelingProjects/2.9.5/vspackage",
+                "url": "https://marketplace.visualstudio.com/items?itemName=ProBITools.MicrosoftAnalysisServicesModelingProjects",
                 "id": "04a86fc2-dbd5-4222-848e-911638e487fe"
             },
             {
                 "name": "Microsoft.DataTools.IntegrationServices.exe",
-                "url": "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/SSIS/vsextensions/SqlServerIntegrationServicesProjects/3.4/vspackage",
+                "url": "https://marketplace.visualstudio.com/items?itemName=SSIS.SqlServerIntegrationServicesProjects",
                 "id": "851E7A09-7B2B-4F06-A15D-BABFCB26B970"
             },
             {
                 "name": "Microsoft.DataTools.ReportingServices.vsix",
-                "url": "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ProBITools/vsextensions/MicrosoftReportProjectsforVisualStudio/2.6.3/vspackage",
+                "url": "https://marketplace.visualstudio.com/items?itemName=ProBITools.MicrosoftReportProjectsforVisualStudio",
                 "id": "717ad572-c4b7-435c-c166-c2969777f718"
             },
             {
                 "name": "Microsoft.VisualStudio.Installer.Projects.vsix",
-                "url": "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/VisualStudioClient/vsextensions/MicrosoftVisualStudio2017InstallerProjects/latest/vspackage",
+                "url": "https://marketplace.visualstudio.com/items?itemName=VisualStudioClient.MicrosoftVisualStudio2017InstallerProjects",
                 "id": "VSInstallerProjects"
             },
             {
                 "name": "BizTalkVsix.vsix",
-                "url": "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-biztalk/vsextensions/BizTalk/3.13.2.0/vspackage",
+                "url": "https://marketplace.visualstudio.com/items?itemName=ms-biztalk.BizTalk",
                 "id": "BizTalkProjectSystem.BD1D0FA0-E48A-4270-995F-F110DD9F7838"
             }
         ]

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -271,23 +271,18 @@
         ],
         "vsix": [
             {
-                "name": "Microsoft Analysis Services Projects",
                 "url": "https://marketplace.visualstudio.com/items?itemName=ProBITools.MicrosoftAnalysisServicesModelingProjects"
             },
             {
-                "name": "SQL Server Integration Services Projects",
                 "url": "https://marketplace.visualstudio.com/items?itemName=SSIS.SqlServerIntegrationServicesProjects"
             },
             {
-                "name": "Microsoft Reporting Services Projects",
                 "url": "https://marketplace.visualstudio.com/items?itemName=ProBITools.MicrosoftReportProjectsforVisualStudio"
             },
             {
-                "name": "Microsoft Visual Studio Installer Projects",
                 "url": "https://marketplace.visualstudio.com/items?itemName=VisualStudioClient.MicrosoftVisualStudio2017InstallerProjects"
             },
             {
-                "name": "BizTalk Server",
                 "url": "https://marketplace.visualstudio.com/items?itemName=ms-biztalk.BizTalk"
             }
         ]

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -271,18 +271,23 @@
         ],
         "vsix": [
             {
+                "name": "Microsoft Analysis Services Projects",
                 "url": "https://marketplace.visualstudio.com/items?itemName=ProBITools.MicrosoftAnalysisServicesModelingProjects"
             },
             {
+                "name": "SQL Server Integration Services Projects",
                 "url": "https://marketplace.visualstudio.com/items?itemName=SSIS.SqlServerIntegrationServicesProjects"
             },
             {
+                "name": "Microsoft Reporting Services Projects",
                 "url": "https://marketplace.visualstudio.com/items?itemName=ProBITools.MicrosoftReportProjectsforVisualStudio"
             },
             {
+                "name": "Microsoft Visual Studio Installer Projects",
                 "url": "https://marketplace.visualstudio.com/items?itemName=VisualStudioClient.MicrosoftVisualStudio2017InstallerProjects"
             },
             {
+                "name": "BizTalk Server",
                 "url": "https://marketplace.visualstudio.com/items?itemName=ms-biztalk.BizTalk"
             }
         ]


### PR DESCRIPTION
# Description
There is a 429 error during vsix packages downloading due to the limitation for unauthorized marketplace users. We have implemented retry logic for it but, unfortunately, it doesn't help all the time. The marketplace support team suggested using direct CDN links, which can be retrieved from an extension webpage.
This PR adds logic to parse the marketplace extension page and get the name, id, CDN URI, and filename of the extension. The software report was also improved to output all the extensions from the toolset.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3074

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
