### PR TITLE
[Windows] Refactor Msys2 installation to use toolset part 1

### DIFF
--- a/images/win/scripts/Installers/Install-Msys2.ps1
+++ b/images/win/scripts/Installers/Install-Msys2.ps1
@@ -52,21 +52,24 @@ Write-Host "`n$dash pacman --noconfirm -Syuu (2nd pass)"
 pacman.exe -Syuu  --noconfirm
 taskkill /f /fi "MODULES eq msys-2.0.dll"
 
+$toolsetContent = (Get-ToolsetContent).MsysPackages
+
 Write-Host "`n$dash Install msys2 packages"
-$msysPackages = (Get-ToolsetContent).MsysPackages.msys2
-pacman.exe -S --noconfirm --needed --noprogressbar $msysPackages
+$msys2Packages = $toolsetContent.msys2
+pacman.exe -S --noconfirm --needed --noprogressbar $$msys2Packages
 taskkill /f /fi "MODULES eq msys-2.0.dll"
 
 Write-Host "`n$dash Remove p7zip/7z package due to conflicts"
 pacman.exe -R --noconfirm --noprogressbar p7zip
 
 # install mingw packages
-$archs = (Get-ToolsetContent).MsysPackages.mingw.arch
+$archs = $toolsetContent.mingw.arch
 foreach ($arch in $archs)
 {
   Write-Host "Installing $arch packages"
-  $runtimePackages = ((Get-ToolsetContent).MsysPackages.mingw | Where-Object { $_.arch -eq $arch }).runtime_packages.name | ForEach-Object { "${arch}-$_" }
-  $additionalPackages = ((Get-ToolsetContent).MsysPackages.mingw | Where-Object { $_.arch -eq $arch }).additional_packages | ForEach-Object { "${arch}-$_" }
+  $archPackages = $toolsetContent.mingw | Where-Object { $_.arch -eq $arch }
+  $runtimePackages = $archPackages.runtime_packages.name | ForEach-Object { "${arch}-$_" }
+  $additionalPackages = $archPackages.additional_packages | ForEach-Object { "${arch}-$_" }
   $packagesToInstall = $runtimePackages + $additionalPackages
   Write-Host "The following packages will be installed: $packagesToInstall"
   pacman.exe -S --noconfirm --needed --noprogressbar $packagesToInstall

--- a/images/win/scripts/Installers/Install-Msys2.ps1
+++ b/images/win/scripts/Installers/Install-Msys2.ps1
@@ -53,39 +53,37 @@ pacman.exe -Syuu  --noconfirm
 taskkill /f /fi "MODULES eq msys-2.0.dll"
 
 Write-Host "`n$dash Install msys2 packages"
-pacman.exe -S --noconfirm --needed --noprogressbar base-devel compression
+$msysPackages = (Get-ToolsetContent).MsysPackages.msys2
+pacman.exe -S --noconfirm --needed --noprogressbar $msysPackages
 taskkill /f /fi "MODULES eq msys-2.0.dll"
 
 Write-Host "`n$dash Remove p7zip/7z package due to conflicts"
 pacman.exe -R --noconfirm --noprogressbar p7zip
 
-# mingw package list
-# libxml2 can be removed from the list after the issue is fixed https://github.com/msys2/MINGW-packages/issues/8658
-$tools64 = "___clang ___clang-tools-extra ___cmake ___libxml2 ___llvm ___toolchain ___ragel"
-$tools32 = "___clang ___cmake ___libxml2 ___llvm ___toolchain ___ragel"
-
-# install mingw64 packages
-Write-Host "`n$dash Install mingw64 packages"
-$pre = "mingw-w64-x86_64-"
-pacman.exe -S --noconfirm --needed --noprogressbar $tools64.replace('___', $pre).split(' ')
-
-# install mingw32 packages
-Write-Host "`n$dash Install mingw32 packages"
-$pre = "mingw-w64-i686-"
-pacman.exe -S --noconfirm --needed --noprogressbar $tools32.replace('___', $pre).split(' ')
+# install mingw packages
+$archs = (Get-ToolsetContent).MsysPackages.mingw.arch
+foreach ($arch in $archs)
+{
+  Write-Host "Installing $arch packages"
+  $runtimePackages = ((Get-ToolsetContent).MsysPackages.mingw | Where-Object { $_.arch -eq $arch }).runtime_packages.name | ForEach-Object { "${arch}-$_" }
+  $additionalPackages = ((Get-ToolsetContent).MsysPackages.mingw | Where-Object { $_.arch -eq $arch }).additional_packages | ForEach-Object { "${arch}-$_" }
+  $packagesToInstall = $runtimePackages + $additionalPackages
+  Write-Host "The following packages will be installed: $packagesToInstall"
+  pacman.exe -S --noconfirm --needed --noprogressbar $packagesToInstall
+}
 
 # clean all packages to decrease image size
 Write-Host "`n$dash Clean packages"
 pacman.exe -Scc --noconfirm
 
-Write-Host "`n$dash Installed mingw64 packages"
-pacman.exe -Q | grep ^mingw-w64-x86_64-
-
-Write-Host "`n$dash Installed mingw32 packages"
-pacman.exe -Q | grep ^mingw-w64-i686-
-
 Write-Host "`n$dash Installed msys2 packages"
 pacman.exe -Q | grep -v ^mingw-w64-
+
+foreach ($arch in $archs)
+{
+  Write-Host "`n$dash Installed $arch packages"
+  pacman.exe -Q | grep ^${arch}-
+}
 
 Write-Host "`nMSYS2 installation completed"
 

--- a/images/win/scripts/Installers/Install-Msys2.ps1
+++ b/images/win/scripts/Installers/Install-Msys2.ps1
@@ -56,7 +56,7 @@ $toolsetContent = (Get-ToolsetContent).MsysPackages
 
 Write-Host "`n$dash Install msys2 packages"
 $msys2Packages = $toolsetContent.msys2
-pacman.exe -S --noconfirm --needed --noprogressbar $$msys2Packages
+pacman.exe -S --noconfirm --needed --noprogressbar $msys2Packages
 taskkill /f /fi "MODULES eq msys-2.0.dll"
 
 Write-Host "`n$dash Remove p7zip/7z package due to conflicts"

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -173,6 +173,79 @@
             "latest": "22"
         }
     },
