### PR TITLE
[Windows] Create default nuget.config in the user's home directory

### DIFF
--- a/images/win/post-generation/Dotnet.ps1
+++ b/images/win/post-generation/Dotnet.ps1
@@ -7,5 +7,8 @@ if (-not $latestPath.Contains($dotnetPath))
     [System.Environment]::SetEnvironmentVariable('PATH', $latestPath, [System.EnvironmentVariableTarget]::Machine)
 }
 
-# Delete empty nuget.config file to prevent the issue with downloading packages from nuget.org https://github.com/actions/virtual-environments/issues/3038
+# Delete empty nuget.config file created by choco and recreate the config using the 'dotnet nuget list source command'
+# before choco or powershell’s ancient embedded nuget does to prevent the issue with downloading packages from nuget.org
+# https://github.com/actions/virtual-environments/issues/3038
 Remove-Item $env:APPDATA\NuGet\NuGet.Config -Force
+dotnet nuget list source


### PR DESCRIPTION
# Description
It turned out that any tool using an old embedded NuGet version creates an empty nuget.config file in the user's home directory. For example that happens during any Powershell module installation.
To prevent the issue .NET team suggested invoking `dotnet nuget list source` command to create the default nuget.config containing the nuget.org source:
```
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <packageSources>
    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
  </packageSources>
</configuration>
```

#### Related issue:
https://github.com/actions/virtual-environments/issues/3038

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
