### PR TITLE
[macOS] Add xcode 12.5.1 to Big Sur

### DIFF
--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -3,7 +3,7 @@
         "default": "12.5",
         "versions": [
             { "link": "13.0", "version": "13.0.0"},
-            { "link": "12.5", "version": "12.5.0"},
+            { "link": "12.5", "version": "12.5.1"},
             { "link": "12.4", "version": "12.4.0"},
             { "link": "12.3", "version": "12.3.0"},
             { "link": "12.2", "version": "12.2.0" },


### PR DESCRIPTION
# Description
[Xcode 12.5.1 has been released](https://developer.apple.com/news/releases/?id=06212021), we need to replace 12.5 in favor of the new version.

#### Related issue:
n\a

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
