### PR TITLE
[Ubuntu20] Remove clang 9 and set clang 11 as the default one

### DIFF
--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -245,12 +245,11 @@
     },
     "clang": {
         "versions": [
-            "9",
             "10",
             "11",
             "12"
         ],
-        "default_version": "10"
+        "default_version": "11"
     },
     "gcc": {
         "versions": [


### PR DESCRIPTION
# Description
Clang 9 will be removed from Ubuntu 20.04 images in favor of Clang 12, also the default one will be set to Clang 11

#### Related issue:
https://github.com/actions/virtual-environments/issues/3235

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
