### PR TITLE
Keep llvm apt repo

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -44,6 +44,11 @@ function Get-ClangVersions {
     return "Clang " + $clangVersions
 }
 
+function Get-LLVMInfo {
+    $aptSourceRepo = Get-AptSourceRepository -PackageName "llvm"
+    return "LLVM libc++ is not preinstalled (apt source to install: $aptSourceRepo)"
+}
+
 function Get-ClangFormatVersions {
     $clangFormatVersions = Get-ClangToolVersions -ToolName "clang-format"
     return "Clang-format " + $clangFormatVersions

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -45,8 +45,10 @@ function Get-ClangVersions {
 }
 
 function Get-LLVMInfo {
+    $clangVersions = Get-ClangToolVersions -ToolName "clang"
+    $clangFormatVersions = Get-ClangToolVersions -ToolName "clang-format"
     $aptSourceRepo = Get-AptSourceRepository -PackageName "llvm"
-    return "LLVM libc++ is not preinstalled (apt source to install: $aptSourceRepo)"
+    return "LLVM components: Clang $clangFormatVersions, Clang-format $clangFormatVersions (apt source: $aptSourceRepo)"
 }
 
 function Get-ClangFormatVersions {

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -39,8 +39,6 @@ $runtimesList = @(
         (Get-BashVersion),
         (Get-CPPVersions),
         (Get-FortranVersions),
-        (Get-ClangVersions),
-        (Get-ClangFormatVersions),
         (Get-ErlangVersion),
         (Get-ErlangRebar3Version),
         (Get-MonoVersion),
@@ -56,6 +54,11 @@ $runtimesList = @(
 
 if (Test-IsUbuntu20) {
     $runtimesList += (Get-LLVMInfo)
+} else {
+    $runtimesList += 
+        (Get-ClangVersions)
+    $runtimesList += 
+        (Get-ClangFormatVersions)
 }
 
 $markdown += New-MDList -Style Unordered -Lines ($runtimesList | Sort-Object)

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -55,10 +55,8 @@ $runtimesList = @(
 if (Test-IsUbuntu20) {
     $runtimesList += (Get-LLVMInfo)
 } else {
-    $runtimesList += 
-        (Get-ClangVersions)
-    $runtimesList += 
-        (Get-ClangFormatVersions)
+    $runtimesList += (Get-ClangVersions)
+    $runtimesList += (Get-ClangFormatVersions)
 }
 
 $markdown += New-MDList -Style Unordered -Lines ($runtimesList | Sort-Object)

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -35,7 +35,7 @@ $markdown += New-MDList -Style Unordered -Lines @(
 $markdown += New-MDHeader "Installed Software" -Level 2
 $markdown += New-MDHeader "Language and Runtime" -Level 3
 
-$markdown += New-MDList -Style Unordered -Lines (@(
+$runtimesList = @(
         (Get-BashVersion),
         (Get-CPPVersions),
         (Get-FortranVersions),
@@ -52,8 +52,13 @@ $markdown += New-MDList -Style Unordered -Lines (@(
         (Get-RubyVersion),
         (Get-SwiftVersion),
         (Get-JuliaVersion)
-        ) | Sort-Object
-)
+        ) 
+
+if (Test-IsUbuntu20) {
+    $runtimesList += (Get-LLVMInfo)
+}
+
+$markdown += New-MDList -Style Unordered -Lines ($runtimesList | Sort-Object)
 
 $markdown += New-MDHeader "Package Management" -Level 3
 

--- a/images/linux/scripts/installers/clang.sh
+++ b/images/linux/scripts/installers/clang.sh
@@ -15,6 +15,8 @@ function InstallClang {
     if [[ $version =~ 9 ]] && isUbuntu16 || [[ $version =~ 12 ]]; then
         ./llvm.sh $version
         apt-get install -y "clang-format-$version"
+	llvm_repo=$(grep '^deb.*apt.llvm.org\/' /etc/apt/sources.list)
+	echo "llvm $llvm_repo" >> $HELPER_SCRIPTS/apt-sources.txt
     else
         apt-get install -y "clang-$version" "lldb-$version" "lld-$version" "clang-format-$version"
     fi    


### PR DESCRIPTION
# Description
Improvement

Users need ability to install llvm related software in their workflows.
Currently the llvm.sh script adds the repos directly to /etc/apt/sources.list and provision scripts clean it up.

In order to use the the llvm component user should have info about the apt repository to install them from.

In order to make clear the same APT repo should be used for all LLVM components i combined clang and clang-format
entries into one labeled "LLVM components"

#### Related issue: https://github.com/actions/virtual-environments/issues/3494

sample Readme output https://github.visualstudio.com/virtual-environments/_build/results?buildId=110833&view=logs&j=50448a2f-9550-51a0-b6c4-5ec64224dd81&t=e0a57dbd-49e7-534b-a8b5-3033d3291897

```
- LLVM components: Clang 10.0.0, 11.0.0, 12.0.1, Clang-format 10.0.0, 11.0.0, 12.0.1 (apt source: deb http://apt.llvm.org/focal/ llvm-toolchain-focal-12)
```


## Check list
- [x] Related issue / work item is attached
- [x] Changes are tested and related VM images are successfully generated
