### PR TITLE
[Ubuntu] Remove bicep from software docs and tests for ubuntu 16

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -109,7 +109,6 @@ $toolsList = @(
     (Get-AzCopyVersion),
     (Get-BazelVersion),
     (Get-BazeliskVersion),
-    (Get-BicepVersion),
     (Get-CodeQLBundleVersion),
     (Get-CMakeVersion),
     (Get-DockerMobyClientVersion),
@@ -145,8 +144,9 @@ $toolsList = @(
 
 if (-not (Test-IsUbuntu16)) {
     $toolsList += @(
-        (Get-PodManVersion),
+        (Get-BicepVersion),
         (Get-BuildahVersion),
+        (Get-PodManVersion),
         (Get-SkopeoVersion),
         (Get-YamllintVersion)
     )

--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -8,7 +8,7 @@ Describe "azcopy" {
     }
 }
 
-Describe "Bicep" {
+Describe "Bicep" -Skip:(Test-IsUbuntu16) {
     It "Bicep" {
         "bicep --version" | Should -ReturnZeroExitCode
     }


### PR DESCRIPTION
# Description
Exclude for Ubuntu16 was forgotten in the PR https://github.com/actions/virtual-environments/pull/3639 thus the image generation for Ubuntu 16 is broken.

#### Related issue:
n\a

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated