### PR TITLE
[Ubuntu] Install default version of Clang last

### DIFF
--- a/images/linux/scripts/installers/clang.sh
+++ b/images/linux/scripts/installers/clang.sh
@@ -37,8 +37,11 @@ versions=$(get_toolset_value '.clang.versions[]')
 default_clang_version=$(get_toolset_value '.clang.default_version')
 
 for version in ${versions[*]}; do
-    InstallClang $version
+    if [[ $version != $default_clang_version ]]; then
+        InstallClang $version
+    fi
 done
+InstallClang $default_clang_version
 
 SetDefaultClang $default_clang_version
 rm llvm.sh


### PR DESCRIPTION
The libomp package provides the OpenMP runtime for Clang. Only one
version of libomp may be installed at a time:

```
$ dpkg -s libomp5-12 | grep Conflicts
Conflicts: libomp-x.y
```

The clang.sh installer script installs clang versions in the order that
they are listed in the configuration file. When clang is installed, APT
also installs the matching version of libomp, which removes the
previously installed version of libomp. This means that the image ends
up with libomp for the last version (currently 12), which is not
necessarily the same as the default version (currently 11).

As a result, even though libomp is installed, `clang -fopenmp` doesn't
work out of the box because the installed version of libomp does not
match the default clang binary.

Fix this by installing the default version last.