### PR TITLE
[macOS] Add PyPy to Big Sur image

### DIFF
--- a/images/macos/software-report/SoftwareReport.Toolcache.psm1
+++ b/images/macos/software-report/SoftwareReport.Toolcache.psm1
@@ -40,11 +40,8 @@ function Build-ToolcacheSection {
     $output += New-MDList -Lines (Get-ToolcacheRubyVersions) -Style Unordered
     $output += New-MDHeader "Python" -Level 4
     $output += New-MDList -Lines (Get-ToolcachePythonVersions) -Style Unordered
-    
-    if ($os.IsLessThanBigSur) {
-        $output += New-MDHeader "PyPy" -Level 4
-        $output += New-MDList -Lines (Get-ToolcachePyPyVersions) -Style Unordered
-    }
+    $output += New-MDHeader "PyPy" -Level 4
+    $output += New-MDList -Lines (Get-ToolcachePyPyVersions) -Style Unordered
 
     if( -not $os.IsHighSierra) {
         $output += New-MDHeader "Node.js" -Level 4

--- a/images/macos/templates/macOS-11.json
+++ b/images/macos/templates/macOS-11.json
@@ -187,6 +187,7 @@
                 "./provision/core/chrome.sh",
                 "./provision/core/edge.sh",
                 "./provision/core/firefox.sh",
+                "./provision/core/pypy.sh",
                 "./provision/core/pipx-packages.sh"
             ]
         },

--- a/images/macos/tests/Toolcache.Tests.ps1
+++ b/images/macos/tests/Toolcache.Tests.ps1
@@ -98,7 +98,7 @@ Describe "Toolcache" {
             }
         }
     }
-    Context "PyPy" -Skip:($os.IsBigSur) {
+    Context "PyPy" {
         $pypyDirectory = Join-Path $toolcacheDirectory "PyPy"
         $pypyPackage = $packages | Where-Object { $_.ToolName -eq "pypy" } | Select-Object -First 1
         $testCase = @{ PypyDirectory = $pypyDirectory }

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -170,6 +170,15 @@
             ]
         },
         {
+            "name": "PyPy",
+            "arch": "x64",
+            "platform" : "darwin",
+            "versions": [
+                "2.7",
+                "3.7"
+            ]
+        },
+        {
             "name": "Node",
             "url" : "https://raw.githubusercontent.com/actions/node-versions/main/versions-manifest.json",
             "platform" : "darwin",


### PR DESCRIPTION
# Description
PyPy 7.3.5 (Python 2.7 and 3.7) works on Big Sur without any issues, we can safely add it to the image

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2282

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
