### PR TITLE
[macOS] Add audio device and utilities for Big Sur

### DIFF
--- a/images/macos/helpers/SoftwareReport.Helpers.psm1
+++ b/images/macos/helpers/SoftwareReport.Helpers.psm1
@@ -49,3 +49,14 @@ function Get-PathWithLink {
     $link = Get-LinkTarget($inputPath)
     return "${inputPath}${link}"
 }
+
+function Get-BrewPackageVersion {
+    param (
+        [string] $CommandName
+    )
+
+    (Get-LinkTarget (Get-Command $CommandName).Source | Out-String) -match "(?<version>(\d+.){2}\d+)" | Out-Null 
+    $packageVersion = $Matches.Version
+
+    return $packageVersion
+}

--- a/images/macos/provision/core/audiodevice.sh
+++ b/images/macos/provision/core/audiodevice.sh
@@ -1,17 +1,28 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
 
-echo "install soundflower"
-brew install --cask soundflower
-
 echo "install switchaudio-osx"
 brew_smart_install "switchaudio-osx"
 
 echo "install sox"
 brew_smart_install "sox"
 
-echo "set Soundflower (2ch) as input/output device"
-SwitchAudioSource -s "Soundflower (2ch)" -t input
-SwitchAudioSource -s "Soundflower (2ch)" -t output
+# Big Sur doesn't support soundflower installation without user interaction https://github.com/mattingalls/Soundflower/releases/tag/2.0b2
+# Install blackhole-2ch for Big Sur instead
+if is_Less_BigSur; then
+    echo "install soundflower"
+    brew install --cask soundflower
+
+    echo "set Soundflower (2ch) as input/output device"
+    SwitchAudioSource -s "Soundflower (2ch)" -t input
+    SwitchAudioSource -s "Soundflower (2ch)" -t output
+else
+    echo "install blackhole-2ch"
+    brew_smart_install "blackhole-2ch"
+
+    echo "set BlackHole 2ch as input/output device"
+    SwitchAudioSource -s "BlackHole 2ch" -t input
+    SwitchAudioSource -s "BlackHole 2ch" -t output
+fi
 
 invoke_tests "System" "Audio Device"

--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -462,6 +462,16 @@ function Get-CabalVersion {
     return "Cabal $cabalVersion"
 }
 
+function Get-SwitchAudioOsxVersion {
+    $switchAudioVersion = Get-BrewPackageVersion -CommandName "SwitchAudioSource"
+    return "Switchaudio-osx $switchAudioVersion"
+}
+
+function Get-SoxVersion {
+    $soxVersion = Get-BrewPackageVersion -CommandName "sox"
+    return "Sox $soxVersion"
+}
+
 function Get-StackVersion {
     $stackVersion = Run-Command "stack --version" | Take-Part -Part 1 | ForEach-Object {$_.replace(",","")}
     return "Stack $stackVersion"

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -145,6 +145,13 @@ if ($os.IsLessThanBigSur) {
     )
 }
 
+if (-not $os.IsHighSierra) {
+    $utilitiesList += @(
+        (Get-SwitchAudioOsxVersion),
+        (Get-SoxVersion)
+    )
+}
+
 $markdown += New-MDList -Style Unordered -Lines ($utilitiesList | Sort-Object)
 $markdown += New-MDNewLine
 

--- a/images/macos/templates/macOS-11.json
+++ b/images/macos/templates/macOS-11.json
@@ -182,6 +182,7 @@
                 "./provision/core/nginx.sh",
                 "./provision/core/postgresql.sh",
                 "./provision/core/mongodb.sh",
+                "./provision/core/audiodevice.sh",
                 "./provision/core/vcpkg.sh",
                 "./provision/core/miniconda.sh",
                 "./provision/core/chrome.sh",

--- a/images/macos/tests/System.Tests.ps1
+++ b/images/macos/tests/System.Tests.ps1
@@ -17,7 +17,7 @@ Describe "Certificate" {
     }
 }
 
-Describe "Audio device" -Skip:($os.IsHighSierra -or $os.IsBigSur) {
+Describe "Audio device" -Skip:($os.IsHighSierra) {
     It "Sox is installed" {
         "sox --version" | Should -ReturnZeroExitCode
     }
@@ -26,8 +26,12 @@ Describe "Audio device" -Skip:($os.IsHighSierra -or $os.IsBigSur) {
         "SwitchAudioSource -c" | Should -ReturnZeroExitCode
     }
 
-    It "Audio channel Soundflower (2ch)" {
+    It "Audio channel Soundflower (2ch)" -Skip:($os.IsBigSur) {
         SwitchAudioSource -c | Should -BeLikeExactly "Soundflower (2ch)"
+    }
+
+    It "Audio channel BlackHole 2ch" -Skip:($os.IsLessThanBigSur) {
+        SwitchAudioSource -c | Should -BeLikeExactly "BlackHole 2ch"
     }
 }
 


### PR DESCRIPTION
# Description
There is no audio device available on macOS Big Sur images, however, we have one on Catalina.
Unfortunately, there is no easy way to install Soundflower on Big Sur as it requires user interaction but we can use blackhole to get the same result.
This PR:
- Adds blackhole installation on Big Sur along with the other audio tools already available on Catalina
- Adds a software report function to retrieve brew package version by its path since neither `sox` nor `switchaudio-osx` doesn't have version output flags
- Adds `sox` and `switchaudio-osx` to the docs

#### Related issue:
https://github.com/actions/virtual-environments/issues/3526

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
