### PR TITLE
Removed Ubuntu 16.04 from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ The "macos-latest" YAML workflow label still uses the macOS 10.15 virtual enviro
 ```
 
 ```
-Ubuntu 16.04 is being deprecated. If any of your workflows use Ubuntu 16.04,
-migrate to Ubuntu 20.04 or 18.04. For more information, see the issue
-https://github.com/actions/virtual-environments/issues/3287.
+Ubuntu 16.04 is being deprecated. If any of your workflows use Ubuntu 16.04, migrate to Ubuntu 20.04 or 18.04.
 ```
 
 ***What images are available for GitHub Actions and Azure DevOps?***

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ The "macos-latest" YAML workflow label still uses the macOS 10.15 virtual enviro
 ```
 
 ```
-Ubuntu 16.04 is being deprecated. If any of your workflows use Ubuntu 16.04, migrate to Ubuntu 20.04 or 18.04.
+Ubuntu 16.04 is being deprecated. It is not recommended for new users. 
+If any of your workflows use Ubuntu 16.04, migrate to Ubuntu 20.04 or 18.04.
 ```
 
 ***What images are available for GitHub Actions and Azure DevOps?***

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ For general questions about using the virtual environments or writing your Actio
 | --------------------|---------------------|--------------------|---------------------|
 | Ubuntu 20.04 | `ubuntu-latest` or `ubuntu-20.04` | [ubuntu-20.04] | [![](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=ubuntu20&badge=1)](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=ubuntu20&redirect=1)
 | Ubuntu 18.04 | `ubuntu-18.04` | [ubuntu-18.04] | [![](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=ubuntu18&badge=1)](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=ubuntu18&redirect=1)
-| Ubuntu 16.04 | `ubuntu-16.04` | [ubuntu-16.04] | [![](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=ubuntu16&badge=1)](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=ubuntu16&redirect=1) |
 | macOS 11.0 | `macos-11.0` | [macOS-11.0] | [![](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=macos-11.0&badge=1)](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=macos-11.0&redirect=1)
 | macOS 10.15 | `macos-latest` or `macos-10.15` | [macOS-10.15] | [![](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=macos-10.15&badge=1)](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=macos-10.15&redirect=1)
 | Windows Server 2019 | `windows-latest` or `windows-2019` | [windows-2019] | [![](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=windows-2019&badge=1)](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=windows-2019&redirect=1)
@@ -20,6 +19,10 @@ For general questions about using the virtual environments or writing your Actio
 ```
 The macOS 11.0 virtual environment is currently provided as a private preview only.
 The "macos-latest" YAML workflow label still uses the macOS 10.15 virtual environment.
+```
+
+```
+Ubuntu 16.04 is being deprecated. If any of your workflows use Ubuntu 16.04, migrate to Ubuntu 20.04 or 18.04. For more information, see the issue https://github.com/actions/virtual-environments/issues/3287.
 ```
 
 ***What images are available for GitHub Actions and Azure DevOps?***

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ The "macos-latest" YAML workflow label still uses the macOS 10.15 virtual enviro
 ```
 
 ```
-Ubuntu 16.04 is being deprecated. If any of your workflows use Ubuntu 16.04, migrate to Ubuntu 20.04 or 18.04. For more information, see the issue https://github.com/actions/virtual-environments/issues/3287.
+Ubuntu 16.04 is being deprecated. If any of your workflows use Ubuntu 16.04,
+migrate to Ubuntu 20.04 or 18.04. For more information, see the issue
+https://github.com/actions/virtual-environments/issues/3287.
 ```
 
 ***What images are available for GitHub Actions and Azure DevOps?***


### PR DESCRIPTION
# Description
We are in the process of Ubuntu 16.04 deprecation and retirement. In this PR I am removing Ubuntu 16.04 from our README.md file as we stepped into the deprecation stage.
![image](https://user-images.githubusercontent.com/8777209/117006565-459dd700-acf1-11eb-8115-70591d0c7c27.png)


<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: https://github.com/actions/virtual-environments/issues/3287

## Check list
- [x] Related issue / work item is attached
- [n/a] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [n/a] Changes are tested and related VM images are successfully generated
