### PR TITLE
Add macOS 11 onboarding guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Ubuntu 16.04 has been deprecated and will be removed on September 20, 2021.
 Existing workflows using `Ubuntu 16.04` should migrate to `Ubuntu 20.04` or `Ubuntu 18.04`
 ```
 
-> The macOS 11 virtual environment is currently in preview, and is automatically available to existing Enterprise plan customers. New Enterprise plan customers, or customers on other plans, should fill this form to request access to macOS 11 virtual environment. Please view our [Big Sur guide](./docs/macos-11-onboarding.md) for more details. <br/>
+> The macOS 11 virtual environment is currently in preview, and is automatically available to existing Enterprise plan customers. New Enterprise plan customers, or customers on other plans, should fill the form to request access to macOS 11 virtual environment. Please view our [Big Sur guide](./docs/macos-11-onboarding.md) for more details. <br/>
 The `macos-latest` YAML workflow label still uses the macOS 10.15 virtual environment.
 
 ***What images are available for GitHub Actions and Azure DevOps?***

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Existing workflows using `Ubuntu 16.04` should migrate to `Ubuntu 20.04` or `Ubu
 New customers or customers on other plans should fill this form to request access to macOS 11 virtual environment. Please view our [Big Sur guide](./docs/macos-11-onboarding.md) for more details. 
 The `macos-latest` YAML workflow label still uses the macOS 10.15 virtual environment.
 
-
 ***What images are available for GitHub Actions and Azure DevOps?***
 The availability of images for GitHub Actions and Azure DevOps is different. See documentation for more details:  
 - [GitHub Actions](https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources)  

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Ubuntu 16.04 has been deprecated and will be removed on September 20, 2021.
 Existing workflows using `Ubuntu 16.04` should migrate to `Ubuntu 20.04` or `Ubuntu 18.04`
 ```
 
-> The macOS 11 Virtual Environment is currently in preview and available by default to existing Enterprise plan customers. <br/>
-New customers or customers on other plans should fill this form to request access to macOS 11 virtual environment. Please view our [Big Sur guide](./docs/macos-11-onboarding.md) for more details. <br/>
+> The macOS 11 virtual environment is currently in preview, and is automatically available to existing Enterprise plan customers. New Enterprise plan customers, or customers on other plans, should fill this form to request access to macOS 11 virtual environment. Please view our [Big Sur guide](./docs/macos-11-onboarding.md) for more details. <br/>
 The `macos-latest` YAML workflow label still uses the macOS 10.15 virtual environment.
 
 ***What images are available for GitHub Actions and Azure DevOps?***

--- a/README.md
+++ b/README.md
@@ -21,11 +21,10 @@ Ubuntu 16.04 is being deprecated. It is not recommended for new users.
 If any of your workflows use Ubuntu 16.04, migrate to Ubuntu 20.04 or 18.04.
 ```
 
-```
-The macOS 11 virtual environment is currently provided as a private preview only.
-The "macos-latest" YAML workflow label still uses the macOS 10.15 virtual environment.
-```
-> macOS 11 is now available for all existing Enterprises. Process of onboarding other plans is described on the [Onboarding page](./docs/macos-11-onboarding.md)
+> The macOS 11 virtual environment is currently in preview and available by default to existing customers on the Enterprise plan. 
+New customers or customers on other plans should fill this form to request access to macOS 11 virtual environment. Please view our [Big Sur guide](./docs/macos-11-onboarding.md) for more details. 
+The `macos-latest` YAML workflow label still uses the macOS 10.15 virtual environment.
+
 
 ***What images are available for GitHub Actions and Azure DevOps?***
 The availability of images for GitHub Actions and Azure DevOps is different. See documentation for more details:  

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Ubuntu 16.04 has been deprecated and will be removed on September 20, 2021.
 Existing workflows using `Ubuntu 16.04` should migrate to `Ubuntu 20.04` or `Ubuntu 18.04`
 ```
 
-> The macOS 11 virtual environment is currently in preview and available by default to existing customers on the Enterprise plan. <br/>
+> The macOS 11 Virtual Environment is currently in preview and available by default to existing Enterprise plan customers. <br/>
 New customers or customers on other plans should fill this form to request access to macOS 11 virtual environment. Please view our [Big Sur guide](./docs/macos-11-onboarding.md) for more details. <br/>
 The `macos-latest` YAML workflow label still uses the macOS 10.15 virtual environment.
 

--- a/README.md
+++ b/README.md
@@ -17,14 +17,15 @@ For general questions about using the virtual environments or writing your Actio
 | Windows Server 2019 | `windows-latest` or `windows-2019` | [windows-2019] | [![](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=windows-2019&badge=1)](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=windows-2019&redirect=1)
 | Windows Server 2016 | `windows-2016` | [windows-2016] | [![](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=windows-2016&badge=1)](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=windows-2016&redirect=1)
 ```
