### PR TITLE
[macOS] Remove Xcode 12.2&12.3 from Big Sur

### DIFF
--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -6,8 +6,6 @@
             { "link": "12.5.1", "version": "12.5.1"},
             { "link": "12.5", "version": "12.5.0"},
             { "link": "12.4", "version": "12.4.0"},
-            { "link": "12.3", "version": "12.3.0"},
-            { "link": "12.2", "version": "12.2.0" },
             { "link": "11.7", "version": "11.7.0", "symlinks": ["11.7_beta"] }
         ]
     },


### PR DESCRIPTION
# Description
Big Sur is mostly requested for building with the latest Xcode 12.5, which provides new Swift 5.4 features and other fixes. So we'd like to keep Xcode 11.7 for old emulators and 2 latest stable Xcode versions

#### Related issue:
https://github.com/actions/virtual-environments/issues/3555

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
