### PR TITLE
[Windows] Add a test to make sure GHC version 9.* is the default one

### DIFF
--- a/images/win/scripts/Tests/Haskell.Tests.ps1
+++ b/images/win/scripts/Tests/Haskell.Tests.ps1
@@ -36,6 +36,11 @@ Describe "Haskell" {
         "ghc --version" | Should -MatchCommandOutput $defaultGhcShortVersion
     }
 
+    # Sometimes choco doesn't return version 9, need to check it explicitly https://github.com/chocolatey/choco/issues/2271
+    It "Default GHC version is 9" -TestCases $ghcDefaultCases {
+        "ghc --version" | Should -MatchCommandOutput "9(\.\d+){2,}"
+    }
+
     It "Cabal is installed" {
         "cabal --version" | Should -ReturnZeroExitCode
     }


### PR DESCRIPTION
# Description
On a rare occasion, `choco search` doesn't return GHC version 9 at all thus the latest GHC version on the image will be downgraded. I've created an issue in the choco repository — https://github.com/chocolatey/choco/issues/2271 but we need to check the default version explicitly until it's fixed.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3223

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
