### PR TITLE
[Windows] Fix image generation error related to zipped az modules

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -230,7 +230,7 @@ function Get-PowerShellAzureModules {
     $modulesPath = "C:\Modules"
     $modules = Get-ChildItem -Path $modulesPath | Sort-Object Name |  Group-Object {$_.Name.Split('_')[0]}
     $modules | ForEach-Object {
-        $group = $_.group | Sort-Object {[Version]$_.Name.Split('_')[1]}
+        $group = $_.group | Sort-Object {[Version]$_.Name.Split('_')[1].Replace(".zip","")}
         $moduleName = $names[$_.Name]
         $moduleVersions = $group | ForEach-Object {$_.Name.Split('_')[1]}
         $moduleVersions = $moduleVersions -join '<br>'


### PR DESCRIPTION
# Description
There is an error during the software report generator related to the zip version of azmodules
```
==> vhd: Sort-Object: C:\image\SoftwareReport\SoftwareReport.Common.psm1:233
==> vhd: Line |
==> vhd:  233 |  …      $group = $_.group | Sort-Object {[Version]$_.Name.Split('_')[1]}
==> vhd:      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
==> vhd:      | Cannot convert value "1.0.0.zip" to type "System.Version". Error: "Input string was not in a correct
==> vhd:      | format."
```
This PR removes the zip extension so that the sorting can be done without errors.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2436

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
