### PR TITLE
Add msys libxml2 package installation

### DIFF
--- a/images/win/scripts/Installers/Install-Msys2.ps1
+++ b/images/win/scripts/Installers/Install-Msys2.ps1
@@ -60,8 +60,9 @@ Write-Host "`n$dash Remove p7zip/7z package due to conflicts"
 pacman.exe -R --noconfirm --noprogressbar p7zip
 
 # mingw package list
-$tools64 = "___clang ___clang-tools-extra ___cmake ___llvm  ___toolchain ___ragel"
-$tools32 = "___clang ___cmake ___llvm  ___toolchain ___ragel"
+# libxml2 can be removed from the list after the issue is fixed https://github.com/msys2/MINGW-packages/issues/8658
+$tools64 = "___clang ___clang-tools-extra ___cmake ___libxml2 ___llvm ___toolchain ___ragel"
+$tools32 = "___clang ___cmake ___libxml2 ___llvm ___toolchain ___ragel"
 
 # install mingw64 packages
 Write-Host "`n$dash Install mingw64 packages"


### PR DESCRIPTION
# Description
Clang package missed libxml2 dependency, which leads to the error:
```
testadm2@VS19Msys2 MINGW64 ~
# clang
C:/msys64/mingw64/bin/clang.exe: error while loading shared libraries: libLLVM.dll: cannot open shared object file: No such file or directory
```
There is an issue in the msys2 repo: https://github.com/msys2/MINGW-packages/issues/8658
This PR adds explicit installation of libxml2. These changes can be safely removed When the initial issue is fixed.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2172

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
