### PR TITLE
[Windows] Add Cmake 3.18.1 for Android

### DIFF
--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -164,6 +164,7 @@
         ],
         "additional_tools": [
             "cmake;3.10.2.4988404",
+            "cmake;3.18.1",
             "patcher;v4",
             "cmdline-tools;latest"
         ],

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -164,6 +164,7 @@
         ],
         "additional_tools": [
             "cmake;3.10.2.4988404",
+            "cmake;3.18.1",
             "patcher;v4",
             "cmdline-tools;latest"
         ],


### PR DESCRIPTION
# Description
CMake 3.18.1 is the default version for Android Studio 4.2.0(Android Gradle Plugin version 4.2.0)

#### Related issue:
https://github.com/actions/virtual-environments/issues/3321

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
