### PR TITLE
[Windows] Don't install KB5003638 update for windows server 2016 as it breaks the VM

### DIFF
--- a/images/win/scripts/Installers/Install-WindowsUpdates.ps1
+++ b/images/win/scripts/Installers/Install-WindowsUpdates.ps1
@@ -5,4 +5,10 @@
 ################################################################################
 
 Write-Host "Run windows updates"
+# KB5003638 causes the windows server 2016 virtual machine to hang on shutdown step
+if (Test-IsWin16) {
+    Get-WUInstall -MicrosoftUpdate
+    Write-Host "Hide update KB5003638"
+    Hide-WindowsUpdate -Confirm:$false -KBArticleID "KB5003638"
+}
 Get-WUInstall -MicrosoftUpdate -AcceptAll -Install -IgnoreUserInput -IgnoreReboot


### PR DESCRIPTION
# Description
[KB5003638](https://support.microsoft.com/en-us/topic/june-8-2021-kb5003638-os-build-14393-4467-d9dfce91-b425-483a-8280-f54d7005b231) causes the virtual machine to hang on shutdown step.
![image](https://user-images.githubusercontent.com/48208649/121382788-9d160f00-c94f-11eb-9c62-d46809eb2714.png)
We need to skip this update for now to fix the image generation.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2287

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
