### PR TITLE
Rework apt-fast installation to get rid of apt repo

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -4,7 +4,7 @@ function Get-AnsibleVersion {
 }
 
 function Get-AptFastVersion {
-    $versionFileContent = Get-Content "/usr/bin/apt-fast" -Raw
+    $versionFileContent = Get-Content (which apt-fast) -Raw
     $match = [Regex]::Match($versionFileContent, '# apt-fast v(.+)\n')
     $aptFastVersion = $match.Groups[1].Value
     return "apt-fast $aptFastVersion"

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -4,7 +4,9 @@ function Get-AnsibleVersion {
 }
 
 function Get-AptFastVersion {
-    $aptFastVersion = apt-fast --version | Select-String "amd64" | Take-OutputPart -Part 1
+    $versionFileContent = Get-Content "/usr/local/sbin/apt-fast"
+    $match = [Regex]::Match($versionFileContent, '# apt-fast v(.+)\n')
+    $aptFastVersion = $match.Groups[1].Value
     return "apt-fast $aptFastVersion"
 }
 

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -4,9 +4,9 @@ function Get-AnsibleVersion {
 }
 
 function Get-AptFastVersion {
-    $versionFileContent = Get-Content "/usr/local/sbin/apt-fast"
+    $versionFileContent = Get-Content "/usr/bin/apt-fast" -Raw
     $match = [Regex]::Match($versionFileContent, '# apt-fast v(.+)\n')
-    $aptFastVersion = $match.Groups[0].Value
+    $aptFastVersion = $match.Groups[1].Value
     return "apt-fast $aptFastVersion"
 }
 

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -6,7 +6,7 @@ function Get-AnsibleVersion {
 function Get-AptFastVersion {
     $versionFileContent = Get-Content "/usr/local/sbin/apt-fast"
     $match = [Regex]::Match($versionFileContent, '# apt-fast v(.+)\n')
-    $aptFastVersion = $match.Groups[1].Value
+    $aptFastVersion = $match.Groups[0].Value
     return "apt-fast $aptFastVersion"
 }
 

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -4,7 +4,7 @@ function Get-AnsibleVersion {
 }
 
 function Get-AptFastVersion {
-    $aptFastVersion = apt-fast --version | Select-String "amd64" | Take-OutputPart -Part 2
+    $aptFastVersion = apt-fast --version | Select-String "amd64" | Take-OutputPart -Part 1
     return "apt-fast $aptFastVersion"
 }
 

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -4,7 +4,7 @@ function Get-AnsibleVersion {
 }
 
 function Get-AptFastVersion {
-    $aptFastVersion = (dpkg-query --showformat='${Version}' --show apt-fast).Split('-')[0]
+    $aptFastVersion = apt-fast --version | Select-String "amd64" | Take-OutputPart -Part 2
     return "apt-fast $aptFastVersion"
 }
 

--- a/images/linux/scripts/base/apt.sh
+++ b/images/linux/scripts/base/apt.sh
@@ -29,4 +29,5 @@ apt-get update
 apt-get install aria2 jq
 
 # Install apt-fast using quick-install.sh
-bash -c "$(curl -sL https://git.io/vokNn)"
+# https://github.com/ilikenwf/apt-fast
+bash -c "$(curl -sL https://raw.githubusercontent.com/ilikenwf/apt-fast/master/quick-install.sh)"

--- a/images/linux/scripts/base/apt.sh
+++ b/images/linux/scripts/base/apt.sh
@@ -17,16 +17,6 @@ echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
 # Uninstall apt-fast
 sudo apt-get purge apt-fast
 
-# Use apt-fast for parallel downloads
-# add-apt-repository -y ppa:apt-fast/stable
-
-# Need to limit arch for default apt repos due to 
-# https://github.com/actions/virtual-environments/issues/1961
-# sed -i'' -E 's/^deb http:\/\/(azure.archive|security).ubuntu.com/deb [arch=amd64,i386] http:\/\/\1.ubuntu.com/' /etc/apt/sources.list
-
-# echo 'APT sources limited to the actual architectures'
-# cat /etc/apt/sources.list
-
 apt-get update
 # Install aria2 , jq and apt-fast
 apt-get install aria2 jq

--- a/images/linux/scripts/base/apt.sh
+++ b/images/linux/scripts/base/apt.sh
@@ -14,19 +14,21 @@ echo "APT::Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries
 # Configure apt to always assume Y
 echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
 
-# Uninstall unattended-upgrades
-apt-get purge unattended-upgrades
+# Uninstall apt-fast
+sudo apt-get purge apt-fast
 
 # Use apt-fast for parallel downloads
-add-apt-repository -y ppa:apt-fast/stable
+# add-apt-repository -y ppa:apt-fast/stable
 
 # Need to limit arch for default apt repos due to 
 # https://github.com/actions/virtual-environments/issues/1961
-sed -i'' -E 's/^deb http:\/\/(azure.archive|security).ubuntu.com/deb [arch=amd64,i386] http:\/\/\1.ubuntu.com/' /etc/apt/sources.list
+# sed -i'' -E 's/^deb http:\/\/(azure.archive|security).ubuntu.com/deb [arch=amd64,i386] http:\/\/\1.ubuntu.com/' /etc/apt/sources.list
 
-echo 'APT sources limited to the actual architectures'
-cat /etc/apt/sources.list
+# echo 'APT sources limited to the actual architectures'
+# cat /etc/apt/sources.list
 
 apt-get update
 # Install aria2 , jq and apt-fast
-apt-get install aria2 jq apt-fast
+apt-get install aria2 jq
+
+bash -c "$(curl -sL https://git.io/vokNn)"

--- a/images/linux/scripts/base/apt.sh
+++ b/images/linux/scripts/base/apt.sh
@@ -14,11 +14,16 @@ echo "APT::Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries
 # Configure apt to always assume Y
 echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
 
-# Uninstall apt-fast
-sudo apt-get purge apt-fast
+# Need to limit arch for default apt repos due to 
+# https://github.com/actions/virtual-environments/issues/1961
+sed -i'' -E 's/^deb http:\/\/(azure.archive|security).ubuntu.com/deb [arch=amd64,i386] http:\/\/\1.ubuntu.com/' /etc/apt/sources.list
+
+echo 'APT sources limited to the actual architectures'
+cat /etc/apt/sources.list
 
 apt-get update
-# Install aria2 , jq and apt-fast
+# Install aria2 , jq
 apt-get install aria2 jq
 
+# Install apt-fast using quick-install.sh
 bash -c "$(curl -sL https://git.io/vokNn)"

--- a/images/linux/scripts/base/apt.sh
+++ b/images/linux/scripts/base/apt.sh
@@ -14,6 +14,9 @@ echo "APT::Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries
 # Configure apt to always assume Y
 echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
 
+# Uninstall unattended-upgrades
+apt-get purge unattended-upgrades
+
 # Need to limit arch for default apt repos due to 
 # https://github.com/actions/virtual-environments/issues/1961
 sed -i'' -E 's/^deb http:\/\/(azure.archive|security).ubuntu.com/deb [arch=amd64,i386] http:\/\/\1.ubuntu.com/' /etc/apt/sources.list

--- a/images/macos/provision/assets/select-xamarin-sdk-v2.sh
+++ b/images/macos/provision/assets/select-xamarin-sdk-v2.sh
@@ -21,7 +21,7 @@ change_framework_version() {
   fi
 
   local framework_path=$(get_framework_path "$framework")
-  sudo rm -f ${framework_path}/Current
+  sudo rm -f "${framework_path}/Current"
   sudo ln -s "${framework_path}/${version}" "${framework_path}/Current"
 }
 

--- a/images/macos/provision/assets/select-xamarin-sdk-v2.sh
+++ b/images/macos/provision/assets/select-xamarin-sdk-v2.sh
@@ -17,7 +17,7 @@ change_framework_version() {
 
   local countDigit=$(echo "${version}" | grep -o "\." | grep -c "\.")
   if [[ countDigit -gt 1 ]]; then
-    echo "[WARNING] It is not recommended to specify version in "a.b.c.d" format because your pipeline can be broken suddenly in future. Use "a.b" format."
+    echo "[WARNING] It is not recommended to specify the exact framework version because your build can be broken with the next patch update. Consider using "major.minor" only format."
   fi
 
   local framework_path=$(get_framework_path "$framework")

--- a/images/macos/provision/assets/select-xamarin-sdk-v2.sh
+++ b/images/macos/provision/assets/select-xamarin-sdk-v2.sh
@@ -16,20 +16,13 @@ change_framework_version() {
   echo "Select $framework $version"
 
   local countDigit=$(echo "${version}" | grep -o "\." | grep -c "\.")
-  
   if [[ countDigit -gt 1 ]]; then
-    echo "[WARNING] It is not recommended to specify the exact framework version because your build can be broken with the next patch update. Consider using "major.minor" only format."
+    echo "[WARNING] It is not recommended to specify version in "a.b.c.d" format because your pipeline can be broken suddenly in future. Use "a.b" format."
   fi
 
   local framework_path=$(get_framework_path "$framework")
-
-  if [ -d "${framework_path}/${version}" ]; then
-    sudo rm -f "${framework_path}/Current"
-    sudo ln -s "${framework_path}/${version}" "${framework_path}/Current"
-  else
-    echo "Invalid framework version ${framework_path}/${version}"
-    exit 1
-  fi
+  sudo rm -f ${framework_path}/Current
+  sudo ln -s "${framework_path}/${version}" "${framework_path}/Current"
 }
 
 for arg in "$@"; do

--- a/images/macos/provision/assets/select-xamarin-sdk-v2.sh
+++ b/images/macos/provision/assets/select-xamarin-sdk-v2.sh
@@ -17,19 +17,18 @@ change_framework_version() {
 
   local countDigit=$(echo "${version}" | grep -o "\." | grep -c "\.")
   
-  if [[( countDigit -gt 1 ) && ( ! countDigit -eq 3)]]; then
+  if [[ countDigit -gt 1 ]]; then
     echo "[WARNING] It is not recommended to specify the exact framework version because your build can be broken with the next patch update. Consider using "major.minor" only format."
   fi
 
   local framework_path=$(get_framework_path "$framework")
-  local is_existed_version=$(find "${framework_path}" -name "${version}*")
 
-  if [ -z "$is_existed_version" ]; then
-    echo "Invalid framework version"
-    exit 1
-  else
+  if [ -d "${framework_path}/${version}" ]; then
     sudo rm -f "${framework_path}/Current"
     sudo ln -s "${framework_path}/${version}" "${framework_path}/Current"
+  else
+    echo "Invalid framework version ${framework_path}/${version}"
+    exit 1
   fi
 }
 

--- a/images/macos/provision/assets/select-xamarin-sdk-v2.sh
+++ b/images/macos/provision/assets/select-xamarin-sdk-v2.sh
@@ -16,13 +16,21 @@ change_framework_version() {
   echo "Select $framework $version"
 
   local countDigit=$(echo "${version}" | grep -o "\." | grep -c "\.")
-  if [[ countDigit -gt 1 ]]; then
+  
+  if [[( countDigit -gt 1 ) && ( ! countDigit -eq 3)]]; then
     echo "[WARNING] It is not recommended to specify the exact framework version because your build can be broken with the next patch update. Consider using "major.minor" only format."
   fi
 
   local framework_path=$(get_framework_path "$framework")
-  sudo rm -f "${framework_path}/Current"
-  sudo ln -s "${framework_path}/${version}" "${framework_path}/Current"
+  local is_existed_version=$(find "${framework_path}" -name "${version}*")
+
+  if [ -z "$is_existed_version" ]; then
+    echo "Invalid framework version"
+    exit 1
+  else
+    sudo rm -f "${framework_path}/Current"
+    sudo ln -s "${framework_path}/${version}" "${framework_path}/Current"
+  fi
 }
 
 for arg in "$@"; do


### PR DESCRIPTION
# Description
It is an improvement that allows installing an apt-fast library and doesn't use apt-get package. It helps to avoid problems with installing and failing downloading packages.

Just for Linux.

#### Related issue: 
https://github.com/actions/virtual-environments-internal/issues/2071

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