+    "MsysPackages": {
+        "msys2": [
+            "base-devel",
+            "compression"
+        ],
+        "mingw": [
+            {
+                "arch": "mingw-w64-x86_64",
+                "runtime_packages": [
+                    {
+                        "name": "clang",
+                        "executables": [
+                            "clang",
+                            "g++",
+                            "gcc"
+                        ]
+                    },
+                    {
+                        "name": "cmake",
+                        "executables": [
+                            "cmake",
+                            "cpack",
+                            "ctest"
+                        ]
+                    },
+                    {
+                        "name": "ragel",
+                        "executables": [
+                            "ragel"
+                        ]
+                    }
+                ],
+                "additional_packages": [
+                    "clang-tools-extra",
+                    "libxml2",
+                    "llvm",
+                    "toolchain"
+                ]
+            },
+            {
+                "arch": "mingw-w64-i686",
+                    "runtime_packages": [
+                        {
+                            "name": "clang",
+                            "executables": [
+                                "clang",
+                                "g++",
+                                "gcc"
+                            ]
+                        },
+                        {
+                            "name": "cmake",
+                            "executables": [
+                                "cmake",
+                                "cpack",
+                                "ctest"
+                            ]
+                        },
+                        {
+                            "name": "ragel",
+                            "executables": [
+                                "ragel"
+                            ]
+                        }
+                    ],
+                    "additional_packages": [
+                        "libxml2",
+                        "llvm",
+                        "toolchain"
+                    ]
+                }
+        ]
+    },
     "visualStudio": {
         "version" : "2017",
         "subversion" : "15",

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -214,36 +214,36 @@
             },
             {
                 "arch": "mingw-w64-i686",
-                    "runtime_packages": [
-                        {
-                            "name": "clang",
-                            "executables": [
-                                "clang",
-                                "g++",
-                                "gcc"
-                            ]
-                        },
-                        {
-                            "name": "cmake",
-                            "executables": [
-                                "cmake",
-                                "cpack",
-                                "ctest"
-                            ]
-                        },
-                        {
-                            "name": "ragel",
-                            "executables": [
-                                "ragel"
-                            ]
-                        }
-                    ],
-                    "additional_packages": [
-                        "libxml2",
-                        "llvm",
-                        "toolchain"
-                    ]
-                }
+                "runtime_packages": [
+                    {
+                        "name": "clang",
+                        "executables": [
+                            "clang",
+                            "g++",
+                            "gcc"
+                        ]
+                    },
+                    {
+                        "name": "cmake",
+                        "executables": [
+                            "cmake",
+                            "cpack",
+                            "ctest"
+                        ]
+                    },
+                    {
+                        "name": "ragel",
+                        "executables": [
+                            "ragel"
+                        ]
+                    }
+                ],
+                "additional_packages": [
+                    "libxml2",
+                    "llvm",
+                    "toolchain"
+                ]
+            }
         ]
     },
     "visualStudio": {

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -214,36 +214,36 @@
             },
             {
                 "arch": "mingw-w64-i686",
-                    "runtime_packages": [
-                        {
-                            "name": "clang",
-                            "executables": [
-                                "clang",
-                                "g++",
-                                "gcc"
-                            ]
-                        },
-                        {
-                            "name": "cmake",
-                            "executables": [
-                                "cmake",
-                                "cpack",
-                                "ctest"
-                            ]
-                        },
-                        {
-                            "name": "ragel",
-                            "executables": [
-                                "ragel"
-                            ]
-                        }
-                    ],
-                    "additional_packages": [
-                        "libxml2",
-                        "llvm",
-                        "toolchain"
-                    ]
-                }
+                "runtime_packages": [
+                    {
+                        "name": "clang",
+                        "executables": [
+                            "clang",
+                            "g++",
+                            "gcc"
+                        ]
+                    },
+                    {
+                        "name": "cmake",
+                        "executables": [
+                            "cmake",
+                            "cpack",
+                            "ctest"
+                        ]
+                    },
+                    {
+                        "name": "ragel",
+                        "executables": [
+                            "ragel"
+                        ]
+                    }
+                ],
+                "additional_packages": [
+                    "libxml2",
+                    "llvm",
+                    "toolchain"
+                ]
+            }
         ]
     },
     "visualStudio": {

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -173,6 +173,79 @@
             "latest": "22"
         }
     },
