### PR TITLE
[macOS] Install Apple certificate for Big Sur via swift binary

### DIFF
--- a/images/macos/provision/configuration/add-certificate.swift
+++ b/images/macos/provision/configuration/add-certificate.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Security
+
+let certInfo: CFDictionary
+
+enum SecurityError: Error {
+    case generalError
+}
+
+func deleteCertificateFromKeyChain(_ certificateLabel: String) -> Bool {
+    let delQuery: [NSString: Any] = [
+        kSecClass: kSecClassCertificate,
+        kSecAttrLabel: certificateLabel,
+    ]
+    let delStatus: OSStatus = SecItemDelete(delQuery as CFDictionary)
+
+    return delStatus == errSecSuccess
+}
+
+func saveCertificateToKeyChain(_ certificate: SecCertificate, certificateLabel: String) throws {
+    SecKeychainSetPreferenceDomain(SecPreferencesDomain.system)
+    deleteCertificateFromKeyChain(certificateLabel)
+
+    let setQuery: [NSString: AnyObject] = [
+        kSecClass: kSecClassCertificate,
+        kSecValueRef: certificate,
+        kSecAttrLabel: certificateLabel as AnyObject,
+        kSecAttrAccessible: kSecAttrAccessibleWhenUnlocked,
+    ]
+    let addStatus: OSStatus = SecItemAdd(setQuery as CFDictionary, nil)
+
+    guard addStatus == errSecSuccess else {
+        throw SecurityError.generalError
+    }
+
+    var status = SecTrustSettingsSetTrustSettings(certificate, SecTrustSettingsDomain.admin, nil)
+}
+
+func getCertificateFromString(stringData: String) throws -> SecCertificate {
+    if let data = NSData(base64Encoded: stringData, options: NSData.Base64DecodingOptions.ignoreUnknownCharacters) {
+        if let certificate = SecCertificateCreateWithData(kCFAllocatorDefault, data) {
+            return certificate
+        }
+    }
+    throw SecurityError.generalError
+}
+
+if CommandLine.arguments.count > 1 {
+    let fileURL = URL(fileURLWithPath: CommandLine.arguments[1])
+    do {
+        let certData = try Data(contentsOf: fileURL)
+        let certificate = SecCertificateCreateWithData(nil, certData as CFData)
+        if certificate != nil {
+            print("Saving certificate")
+            try? saveCertificateToKeyChain(certificate!, certificateLabel: "Test")
+        } else {
+            print("Certificate can't be read")
+        }
+    } catch {
+        print("Unable to read the file \(CommandLine.arguments[1])")
+    }
+} else {
+    print("Usage: \(CommandLine.arguments[0]) [cert.file]")
+}

--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e -o pipefail
 
+source ~/utils/utils.sh
+
 echo "Enabling safari driver..."
 # https://developer.apple.com/documentation/webkit/testing_with_webdriver_in_safari
 # Safari’s executable is located at /usr/bin/safaridriver
@@ -22,7 +24,14 @@ sudo "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1176 885
 # Confirm that the correct intermediate certificate is installed by verifying the expiration date is set to 2030.
 # sudo security delete-certificate -Z FF6797793A3CD798DC5B2ABEF56F73EDC9F83A64 /Library/Keychains/System.keychain
 curl https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer --output $HOME/AppleWWDRCAG3.cer --silent
-sudo security add-trusted-cert -d -r unspecified -k /Library/Keychains/System.keychain $HOME/AppleWWDRCAG3.cer
+# Big Sur requires user interaction to add a cert https://developer.apple.com/forums/thread/671582, we need to use a workaround with SecItemAdd swift method
+if is_Less_BigSur; then
+    sudo security add-trusted-cert -d -r unspecified -k /Library/Keychains/System.keychain $HOME/AppleWWDRCAG3.cer
+else
+    swiftc $HOME/image-generation/add-certificate.swift
+    sudo ./add-certificate $HOME/AppleWWDRCAG3.cer
+    rm add-certificate
+fi
 rm $HOME/AppleWWDRCAG3.cer
 
 # Create symlink for tests running

--- a/images/macos/templates/macOS-11.0.json
+++ b/images/macos/templates/macOS-11.0.json
@@ -63,6 +63,11 @@
         },
         {
             "type": "file",
+            "source": "./provision/configuration/add-certificate.swift",
+            "destination": "~/image-generation/add-certificate.swift"
+        },
+        {
+            "type": "file",
             "source": "./provision/configuration/environment/bashrc",
             "destination": "~/.bashrc"
         },
@@ -109,6 +114,7 @@
             "scripts": [
                 "./provision/configuration/preimagedata.sh",
                 "./provision/configuration/configure-ssh.sh",
+                "./provision/core/xcode-clt.sh",
                 "./provision/configuration/configure-machine.sh"
             ],
             "environment_vars": [
@@ -127,7 +133,6 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "pause_before": "30s",
             "scripts": [
-                "./provision/core/xcode-clt.sh",
                 "./provision/core/homebrew.sh",
                 "./provision/core/powershell.sh",
                 "./provision/core/dotnet.sh",


### PR DESCRIPTION
# Description
Starting from Big Sur 11.3 certificate installation requires user interaction, however it can be bypassed by using SecItemAdd method.
https://stackoverflow.com/questions/65699160/electron-import-x509-cert-to-local-keychain-macos-the-authorization-was-deni
Xcode command-line tools need to be installed to use `swiftc` hence the clt installation was moved before the configure-machine script.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2115

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
