### PR TITLE
Allow most recent RC versions for Android build-tools in Linux/Mac

### DIFF
--- a/images/linux/scripts/installers/android.sh
+++ b/images/linux/scripts/installers/android.sh
@@ -95,8 +95,10 @@ if isUbuntu20; then
 fi
 
 availablePlatforms=($($SDKMANAGER --list | sed -n '/Available Packages:/,/^$/p' | grep "platforms;android-" | cut -d"|" -f 1))
-allBuildTools=($($SDKMANAGER --list | grep "build-tools;" | cut -d"|" -f 1 | sort -u))
-availableBuildTools=$(echo ${allBuildTools[@]//*rc[0-9]/})
+allBuildTools=($(${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --list --include_obsolete | grep -A99999 'Available Packages:.*' | grep "build-tools;" | cut -d"|" -f 1 | sort -u))
+stableBuildTools=$(echo ${allBuildTools[@]//*rc[0-9]/})
+recentBuildToolsRCs=($(${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --list | grep -A99999 'Available Packages:.*' | grep "build-tools;[0-9\.]*-rc" | cut -d"|" -f 1))
+availableBuildTools=(${stableBuildTools[@]} ${recentBuildToolsRCs[@]})
 
 filter_components_by_version $minimumPlatformVersion "${availablePlatforms[@]}"
 filter_components_by_version $minimumBuildToolVersion "${availableBuildTools[@]}"

--- a/images/macos/provision/core/android-toolsets.sh
+++ b/images/macos/provision/core/android-toolsets.sh
@@ -58,7 +58,7 @@ mv tools $ANDROID_HOME
 
 export PATH=$PATH:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin
 
-SDKMANAGER=$ANDROID_HOME/tools/bin/sdkmanager
+SDKMANAGER=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
 
 # Mark the different Android licenses as accepted
 mkdir -p $ANDROID_HOME/licenses
@@ -80,14 +80,16 @@ ln -s $ANDROID_HOME/ndk/$ndkLtsLatest $ANDROID_HOME/ndk-bundle
 ANDROID_NDK_LATEST_HOME=$ANDROID_HOME/ndk/$ndkLatest
 echo "export ANDROID_NDK_LATEST_HOME=$ANDROID_NDK_LATEST_HOME" >> "${HOME}/.bashrc"
 
-availablePlatforms=($(${ANDROID_HOME}/tools/bin/sdkmanager --list | grep "platforms;android-" | cut -d"|" -f 1 | sort -u))
+availablePlatforms=($(${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --list | grep "platforms;android-" | cut -d"|" -f 1 | sort -u))
 filter_components_by_version $ANDROID_PLATFORM "${availablePlatforms[@]}"
 
-allBuildTools=($(${ANDROID_HOME}/tools/bin/sdkmanager --list --include_obsolete | grep "build-tools;" | cut -d"|" -f 1 | sort -u))
-availableBuildTools=$(echo ${allBuildTools[@]//*rc[0-9]/})
+allBuildTools=($(${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --list --include_obsolete | grep -A99999 'Available Packages:.*' | grep "build-tools;" | cut -d"|" -f 1 | sort -u))
+stableBuildTools=$(echo ${allBuildTools[@]//*rc[0-9]/})
+recentBuildToolsRCs=($(${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --list | grep -A99999 'Available Packages:.*' | grep "build-tools;[0-9\.]*-rc" | cut -d"|" -f 1))
+availableBuildTools=(${stableBuildTools[@]} ${recentBuildToolsRCs[@]})
 filter_components_by_version $ANDROID_BUILD_TOOL "${availableBuildTools[@]}"
 
-echo "y" | ${ANDROID_HOME}/tools/bin/sdkmanager ${components[@]}
+echo "y" | ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager ${components[@]}
 
 for extra_name in "${ANDROID_EXTRA_LIST[@]}"
 do


### PR DESCRIPTION
# Description
New tool, Bug fixing, or Improvement?  

Improvements for Linux and Mac to support the latest Android RC versions so Android developers can work with 31.x.x versions of the Android build tools. I haven't messed with Powershell in awhile if someone wants to help with Windows.

#### Related issue: #3423

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
