### PR TITLE
Update ORAS URL

### DIFF
--- a/images/linux/scripts/installers/oras-cli.sh
+++ b/images/linux/scripts/installers/oras-cli.sh
@@ -7,8 +7,8 @@
 source $HELPER_SCRIPTS/install.sh
 
 # Determine latest ORAS CLI version
-ORAS_CLI_LATEST_VERSION_URL=https://api.github.com/repos/deislabs/oras/releases/latest
-ORAS_CLI_DOWNLOAD_URL=$(curl -s $ORAS_CLI_LATEST_VERSION_URL | jq -r '.assets[].browser_download_url | select(endswith("linux_amd64.tar.gz"))')
+ORAS_CLI_LATEST_VERSION_URL=https://api.github.com/repos/oras-project/oras/releases/latest
+ORAS_CLI_DOWNLOAD_URL=$(curl -sfL $ORAS_CLI_LATEST_VERSION_URL | jq -r '.assets[].browser_download_url | select(endswith("linux_amd64.tar.gz"))')
 ORAS_CLI_ARCHIVE=$(basename $ORAS_CLI_DOWNLOAD_URL)
 
 # Install ORAS CLI


### PR DESCRIPTION
# Description

ORAS repository has been moved to a new org called `oras-project`. This PR update the script to fix the next error:
```
==> azure-arm: Provisioning with shell script: C:\agent\_work\6\s\images\linux/scripts/installers/oras-cli.sh
==> azure-arm: jq: error (at <stdin>:5): Cannot iterate over null (null)
```

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
