### PR TITLE
Revert "[Windows] Don't install KB5003638 update for windows server 2016 as it breaks the VM"

### DIFF
--- a/images/win/scripts/Installers/Install-WindowsUpdates.ps1
+++ b/images/win/scripts/Installers/Install-WindowsUpdates.ps1
@@ -5,10 +5,4 @@
 ################################################################################
 
 Write-Host "Run windows updates"
-# KB5003638 causes the windows server 2016 virtual machine to hang on shutdown step
-if (Test-IsWin16) {
-    Get-WUInstall -MicrosoftUpdate
-    Write-Host "Hide update KB5003638"
-    Hide-WindowsUpdate -Confirm:$false -KBArticleID "KB5003638"
-}
 Get-WUInstall -MicrosoftUpdate -AcceptAll -Install -IgnoreUserInput -IgnoreReboot


### PR DESCRIPTION
Reverts actions/virtual-environments#3557 as the issue seems to be fixed