### PR TITLE
[Ubuntu] Increase Linux stack space to 16384KB

### DIFF
--- a/images/linux/scripts/base/limits.sh
+++ b/images/linux/scripts/base/limits.sh
@@ -7,4 +7,5 @@ echo 'session required pam_limits.so' >> /etc/pam.d/common-session-noninteractiv
 echo 'DefaultLimitNOFILE=65536' >> /etc/systemd/system.conf
 
 # Double stack size from default 8192KB
-ulimit -s 16384
+echo '* soft stack 16384' >> /etc/security/limits.conf
+echo '* hard stack 16384' >> /etc/security/limits.conf

--- a/images/linux/scripts/base/limits.sh
+++ b/images/linux/scripts/base/limits.sh
@@ -5,3 +5,6 @@ echo '* hard nofile 65536' >> /etc/security/limits.conf
 echo 'session required pam_limits.so' >> /etc/pam.d/common-session
 echo 'session required pam_limits.so' >> /etc/pam.d/common-session-noninteractive
 echo 'DefaultLimitNOFILE=65536' >> /etc/systemd/system.conf
+
+# Double stack size from default 8192KB
+ulimit -s 16384


### PR DESCRIPTION
# Description
Increases the Linux stack space from kernel default of `8192KB` to `16384KB`.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: #3257

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
