### PR TITLE
Add libc++ and libc++abi when installing Clang and LLVM.

### DIFF
--- a/images/linux/scripts/installers/clang.sh
+++ b/images/linux/scripts/installers/clang.sh
@@ -14,9 +14,9 @@ function InstallClang {
     echo "Installing clang-$version..."
     if [[ $version =~ 9 ]] && isUbuntu16 || [[ $version =~ 12 ]]; then
         ./llvm.sh $version
-        apt-get install -y "clang-format-$version"
+        apt-get install -y "clang-format-$version" "libc++-$version-dev" "libc++abi-$version-dev"
     else
-        apt-get install -y "clang-$version" "lldb-$version" "lld-$version" "clang-format-$version"
+        apt-get install -y "clang-$version" "lldb-$version" "lld-$version" "clang-format-$version" "libc++-$version-dev" "libc++abi-$version-dev"
     fi    
 }
 


### PR DESCRIPTION

# Description
These are relatively small, and important parts of the Clang/LLVM C++
toolchain, but are not installed by the script.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated

Not sure which of these I need to do -- just trying to help out by doing this here rather than requiring folks to do this in each individual action configuration.