### PR TITLE
[macOS] Refactor rubygems installation to use the toolset

### DIFF
--- a/images/macos/provision/core/rubygem.sh
+++ b/images/macos/provision/core/rubygem.sh
@@ -4,33 +4,12 @@ source ~/utils/utils.sh
 echo Updating RubyGems...
 gem update --system
 
-echo Installing xcode-install utility...
-gem install xcode-install --force
-
-echo Installing CocoaPods...
-gem install cocoapods
-
-if is_Less_BigSur; then
-    # fix nomad-cli installation
-    if is_HighSierra; then
-        brew_smart_install "libxml2"
-        gem install nokogiri -v 1.6.8.1 -- --use-system-libraries --with-xml2-include=$(brew --prefix libxml2)/include/libxml2
-    fi
-
-    echo Installing nomad-cli...
-    gem install nomad-cli
+gemsToInstall=$(get_toolset_value ".rubygems[]")
+if [ -n "$gemsToInstall" ]; then
+    for gem in $gemsToInstall; do
+        echo "Installing gem $gem"
+        gem install $gem
+    done
 fi
-
-echo Installing xcpretty...
-gem install xcpretty
-
-echo Installing bundler...
-gem install bundler --force
-
-# AppStoreRelease Azure DevOps has issues with Fastlane 2.184.0. Temporary hardcoding the version until the issue is fixed
-# https://github.com/microsoft/app-store-vsts-extension/issues/244
-echo Installing fastlane tools...
-gem uninstall fastlane -aI
-gem install fastlane -v 2.183.2
 
 invoke_tests "RubyGem"

--- a/images/macos/software-report/SoftwareReport.Xcode.psm1
+++ b/images/macos/software-report/SoftwareReport.Xcode.psm1
@@ -234,13 +234,18 @@ function Build-XcodeSupportToolsSection {
         "xcversion $xcversion"
     )
 
+    $nomadOutput = Run-Command "gem list nomad-cli"
+    $nomadCLI = [regex]::matches($nomadOutput, "(\d+.){2}\d+").Value
+    $nomadShenzhenOutput = Run-Command "ipa -version"
+    $nomadShenzhen = [regex]::matches($nomadShenzhenOutput, "(\d+.){2}\d+").Value
+    $toolList += @(
+        "Nomad CLI $nomadCLI",
+        "Nomad shenzhen CLI $nomadShenzhen"
+    )
+
     if ($os.IsLessThanBigSur) {
-        $nomadCLI = Run-Command "gem -v nomad-cli"
-        $nomadIPA = Run-Command "ipa -version"
         $xctool = Run-Command "xctool --version"
         $toolList += @(
-            "Nomad CLI $nomadCLI",
-            "Nomad CLI IPA $nomadIPA",
             "xctool $xctool"
         )
     }

--- a/images/macos/tests/RubyGem.Tests.ps1
+++ b/images/macos/tests/RubyGem.Tests.ps1
@@ -1,4 +1,15 @@
-$os = Get-OSVersion
+Describe "RubyGems" {
+    $gemTestCases = Get-ToolsetValue -KeyPath "rubygems" | ForEach-Object {
+        @{gemName = $_}
+    }
+
+    if ($gemTestCases)
+    {
+        It "Gem <gemName> is installed" -TestCases $gemTestCases {
+            "gem list -i '^$gemName$'" | Should -MatchCommandOutput "true"
+        }
+    }
+}
 
 Describe "Bundler" {
     It "Bundler" {
@@ -6,17 +17,9 @@ Describe "Bundler" {
     }
 }
 
-Describe "Nomad" -Skip:($os.IsBigSur) {
-    Context "Nomad" {
-        It "Nomad CLI" {
-            $result = Get-CommandResult "gem list"
-            $result.Output | Should -BeLike "*nomad-cli*"
-        }
-    }
-    Context "Nomad CLI" {
-        It "Nomad CLI IPA" {
-            "ipa --version" | Should -ReturnZeroExitCode
-        }
+Describe "Nomad shenzhen CLI" {
+    It "Nomad shenzhen CLI" {
+        "ipa --version" | Should -ReturnZeroExitCode
     }
 }
 

--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -339,5 +339,13 @@
         "versions": [
             "2.1"
         ]
-    }
+    },
+    "rubygems": [
+        "xcode-install",
+        "cocoapods",
+        "nomad-cli",
+        "xcpretty",
+        "bundler",
+        "fastlane"
+    ]
 }

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -294,5 +294,13 @@
             "3.1",
             "5.0"
         ]
-    }
+    },
+    "rubygems": [
+        "xcode-install",
+        "cocoapods",
+        "nomad-cli",
+        "xcpretty",
+        "bundler",
+        "fastlane"
+    ]
 }

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -214,5 +214,13 @@
             "3.1",
             "5.0"
         ]
-    }
+    },
+    "rubygems": [
+        "xcode-install",
+        "cocoapods",
+        "nomad-cli",
+        "xcpretty",
+        "bundler",
+        "fastlane"
+    ]
 }


### PR DESCRIPTION
# Description
This PR change RubyGems installation to use the toolset and as an addition:
- Fastlane installation was reverted to the latest version since there is no ETA for the task to be fixed and users can setup another Fastlane version in runtime
- Conditions for 10.13 were removed as it's deprecated
- Nomad-cli version output was fixed to show the real version instead of the RubyGems version
- Nomad-ipa renamed to Nomad shenzhen CLI as it's the real name
- Xctool was returned to Big Sur

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2202

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