-The macOS 11.0 virtual environment is currently provided as a private preview only.
-The "macos-latest" YAML workflow label still uses the macOS 10.15 virtual environment.
-```
-
-```
 Ubuntu 16.04 is being deprecated. It is not recommended for new users. 
 If any of your workflows use Ubuntu 16.04, migrate to Ubuntu 20.04 or 18.04.
 ```
+
+```
+The macOS 11 virtual environment is currently provided as a private preview only.
+The "macos-latest" YAML workflow label still uses the macOS 10.15 virtual environment.
+```
+Onboarding of new customers to macOS 11 is now opened. For more information, see [Onboarding page](./docs/macos-11-onboarding.md)
 
 ***What images are available for GitHub Actions and Azure DevOps?***
 The availability of images for GitHub Actions and Azure DevOps is different. See documentation for more details:  

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If any of your workflows use Ubuntu 16.04, migrate to Ubuntu 20.04 or 18.04.
 The macOS 11 virtual environment is currently provided as a private preview only.
 The "macos-latest" YAML workflow label still uses the macOS 10.15 virtual environment.
 ```
-Onboarding of new customers to macOS 11 is now opened. For more information, see [Onboarding page](./docs/macos-11-onboarding.md)
+> Onboarding of new customers to macOS 11 is now opened. For more information, see the [Onboarding page](./docs/macos-11-onboarding.md)
 
 ***What images are available for GitHub Actions and Azure DevOps?***
 The availability of images for GitHub Actions and Azure DevOps is different. See documentation for more details:  

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If any of your workflows use Ubuntu 16.04, migrate to Ubuntu 20.04 or 18.04.
 The macOS 11 virtual environment is currently provided as a private preview only.
 The "macos-latest" YAML workflow label still uses the macOS 10.15 virtual environment.
 ```
-> macOS 11 is now available for all existing Enterprises. Process of onboarding other plans is described on [Onboarding page](./docs/macos-11-onboarding.md)
+> macOS 11 is now available for all existing Enterprises. Process of onboarding other plans is described on the [Onboarding page](./docs/macos-11-onboarding.md)
 
 ***What images are available for GitHub Actions and Azure DevOps?***
 The availability of images for GitHub Actions and Azure DevOps is different. See documentation for more details:  

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Ubuntu 16.04 has been deprecated and will be removed on September 20, 2021.
 Existing workflows using `Ubuntu 16.04` should migrate to `Ubuntu 20.04` or `Ubuntu 18.04`
 ```
 
