### PR TITLE
[Ubuntu] Change rebar installation to use GitHub releases

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -56,6 +56,13 @@ function Get-ErlangVersion {
     return "Erlang $erlangVersion (Eshell $shellVersion)"
 }
 
+function Get-ErlangRebar3Version {
+    $result = Get-CommandResult "rebar3 --version"
+    $result.Output -match "rebar (?<version>(\d+.){2}\d+)" | Out-Null
+    $rebarVersion = $Matches.version
+    return "Erlang rebar3 $rebarVersion"
+}
+
 function Get-MonoVersion {
     $monoVersion = mono --version | Out-String | Take-OutputPart -Part 4
     $aptSourceRepo = Get-AptSourceRepository -PackageName "mono"

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -42,6 +42,7 @@ $markdown += New-MDList -Style Unordered -Lines (@(
         (Get-ClangVersions),
         (Get-ClangFormatVersions),
         (Get-ErlangVersion),
+        (Get-ErlangRebar3Version),
         (Get-MonoVersion),
         (Get-MsbuildVersion),
         (Get-NodeVersion),

--- a/images/linux/scripts/installers/erlang.sh
+++ b/images/linux/scripts/installers/erlang.sh
@@ -4,6 +4,9 @@
 ##  Desc:  Installs erlang
 ################################################################################
 
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/install.sh
+
 source_list=/etc/apt/sources.list.d/eslerlang.list
 
 # Install Erlang

--- a/images/linux/scripts/installers/erlang.sh
+++ b/images/linux/scripts/installers/erlang.sh
@@ -13,9 +13,12 @@ apt-get update
 apt-get install -y --no-install-recommends esl-erlang
 
 # Install rebar3
-wget -q -O rebar3 https://s3.amazonaws.com/rebar3/rebar3
-chmod +x rebar3
-mv rebar3 /usr/local/bin/rebar3
+json=$(curl -sL "https://api.github.com/repos/erlang/rebar3/releases")
+rebar3Version=$(echo $json | jq -r '.[] | select(.tag_name | contains("-") | not).tag_name' | sort -V | tail -n1)
+rebar3DownloadUrl=$(echo $json | jq -r ".[] | select(.tag_name==\"$rebar3Version\").assets[].browser_download_url")
+download_with_retries $rebar3DownloadUrl "/tmp"
+mv /tmp/rebar3 /usr/local/bin/rebar3
+chmod +x /usr/local/bin/rebar3
 
 invoke_tests "Tools" "erlang"
 


### PR DESCRIPTION
# Description
Recently the wrong binary was uploaded to the S3 rebar3 bucket — 3.13.1 instead of 3.16.1, which caused issues with erlang compatibility. The root cause is that the 3.13.3 release is marked as the latest in GH rebar3 repo:
![image](https://user-images.githubusercontent.com/48208649/120218050-dd83d780-c241-11eb-8449-506217e726df.png)
Today the issue was fixed on the rebar3 side — the S3 bucket contains 3.16.1 now, but it's better to use the GH releases page to get the latest version anyway to avoid such issues in the future.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2246

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
