### PR TITLE
[macOS] Switch android tools installation to use cmdline-tools' sdkmanager

### DIFF
--- a/images/macos/provision/core/android-toolsets.sh
+++ b/images/macos/provision/core/android-toolsets.sh
@@ -33,38 +33,27 @@ ANDROID_ADDON_LIST=($(get_toolset_value '.android."addon-list"[]'))
 ANDROID_ADDITIONAL_TOOLS=($(get_toolset_value '.android."additional-tools"[]'))
 ANDROID_NDK_MAJOR_LTS=($(get_toolset_value '.android.ndk.lts'))
 ANDROID_NDK_MAJOR_LATEST=($(get_toolset_value '.android.ndk.latest'))
-# Get the latest command line tools from https://developer.android.com/studio/index.html
-# Release note: https://developer.android.com/studio/releases/sdk-tools.html
-ANDROID_OSX_SDK_LOCATION="https://dl.google.com/android/repository/sdk-tools-darwin-3859397.zip"
+# Get the latest command line tools from https://developer.android.com/studio#cmdline-tools
+ANDROID_OSX_SDK_URL="https://dl.google.com/android/repository/commandlinetools-mac-7302050_latest.zip"
 ANDROID_HOME=$HOME/Library/Android/sdk
 ANDROID_OSX_SDK_FILE=tools-macosx.zip
 
 pushd $HOME
 
-# Prevent the warning of sdkmanager
-mkdir $HOME/.android
-echo "count=0" >> $HOME/.android/repositories.cfg
+echo "Downloading android command line tools..."
+download_with_retries $ANDROID_OSX_SDK_URL "." $ANDROID_OSX_SDK_FILE
 
-echo "Downloading android sdk..."
-curl -L -o $ANDROID_OSX_SDK_FILE $ANDROID_OSX_SDK_LOCATION
-
-echo "Uncompressing android sdk..."
-unzip -q $ANDROID_OSX_SDK_FILE && rm -f $ANDROID_OSX_SDK_FILE
-rm -rf $HOME/Library/Android/sdk
+echo "Uncompressing android command line tools..."
 mkdir -p $HOME/Library/Android/sdk
+unzip -q $ANDROID_OSX_SDK_FILE -d $HOME/Library/Android/sdk/cmdline-tools
+# Command line tools need to be placed in $HOME/Library/Android/sdk/cmdline-tools/latest to function properly
+mv $HOME/Library/Android/sdk/cmdline-tools/cmdline-tools $HOME/Library/Android/sdk/cmdline-tools/latest
+rm -f $ANDROID_OSX_SDK_FILE
 
 echo ANDROID_HOME is $ANDROID_HOME
-mv tools $ANDROID_HOME
+export PATH=$PATH:$ANDROID_HOME/cmdline-tools/latest:$ANDROID_HOME/cmdline-tools/latest/bin
 
-export PATH=$PATH:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin
-
-SDKMANAGER=$ANDROID_HOME/tools/bin/sdkmanager
-
-# Mark the different Android licenses as accepted
-mkdir -p $ANDROID_HOME/licenses
-echo "8933bad161af4178b1185d1a37fbf41ea5269c55
-d56f5187479451eabf01fb78af6dfcb131a6481e" >> $ANDROID_HOME/licenses/android-sdk-license
-echo "84831b9409646a918e30573bab4c9c91346d8abd" >> $ANDROID_HOME/licenses/android-sdk-preview-license
+SDKMANAGER=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
 
 echo "Installing latest tools & platform tools..."
 echo y | $SDKMANAGER "tools" "platform-tools"
@@ -80,14 +69,14 @@ ln -s $ANDROID_HOME/ndk/$ndkLtsLatest $ANDROID_HOME/ndk-bundle
 ANDROID_NDK_LATEST_HOME=$ANDROID_HOME/ndk/$ndkLatest
 echo "export ANDROID_NDK_LATEST_HOME=$ANDROID_NDK_LATEST_HOME" >> "${HOME}/.bashrc"
 
-availablePlatforms=($(${ANDROID_HOME}/tools/bin/sdkmanager --list | grep "platforms;android-" | cut -d"|" -f 1 | sort -u))
+availablePlatforms=($($SDKMANAGER --list | grep "platforms;android-" | cut -d"|" -f 1 | sort -u))
 filter_components_by_version $ANDROID_PLATFORM "${availablePlatforms[@]}"
 
