### PR TITLE
[Windows] Improve Pester tests coverage for MSYS2

### DIFF
--- a/images/win/scripts/Installers/Install-Msys2.ps1
+++ b/images/win/scripts/Installers/Install-Msys2.ps1
@@ -88,6 +88,7 @@ foreach ($arch in $archs)
   pacman.exe -Q | grep ^${arch}-
 }
 
+$env:PATH = $origPath
 Write-Host "`nMSYS2 installation completed"
 
 Invoke-PesterTests -TestFile "MSYS2"

--- a/images/win/scripts/Tests/MSYS2.Tests.ps1
+++ b/images/win/scripts/Tests/MSYS2.Tests.ps1
@@ -22,7 +22,7 @@ Describe "MSYS2 packages" {
     )
 
     It "<ToolName> is installed in <msys2Dir>" -TestCases $TestCases {
-        (get-command "$ToolName").Source | Should -BeLike "$msys2Dir*"
+        (Get-Command "$ToolName").Source | Should -BeLike "$msys2Dir*"
     }
 
     It "<ToolName> is avaialable" -TestCases $TestCases {
@@ -62,7 +62,7 @@ foreach ($arch in $archs) {
                 }
 
                 It "<ExecName> is installed in <ExecDir>" -TestCases $executables {
-                    (get-command "$ExecName").Source | Should -BeLike "$ExecDir*"
+                    (Get-Command "$ExecName").Source | Should -BeLike "$ExecDir*"
                 }
 
                 It "<ExecName> is available" -TestCases $executables {

--- a/images/win/scripts/Tests/MSYS2.Tests.ps1
+++ b/images/win/scripts/Tests/MSYS2.Tests.ps1
@@ -18,7 +18,7 @@ Describe "MSYS2 packages" {
 
     It "<ToolName> is installed in <msys2Dir>" -TestCases $TestCases {
         $env:PATH = "$msys2Dir;$env:PATH"
-        (get-command "$ToolName").Source | Should -BeLike "$msys2Dir*"
+        (Get-Command "$ToolName").Source | Should -BeLike "$msys2Dir*"
     }
 
     It "<ToolName> is avaialable" -TestCases $TestCases {
@@ -51,7 +51,7 @@ foreach ($arch in $archs) {
 
                 It "<ExecName> is installed in <ExecDir>" -TestCases $executables {
                     $env:PATH = "$ExecDir;$env:PATH"
-                    (get-command "$ExecName").Source | Should -BeLike "$ExecDir*"
+                    (Get-Command "$ExecName").Source | Should -BeLike "$ExecDir*"
                 }
 
                 It "<ExecName> is available" -TestCases $executables {

--- a/images/win/scripts/Tests/MSYS2.Tests.ps1
+++ b/images/win/scripts/Tests/MSYS2.Tests.ps1
@@ -7,6 +7,10 @@ BeforeAll {
 }
 
 Describe "MSYS2 packages" {
+    BeforeEach {
+        $env:PATH = "$msys2Dir;$env:PATH"
+    }
+
     It "msys2Dir exists" {
         $msys2Dir | Should -Exist
     }
@@ -18,14 +22,14 @@ Describe "MSYS2 packages" {
     )
 
     It "<ToolName> is installed in <msys2Dir>" -TestCases $TestCases {
-        $env:PATH = "$msys2Dir;$env:PATH"
         (get-command "$ToolName").Source | Should -BeLike "$msys2Dir*"
-        $env:PATH = $originalPath
     }
 
     It "<ToolName> is avaialable" -TestCases $TestCases {
-        $env:PATH = "$msys2Dir;$env:PATH"
         "$ToolName" | Should -ReturnZeroExitCodeWithParam
+    }
+
+    AfterEach {
         $env:PATH = $originalPath
     }
 }
@@ -53,15 +57,19 @@ foreach ($arch in $archs) {
                     }
                 }
 
-                It "<ExecName> is installed in <ExecDir>" -TestCases $executables {
+                BeforeEach {
                     $env:PATH = "$ExecDir;$env:PATH"
+                }
+
+                It "<ExecName> is installed in <ExecDir>" -TestCases $executables {
                     (get-command "$ExecName").Source | Should -BeLike "$ExecDir*"
-                    $env:PATH = $originalPath
                 }
 
                 It "<ExecName> is available" -TestCases $executables {
-                    $env:PATH = "$ExecDir;$env:PATH"
                     "$ExecName" | Should -ReturnZeroExitCodeWithParam
+                }
+
+                AfterEach {
                     $env:PATH = $originalPath
                 }
             }

--- a/images/win/scripts/Tests/MSYS2.Tests.ps1
+++ b/images/win/scripts/Tests/MSYS2.Tests.ps1
@@ -1,15 +1,16 @@
 $toolsetContent = (Get-ToolsetContent).MsysPackages
 $archs = $toolsetContent.mingw.arch
 
-Describe "MSYS2 packages" {
-    BeforeAll {
-        $msys2Dir = "C:\msys64\usr\bin"
-    }
+BeforeAll {
+    $msys2Dir = "C:\msys64\usr\bin"
+    $originalPath = $env:PATH
+}
 
+Describe "MSYS2 packages" {
     It "msys2Dir exists" {
         $msys2Dir | Should -Exist
     }
-    
+
     $TestCases = @(
         @{ ToolName = "bash.exe" }
         @{ ToolName = "tar.exe" }
@@ -18,11 +19,14 @@ Describe "MSYS2 packages" {
 
     It "<ToolName> is installed in <msys2Dir>" -TestCases $TestCases {
         $env:PATH = "$msys2Dir;$env:PATH"
-        (Get-Command "$ToolName").Source | Should -BeLike "$msys2Dir*"
+        (get-command "$ToolName").Source | Should -BeLike "$msys2Dir*"
+        $env:PATH = $originalPath
     }
 
     It "<ToolName> is avaialable" -TestCases $TestCases {
+        $env:PATH = "$msys2Dir;$env:PATH"
         "$ToolName" | Should -ReturnZeroExitCodeWithParam
+        $env:PATH = $originalPath
     }
 }
 
@@ -31,17 +35,17 @@ foreach ($arch in $archs) {
         $archPackages = $toolsetContent.mingw | Where-Object { $_.arch -eq $arch }
         $tools = $archPackages.runtime_packages.name
 
+        if ($arch -eq "mingw-w64-i686")
+        {
+            $ExecDir = "C:\msys64\mingw32\bin"
+        }
+        else
+        {
+            $ExecDir = "C:\msys64\mingw64\bin"
+        }
+        
         foreach ($tool in $tools) {
             Context "$tool package"{
-                if ($arch -eq "mingw-w64-i686")
-                {
-                    $ExecDir = "C:\msys64\mingw32\bin"
-                }
-                else
-                {
-                    $ExecDir = "C:\msys64\mingw64\bin"
-                }
-
                 $executables = ($archPackages.runtime_packages | Where-Object { $_.name -eq $tool }).executables | ForEach-Object {
                     @{
                         ExecName = $_
@@ -51,12 +55,14 @@ foreach ($arch in $archs) {
 
                 It "<ExecName> is installed in <ExecDir>" -TestCases $executables {
                     $env:PATH = "$ExecDir;$env:PATH"
-                    (Get-Command "$ExecName").Source | Should -BeLike "$ExecDir*"
+                    (get-command "$ExecName").Source | Should -BeLike "$ExecDir*"
+                    $env:PATH = $originalPath
                 }
 
                 It "<ExecName> is available" -TestCases $executables {
                     $env:PATH = "$ExecDir;$env:PATH"
                     "$ExecName" | Should -ReturnZeroExitCodeWithParam
+                    $env:PATH = $originalPath
                 }
             }
         }

--- a/images/win/windows2016.json
+++ b/images/win/windows2016.json
@@ -303,8 +303,6 @@
             "environment_vars": [
                 "TOOLSET_JSON_PATH={{user `toolset_json_path`}}"
             ],
-            "elevated_user": "SYSTEM",
-            "elevated_password": "",
             "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-Msys2.ps1"
             ]

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -274,8 +274,6 @@
             "environment_vars": [
                 "TOOLSET_JSON_PATH={{user `toolset_json_path`}}"
             ],
-            "elevated_user": "SYSTEM",
-            "elevated_password": "",
             "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-Msys2.ps1"
             ]


### PR DESCRIPTION
# Description
There are no tests for the tools installed by msys2 thus we don't know that something is not working until canary tests are performed against the image.
This PR:
- Adds a new set of tests that check all the main binaries provided with installed msys2 and mingw packages.
  - Main msys2 packages are tested — bash, tar, make
  - Mingw packages have their on Describe for both architectures
![image](https://user-images.githubusercontent.com/48208649/122252758-428f2c80-ced4-11eb-98bb-55d163b64b33.png)
- Get rid of elevated user SYSTEM as msys2 is perfectly installed without it and bash from msys has an issue when run under system user

- Adds `ShouldReturnZeroExitCodeWithParam` function to avoid hardcoding the exact param for each tool since some tools have `version` flag and some have `-version` or `--version`. The parameter `version` can be changed to `help` or any other if needed —  `"$ExecName" | Should -ReturnZeroExitCodeWithParam -CallParameter "help"`

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2262
https://github.com/actions/virtual-environments-internal/issues/2172

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
