### PR TITLE
[Ubuntu] Revert "Rework php installation"

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -211,11 +211,10 @@ function Get-SbtVersion {
 
 function Get-PHPVersions {
     $result = Get-CommandResult "apt list --installed" -Multiline
-    $aptSourceRepo = Get-AptSourceRepository -PackageName "php"
-    $versionsList = $result.Output | Where-Object { $_ -match "^php\d+\.\d+/"} | ForEach-Object {
+    return $result.Output | Where-Object { $_ -match "^php\d+\.\d+/"} | ForEach-Object {
         $_ -match "now (?<version>\d+\.\d+\.\d+)-" | Out-Null
-        $Matches.version }
-    return $versionsList + "(apt source repository: $aptSourceRepo)"
+        $Matches.version
+    }
 }
 
 function Get-ComposerVersion {

--- a/images/linux/scripts/installers/php.sh
+++ b/images/linux/scripts/installers/php.sh
@@ -10,8 +10,7 @@ source $HELPER_SCRIPTS/os.sh
 source $HELPER_SCRIPTS/install.sh
 
 # add repository
-REPO_URL="ppa:ondrej/php"
-apt-add-repository $REPO_URL -y
+apt-add-repository ppa:ondrej/php -y
 apt-get update
 
 # Install PHP
@@ -99,10 +98,11 @@ wget -q -O phpunit https://phar.phpunit.de/phpunit-8.phar
 chmod +x phpunit
 mv phpunit /usr/local/bin/phpunit
 
-# remove repository after successfull installation
-rm -r /etc/apt/sources.list.d/ondrej-ubuntu-php-*
-
-echo "php $REPO_URL" >> $HELPER_SCRIPTS/apt-sources.txt
-apt-get update
+# ubuntu 20.04 libzip-dev is libzip5 based and is not compatible libzip-dev of ppa:ondrej/php
+# see https://github.com/actions/virtual-environments/issues/1084
+if isUbuntu20 ; then
+  rm /etc/apt/sources.list.d/ondrej-ubuntu-php-focal.list
+  apt-get update
+fi
 
 invoke_tests "Common" "PHP"


### PR DESCRIPTION
This PR https://github.com/actions/virtual-environments/pull/3272 introduced a lot of issues for customers since it's not obvious that some of the packages depend on `ppa:ondrej/php`:
https://github.com/actions/virtual-environments/issues/3317
https://github.com/actions/virtual-environments/issues/3335
https://github.com/actions/virtual-environments/issues/3339

We need to revert the changes until we have implemented a better strategy to remove this ppa.
