### PR TITLE
[macOS] Skip AppleWWDRCAG3 certificate installation for Big Sur

### DIFF
--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e -o pipefail
 
+source ~/utils/utils.sh
+
 echo "Enabling safari driver..."
 # https://developer.apple.com/documentation/webkit/testing_with_webdriver_in_safari
 # Safari’s executable is located at /usr/bin/safaridriver

--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -21,9 +21,13 @@ sudo "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1176 885
 # Rotate the certificate before expiration to ensure your apps are installed and signed with an active certificate.
 # Confirm that the correct intermediate certificate is installed by verifying the expiration date is set to 2030.
 # sudo security delete-certificate -Z FF6797793A3CD798DC5B2ABEF56F73EDC9F83A64 /Library/Keychains/System.keychain
-curl https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer --output $HOME/AppleWWDRCAG3.cer --silent
-sudo security add-trusted-cert -d -r unspecified -k /Library/Keychains/System.keychain $HOME/AppleWWDRCAG3.cer
-rm $HOME/AppleWWDRCAG3.cer
+# Big Sur asks for user password https://developer.apple.com/forums/thread/671582, we need to make sure this cert is installed on the base image
+if is_Less_BigSur; then
+    curl https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer --output $HOME/AppleWWDRCAG3.cer --silent
+    sudo security add-trusted-cert -d -r unspecified -k /Library/Keychains/System.keychain $HOME/AppleWWDRCAG3.cer
+    rm $HOME/AppleWWDRCAG3.cer
+fi
+
 
 # Create symlink for tests running
 if [ ! -d "/usr/local/bin" ];then

--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -21,7 +21,7 @@ sudo "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1176 885
 # Rotate the certificate before expiration to ensure your apps are installed and signed with an active certificate.
 # Confirm that the correct intermediate certificate is installed by verifying the expiration date is set to 2030.
 # sudo security delete-certificate -Z FF6797793A3CD798DC5B2ABEF56F73EDC9F83A64 /Library/Keychains/System.keychain
-# Big Sur asks for user password https://developer.apple.com/forums/thread/671582, we need to make sure this cert is installed on the base image
+# Big Sur requires user interaction to add a cert https://developer.apple.com/forums/thread/671582, we need to make sure this cert is installed on the base image
 if is_Less_BigSur; then
     curl https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer --output $HOME/AppleWWDRCAG3.cer --silent
     sudo security add-trusted-cert -d -r unspecified -k /Library/Keychains/System.keychain $HOME/AppleWWDRCAG3.cer

--- a/images/macos/tests/System.Tests.ps1
+++ b/images/macos/tests/System.Tests.ps1
@@ -10,7 +10,7 @@ Describe "Disk free space" {
 }
 
 Describe "Certificate" {
-    It "Apple Worldwide Developer Relations Certification Authority[expired: 2030-02] is installed" {
+    It "Apple Worldwide Developer Relations Certification Authority[expired: 2030-02] is installed (Should be on the base image for Big Sur)" {
         $sha1Hash = "06EC06599F4ED0027CC58956B4D3AC1255114F35"
         $certs = security find-certificate -a -c Worldwide -p -Z | Out-String
         $certs | Should -Match $sha1Hash


### PR DESCRIPTION
# Description
Starting from Big Sur 11.3 certificate installation requires user interaction thus we need to add the AppleWWDRCAG3 certificate to the base image and avoid installing it during the provisioning process.
![image](https://user-images.githubusercontent.com/48208649/116271371-97da7780-a788-11eb-9b68-4c06f31caa3e.png)

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2115

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
