### PR TITLE
[Windows] Return VS2017 SSDT extensions to the readme

### DIFF
--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -309,7 +309,7 @@ function Get-VSExtensionVersion
 
     if (-not $packageVersion)
     {
-        Write-Host "Installed package $packageName for Visual Studio 2019 was not found"
+        Write-Host "Installed package $packageName for Visual Studio was not found"
         exit 1
     }
 

--- a/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
@@ -41,7 +41,7 @@ function Get-VisualStudioExtensions {
     {
         $analysisPackageVersion = Get-VSExtensionVersion -packageName '04a86fc2-dbd5-4222-848e-911638e487fe'
         $reportingPackageVersion = Get-VSExtensionVersion -packageName '717ad572-c4b7-435c-c166-c2969777f718'
-        $integrationPackageName = Get-VSExtensionVersion -packageName 'D1B09713-C12E-43CC-9EF4-6562298285AB'
+        $integrationPackageName = Get-VSExtensionVersion -packageName 'd1b09713-c12e-43cc-9ef4-6562298285ab'
         $ssdtPackages = @(
             @{Package = 'SSDT Microsoft Analysis Services Projects'; Version = $analysisPackageVersion}
             @{Package = 'SSDT SQL Server Integration Services Projects'; Version = $reportingPackageVersion}

--- a/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
@@ -35,8 +35,21 @@ function Get-VisualStudioExtensions {
         }
     }
 
-    # Wix
+    # SSDT extensions for VS2017
     $vs = (Get-VisualStudioVersion).Name.Split()[-1]
+    if ($vs -eq "2017")
+    {
+        $analysisPackageVersion = Get-VSExtensionVersion -packageName '04a86fc2-dbd5-4222-848e-911638e487fe'
+        $reportingPackageVersion = Get-VSExtensionVersion -packageName '717ad572-c4b7-435c-c166-c2969777f718'
+        $integrationPackageName = Get-VSExtensionVersion -packageName 'D1B09713-C12E-43CC-9EF4-6562298285AB'
+        $ssdtPackages = @(
+            @{Package = 'SSDT Microsoft Analysis Services Projects'; Version = $analysisPackageVersion}
+            @{Package = 'SSDT SQL Server Integration Services Projects'; Version = $reportingPackageVersion}
+            @{Package = 'SSDT Microsoft Reporting Services Projects'; Version = $integrationPackageName}
+        )
+    }
+
+    # Wix
     $wixPackageVersion = Get-WixVersion
     $wixExtensionVersion = (Get-VisualStudioPackages | Where-Object {$_.Id -match 'WixToolset.VisualStudioExtension.Dev' -and $_.type -eq 'vsix'}).Version
 
@@ -46,6 +59,7 @@ function Get-VisualStudioExtensions {
 
     $extensions = @(
         $vsixs
+        $ssdtPackages
         @{Package = 'Windows Driver Kit'; Version = $wdkPackageVersion}
         @{Package = 'Windows Driver Kit Visual Studio Extension'; Version = $wdkExtensionVersion}
         @{Package = 'WIX Toolset'; Version = $wixPackageVersion}


### PR DESCRIPTION
# Description
VS2017 has a separate SSDT installation, which includes 3 extensions that should be mentioned in the docs.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3074

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
