### PR TITLE
Remove apt sources used to install azure-cli only

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -184,7 +184,8 @@ function Get-JqVersion {
 
 function Get-AzureCliVersion {
     $azcliVersion = az -v | Select-String "azure-cli" | Take-OutputPart -Part -1
-    return "Azure CLI (azure-cli) $azcliVersion"
+    $aptSourceRepo = Get-AptSourceRepository -PackageName "azure-cli"
+    return "Azure CLI (azure-cli) $azcliVersion (installation method: $aptSourceRepo)"
 }
 
 function Get-AzureDevopsVersion {

--- a/images/linux/scripts/installers/azure-cli.sh
+++ b/images/linux/scripts/installers/azure-cli.sh
@@ -6,5 +6,8 @@
 
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+echo "azure-cli https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt" >> $HELPER_SCRIPTS/apt-sources.txt
+rm -f /etc/apt/sources.list.d/azure-cli.list
+rm -f /etc/apt/sources.list.d/azure-cli.list.save
 
 invoke_tests "CLI.Tools" "Azure CLI"


### PR DESCRIPTION
# Description
Improvement

Remove PPA repo from the apt/sources.list

#### Related issues: https://github.com/actions/virtual-environments-internal/issues/2075
https://github.com/actions/virtual-environments/issues/2951#issuecomment-819658892

## Check list
- [x] Related issue / work item is attacheda
- [x] Changes are tested and related VM images are successfully generated
