### PR TITLE
[macOS] Skip Intel HAXM installation on Big Sur

### DIFF
--- a/images/macos/provision/core/android-toolsets.sh
+++ b/images/macos/provision/core/android-toolsets.sh
@@ -85,10 +85,13 @@ do
 done
 
 # Intel x86 Emulator Accelerator (HAXM installer)
-# see Issue 31164 notes
-# Command needs to be run under sudo.
-chmod +x $ANDROID_HOME/extras/intel/Hardware_Accelerated_Execution_Manager/silent_install.sh
-sudo $ANDROID_HOME/extras/intel/Hardware_Accelerated_Execution_Manager/silent_install.sh
+# The Android Emulator uses the built-in Hypervisor.Framework by default, and falls back to using Intel HAXM if Hypervisor.Framework fails to initialize
+# https://developer.android.com/studio/run/emulator-acceleration#vm-mac
+# The installation doesn't work properly on macOS Big Sur, /dev/HAX is not created
+if is_Less_BigSur; then
+    chmod +x $ANDROID_HOME/extras/intel/Hardware_Accelerated_Execution_Manager/silent_install.sh
+    sudo $ANDROID_HOME/extras/intel/Hardware_Accelerated_Execution_Manager/silent_install.sh
+fi
 
 for addon_name in "${ANDROID_ADDON_LIST[@]}"
 do

--- a/images/macos/software-report/SoftwareReport.Android.psm1
+++ b/images/macos/software-report/SoftwareReport.Android.psm1
@@ -187,3 +187,11 @@ function Get-AndroidNDKVersions {
 
     return ($versions -Join "<br>")
 }
+
+function Get-IntelHaxmVersion {
+    kextstat | Where-Object { $_ -match "com.intel.kext.intelhaxm \((?<version>(\d+\.){1,}\d+)\)" } | Out-Null
+    return [PSCustomObject] @{
+        "Package Name" = "Intel HAXM"
+        "Version" = $Matches.Version
+    }
+}

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -276,7 +276,11 @@ $markdown += New-MDNewLine
 
 # Android section
 $markdown += New-MDHeader "Android" -Level 3
-$markdown += Build-AndroidTable | New-MDTable
+$androidTable = Build-AndroidTable
+if ($os.IsLessThanBigSur) {
+    $androidTable += Get-IntelHaxmVersion
+}
+$markdown += $androidTable | New-MDTable
 $markdown += New-MDNewLine
 $markdown += New-MDHeader "Environment variables" -Level 4
 $markdown += Build-AndroidEnvironmentTable | New-MDTable

--- a/images/macos/tests/Android.Tests.ps1
+++ b/images/macos/tests/Android.Tests.ps1
@@ -83,8 +83,7 @@ Describe "Android" {
         }
     }
 
-    It "HAXM is installed" {
-        $haxmPath = Join-Path $ANDROID_SDK_DIR "extras" "intel" "Hardware_Accelerated_Execution_Manager" "silent_install.sh"
-        "$haxmPath -v" | Should -ReturnZeroExitCode
+    It "HAXM is installed" -Skip:($os.IsBigSur) {
+        "kextstat | grep 'com.intel.kext.intelhaxm'" | Should -ReturnZeroExitCode
     }
 }


### PR DESCRIPTION
# Description
Intel HAXM installation doesn't work on macOS Big Sur — neither `/dev/HAX` is created nor `com.intel.kext.intelhaxm` is loaded.
According to the official documentation, the Android Emulator uses the built-in Hypervisor.Framework by default, and falls back to using Intel HAXM only if Hypervisor.Framework fails to initialize, thus we can skip the installation of HAXM at all at least for Big Sur.
This PR also:
- Changes the HAXM test to check not the installation script but the loaded kext
- Adds Intel HAXM version to the software docs

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2390

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
