### PR TITLE
Make /run/user/<id> directory

### DIFF
--- a/images/linux/scripts/installers/make-run-user.sh
+++ b/images/linux/scripts/installers/make-run-user.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+################################################################################
+##  File:  make-run-user.sh
+##  Desc:  Create /run/user/<runner user id> directory as the pam_systemd did.
+##         We need to do this here because the agent runs the shell script
+##         by passing PAM subsytem but some apps (like snap) expect pam_systemd
+##         to make this directore to store user's tmp files
+################################################################################
+
+runtmp="/run/user/$(id -u)"
+sudo mkdir $runtmp
+sudo chown `whoami` $runtmp
+sudo chgrp `whoami` $runtmp
+sudo chmod 770 $runtmp

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -295,6 +295,11 @@
         },
         {
             "type": "shell",
+            "script": "{{template_dir}}/scripts/installers/make-run-user.sh",
+            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
             "script": "{{template_dir}}/scripts/base/apt-mock-remove.sh",
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -67,8 +67,8 @@
         },
         {
             "type": "shell",
-            "script": "{{template_dir}}/scripts/base/apt-mock.sh",
-            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+            "script": "{{template_dir}}/scripts/installers/make-run-user.sh",
+            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {
             "type": "shell",
@@ -306,6 +306,11 @@
             "scripts": [
                 "{{template_dir}}/scripts/installers/cleanup.sh"
             ],
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "script": "{{template_dir}}/scripts/base/apt-mock.sh",
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -311,6 +311,11 @@
         },
         {
             "type": "shell",
+            "script": "{{template_dir}}/scripts/installers/make-run-user.sh",
+            "execute_command": "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
             "script": "{{template_dir}}/scripts/base/apt-mock-remove.sh",
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },


### PR DESCRIPTION
# Description
Bug fixing

Create /run/user/<runner user id> directory as the pam_systemd did. We need to do this here because the agent runs the shell script by passing PAM subsytem but some apps (like snap) expect pam_systemd to make this directore to store user's tmp files

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/2042

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
