### PR TITLE
[Windows] Switch to use OData query instead of choco search for ghc installation

### DIFF
--- a/images/win/scripts/Installers/Install-Haskell.ps1
+++ b/images/win/scripts/Installers/Install-Haskell.ps1
@@ -6,10 +6,9 @@
 # Get 3 latest versions of GHC, use OData query for that since choco search has issues https://github.com/chocolatey/choco/issues/2271
 $ODataQuery = '$filter=(Title eq ''ghc'') and (IsPrerelease eq false)&$orderby=Version desc'
 $Url = "https://community.chocolatey.org/api/v2/Packages()?$ODataQuery"
-$ChocoVersionsOutput = Invoke-RestMethod -Uri $Url | ForEach-Object { [Version]$_.properties.Version }
-$GroupedVersions = $ChocoVersionsOutput | Group-Object { $_.ToString(2) }
-$LatestMajorMinor = $GroupedVersions | ForEach-Object { [Version]$_.Name } | Sort-Object | Select-Object -last 3
-$VersionsList = $GroupedVersions | Where-Object { $_.Name -in $LatestMajorMinor } | ForEach-Object { $_.Group | Select-Object -First 1 } | Sort-Object
+$ChocoVersionsOutput = [Version[]](Invoke-RestMethod -Uri $Url).properties.Version
+$LatestMajorMinor = $ChocoVersionsOutput | Group-Object { $_.ToString(2) } | Sort-Object { [Version]$_.Name } | Select-Object -last 3
+$VersionsList = $LatestMajorMinor | ForEach-Object { $_.Group | Select-Object -First 1 } | Sort-Object
 
 # The latest version will be installed as a default
 ForEach ($version in $VersionsList)

--- a/images/win/scripts/Installers/Install-Haskell.ps1
+++ b/images/win/scripts/Installers/Install-Haskell.ps1
@@ -3,10 +3,13 @@
 ##  Desc:  Install Haskell for Windows
 ################################################################################
 
-# Get 3 latest versions of GHC
-[Version[]] $ChocoVersionsOutput = & choco search ghc --allversions | Where-Object { $_.StartsWith('ghc ') -and $_ -match 'Approved' } | ForEach-Object { [regex]::matches($_, '\d+(\.\d+){2,}').value }
-$MajorMinorGroups = $ChocoVersionsOutput | Sort-Object -Descending | Group-Object { $_.ToString(2) } | Select-Object -First 3
-$VersionsList = $MajorMinorGroups | ForEach-Object { $_.Group | Select-Object -First 1 } | Sort-Object
+# Get 3 latest versions of GHC, use OData query for that since choco search has issues https://github.com/chocolatey/choco/issues/2271
+$ODataQuery = '$filter=(Title eq ''ghc'') and (IsPrerelease eq false)&$orderby=Version desc'
+$Url = "https://community.chocolatey.org/api/v2/Packages()?$ODataQuery"
+$ChocoVersionsOutput = Invoke-RestMethod -Uri $Url | ForEach-Object { [Version]$_.properties.Version }
+$GroupedVersions = $ChocoVersionsOutput | Group-Object { $_.ToString(2) }
+$LatestMajorMinor = $GroupedVersions | ForEach-Object { [Version]$_.Name } | Sort-Object | Select-Object -last 3
+$VersionsList = $GroupedVersions | Where-Object { $_.Name -in $LatestMajorMinor } | ForEach-Object { $_.Group | Select-Object -First 1 } | Sort-Object
 
 # The latest version will be installed as a default
 ForEach ($version in $VersionsList)


### PR DESCRIPTION
# Description
Judging by this @HUMBERP comment in the original choco issue https://github.com/chocolatey/choco/issues/2271 — OData query returns correct results when choco search doesn't.
This PR switches the installation to use OData for versions retrieving. 
As an addition, the calculation of 3 latest major-minor versions is changed to work both in Powershell 5 and 7 as the current approach works in Powershell 5 only due to the difference in `Group-Object` sort between the versions.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3434

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
