### PR TITLE
Wrap gcc++ with the script to setup libstdc++.so link

### DIFF
--- a/images/linux/scripts/installers/gcc.sh
+++ b/images/linux/scripts/installers/gcc.sh
@@ -13,7 +13,35 @@ function InstallGcc {
 
     echo "Installing $version..."
     apt-get install $version -y
+
+   # replace the original binaries with the script
+   # to make link libstdc++.so to target libstdc++.so.6.0.29
+   # not sure it is required for gcc++-9 and gcc++-10
+    binary=`which $version`
+    mv "$binary" "$binary.orig"
+    cat > "$binary" <<EOT
+#!/bin/sh
+
+$target=$(basename $(readlink -f /usr/lib/x86_64-linux-gnu/libstdc++.so.6))
+if [ $target != libstdc++.so.6.0.29 ];then
+ echo "WARNING: your are using $version that requires libstdc++.so.6.0.29"
+ echo "         the binaries compiled against it may crash on fresh Ubuntu images"
+ ln -s /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.29
+ echo "         libstdc++.so is a link to libstdc++.so.6.0.29 now"
+fi
+$binary.orig $@
+EOT
+    chmod +x "$binary"
 }
+
+# apt install of gcc-11 removes the existing
+# libstdc++ and replaces it with libstdc++.so.6.0.29
+# lets backup the default ubuntu distribution libstdc++
+#
+# make a copy of libstdc++ on ubuntu 20.04
+test -f /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28 && cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28 /tmp
+# make a copy of libstdc++ on ubuntu 18.04
+test -f /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25 && cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25 /tmp
 
 # Install GNU C++ compiler
 add-apt-repository ppa:ubuntu-toolchain-r/test -y
@@ -24,5 +52,15 @@ versions=$(get_toolset_value '.gcc.versions[]')
 for version in ${versions[*]}; do
     InstallGcc $version
 done
+
+if [ -f /tmp/libstdc++.so.6.0.25];then
+  sudo cp /tmp/libstdc++.so.6.0.25 /usr/lib/x86_64-linux-gnu
+  sudo ln -s /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25
+fi
+
+if [ -f /tmp/libstdc++.so.6.0.28];then
+  sudo cp /tmp/libstdc++.so.6.0.28 /usr/lib/x86_64-linux-gnu
+  sudo ln -s /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28
+fi
 
 invoke_tests "Tools" "gcc"


### PR DESCRIPTION
# Description
Improvement?  

Installing gcc++ brings libstdc++ of 29 version that makes the binaries built with the actions non-executable on fresh
ubuntu images.

I suggest to backup  the Ubutu default libstdc++ and use them as default till g++-9, g++-10, g++-11 runs for very first time.

g++-9, g++-10, g++-11 are wrapped with a script to setup the link target to 29th version 

#### Related issue: https://github.com/actions/virtual-environments/issues/3432

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