-> The macOS 11 virtual environment is currently in preview and available by default to existing customers on the Enterprise plan. 
-New customers or customers on other plans should fill this form to request access to macOS 11 virtual environment. Please view our [Big Sur guide](./docs/macos-11-onboarding.md) for more details. 
+> The macOS 11 virtual environment is currently in preview and available by default to existing customers on the Enterprise plan. <br/>
+New customers or customers on other plans should fill this form to request access to macOS 11 virtual environment. Please view our [Big Sur guide](./docs/macos-11-onboarding.md) for more details. <br/>
 The `macos-latest` YAML workflow label still uses the macOS 10.15 virtual environment.
 
 ***What images are available for GitHub Actions and Azure DevOps?***

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If any of your workflows use Ubuntu 16.04, migrate to Ubuntu 20.04 or 18.04.
 The macOS 11 virtual environment is currently provided as a private preview only.
 The "macos-latest" YAML workflow label still uses the macOS 10.15 virtual environment.
 ```
-> Onboarding of new customers to macOS 11 is now opened. For more information, see the [Onboarding page](./docs/macos-11-onboarding.md)
+> macOS 11 is now available for all existing Enterprises. Process of onboarding other plans is described on [Onboarding page](./docs/macos-11-onboarding.md)
 
 ***What images are available for GitHub Actions and Azure DevOps?***
 The availability of images for GitHub Actions and Azure DevOps is different. See documentation for more details:  

--- a/docs/macos-11-onboarding.md
+++ b/docs/macos-11-onboarding.md
@@ -1,10 +1,10 @@
 # macOS 11 (Big Sur) onboarding guide
 
-macOS 11 pools were opened to existing customers only, and we are working on making them ready for production use, rebalancing capacity and analyzing possible load.
+macOS 11 pools were opened to existing customers only, and we are working on making them ready for production use, rebalancing capacity, and analyzing possible load.
 
 Meanwhile, we'd like to start including customers to private preview on demand. 
 
-> Big Sur will automatically became available to existing Enterprise customers. New enterprises and customers on other plans, please go through the sign up process described below.
+> Big Sur will automatically become available to existing Enterprise customers. New enterprises and customers on other plans, please go through the sign up process described below.
 
 ## Sign up process
 

--- a/docs/macos-11-onboarding.md
+++ b/docs/macos-11-onboarding.md
@@ -1,0 +1,23 @@
+# macOS 11 (Big Sur) onboarding guide
+
+macOS 11 pools are opened to existing customers only, and we are working on making them ready for production use, rebalancing capacity and analyzing possible load.
+
+Meanwhile, we'd like to start including customers to private preview on demand.
+
+## Sign up process
+
+If you need to build and test your project with macOS 11, please, fill out this [onboarding form](https://forms.office.com/r/Pn0a7NqBXg).
+
+Once in a week we will review the incoming requests and open macOS 11 pool for some amount of them. These are the aspects we consider when processing requests:
+- _Pool capacity_. Onboarding is possible only if current performace won't degrade for existing customers.
+- _Necessity of macOS 11_. Currently, we can afford adding only those projects that really depends on the latest macOS version and its features.
+
+## Usage
+
+macOS 11 image label was changed to `macos-11` to avoid confusing of minor version. We always update images to the latest available OS version. Use the following code snippet to run your builds on macOS Big Sur:
+```
+jobs:
+  build:
+    runs-on: macos-11
+```
+

--- a/docs/macos-11-onboarding.md
+++ b/docs/macos-11-onboarding.md
@@ -2,7 +2,9 @@
 
 macOS 11 pools are opened to existing customers only, and we are working on making them ready for production use, rebalancing capacity and analyzing possible load.
 
-Meanwhile, we'd like to start including customers to private preview on demand.
+Meanwhile, we'd like to start including customers to private preview on demand. 
+
+> Big Sur will automatically became available for current Enterprise customers. New enterprises and customers on other plans, please go through the sign up process described below.
 
 ## Sign up process
 
@@ -10,6 +12,7 @@ If you need to build and test your project with macOS 11, please, fill out the [
 
 We will review the incoming requests periodically and open macOS 11 pool for some amount of them. These are the aspects we consider when processing requests:
 - _Pool capacity_. New onboardings are only possible if current performace won't degrade for existing customers.
+- _Billing plan_. New Enterprise or Teams customers will be given a prioroty in joining macOS 11.
 - _Necessity of macOS 11_. Currently, we can afford adding only those projects who really depends on the latest macOS version and its features.
 
 ## Usage

--- a/docs/macos-11-onboarding.md
+++ b/docs/macos-11-onboarding.md
@@ -13,11 +13,11 @@ If you need to build and test your project with macOS 11, please, fill out the [
 We will review the incoming requests periodically and open macOS 11 pool for some amount of them. These are the aspects we consider when processing requests:
 - _Pool capacity_. New onboardings are only possible if current performance won't degrade for existing customers.
 - _Billing plan_. New Enterprise or Teams customers will be given a priority in joining macOS 11.
-- _Necessity of macOS 11_. Currently, we can afford adding only those projects who really depends on the latest macOS version and its features.
+- _Necessity of macOS 11_. We can currently afford to add only those projects that really depend on the latest macOS version and its features.
 
 ## Usage
 
-macOS 11 image label was changed to `macos-11` to avoid confusion with minor version. We always update images to the latest available OS version. Use the following code snippet to run your builds on macOS Big Sur:
+macOS 11 image label was changed to `macos-11` to avoid confusion with the minor version. We always update images to the latest available OS version. Use the following code snippet to run your builds on macOS Big Sur:
 ```
 jobs:
   build:

