### PR TITLE
[Ubuntu] Set DefaultLimitSTACK=16384 limit

### DIFF
--- a/images/linux/scripts/base/limits.sh
+++ b/images/linux/scripts/base/limits.sh
@@ -5,6 +5,7 @@ echo '* hard nofile 65536' >> /etc/security/limits.conf
 echo 'session required pam_limits.so' >> /etc/pam.d/common-session
 echo 'session required pam_limits.so' >> /etc/pam.d/common-session-noninteractive
 echo 'DefaultLimitNOFILE=65536' >> /etc/systemd/system.conf
+echo 'DefaultLimitSTACK=16384' >> /etc/systemd/system.conf
 
 # Double stack size from default 8192KB
 echo '* soft stack 16384' >> /etc/security/limits.conf

--- a/images/linux/scripts/base/limits.sh
+++ b/images/linux/scripts/base/limits.sh
@@ -1,11 +1,13 @@
 #!/bin/bash -e
 
-echo '* soft nofile 65536' >> /etc/security/limits.conf
-echo '* hard nofile 65536' >> /etc/security/limits.conf
 echo 'session required pam_limits.so' >> /etc/pam.d/common-session
 echo 'session required pam_limits.so' >> /etc/pam.d/common-session-noninteractive
 echo 'DefaultLimitNOFILE=65536' >> /etc/systemd/system.conf
-echo 'DefaultLimitSTACK=16384' >> /etc/systemd/system.conf
+echo 'DefaultLimitSTACK=16M:infinity' >> /etc/systemd/system.conf
+
+# Raise Number of File Descriptors
+echo '* soft nofile 65536' >> /etc/security/limits.conf
+echo '* hard nofile 65536' >> /etc/security/limits.conf
 
 # Double stack size from default 8192KB
 echo '* soft stack 16384' >> /etc/security/limits.conf


### PR DESCRIPTION
# Description
In the https://github.com/actions/virtual-environments/pull/3260 PR, we have configured limits in the `/etc/security/limits.conf` file.The file `limits.conf` is intentionally ignored by systemd in that case we should update `DefaultLimitSTACK` limits in the `/etc/systemd/system.conf`.

man 5 systemd-system.conf
`These settings control various default resource limits for units. See setrlimit(2) for details. The resource limit is possible to specify in two formats, value to set soft and hard limits to the same value, or soft:hard to set both limits individually (e.g. DefaultLimitAS=4G:16G).`

Before:
```
ulimit -s [8192]
ulimit -Hs [unlimited]
```

After:
```
ulimit -s [16384]
ulimit -Hs [unlimited]
```

#### Related issue:
https://github.com/actions/virtual-environments/issues/3257

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
