### PR TITLE
Adds poetry package manager to Windows and Ubuntu

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -346,6 +346,13 @@ function Get-PipxVersion {
     return "Pipx $pipxVersion"
 }
 
+function Get-PoetryVersion {
+    $result = Get-CommandResult "poetry --version"
+    $result.Output -match "Poetry version (?<version>\d+\.\d+\.\d+)" | Out-Null
+    $pipVersion = $Matches.version
+    return "Poetry $pipVersion"
+}
+
 function Get-GraalVMVersion {
     $version = & "$env:GRAALVM_11_ROOT\bin\java" --version | Select-String -Pattern "GraalVM" | Take-OutputPart -Part 5,6
     return $version

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -72,6 +72,7 @@ $packageManagementList = @(
 if (-not (Test-IsUbuntu16)) {
     $packageManagementList += @(
         (Get-PipxVersion)
+		(Get-PoetryVersion)
     )
 }
 

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -229,6 +229,10 @@
         {
             "package": "ansible-base",
             "cmd": "ansible"
+        },
+        {
+            "package": "poetry",
+            "cmd": "poetry"
         }
     ],
     "dotnet": {

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -229,6 +229,10 @@
         {
             "package": "ansible-base",
             "cmd": "ansible"
+        },
+        {
+            "package": "poetry",
+            "cmd": "poetry"
         }
     ],
     "dotnet": {

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -315,6 +315,11 @@ function Get-PipxVersion {
     return "Pipx $pipxVersion"
 }
 
+function Get-PoetryVersion {
+    $poetryVersion = poetry --version
+    return "Poetry $poetryVersion"
+}
+
 function Build-PackageManagementEnvironmentTable {
     return @(
         @{

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -53,6 +53,7 @@ $markdown += New-MDList -Style Unordered -Lines (@(
     (Get-NugetVersion),
     (Get-PipxVersion),
     (Get-PipVersion),
+	(Get-PoetryVersion)
     (Get-RubyGemsVersion),
     (Get-VcpkgVersion),
     (Get-YarnVersion)

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -262,6 +262,10 @@
         {
             "package": "yamllint",
             "cmd": "yamllint --version"
+        },
+        {
+            "package": "poetry",
+            "cmd": "poetry --version"
         }
     ],
     "dotnet": {

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -290,6 +290,10 @@
         {
             "package": "yamllint",
             "cmd": "yamllint --version"
+        },
+        {
+            "package": "poetry",
+            "cmd": "poetry --version"
         }
     ],
     "dotnet": {


### PR DESCRIPTION
# Description
Adds poetry package manager to Windows and Ubuntu (18.04 and 20.04)
This will reduce a step often needed in workflows to install poetry after Python has been setup  

**For new tools, please provide total size and installation time.**
About 73 MB installed, and the install takes less than a minute, often just ~15 seconds

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: #3292

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
