### PR TITLE
[Ubuntu] Fix npm global modules installation

### DIFF
--- a/images/linux/scripts/installers/nodejs.sh
+++ b/images/linux/scripts/installers/nodejs.sh
@@ -30,6 +30,11 @@ done
 echo "Creating the symlink for [now] command to vercel CLI"
 ln -s /usr/local/bin/vercel /usr/local/bin/now
 
+# fix global modules installation as regular user
+# related issue https://github.com/actions/virtual-environments/issues/3727
+sudo chmod 777 /usr/local/lib/node_modules -R
+sudo chmod 777 /usr/local/bin
+
 rm -rf ~/n
 
 invoke_tests "Node" "Node.js"

--- a/images/linux/scripts/installers/nodejs.sh
+++ b/images/linux/scripts/installers/nodejs.sh
@@ -32,8 +32,8 @@ ln -s /usr/local/bin/vercel /usr/local/bin/now
 
 # fix global modules installation as regular user
 # related issue https://github.com/actions/virtual-environments/issues/3727
-sudo chmod 777 /usr/local/lib/node_modules -R
-sudo chmod 777 /usr/local/bin
+sudo chmod -R 777 /usr/local/lib/node_modules 
+sudo chmod -R 777 /usr/local/bin
 
 rm -rf ~/n
 


### PR DESCRIPTION
Runner user doesn't have required permissions to install npm global modules on Ubuntu images without sudo, this PR fix it.

#### Related issue: #3727

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
