### PR TITLE
[Windows] Fix android-apis output in the software docs

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -150,7 +150,7 @@ function Get-AndroidGoogleAPIsVersions {
         [object] $PackageInfo
     )
 
-    $versions = $packageInfo | Where-Object { $_ -Match "Google APIs" } | ForEach-Object {
+    $versions = $packageInfo | Where-Object { $_ -Match "addon-google_apis" } | ForEach-Object {
         $packageInfoParts = Split-TableRowByColumns $_
         return $packageInfoParts[0].split(";")[1]
     }


### PR DESCRIPTION
# Description
It turned out that we have a system image that comes along with the Android SDK package for visual studio 2017. This component also matches to "Google APIs" condition thus the readme provides extra data about available google apis:
![image](https://user-images.githubusercontent.com/48208649/125269682-9cd3af80-e311-11eb-8649-ffe236bbf225.png)
This PR fixes the condition to retrieve only google-api addons.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2432

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
