### PR TITLE
[macOS] Return xcode 12.5 to Big Sur

### DIFF
--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -3,7 +3,8 @@
         "default": "12.5",
         "versions": [
             { "link": "13.0", "version": "13.0.0"},
-            { "link": "12.5", "version": "12.5.1"},
+            { "link": "12.5.1", "version": "12.5.1"},
+            { "link": "12.5", "version": "12.5.0"},
             { "link": "12.4", "version": "12.4.0"},
             { "link": "12.3", "version": "12.3.0"},
             { "link": "12.2", "version": "12.2.0" },


### PR DESCRIPTION
# Description
It turned out we can't remove 12.5 in favor of 12.5.1 at the moment. This PR adds Xcode 12.5 back.

#### Related issue:
n\a

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
