### PR TITLE
[Windows] Change Add-AssertionOperator to Add-ShouldOperator

### DIFF
--- a/images/win/scripts/ImageHelpers/TestsHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/TestsHelpers.ps1
@@ -128,7 +128,7 @@ function ShouldMatchCommandOutput {
     }
 }
 
-If (Get-Command -Name Add-AssertionOperator -ErrorAction SilentlyContinue) {
-    Add-AssertionOperator -Name ReturnZeroExitCode -InternalName ShouldReturnZeroExitCode -Test ${function:ShouldReturnZeroExitCode}
-    Add-AssertionOperator -Name MatchCommandOutput -InternalName ShouldMatchCommandOutput -Test ${function:ShouldMatchCommandOutput}
+If (Get-Command -Name Add-ShouldOperator -ErrorAction SilentlyContinue) {
+    Add-ShouldOperator -Name ReturnZeroExitCode -InternalName ShouldReturnZeroExitCode -Test ${function:ShouldReturnZeroExitCode}
+    Add-ShouldOperator -Name MatchCommandOutput -InternalName ShouldMatchCommandOutput -Test ${function:ShouldMatchCommandOutput}
 }


### PR DESCRIPTION
# Description
In Pester version 5 `Add-AssertionOperator` was renamed to `Add-ShouldOperator`, and even though `Add-AssertionOperator` is not yet deprecated (it's an alias for `Add-ShouldOperator` now), it's better to follow the new syntax to avoid mixing up the stuff from version 4 and 5.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2175

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
