### PR TITLE
[macOS] Upgrade azure powershell from 5.7.0 to 5.9.0

### DIFF
--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -224,7 +224,7 @@
         {
             "name": "Az",
             "versions": [
-                "5.7.0"
+                "5.9.0"
             ]
         },
         {"name": "MarkdownPS"},

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -176,7 +176,7 @@
         {
             "name": "Az",
             "versions": [
-                "5.7.0"
+                "5.9.0"
             ]
         },
         {"name": "MarkdownPS"},

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -125,7 +125,7 @@
         {
             "name": "Az",
             "versions": [
-                "5.7.0"
+                "5.9.0"
             ]
         },
         {"name": "MarkdownPS"},


### PR DESCRIPTION
# Description
5.9.0 is the latest minor update before the major update 6.0.
This version includes some crucial fixes regarding the bicep.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3558

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
