### PR TITLE
[macOS] Upgrade Azure PowerShell from 5.9.0 to 6.1.0

### DIFF
--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -224,7 +224,7 @@
         {
             "name": "Az",
             "versions": [
-                "5.9.0"
+                "6.1.0"
             ]
         },
         {"name": "MarkdownPS"},

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -176,7 +176,7 @@
         {
             "name": "Az",
             "versions": [
-                "5.9.0"
+                "6.1.0"
             ]
         },
         {"name": "MarkdownPS"},

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -124,7 +124,7 @@
         {
             "name": "Az",
             "versions": [
-                "5.9.0"
+                "6.1.0"
             ]
         },
         {"name": "MarkdownPS"},


### PR DESCRIPTION
# Description
6.1.0 is the latest available version of Azure PowerShell module.

#### Related issue: [#3674](https://github.com/actions/virtual-environments/issues/3674)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
