### PR TITLE
[macOS] Add GCC 11

### DIFF
--- a/images/macos/provision/core/gcc.sh
+++ b/images/macos/provision/core/gcc.sh
@@ -1,15 +1,16 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
 
-echo "Installing GCC@8 using homebrew..."
-brew_smart_install "gcc@8"
+gccVersions=$(get_toolset_value '.gcc.versions | .[]')
 
-echo "Installing GCC@9 using homebrew..."
-brew_smart_install "gcc@9"
+for gccVersion in $gccVersions; do
+    brew_smart_install "gcc@${gccVersion}"
+done
 
-# https://github.com/actions/virtual-environments/issues/1280
-echo "Installing GCC@10 using homebrew..."
-brew_smart_install "gcc@10"
-rm $(which gfortran)
+# Delete default gfortran link if it exists https://github.com/actions/virtual-environments/issues/1280
+gfortranPath=$(which gfortran)
+if [ $gfortranPath ]; then
+    rm $gfortranPath
+fi
 
 invoke_tests "Common" "GCC"

--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -91,7 +91,7 @@ function Get-FortranVersion {
     $versionList = Get-ToolsetValue -KeyPath gcc.versions
     $versionList | Foreach-Object {
         $version = Run-Command "gfortran-${_} --version" | Select-Object -First 1
-        "$version  - available by ``gfortran-${_}`` alias"
+        "$version - available by ``gfortran-${_}`` alias"
     }
 }
 

--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -80,7 +80,7 @@ function Get-VcpkgVersion {
 }
 
 function Get-GccVersion {
-    $versionList = @("8", "9", "10")
+    $versionList = Get-ToolsetValue -KeyPath gcc.versions
     $versionList | Foreach-Object {
         $version = Run-Command "gcc-${_} --version" | Select-Object -First 1
         "$version - available by ``gcc-${_}`` alias"
@@ -88,7 +88,7 @@ function Get-GccVersion {
 }
 
 function Get-FortranVersion {
-    $versionList = @("8", "9", "10")
+    $versionList = Get-ToolsetValue -KeyPath gcc.versions
     $versionList | Foreach-Object {
         $version = Run-Command "gfortran-${_} --version" | Select-Object -First 1
         "$version  - available by ``gfortran-${_}`` alias"

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -60,7 +60,9 @@ if ($os.IsLessThanBigSur) {
     )
 }
 
-$markdown += New-MDList -Style Unordered -Lines ($languageAndRuntimeList | Sort-Object)
+# To sort GCC and Gfortran correctly, we need to use natural sort https://gist.github.com/markwragg/e2a9dc05f3464103d6998298fb575d4e#file-sort-natural-ps1
+$toNatural = { [regex]::Replace($_, '\d+', { $args[0].Value.PadLeft(20) }) }
+$markdown += New-MDList -Style Unordered -Lines ($languageAndRuntimeList | Sort-Object $toNatural)
 
 # Package Management
 $markdown += New-MDHeader "Package Management" -Level 3

--- a/images/macos/tests/Common.Tests.ps1
+++ b/images/macos/tests/Common.Tests.ps1
@@ -10,7 +10,7 @@ Describe ".NET" {
 }
 
 Describe "GCC" -Skip:($os.IsHighSierra) {
-    $testCases = @("8", "9", "10") | ForEach-Object { @{Version = $_} }
+    $testCases = Get-ToolsetValue -KeyPath gcc.versions | ForEach-Object { @{Version = $_} }
 
     It "GCC <Version>" -TestCases $testCases {
         param (

--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -263,6 +263,14 @@
             "virtualbox"
         ]
     },
+    "gcc": {
+        "versions": [
+            "8",
+            "9",
+            "10",
+            "11"
+        ]
+    },
     "toolcache": [
         {
             "name": "Python",

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -222,6 +222,14 @@
             "virtualbox"
         ]
     },
+    "gcc": {
+        "versions": [
+            "8",
+            "9",
+            "10",
+            "11"
+        ]
+    },
     "toolcache": [
         {
             "name": "Python",

--- a/images/macos/toolsets/toolset-11.0.json
+++ b/images/macos/toolsets/toolset-11.0.json
@@ -150,6 +150,14 @@
             "julia"
         ]
     },
+    "gcc": {
+        "versions": [
+            "8",
+            "9",
+            "10",
+            "11"
+        ]
+    },
     "toolcache": [
         {
             "name": "Python",


### PR DESCRIPTION
# Description
This PR adds GCC 11 and reworks the installation script to use the toolset file. As an addition, gfortran symlink will now be deleted if only it exists.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3359
https://github.com/actions/virtual-environments-internal/issues/2153

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
