### PR TITLE
Remove config

### DIFF
--- a/images/linux/scripts/installers/Install-Toolset.ps1
+++ b/images/linux/scripts/installers/Install-Toolset.ps1
@@ -43,13 +43,13 @@ foreach ($tool in $tools) {
 
         Write-Host "Installing $($tool.name) $toolVersion $($tool.arch)..."
         if ($null -ne $asset) {
-            #Install-Asset -ReleaseAsset $asset
+            Install-Asset -ReleaseAsset $asset
         } else {
             Write-Host "Asset was not found in versions manifest"
             exit 1
         }
     }
-} 
+}
 if ($toolsToInstall -contains "Python"){chown -R "$($env:SUDO_USER):$($env:SUDO_USER)" /opt/hostedtoolcache/Python}
 if ($toolsToInstall -contains "node"){chown -R "$($env:SUDO_USER):$($env:SUDO_USER)" /opt/hostedtoolcache/node}
 if ($toolsToInstall -contains "go"){chown -R "$($env:SUDO_USER):$($env:SUDO_USER)" /opt/hostedtoolcache/go}

--- a/images/linux/scripts/installers/Install-Toolset.ps1
+++ b/images/linux/scripts/installers/Install-Toolset.ps1
@@ -50,6 +50,6 @@ foreach ($tool in $tools) {
         }
     }
 } 
-if ($toolsToInstall.Contains("Python")){chown -R "$($env:SUDO_USER):$($env:SUDO_USER)" /opt/hostedtoolcache/Python}
-if ($toolsToInstall.Contains("node")){chown -R "$($env:SUDO_USER):$($env:SUDO_USER)" /opt/hostedtoolcache/node}
-if ($toolsToInstall.Contains("go")){chown -R "$($env:SUDO_USER):$($env:SUDO_USER)" /opt/hostedtoolcache/go}
+if ($toolsToInstall -contains "Python"){chown -R "$($env:SUDO_USER):$($env:SUDO_USER)" /opt/hostedtoolcache/Python}
+if ($toolsToInstall -contains "node"){chown -R "$($env:SUDO_USER):$($env:SUDO_USER)" /opt/hostedtoolcache/node}
+if ($toolsToInstall -contains "go"){chown -R "$($env:SUDO_USER):$($env:SUDO_USER)" /opt/hostedtoolcache/go}

--- a/images/linux/scripts/installers/Install-Toolset.ps1
+++ b/images/linux/scripts/installers/Install-Toolset.ps1
@@ -29,7 +29,9 @@ $ErrorActionPreference = "Stop"
 # Get toolset content
 $toolset = Get-Content -Path "$env:INSTALLER_SCRIPT_FOLDER/toolset.json" -Raw
 $toolsToInstall = ConvertFrom-Json -InputObject $toolset | Select-Object -ExpandProperty tools
+
 $tools = ConvertFrom-Json -InputObject $toolset | Select-Object -ExpandProperty toolcache | Where-Object {$toolsToInstall -contains $_.Name}
+
 foreach ($tool in $tools) {
     # Get versions manifest for current tool
     $assets = Invoke-RestMethod $tool.url

--- a/images/linux/scripts/installers/Install-Toolset.ps1
+++ b/images/linux/scripts/installers/Install-Toolset.ps1
@@ -28,10 +28,8 @@ $ErrorActionPreference = "Stop"
 
 # Get toolset content
 $toolset = Get-Content -Path "$env:INSTALLER_SCRIPT_FOLDER/toolset.json" -Raw
-$toolsToInstall = @("Python", "Node", "Go")
-
-$tools = ConvertFrom-Json -InputObject $toolset | Select-Object -ExpandProperty toolcache | Where-Object {$ToolsToInstall -contains $_.Name}
-
+$toolsToInstall = ConvertFrom-Json -InputObject $toolset | Select-Object -ExpandProperty tools
+$tools = ConvertFrom-Json -InputObject $toolset | Select-Object -ExpandProperty toolcache | Where-Object {$toolsToInstall -contains $_.Name}
 foreach ($tool in $tools) {
     # Get versions manifest for current tool
     $assets = Invoke-RestMethod $tool.url
@@ -45,14 +43,13 @@ foreach ($tool in $tools) {
 
         Write-Host "Installing $($tool.name) $toolVersion $($tool.arch)..."
         if ($null -ne $asset) {
-            Install-Asset -ReleaseAsset $asset
+            #Install-Asset -ReleaseAsset $asset
         } else {
             Write-Host "Asset was not found in versions manifest"
             exit 1
         }
     }
-}
-
-chown -R "$($env:SUDO_USER):$($env:SUDO_USER)" /opt/hostedtoolcache/Python
-chown -R "$($env:SUDO_USER):$($env:SUDO_USER)" /opt/hostedtoolcache/node
-chown -R "$($env:SUDO_USER):$($env:SUDO_USER)" /opt/hostedtoolcache/go
+} 
+if ($toolsToInstall.Contains("Python")){chown -R "$($env:SUDO_USER):$($env:SUDO_USER)" /opt/hostedtoolcache/Python}
+if ($toolsToInstall.Contains("node")){chown -R "$($env:SUDO_USER):$($env:SUDO_USER)" /opt/hostedtoolcache/node}
+if ($toolsToInstall.Contains("go")){chown -R "$($env:SUDO_USER):$($env:SUDO_USER)" /opt/hostedtoolcache/go}

--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -68,6 +68,11 @@
             ]
         }
     ],
+    "tools":[
+      "node",
+      "Python",
+      "go"
+    ],
     "java": {
         "default": "8",
         "versions": [

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -68,6 +68,11 @@
             ]
         }
     ],
+    "tools":[
+      "node",
+      "Python",
+      "go"
+    ],
     "java": {
         "default": "8",
         "versions": [

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -68,6 +68,11 @@
             ]
         }
     ],
+    "tools":[
+      "node",
+      "Python",
+      "go"
+    ],
     "java": {
         "default": "11",
         "versions": [


### PR DESCRIPTION
# Description
This is an Improvement, where one Piece of Information/Configuration on what Software to Install was previously hidden in a Script. This was problematic because a Script is a bad place for configuration we want to change via Script, as breaking changes could easily be made. This has been fixed and the Configuration now resides in the Toolset.json for all Ubuntu Versions as discussed in [this](https://github.com/actions/virtual-environments/discussions/3535) discussion.
The new Version has been tested for Ubuntu-2004.
New tool, Bug fixing, or Improvement?  
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.  
**For new tools, please provide total size and installation time.**

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
