### PR TITLE
Clean way to disable the pcov PHP Extension

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -249,6 +249,17 @@ function Build-PHPTable {
     }
 }
 
+function Build-PHPSection {
+    $output = ""
+    $output += New-MDHeader "PHP" -Level 3
+    $output += Build-PHPTable | New-MDTable
+    $output += New-MDCode -Lines @(
+        "Both Xdebug and PCOV extensions are installed, but only Xdebug is enabled."
+    )
+
+    return $output
+}
+
 function Get-GHCVersion {
     $(ghc --version) -match "version (?<version>\d+\.\d+\.\d+)" | Out-Null
     $ghcVersion = $Matches.version

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -178,9 +178,7 @@ if (Test-IsUbuntu20) {
     $markdown += New-MDNewLine
 }
 
-$markdown += New-MDHeader "PHP" -Level 3
-$markdown += Build-PHPTable | New-MDTable
-$markdown += New-MDNewLine
+$markdown += Build-PHPSection
 
 $markdown += New-MDHeader "Haskell" -Level 3
 $markdown += New-MDList -Style Unordered -Lines (@(

--- a/images/linux/scripts/installers/php.sh
+++ b/images/linux/scripts/installers/php.sh
@@ -81,7 +81,7 @@ for version in $php_versions; do
 
         # Disable PCOV, as Xdebug is enabled by default
         # https://github.com/krakjoe/pcov#interoperability
-        phpdismod pcov
+        phpdismod -v $version pcov
     fi
 
     if [[ $version = "7.0" || $version = "7.1" ]]; then

--- a/images/linux/scripts/installers/php.sh
+++ b/images/linux/scripts/installers/php.sh
@@ -80,6 +80,7 @@ for version in $php_versions; do
         apt-fast install -y --no-install-recommends php$version-pcov
 
         # Disable PCOV, as Xdebug is enabled by default
+        # https://github.com/krakjoe/pcov#interoperability
         phpdismod pcov
     fi
 

--- a/images/linux/scripts/installers/php.sh
+++ b/images/linux/scripts/installers/php.sh
@@ -80,7 +80,7 @@ for version in $php_versions; do
         apt-fast install -y --no-install-recommends php$version-pcov
 
         # Disable PCOV, as Xdebug is enabled by default
-        echo "" | sudo tee /etc/php/$version/mods-available/pcov.ini
+        phpdismod pcov
     fi
 
     if [[ $version = "7.0" || $version = "7.1" ]]; then


### PR DESCRIPTION
# Description
Use phpdismod to disable th pcov PHP extension

#### Related issue:
https://github.com/actions/virtual-environments/issues/3470

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
