### PR TITLE
[Windows] Fix pre-cached GHC list

### DIFF
--- a/images/win/scripts/Installers/Install-Haskell.ps1
+++ b/images/win/scripts/Installers/Install-Haskell.ps1
@@ -5,7 +5,7 @@
 
 # Get 3 latest versions of GHC
 [Version[]] $ChocoVersionsOutput = & choco search ghc --allversions | Where-Object { $_.StartsWith('ghc ') -and $_ -match 'Approved' } | ForEach-Object { [regex]::matches($_, '\d+(\.\d+){2,}').value }
-$MajorMinorGroups = $ChocoVersionsOutput | Group-Object { $_.ToString(2) } | Sort-Object Name -Descending | Select-Object -First 3
+$MajorMinorGroups = $ChocoVersionsOutput | Sort-Object -Descending | Group-Object { $_.ToString(2) } | Select-Object -First 3
 $VersionsList = $MajorMinorGroups | ForEach-Object { $_.Group | Select-Object -First 1 } | Sort-Object
 
 # The latest version will be installed as a default


### PR DESCRIPTION
# Description
Currently, the sort doesn't work properly since it sorts strings, not the version and as a result version 8.8 > 8.10.
This PR fixes it by sorting the version before grouping them.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3223

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
