### PR TITLE
[macOS] Fix default java postfix in the software readme

### DIFF
--- a/images/macos/software-report/SoftwareReport.Java.psm1
+++ b/images/macos/software-report/SoftwareReport.Java.psm1
@@ -1,5 +1,5 @@
 function Get-JavaVersions {
-    $defaultJavaPath = Get-Item env:JAVA_HOME
+    $defaultJavaPath = (Get-Item env:JAVA_HOME).value
     $javaVersions = Get-Item env:JAVA_HOME_*_X64
     $sortRules = @{
         Expression = { [Int32]$_.Name.Split("_")[2] }  


### PR DESCRIPTION
# Description
There is no postfix for the default java version at the moment:
https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
![image](https://user-images.githubusercontent.com/48208649/120603100-53f82380-c454-11eb-880f-5ed740bb394f.png)
This PR fixes the root cause — we need to compare the value of env:JAVA_HOME, not the whole object.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2264

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
