### PR TITLE
select-xamarin-sdk-v2

### DIFF
--- a/images/macos/provision/assets/select-xamarin-sdk-v2.sh
+++ b/images/macos/provision/assets/select-xamarin-sdk-v2.sh
@@ -22,7 +22,7 @@ change_framework_version() {
   fi
 
   local framework_path=$(get_framework_path "$framework")
-  sudo rm -f ${framework_path}/Current
+  sudo rm -f "${framework_path}/Current"
   sudo ln -s "${framework_path}/${version}" "${framework_path}/Current"
 }
 

--- a/images/macos/provision/assets/select-xamarin-sdk-v2.sh
+++ b/images/macos/provision/assets/select-xamarin-sdk-v2.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e -o pipefail
-
 get_framework_path() {
   case $1 in
   --mono) echo '/Library/Frameworks/Mono.framework/Versions' ;;
@@ -17,13 +16,21 @@ change_framework_version() {
   echo "Select $framework $version"
 
   local countDigit=$(echo "${version}" | grep -o "\." | grep -c "\.")
-  if [[ countDigit -gt 1 ]]; then
+  
+  if [[( countDigit -gt 1 ) && ( ! countDigit -eq 3)]]; then
     echo "[WARNING] It is not recommended to specify the exact framework version because your build can be broken with the next patch update. Consider using "major.minor" only format."
   fi
 
   local framework_path=$(get_framework_path "$framework")
-  sudo rm -f "${framework_path}/Current"
-  sudo ln -s "${framework_path}/${version}" "${framework_path}/Current"
+  local is_existed_version=$(find "${framework_path}" -name "${version}*")
+
+  if [ -z "$is_existed_version" ]; then
+    echo "Invalid framework version"
+    exit 1
+  else
+    sudo rm -f "${framework_path}/Current"
+    sudo ln -s "${framework_path}/${version}" "${framework_path}/Current"
+  fi
 }
 
 for arg in "$@"; do

--- a/images/macos/provision/assets/select-xamarin-sdk-v2.sh
+++ b/images/macos/provision/assets/select-xamarin-sdk-v2.sh
@@ -18,7 +18,7 @@ change_framework_version() {
 
   local countDigit=$(echo "${version}" | grep -o "\." | grep -c "\.")
   if [[ countDigit -gt 1 ]]; then
-    echo "[WARNING] It is not recommended to specify version in "a.b.c.d" format because your pipeline can be broken suddenly in future. Use "a.b" format."
+    echo "[WARNING] It is not recommended to specify the exact framework version because your build can be broken with the next patch update. Consider using "major.minor" only format."
   fi
 
   local framework_path=$(get_framework_path "$framework")

--- a/images/macos/provision/assets/select-xamarin-sdk-v2.sh
+++ b/images/macos/provision/assets/select-xamarin-sdk-v2.sh
@@ -17,19 +17,18 @@ change_framework_version() {
 
   local countDigit=$(echo "${version}" | grep -o "\." | grep -c "\.")
   
-  if [[( countDigit -gt 1 ) && ( ! countDigit -eq 3)]]; then
+  if [[ countDigit -gt 1 ]]; then
     echo "[WARNING] It is not recommended to specify the exact framework version because your build can be broken with the next patch update. Consider using "major.minor" only format."
   fi
 
   local framework_path=$(get_framework_path "$framework")
-  local is_existed_version=$(find "${framework_path}" -name "${version}*")
 
-  if [ -z "$is_existed_version" ]; then
-    echo "Invalid framework version"
-    exit 1
-  else
+  if [ -d "${framework_path}/${version}" ]; then
     sudo rm -f "${framework_path}/Current"
     sudo ln -s "${framework_path}/${version}" "${framework_path}/Current"
+  else
+    echo "Invalid framework version ${framework_path}/${version}"
+    exit 1
   fi
 }
 

--- a/images/macos/provision/assets/select-xamarin-sdk-v2.sh
+++ b/images/macos/provision/assets/select-xamarin-sdk-v2.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -e -o pipefail
+
+get_framework_path() {
+  case $1 in
+  --mono) echo '/Library/Frameworks/Mono.framework/Versions' ;;
+  --ios) echo '/Library/Frameworks/Xamarin.iOS.framework/Versions' ;;
+  --android) echo '/Library/Frameworks/Xamarin.Android.framework/Versions' ;;
+  --mac) echo '/Library/Frameworks/Xamarin.Mac.framework/Versions' ;;
+  *) ;;
+  esac
+}
+
+change_framework_version() {
+  local framework=$1
+  local version=$2
+
+  echo "Select $framework $version"
+
+  local countDigit=$(echo "${version}" | grep -o "\." | grep -c "\.")
+  if [[ countDigit -gt 1 ]]; then
+    echo "[WARNING] It is not recommended to specify version in "a.b.c.d" format because your pipeline can be broken suddenly in future. Use "a.b" format."
+  fi
+
+  local framework_path=$(get_framework_path "$framework")
+  sudo rm -f ${framework_path}/Current
+  sudo ln -s "${framework_path}/${version}" "${framework_path}/Current"
+}
+
+for arg in "$@"; do
+  key=$(echo $arg | cut -f1 -d=)
+  value=$(echo $arg | cut -f2 -d=)
+
+  case $key in
+  --mono | --ios | --android | --mac) change_framework_version $key $value ;;
+  *)
+  echo "Invalid parameter <${key}>"   
+  exit 1
+  ;;
+  esac
+done


### PR DESCRIPTION
# Description

It is a new script that allows choosing a version for any Xamarin frameworks. 
Now you should run the script with params, e.g.: select-xamarin-sdk-v2 --mono=6.2 --android=10.0 --ios=9.2 --mac=16.2. 
You also can combine a few params that u need, not all of them, e.g.: select-xamarin-sdk-v2 --android=10.0 --mac=16.2. 

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
