### PR TITLE
Revert "[ubuntu] Add GCC 11 (#3291)"

### DIFF
--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -249,15 +249,13 @@
     "gcc": {
         "versions": [
             "g++-9",
-            "g++-10",
-            "g++-11"
+            "g++-10"
         ]
     },
     "gfortran": {
         "versions": [
             "gfortran-9",
-            "gfortran-10",
-            "gfortran-11"
+            "gfortran-10"
         ]
     },
     "php": {

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -251,15 +251,13 @@
     "gcc": {
         "versions": [
             "g++-9",
-            "g++-10",
-            "g++-11"
+            "g++-10"
         ]
     },
     "gfortran": {
         "versions": [
             "gfortran-9",
-            "gfortran-10",
-            "gfortran-11"
+            "gfortran-10"
         ]
     },
     "php": {


### PR DESCRIPTION
This reverts commit 3ebf601284cae6a4406b7ea1ad08cd593a4d619b.

# Description

Bug fix

It is a not good idea to add experimental toolchain to the image, as the addition/modification of standard C/C++ headers and libraries can have wide-ranging (and often undesired) consequences across the whole system.

#### Related issue:

#3376