### PR TITLE
[Ubuntu] Change azure ps module from 5.7.0 to 5.9.0

### DIFF
--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -109,7 +109,7 @@
             "name": "az",
             "url" : "https://raw.githubusercontent.com/Azure/az-ps-module-versions/main/versions-manifest.json",
             "versions": [
-                "5.7.0"
+                "5.9.0"
             ],
             "zip_versions": [
                 "3.1.0",

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -107,7 +107,7 @@
             "name": "az",
             "url" : "https://raw.githubusercontent.com/Azure/az-ps-module-versions/main/versions-manifest.json",
             "versions": [
-                "5.7.0"
+                "5.9.0"
             ],
             "zip_versions": [
                 "3.1.0",


### PR DESCRIPTION
# Description
5.9.0 is the latest minor update before the major update 6.0.
This version includes some crucial fixes regarding the bicep.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3558

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
