### PR TITLE
[macOS] Temporary hardcoding fastlane 2.183.2

### DIFF
--- a/images/macos/provision/core/rubygem.sh
+++ b/images/macos/provision/core/rubygem.sh
@@ -27,7 +27,9 @@ gem install xcpretty
 echo Installing bundler...
 gem install bundler --force
 
+# AppStoreRelease Azure DevOps has issues with Fastlane 2.184.0. Temporary hardcoding the version until the issue is fixed
+# https://github.com/microsoft/app-store-vsts-extension/issues/244
 echo Installing fastlane tools...
-gem install fastlane
+gem install fastlane -v 2.183.2
 
 invoke_tests "RubyGem"


### PR DESCRIPTION
# Description
Looks like these Fastlane changes — https://github.com/fastlane/fastlane/pull/18186, which are included in version 2.184, change authorization method and broke [AppStoreRelease Azure DevOps task
](https://github.com/microsoft/app-store-vsts-extension/tree/master/Tasks/AppStoreRelease)
We need to avoid 2.184 installation until the issue is fixed in the task repo:
https://github.com/microsoft/app-store-vsts-extension/issues/244

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2202

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
