### PR TITLE
fix(windows): update npm registry to https

### DIFF
--- a/images/win/scripts/Installers/Install-NodeLts.ps1
+++ b/images/win/scripts/Installers/Install-NodeLts.ps1
@@ -19,7 +19,7 @@ setx npm_config_prefix $PrefixPath /M
 $env:npm_config_prefix = $PrefixPath
 
 npm config set cache $CachePath --global
-npm config set registry http://registry.npmjs.org/
+npm config set registry https://registry.npmjs.org/
 
 npm install -g cordova
 npm install -g grunt-cli


### PR DESCRIPTION
# Description
Yarn installation fails with connection reset issues due to HTTP protocol. Updating it to HTTPS will make it more secure.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
