### PR TITLE
[macOS] Temporary hardcoding fastlane 2.183.2 rev2

### DIFF
--- a/images/macos/provision/core/rubygem.sh
+++ b/images/macos/provision/core/rubygem.sh
@@ -30,6 +30,7 @@ gem install bundler --force
 # AppStoreRelease Azure DevOps has issues with Fastlane 2.184.0. Temporary hardcoding the version until the issue is fixed
 # https://github.com/microsoft/app-store-vsts-extension/issues/244
 echo Installing fastlane tools...
+gem uninstall fastlane -aI
 gem install fastlane -v 2.183.2
 
 invoke_tests "RubyGem"


### PR DESCRIPTION
# Description
It turned out that Fastlane 2.184.0 comes with the xcode-install utility hence we need to uninstall the new version before installing the 2.183.2 one.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2202

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
