### PR TITLE
[Ubuntu] Fix Minikube version output in README

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -135,7 +135,7 @@ function Get-KubectlVersion {
 }
 
 function Get-MinikubeVersion {
-    $minikubeVersion = minikube version --short | Take-OutputPart -Part 2 | Take-OutputPart -Part 0 -Delimiter "v"
+    $minikubeVersion = minikube version --short | Take-OutputPart -Part 0 -Delimiter "v"
     return "Minikube $minikubeVersion"
 }
 


### PR DESCRIPTION
# Description
In scope of this PR we are fixing Minikube version output in README.
![minikube](https://user-images.githubusercontent.com/61747324/117653656-5b9e1280-b19d-11eb-80bf-a7f849d68219.jpg)

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
