### PR TITLE
[macOS] Stick to mongodb 4.4

### DIFF
--- a/images/macos/provision/core/mongodb.sh
+++ b/images/macos/provision/core/mongodb.sh
@@ -8,6 +8,7 @@ source ~/utils/utils.sh
 echo "Installing mongodb..."
 
 brew tap mongodb/brew
-brew_smart_install "mongodb-community"
+brew_smart_install "mongodb-community@4.4"
+ln -sf $(brew --prefix mongodb-community@4.4)/bin/* /usr/local/bin/
 
 invoke_tests "Databases" "Mongo"


### PR DESCRIPTION
# Description
Mongodb homebrew formula was updated recently https://github.com/mongodb/homebrew-brew/pull/110 and currently points to version 5.0rc. We need to announce such a major version change before providing it to customers.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2249

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
