### PR TITLE
[macOS] Switch the default Xcode version from 12.4 to 12.5 for macOS Big Sur

### DIFF
--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -1,6 +1,6 @@
 {
     "xcode": {
-        "default": "12.4",
+        "default": "12.5",
         "versions": [
             { "link": "13.0", "version": "13.0.0"},
             { "link": "12.5", "version": "12.5.0"},


### PR DESCRIPTION
# Description
We would like to provide images with the latest stable Xcode as the default one thus need to switch the version from 12.4 to 12.5.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3522

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