+    "MsysPackages": {
+        "msys2": [
+            "base-devel",
+            "compression"
+        ],
+        "mingw": [
+            {
+                "arch": "mingw-w64-x86_64",
+                "runtime_packages": [
+                    {
+                        "name": "clang",
+                        "executables": [
+                            "clang",
+                            "g++",
+                            "gcc"
+                        ]
+                    },
+                    {
+                        "name": "cmake",
+                        "executables": [
+                            "cmake",
+                            "cpack",
+                            "ctest"
+                        ]
+                    },
+                    {
+                        "name": "ragel",
+                        "executables": [
+                            "ragel"
+                        ]
+                    }
+                ],
+                "additional_packages": [
+                    "clang-tools-extra",
+                    "libxml2",
+                    "llvm",
+                    "toolchain"
+                ]
+            },
+            {
+                "arch": "mingw-w64-i686",
+                    "runtime_packages": [
+                        {
+                            "name": "clang",
+                            "executables": [
+                                "clang",
+                                "g++",
+                                "gcc"
+                            ]
+                        },
+                        {
+                            "name": "cmake",
+                            "executables": [
+                                "cmake",
+                                "cpack",
+                                "ctest"
+                            ]
+                        },
+                        {
+                            "name": "ragel",
+                            "executables": [
+                                "ragel"
+                            ]
+                        }
+                    ],
+                    "additional_packages": [
+                        "libxml2",
+                        "llvm",
+                        "toolchain"
+                    ]
+                }
+        ]
+    },
     "visualStudio": {
         "version" : "2019",
         "subversion" : "16",

--- a/images/win/windows2016.json
+++ b/images/win/windows2016.json
@@ -299,6 +299,9 @@
         },
         {
             "type": "powershell",
+            "environment_vars": [
+                "TOOLSET_JSON_PATH={{user `toolset_json_path`}}"
+            ],
             "elevated_user": "SYSTEM",
             "elevated_password": "",
             "scripts": [

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -270,6 +270,9 @@
         },
         {
             "type": "powershell",
+            "environment_vars": [
+                "TOOLSET_JSON_PATH={{user `toolset_json_path`}}"
+            ],
             "elevated_user": "SYSTEM",
             "elevated_password": "",
             "scripts": [


### PR DESCRIPTION
# Description
This is the first PR with msys2 installation refactoring, the second one will contain test changes.
Currently, we don't test the tools installed by msys thus we don't know that something is not working until canary tests are performed against the image — the latest example https://github.com/msys2/MINGW-packages/issues/8658. 
The toolset file contains executables that come along with each package and these executables will be tested with Pester later.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2175

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
