### PR TITLE
[Windows] Fix Haskell path in the pester tests

### DIFF
--- a/images/win/scripts/Tests/Haskell.Tests.ps1
+++ b/images/win/scripts/Tests/Haskell.Tests.ps1
@@ -12,8 +12,8 @@ Describe "Haskell" {
         $ghcVersion = $_
         $ghcShortVersion = ([version]$ghcVersion).ToString(3)
         $binGhcPath = Join-Path $chocoPackagesPath "ghc.$ghcVersion\tools\ghc-$ghcShortVersion\bin\ghc.exe"
-        # Starting from version 9 haskell installation directory is $env:ChocolateyToolsLocation instead of $env:ChocolateyInstall\lib
-        if ($ghcVersion -notmatch "^[0-8]\.\d+.*")
+        # The most recent GHC versions installation directory is $env:ChocolateyToolsLocation instead of $env:ChocolateyInstall\lib
+        if (-not (Test-Path $binGhcPath))
         {
             $binGhcPath = Join-Path $env:ChocolateyToolsLocation "ghc-$ghcShortVersion\bin\ghc.exe"
         }
@@ -34,11 +34,6 @@ Describe "Haskell" {
 
     It "GHC <defaultGhcVersion> is the default version and should be the latest installed" -TestCases $ghcDefaultCases {
         "ghc --version" | Should -MatchCommandOutput $defaultGhcShortVersion
-    }
-
-    # Sometimes choco doesn't return version 9, need to check it explicitly https://github.com/chocolatey/choco/issues/2271
-    It "Default GHC version is 9" -TestCases $ghcDefaultCases {
-        "ghc --version" | Should -MatchCommandOutput "9(\.\d+){2,}"
     }
 
     It "Cabal is installed" {


### PR DESCRIPTION
# Description
Recent Haskell versions are installed into `$env:ChocolateyToolsLocation` instead of `$env:ChocolateyInstall\lib.` Recent version 8.10.5 is also installed in the new directory, but our test checks that directory only for version 9.
This PR:
- changes the test to avoid sticking a version to the exact path
- removes `Default GHC version is 9` test since we don't need it anymore after switching to use OData query for versions retrieval

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2284

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
