### PR TITLE
Rework Mono installation to avoid using apt repos on Ubuntu images

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -58,7 +58,8 @@ function Get-ErlangVersion {
 
 function Get-MonoVersion {
     $monoVersion = mono --version | Out-String | Take-OutputPart -Part 4
-    return "Mono $monoVersion"
+    $aptSourceRepo = Get-AptSourceRepository -PackageName "mono"
+    return "Mono $monoVersion (apt source repository: $aptSourceRepo)"
 }
 
 function Get-MsbuildVersion {

--- a/images/linux/scripts/helpers/SoftwareReport.Helpers.psm1
+++ b/images/linux/scripts/helpers/SoftwareReport.Helpers.psm1
@@ -106,7 +106,7 @@ function Get-CachedToolInstances
 function Get-AptSourceRepository {
     param([String] $PackageName)
 
-    $sourceUrl = Get-Content "$PSScriptRoot/../helpers/apt-sources.txt" | Select-String -Pattern $PackageName | Take-OutputPart -Part 1
+    $sourceUrl = Get-Content "$PSScriptRoot/../helpers/apt-sources.txt" | Select-String -Pattern $PackageName | Take-OutputPart -Part (1..3)
     return $sourceUrl
 }
 

--- a/images/linux/scripts/installers/mono.sh
+++ b/images/linux/scripts/installers/mono.sh
@@ -14,4 +14,8 @@ echo "deb https://download.mono-project.com/repo/ubuntu stable-$LSB_CODENAME mai
 apt-get update
 apt-get install -y --no-install-recommends apt-transport-https mono-complete nuget
 
+rm /etc/apt/sources.list.d/mono-official-stable.list
+rm -f /etc/apt/sources.list.d/mono-official-stable.list.save
+echo "mono https://download.mono-project.com/repo/ubuntu stable-$LSB_CODENAME main" >> $HELPER_SCRIPTS/apt-sources.txt
+
 invoke_tests "Tools" "Mono"


### PR DESCRIPTION
# Description
Improvement

Remove download.mono-project.com repo from the apt/sources.list

#### Related issues: https://github.com/actions/virtual-environments-internal/issues/2070
https://github.com/actions/virtual-environments/issues/2951#issuecomment-819658892

## Check list
- [x] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
