### PR TITLE
[macOS] Add Cmake 3.18.1 for Android

### DIFF
--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -212,6 +212,7 @@
         ],
         "additional-tools": [
             "cmake;3.10.2.4988404",
+            "cmake;3.18.1",
             "cmdline-tools;latest"
         ],
         "ndk": {

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -164,6 +164,7 @@
         ],
         "additional-tools": [
             "cmake;3.10.2.4988404",
+            "cmake;3.18.1",
             "cmdline-tools;latest"
         ],
         "ndk": {

--- a/images/macos/toolsets/toolset-11.0.json
+++ b/images/macos/toolsets/toolset-11.0.json
@@ -98,6 +98,7 @@
         "addon-list": [],
         "additional-tools": [
             "cmake;3.10.2.4988404",
+            "cmake;3.18.1",
             "cmdline-tools;latest"
         ],
         "ndk": {


### PR DESCRIPTION
# Description
CMake 3.18.1 is the default version for Android Studio 4.2.0(Android Gradle Plugin version 4.2.0)

#### Related issue:
https://github.com/actions/virtual-environments/issues/3321

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
