### PR TITLE
[Ubuntu] Switch android tools installation to use sdkmanager from command-line tools

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -117,7 +117,7 @@ function Get-AndroidPlatformVersions {
 
 function Get-AndroidCommandLineToolsVersion {
     $commandLineTools = Get-AndroidSDKManagerPath
-    (& $commandLineTools --version | Out-String).Trim() -match "^\d+\.{1,}\d+$" | Out-Null
+    (& $commandLineTools --version | Out-String).Trim() -match "^(\d+\.){1,}\d+$" | Out-Null
     $commandLineToolsVersion = $Matches.Values
     return $commandLineToolsVersion
 }

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -117,8 +117,8 @@ function Get-AndroidPlatformVersions {
 
 function Get-AndroidCommandLineToolsVersion {
     $commandLineTools = Get-AndroidSDKManagerPath
-    (& $commandLineTools --version | Out-String).Trim() -match "^(\d+\.){1,}\d+$" | Out-Null
-    $commandLineToolsVersion = $Matches.Values
+    (& $commandLineTools --version | Out-String).Trim() -match "(?<version>^(\d+\.){1,}\d+$)" | Out-Null
+    $commandLineToolsVersion = $Matches.Version
     return $commandLineToolsVersion
 }
 

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -11,7 +11,7 @@ function Get-AndroidSDKRoot {
 
 function Get-AndroidSDKManagerPath {
     $androidSDKDir = Get-AndroidSDKRoot
-    return Join-Path $androidSDKDir "tools" "bin" "sdkmanager"
+    return Join-Path $androidSDKDir "cmdline-tools" "latest" "bin" "sdkmanager"
 }
 
 function Get-AndroidInstalledPackages {

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -16,16 +16,8 @@ function Get-AndroidSDKManagerPath {
 
 function Get-AndroidInstalledPackages {
     $androidSDKManagerPath = Get-AndroidSDKManagerPath
-    $androidSDKManagerList = Invoke-Expression "$androidSDKManagerPath --list --include_obsolete"
-    $androidInstalledPackages = @()
-    foreach($packageInfo in $androidSDKManagerList) {
-        if($packageInfo -Match "Available Packages:") {
-            break
-        }
-
-        $androidInstalledPackages += $packageInfo
-    }
-    return $androidInstalledPackages
+    $androidSDKManagerList = Invoke-Expression "$androidSDKManagerPath --list_installed --include_obsolete"
+    return $androidSDKManagerList
 }
 
 
@@ -34,7 +26,7 @@ function Build-AndroidTable {
     return @(
         @{
             "Package" = "Android Command Line Tools"
-            "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android SDK Command-line Tools"
+            "Version" = Get-AndroidCommandLineToolsVersion
         },
         @{
             "Package" = "Android Emulator"
@@ -121,6 +113,13 @@ function Get-AndroidPlatformVersions {
     }
     [array]::Reverse($versions)
     return ($versions -Join "<br>")
+}
+
+function Get-AndroidCommandLineToolsVersion {
+    $commandLineTools = Get-AndroidSDKManagerPath
+    (& $commandLineTools --version | Out-String).Trim() -match "^\d+\.{1,}\d+$" | Out-Null
+    $commandLineToolsVersion = $Matches.Values
+    return $commandLineToolsVersion
 }
 
 function Get-AndroidBuildToolVersions {

--- a/images/linux/scripts/helpers/Common.Helpers.psm1
+++ b/images/linux/scripts/helpers/Common.Helpers.psm1
@@ -56,7 +56,7 @@ function Get-ToolsetValue {
 }
 
 function Get-AndroidPackages {
-    $androidSDKManagerPath = "/usr/local/lib/android/sdk/tools/bin/sdkmanager"
+    $androidSDKManagerPath = "/usr/local/lib/android/sdk/cmdline-tools/latest/bin/sdkmanager"
     $androidPackages = & $androidSDKManagerPath --list --verbose
     return $androidPackages
 }

--- a/images/linux/scripts/installers/android.sh
+++ b/images/linux/scripts/installers/android.sh
@@ -26,9 +26,7 @@ function filter_components_by_version {
 
 function get_full_ndk_version {
     majorVersion=$1
-
     ndkFullVersion=$($SDKMANAGER --list | grep "ndk;${majorVersion}.*" | awk '{gsub("ndk;", ""); print $1}' | sort -V | tail -n1)
-
     echo "$ndkFullVersion"
 }
 
@@ -36,7 +34,7 @@ function get_full_ndk_version {
 ANDROID_ROOT=/usr/local/lib/android
 ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
 ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
-SDKMANAGER=${ANDROID_SDK_ROOT}/tools/bin/sdkmanager
+SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
 echo "ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT}" | tee -a /etc/environment
 
 # ANDROID_HOME is deprecated, but older versions of Gradle rely on it
@@ -51,14 +49,12 @@ mkdir -p ${ANDROID_SDK_ROOT}
 
 # Download the latest command line tools so that we can accept all of the licenses.
 # See https://developer.android.com/studio/#command-tools
-download_with_retries https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip "." android-sdk.zip
-unzip -qq android-sdk.zip -d ${ANDROID_SDK_ROOT}
-rm -f android-sdk.zip
-
-if isUbuntu20 ; then
-    # Sdk manager doesn't work with Java > 8, set version 8 explicitly
-    sed -i "2i export JAVA_HOME=${JAVA_HOME_8_X64}" "$SDKMANAGER"
-fi
+cmdlineTools="android-cmdline-tools.zip"
+download_with_retries https://dl.google.com/android/repository/commandlinetools-linux-7302050_latest.zip "." $cmdlineTools
+unzip -qq $cmdlineTools -d ${ANDROID_SDK_ROOT}/cmdline-tools
+# Command line tools need to be placed in ${ANDROID_SDK_ROOT}/sdk/cmdline-tools/latest to determine SDK root
+mv ${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools ${ANDROID_SDK_ROOT}/cmdline-tools/latest
+rm -f $cmdlineTools
 
 # Check sdk manager installation
 ${SDKMANAGER} --list 1>/dev/null
@@ -79,9 +75,9 @@ ANDROID_NDK_MAJOR_LTS=($(get_toolset_value '.android.ndk.lts'))
 ndkLTSFullVersion=$(get_full_ndk_version $ANDROID_NDK_MAJOR_LTS)
 
 components=("${extras[@]}" "${addons[@]}" "${additional[@]}" "ndk;$ndkLTSFullVersion")
-if isUbuntu20 ; then
+if isUbuntu20; then
     ANDROID_NDK_MAJOR_LATEST=($(get_toolset_value '.android.ndk.latest'))
-    ndkLatestFullVersion=$(get_full_ndk_version $ANDROID_NDK_MAJOR_LATEST) 
+    ndkLatestFullVersion=$(get_full_ndk_version $ANDROID_NDK_MAJOR_LATEST)
     components+=("ndk;$ndkLatestFullVersion")
 fi
 
@@ -102,6 +98,11 @@ filter_components_by_version $minimumPlatformVersion "${availablePlatforms[@]}"
 filter_components_by_version $minimumBuildToolVersion "${availableBuildTools[@]}"
 
 echo "y" | $SDKMANAGER ${components[@]}
+
+# Old skdmanager from sdk tools doesn't work with Java > 8, set version 8 explicitly
+if isUbuntu20; then
+    sed -i "2i export JAVA_HOME=${JAVA_HOME_8_X64}" ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager
+fi
 
 # Add required permissions
 chmod -R a+rwx ${ANDROID_SDK_ROOT}

--- a/images/linux/scripts/installers/android.sh
+++ b/images/linux/scripts/installers/android.sh
@@ -7,6 +7,7 @@
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/os.sh
 source $HELPER_SCRIPTS/install.sh
+source $HELPER_SCRIPTS/etc-environment.sh
 
 function filter_components_by_version {
     minimumVersion=$1
@@ -107,4 +108,5 @@ fi
 # Add required permissions
 chmod -R a+rwx ${ANDROID_SDK_ROOT}
 
+reloadEtcEnvironment
 invoke_tests "Android"

--- a/images/linux/scripts/tests/Android.Tests.ps1
+++ b/images/linux/scripts/tests/Android.Tests.ps1
@@ -32,8 +32,6 @@ Describe "Android" {
     $androidPackages = $androidPackages | ForEach-Object { $_ }
 
     BeforeAll {
-        $ANDROID_SDK_DIR = "/usr/local/lib/android/sdk"
-
         function Validate-AndroidPackage {
             param (
                 [Parameter(Mandatory=$true)]
@@ -45,7 +43,7 @@ Describe "Android" {
             #         'cmake;3.6.4111459' -> 'cmake/3.6.4111459'
             #         'patcher;v4' -> 'patcher/v4'
             $PackageName = $PackageName.Replace(";", "/")
-            $targetPath = Join-Path $ANDROID_SDK_DIR $PackageName
+            $targetPath = Join-Path $env:ANDROID_HOME $PackageName
             $targetPath | Should -Exist
         }
     }
@@ -54,11 +52,11 @@ Describe "Android" {
         $testCases = @(
             @{
                 PackageName = "SDK tools"
-                Sdkmanager = "/usr/local/lib/android/sdk/tools/bin/sdkmanager"
+                Sdkmanager = "$env:ANDROID_HOME/tools/bin/sdkmanager"
             },
             @{
                 PackageName = "Command-line tools"
-                Sdkmanager = "/usr/local/lib/android/sdk/cmdline-tools/latest/bin/sdkmanager"
+                Sdkmanager = "$env:ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
             }
         )
 

--- a/images/linux/scripts/tests/Android.Tests.ps1
+++ b/images/linux/scripts/tests/Android.Tests.ps1
@@ -50,6 +50,23 @@ Describe "Android" {
         }
     }
 
+    Context "SDKManagers" {
+        $testCases = @(
+            @{
+                PackageName = "SDK tools"
+                Sdkmanager = "/usr/local/lib/android/sdk/tools/bin/sdkmanager"
+            },
+            @{
+                PackageName = "Command-line tools"
+                Sdkmanager = "/usr/local/lib/android/sdk/cmdline-tools/latest/bin/sdkmanager"
+            }
+        )
+
+        It "Sdkmanager from <PackageName> is available" -TestCases $testCases {
+            "$Sdkmanager --version" | Should -ReturnZeroExitCode
+        }
+    }
+
     Context "Packages" {
         $testCases = $androidPackages | ForEach-Object { @{ PackageName = $_ } }
 

--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -96,9 +96,7 @@
         "additional_tools": [
             "cmake;3.10.2.4988404",
             "cmake;3.18.1",
-            "patcher;v4",
-            "platform-tools",
-            "cmdline-tools;latest"
+            "platform-tools"
         ],
         "ndk": {
             "lts": "21"

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -92,9 +92,7 @@
         "additional_tools": [
             "cmake;3.10.2.4988404",
             "cmake;3.18.1",
-            "patcher;v4",
-            "platform-tools",
-            "cmdline-tools;latest"
+            "platform-tools"
         ],
         "ndk": {
             "lts": "21"

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -88,9 +88,7 @@
         "additional_tools": [
             "cmake;3.10.2.4988404",
             "cmake;3.18.1",
-            "patcher;v4",
-            "platform-tools",
-            "cmdline-tools;latest"
+            "platform-tools"
         ],
         "ndk": {
             "lts": "21",


### PR DESCRIPTION
# Description
SDK Tools package is deprecated and no longer receiving updates. We need to switch to command-line tools instead
https://developer.android.com/studio/releases/sdk-tools
![image](https://user-images.githubusercontent.com/48208649/123268591-d7161200-d506-11eb-860e-b1acc7a01573.png)

A few notes:
- Old `SDK-tools` will also be available on the image as they are installed as a part of `build-tools` packages.
- `Patcher;v4` is installed as a part of `extras;google;m2repository` so we don't need additional installation.
- A test added to make sure both "old" and "new" sdkmanagers are available

#### Related issue:
https://github.com/actions/virtual-environments/issues/3638

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
