### PR TITLE
[Ubuntu] Avoid updating gems

### DIFF
--- a/images/linux/scripts/installers/ruby.sh
+++ b/images/linux/scripts/installers/ruby.sh
@@ -8,7 +8,6 @@ source $HELPER_SCRIPTS/os.sh
 source $HELPER_SCRIPTS/install.sh
 
 apt-get install ruby-full
-gem update
 
 # temporary fix for fastlane installation https://github.com/fastlane/fastlane/issues/18642
 if isUbuntu20 ; then

--- a/images/linux/scripts/installers/ruby.sh
+++ b/images/linux/scripts/installers/ruby.sh
@@ -9,12 +9,6 @@ source $HELPER_SCRIPTS/install.sh
 
 apt-get install ruby-full
 
-# temporary fix for fastlane installation https://github.com/fastlane/fastlane/issues/18642
-if isUbuntu20 ; then
-    gem uninstall rdoc
-    gem install rdoc -v 6.3.0
-fi
-
 # Install ruby gems from toolset
 gemsToInstall=$(get_toolset_value ".rubygems[] .name")
 if [ -n "$gemsToInstall" ]; then


### PR DESCRIPTION
# Description
It turned out that updated gems can cause issues during other gem installations like Fastlane or puppet. It's better to avoid updating gems that come along with ruby. Customers can update specific gems in runtime if needed. 

#### Related issue:
https://github.com/actions/virtual-environments/issues/3307
https://github.com/actions/virtual-environments/issues/3310

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
