### PR TITLE
[Ubuntu] Update ansible-base to ansible-core

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -1,5 +1,5 @@
 function Get-AnsibleVersion {
-    $ansibleVersion = ansible --version | Select-Object -First 1 | Take-OutputPart -Part 1
+    $ansibleVersion = (ansible --version)[0] -replace "[^\d.]"
     return "Ansible $ansibleVersion"
 }
 

--- a/images/linux/scripts/installers/pipx-packages.sh
+++ b/images/linux/scripts/installers/pipx-packages.sh
@@ -22,7 +22,7 @@ for package in $pipx_packages; do
         # https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html
         # Install ansible into an existing ansible-core Virtual Environment
         if [[ $package == "ansible-core" ]]; then
-            pipx inject ansible-core ansible
+            pipx inject $package ansible
         fi
     fi
 

--- a/images/linux/scripts/installers/pipx-packages.sh
+++ b/images/linux/scripts/installers/pipx-packages.sh
@@ -19,9 +19,10 @@ for package in $pipx_packages; do
         echo "Install $package into default python"
         pipx install $package
 
-        # Install ansible into an existing ansible-base Virtual Environment
-        if [[ $package == "ansible-base" ]]; then
-            pipx inject ansible-base ansible
+        # https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html
+        # Install ansible into an existing ansible-core Virtual Environment
+        if [[ $package == "ansible-core" ]]; then
+            pipx inject ansible-core ansible
         fi
     fi
 

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -223,7 +223,7 @@
             "cmd": "yamllint"
         },
         {
-            "package": "ansible-base",
+            "package": "ansible-core",
             "cmd": "ansible"
         }
     ],

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -223,7 +223,7 @@
             "cmd": "yamllint"
         },
         {
-            "package": "ansible-base",
+            "package": "ansible-core",
             "cmd": "ansible"
         }
     ],


### PR DESCRIPTION
# Description
Update `ansible-base` 2.10(only exists for version 2.10 and in Ansible 3) to `ansible-core` 2.11[(roadmap](https://docs.ansible.com/ansible-core/devel/roadmap/ROADMAP_2_11.html), [changelog](https://github.com/ansible/ansible/blob/stable-2.11/changelogs/CHANGELOG-v2.11.rst#release-summary)).

#### Related issue:
https://github.com/actions/virtual-environments/issues/3708

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
