### PR TITLE
[Ubuntu] Add PHP extensions: imagick, pcov and sodium

### DIFF
--- a/images/linux/scripts/installers/php.sh
+++ b/images/linux/scripts/installers/php.sh
@@ -35,6 +35,7 @@ for version in $php_versions; do
         php$version-gd \
         php$version-gmp \
         php$version-igbinary \
+        php$version-imagick \
         php$version-imap \
         php$version-interbase \
         php$version-intl \
@@ -73,6 +74,17 @@ for version in $php_versions; do
 
     if [[ $version != "8.0" ]]; then
         apt-fast install -y --no-install-recommends php$version-xmlrpc php$version-json
+    fi
+
+    if [[ $version != "5.6" && $version != "7.0" ]]; then
+        apt-fast install -y --no-install-recommends php$version-pcov
+
+        # Disable PCOV, as Xdebug is enabled by default
+        echo "" | sudo tee /etc/php/$version/mods-available/pcov.ini
+    fi
+
+    if [[ $version = "7.0" || $version = "7.1" ]]; then
+        apt-fast install -y --no-install-recommends php$version-sodium
     fi
 done
 


### PR DESCRIPTION
# Description
Improvement

This PR adds `imagick`, `pcov` and `sodium` PHP extensions on Ubuntu.
imagick on all supported PHP versions, sodium on PHP 7.0 and 7.1 and pcov on PHP 7.1 and newer.

**Note:** `PCOV` is disabled, as `Xdebug` is enabled by default. These two extensions should not be enabled at the same time.
Ref: https://github.com/krakjoe/pcov#interoperability

#### Related issue: #3341

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
