### PR TITLE
installing the latest patch version for every feature version

### DIFF
--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -36,7 +36,7 @@ for version in ${DOTNET_VERSIONS[@]}; do
     rm ./${version}.json
 done
 
-sortedSdks=$(echo ${sdks[@]} | tr ' ' '\n' | grep -v preview | grep -v rc | grep -v display | cut -d\" -f2 | sort -r |  uniq -w 5)
+sortedSdks=$(echo ${sdks[@]} | tr ' ' '\n' | grep -v preview | grep -v rc | grep -v display | cut -d\" -f2 | sort -r | uniq -w 5)
 
 extract_dotnet_sdk() {
     local ARCHIVE_NAME="$1"

--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -27,24 +27,16 @@ done
 
 # Get list of all released SDKs from channels which are not end-of-life or preview
 sdks=()
-for dotnet_version in ${DOTNET_VERSIONS[@]}; do
-    release_url="https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/${dotnet_version}/releases.json"
-    download_with_retries "${release_url}" "." "${dotnet_version}.json"
-    releases=$(cat "./${dotnet_version}.json")
-    versions=()
-    versions=("${versions[@]}" $(echo "${releases}" | jq '.releases[]' | jq '.sdk.version'))
-    versions=("${versions[@]}" $(echo "${releases}" | jq '.releases[]' | jq '.sdks[]?' | jq '.version'))
-    versions_sorted=$(echo ${versions[@]} | tr ' ' '\n' | grep -v preview | grep -v rc | grep -v display | cut -d\" -f2 | sort -u)
-
-    unset features
-    declare -A features
-    for version in $versions_sorted; do
-        feature=$(echo $version|grep -oP '\d+\.\d+\.\d')
-        features[$feature]=$version
-    done
-    sdks=("${sdks[@]}" $(echo ${features[@]}))
-    rm ./${dotnet_version}.json
+for version in ${DOTNET_VERSIONS[@]}; do
+    release_url="https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/${version}/releases.json"
+    download_with_retries "${release_url}" "." "${version}.json"
+    releases=$(cat "./${version}.json")
+    sdks=("${sdks[@]}" $(echo "${releases}" | jq '.releases[]' | jq '.sdk.version'))
+    sdks=("${sdks[@]}" $(echo "${releases}" | jq '.releases[]' | jq '.sdks[]?' | jq '.version'))
+    rm ./${version}.json
 done
+
+sortedSdks=$(echo ${sdks[@]} | tr ' ' '\n' | grep -v preview | grep -v rc | grep -v display | cut -d\" -f2 | sort -r |  uniq -w 5)
 
 extract_dotnet_sdk() {
     local ARCHIVE_NAME="$1"
@@ -62,11 +54,9 @@ extract_dotnet_sdk() {
 export -f download_with_retries
 export -f extract_dotnet_sdk
 
-echo ".net sdks to be installed: ${sdks[@]}"
-
 parallel --jobs 0 --halt soon,fail=1 \
     'url="https://dotnetcli.blob.core.windows.net/dotnet/Sdk/{}/dotnet-sdk-{}-linux-x64.tar.gz"; \
-    download_with_retries $url' ::: "${sdks[@]}"
+    download_with_retries $url' ::: "${sortedSdks[@]}"
 
 find . -name "*.tar.gz" | parallel --halt soon,fail=1 'extract_dotnet_sdk {}'
 


### PR DESCRIPTION
# Description
Improvement

The .NET versions maintenance strategy will be changed on Ubuntu images. Currently, we install all available and supported versions of .NET SDK (2.1.x, 3.1.x, 5.0.x). This approach will be changed in favor of installing the latest patch version for every feature version


#### Related issue: https://github.com/actions/virtual-environments/issues/3338

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
