### PR TITLE
Updated maven from 3.6.3 to 3.8.1

### DIFF
--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -62,10 +62,10 @@ apt-fast install -y --no-install-recommends ant ant-optional
 echo "ANT_HOME=/usr/share/ant" | tee -a /etc/environment
 
 # Install Maven
-curl -sL https://www-eu.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip
+curl -sL https://www-eu.apache.org/dist/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.zip -o maven.zip
 unzip -qq -d /usr/share maven.zip
 rm maven.zip
-ln -s /usr/share/apache-maven-3.6.3/bin/mvn /usr/bin/mvn
+ln -s /usr/share/apache-maven-3.8.1/bin/mvn /usr/bin/mvn
 
 # Install Gradle
 # This script downloads the latest HTML list of releases at https://gradle.org/releases/.

--- a/images/win/scripts/Installers/Install-JavaTools.ps1
+++ b/images/win/scripts/Installers/Install-JavaTools.ps1
@@ -105,7 +105,7 @@ foreach ($jdkVersion in $jdkVersions) {
 # Install Java tools
 # Force chocolatey to ignore dependencies on Ant and Maven or else they will download the Oracle JDK
 Choco-Install -PackageName ant -ArgumentList "-i"
-Choco-Install -PackageName maven -ArgumentList "-i", "--version=3.6.3"
+Choco-Install -PackageName maven -ArgumentList "-i", "--version=3.8.1"
 Choco-Install -PackageName gradle
 
 # Move maven variables to Machine. They may not be in the environment for this script so we need to read them from the registry.


### PR DESCRIPTION
# Description
Maven 3.8.1 was released recently it would be great if we could update it to be the new default as part of the Java setup.
Fixes #3246 

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