-allBuildTools=($(${ANDROID_HOME}/tools/bin/sdkmanager --list --include_obsolete | grep "build-tools;" | cut -d"|" -f 1 | sort -u))
+allBuildTools=($($SDKMANAGER --list --include_obsolete | grep "build-tools;" | cut -d"|" -f 1 | sort -u))
 availableBuildTools=$(echo ${allBuildTools[@]//*rc[0-9]/})
 filter_components_by_version $ANDROID_BUILD_TOOL "${availableBuildTools[@]}"
 
-echo "y" | ${ANDROID_HOME}/tools/bin/sdkmanager ${components[@]}
+echo "y" | $SDKMANAGER ${components[@]}
 
 for extra_name in "${ANDROID_EXTRA_LIST[@]}"
 do

--- a/images/macos/provision/core/xamarin-android-ndk.sh
+++ b/images/macos/provision/core/xamarin-android-ndk.sh
@@ -3,7 +3,7 @@ source ~/utils/utils.sh
 
 ANDROID_HOME=$HOME/Library/Android/sdk
 ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle
-SDKMANAGER=$ANDROID_HOME/tools/bin/sdkmanager
+SDKMANAGER=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
 
 # Android NDK v16 is not compatible with old Xamarin.Android SDK
 # and fails builds with BundleAssemblies enabled

--- a/images/macos/software-report/SoftwareReport.Android.psm1
+++ b/images/macos/software-report/SoftwareReport.Android.psm1
@@ -13,21 +13,13 @@ function Get-AndroidSDKRoot {
 
 function Get-AndroidSDKManagerPath {
     $androidSDKDir = Get-AndroidSDKRoot
-    return Join-Path $androidSDKDir "tools" "bin" "sdkmanager"
+    return Join-Path $androidSDKDir "cmdline-tools" "latest" "bin" "sdkmanager"
 }
 
 function Get-AndroidInstalledPackages {
     $androidSDKManagerPath = Get-AndroidSDKManagerPath
-    $androidSDKManagerList = Invoke-Expression "$androidSDKManagerPath --list --include_obsolete"
-    $androidInstalledPackages = @()
-    foreach($packageInfo in $androidSDKManagerList) {
-        if($packageInfo -Match "Available Packages:") {
-            break
-        }
-
-        $androidInstalledPackages += $packageInfo
-    }
-    return $androidInstalledPackages
+    $androidSDKManagerList = Invoke-Expression "$androidSDKManagerPath --list_installed"
+    return $androidSDKManagerList
 }
 
 function Get-AndroidPackages {
@@ -42,7 +34,7 @@ function Build-AndroidTable {
     return @(
         @{
             "Package" = "Android Command Line Tools"
-            "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android SDK Command-line Tools"
+            "Version" = Get-AndroidCommandLineToolsVersion
         },
         @{
             "Package" = "Android Emulator"
@@ -141,6 +133,13 @@ function Get-AndroidPlatformVersions {
     }
     [array]::Reverse($versions)
     return ($versions -Join "<br>")
+}
+
+function Get-AndroidCommandLineToolsVersion {
+    $commandLineTools = Get-AndroidSDKManagerPath
+    (& $commandLineTools --version | Out-String).Trim() -match "^(\d+\.){1,}\d+$" | Out-Null
+    $commandLineToolsVersion = $Matches.Values
+    return $commandLineToolsVersion
 }
 
 function Get-AndroidBuildToolVersions {

--- a/images/macos/software-report/SoftwareReport.Android.psm1
+++ b/images/macos/software-report/SoftwareReport.Android.psm1
@@ -137,8 +137,8 @@ function Get-AndroidPlatformVersions {
 
 function Get-AndroidCommandLineToolsVersion {
     $commandLineTools = Get-AndroidSDKManagerPath
-    (& $commandLineTools --version | Out-String).Trim() -match "^(\d+\.){1,}\d+$" | Out-Null
-    $commandLineToolsVersion = $Matches.Values
+    (& $commandLineTools --version | Out-String).Trim() -match "(?<version>^(\d+\.){1,}\d+$)" | Out-Null
+    $commandLineToolsVersion = $Matches.Version
     return $commandLineToolsVersion
 }
 

--- a/images/macos/tests/Android.Tests.ps1
+++ b/images/macos/tests/Android.Tests.ps1
@@ -57,6 +57,23 @@ Describe "Android" {
         }
     }
 
+    Context "SDKManagers" {
+        $testCases = @(
+            @{
+                PackageName = "SDK tools"
+                Sdkmanager = "$env:ANDROID_HOME/tools/bin/sdkmanager"
+            },
+            @{
+                PackageName = "Command-line tools"
+                Sdkmanager = "$env:ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+            }
+        )
+
+        It "Sdkmanager from <PackageName> is available" -TestCases $testCases {
+            "$Sdkmanager --version" | Should -ReturnZeroExitCode
+        }
+    }
+
     Context "Packages" {
         $testCases = $androidPackages | ForEach-Object { @{ PackageName = $_ } }
 

--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -212,8 +212,7 @@
         ],
         "additional-tools": [
             "cmake;3.10.2.4988404",
-            "cmake;3.18.1",
-            "cmdline-tools;latest"
+            "cmake;3.18.1"
         ],
         "ndk": {
             "lts": "21",

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -164,8 +164,7 @@
         ],
         "additional-tools": [
             "cmake;3.10.2.4988404",
-            "cmake;3.18.1",
-            "cmdline-tools;latest"
+            "cmake;3.18.1"
         ],
         "ndk": {
             "lts": "21",

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -112,8 +112,7 @@
         "addon-list": [],
         "additional-tools": [
             "cmake;3.10.2.4988404",
-            "cmake;3.18.1",
-            "cmdline-tools;latest"
+            "cmake;3.18.1"
         ],
         "ndk": {
             "lts": "21",


### PR DESCRIPTION
# Description
SDK Tools package is deprecated and no longer receiving updates. We need to switch to command-line tools instead
https://developer.android.com/studio/releases/sdk-tools
![image](https://user-images.githubusercontent.com/48208649/123268591-d7161200-d506-11eb-860e-b1acc7a01573.png)

A few notes:
- The hardcoded values for licenses were removed as we accept them during the installation anyway
- Redundant step, which is supposed to prevent some warnings, was removed as it does nothing in the current configuration
- Old `SDK-tools` will also be available on the image as they are installed as a part of `build-tools` packages.
- A test added to make sure both "old" and "new" sdkmanagers are available

#### Related issue:
https://github.com/actions/virtual-environments/issues/3638
https://github.com/actions/virtual-environments-internal/issues/2340

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
