### PR TITLE
[Ubuntu] Remove pip symlink creation

### DIFF
--- a/images/linux/scripts/installers/python.sh
+++ b/images/linux/scripts/installers/python.sh
@@ -11,13 +11,10 @@ source $HELPER_SCRIPTS/os.sh
 
 # Install Python, Python 3, pip, pip3
 if isUbuntu16 || isUbuntu18; then
-    apt-get install -y --no-install-recommends python python-dev python-pip python3 python3-dev python3-pip python3-venv
+    apt-get install -y --no-install-recommends python python-dev python-pip
 fi
 
-if isUbuntu20; then
-    apt-get install -y --no-install-recommends python3 python3-dev python3-pip python3-venv
-    ln -s /usr/bin/pip3 /usr/bin/pip
-fi
+apt-get install -y --no-install-recommends python3 python3-dev python3-pip python3-venv
 
 if isUbuntu18 || isUbuntu20 ; then
     # Install pipx


### PR DESCRIPTION
# Description
Ubuntu 20 build fails with:
`ln: failed to create symbolic link '/usr/bin/pip': File exists`
There is no need to create pip3 -> pip symlink anymore since pip executable is now included in the python3-pip package.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2157

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