--- a/docs/macos-11-onboarding.md
+++ b/docs/macos-11-onboarding.md
@@ -1,6 +1,6 @@
 # macOS 11 (Big Sur) onboarding guide
 
-macOS 11 pools are opened to existing customers only, and we are working on making them ready for production use, rebalancing capacity and analyzing possible load.
+macOS 11 pools were opened to existing customers only, and we are working on making them ready for production use, rebalancing capacity and analyzing possible load.
 
 Meanwhile, we'd like to start including customers to private preview on demand. 
 

--- a/docs/macos-11-onboarding.md
+++ b/docs/macos-11-onboarding.md
@@ -4,7 +4,7 @@ macOS 11 pools were opened to existing customers only, and we are working on mak
 
 Meanwhile, we'd like to start including customers to private preview on demand. 
 
-> Big Sur will automatically became available for current Enterprise customers. New enterprises and customers on other plans, please go through the sign up process described below.
+> Big Sur will automatically became available to existing Enterprise customers. New enterprises and customers on other plans, please go through the sign up process described below.
 
 ## Sign up process
 

--- a/docs/macos-11-onboarding.md
+++ b/docs/macos-11-onboarding.md
@@ -6,15 +6,15 @@ Meanwhile, we'd like to start including customers to private preview on demand.
 
 ## Sign up process
 
-If you need to build and test your project with macOS 11, please, fill out this [onboarding form](https://forms.office.com/r/Pn0a7NqBXg).
+If you need to build and test your project with macOS 11, please, fill out the [form](https://forms.office.com/r/Pn0a7NqBXg).
 
-Once in a week we will review the incoming requests and open macOS 11 pool for some amount of them. These are the aspects we consider when processing requests:
-- _Pool capacity_. Onboarding is possible only if current performace won't degrade for existing customers.
-- _Necessity of macOS 11_. Currently, we can afford adding only those projects that really depends on the latest macOS version and its features.
+We will review the incoming requests periodically and open macOS 11 pool for some amount of them. These are the aspects we consider when processing requests:
+- _Pool capacity_. New onboardings are only possible if current performace won't degrade for existing customers.
+- _Necessity of macOS 11_. Currently, we can afford adding only those projects who really depends on the latest macOS version and its features.
 
 ## Usage
 
-macOS 11 image label was changed to `macos-11` to avoid confusing of minor version. We always update images to the latest available OS version. Use the following code snippet to run your builds on macOS Big Sur:
+macOS 11 image label was changed to `macos-11` to avoid confusion with minor version. We always update images to the latest available OS version. Use the following code snippet to run your builds on macOS Big Sur:
 ```
 jobs:
   build:

--- a/images/win/scripts/Installers/Install-Haskell.ps1
+++ b/images/win/scripts/Installers/Install-Haskell.ps1
@@ -5,7 +5,7 @@
 
 # Get 3 latest versions of GHC
 [Version[]] $ChocoVersionsOutput = & choco search ghc --allversions | Where-Object { $_.StartsWith('ghc ') -and $_ -match 'Approved' } | ForEach-Object { [regex]::matches($_, '\d+(\.\d+){2,}').value }
-$MajorMinorGroups = $ChocoVersionsOutput | Group-Object { $_.ToString(2) } | Sort-Object Name -Descending | Select-Object -First 3
+$MajorMinorGroups = $ChocoVersionsOutput | Sort-Object -Descending | Group-Object { $_.ToString(2) } | Select-Object -First 3
 $VersionsList = $MajorMinorGroups | ForEach-Object { $_.Group | Select-Object -First 1 } | Sort-Object
 
 # The latest version will be installed as a default


### PR DESCRIPTION
# Description
Adding a guide for macOS 11 onboarding when it became available for new customers.

[Rendered version](https://github.com/AlenaSviridenko/virtual-environments/blob/add-macos-11-onboarding-guide/docs/macos-11-onboarding.md)

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/2212

## Check list
- [x] Related issue / work item is attached
- [n\a] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [n\a] Changes are tested and related VM images are successfully generated
