### PR TITLE
update minGW version

### DIFF
--- a/images/win/scripts/Installers/Install-Mingw64.ps1
+++ b/images/win/scripts/Installers/Install-Mingw64.ps1
@@ -3,7 +3,7 @@
 ##  Desc:  Install GNU tools for Windows
 ################################################################################
 
-Choco-Install -PackageName mingw -ArgumentList "--version=8.1.0"
+Choco-Install -PackageName mingw -ArgumentList "--version=10.2.0"
 
 # Make a copy of mingw32-make.exe to make.exe, which is a more discoverable name
 # and so the same command line can be used on Windows as on macOS and Linux


### PR DESCRIPTION
# Description
Helly everybody,
i want to suggest an update of the quite old minGW version in the windows VM.
The version is currently 8.1.0 which means a gcc version of 8.1.0. This version does not cotain a windows implementation of `std::filesystem`. Even GCC 9 does still has only >Incomplete support for the C++17 Filesystem library and the Filesystem TS on Windows. which is a quote from https://gcc.gnu.org/gcc-9/changes.html.

Therefore,  building code in the windows VM which uses `std::filesystem` does not compile.

I tried it this at https://github.com/alandefreitas/matplotplusplus/pull/161 where i witnesses this drawback.
