### PR TITLE
Update to latest Go Patch releases 1.15.14 and 1.16.6

### DIFF
--- a/images/linux/Ubuntu1804-README.md
+++ b/images/linux/Ubuntu1804-README.md
@@ -180,7 +180,7 @@
 #### Go
 - 1.13.15
 - 1.14.15
-- 1.15.13
+- 1.15.14
 
 #### Node.js
 - 10.24.1
@@ -211,7 +211,7 @@
 | --------------- | ----------------------------------- | ------------ |
 | GOROOT_1_13_X64 | /opt/hostedtoolcache/go/1.13.15/x64 | x64          |
 | GOROOT_1_14_X64 | /opt/hostedtoolcache/go/1.14.15/x64 | x64          |
-| GOROOT_1_15_X64 | /opt/hostedtoolcache/go/1.15.13/x64 | x64          |
+| GOROOT_1_15_X64 | /opt/hostedtoolcache/go/1.15.14/x64 | x64          |
 
 ### PowerShell Tools
 - PowerShell 7.1.3

--- a/images/linux/Ubuntu2004-README.md
+++ b/images/linux/Ubuntu2004-README.md
@@ -184,8 +184,8 @@
 ### Cached Tools
 #### Go
 - 1.14.15
-- 1.15.13
-- 1.16.5
+- 1.15.14
+- 1.16.6
 
 #### Node.js
 - 10.24.1
@@ -215,8 +215,8 @@
 | Name            | Value                               | Architecture |
 | --------------- | ----------------------------------- | ------------ |
 | GOROOT_1_14_X64 | /opt/hostedtoolcache/go/1.14.15/x64 | x64          |
-| GOROOT_1_15_X64 | /opt/hostedtoolcache/go/1.15.13/x64 | x64          |
-| GOROOT_1_16_X64 | /opt/hostedtoolcache/go/1.16.5/x64  | x64          |
+| GOROOT_1_15_X64 | /opt/hostedtoolcache/go/1.15.14/x64 | x64          |
+| GOROOT_1_16_X64 | /opt/hostedtoolcache/go/1.16.6/x64  | x64          |
 
 ### PowerShell Tools
 - PowerShell 7.1.3

--- a/images/macos/macos-10.14-Readme.md
+++ b/images/macos/macos-10.14-Readme.md
@@ -21,7 +21,7 @@
 - GNU Fortran (Homebrew GCC 9.4.0) 9.4.0 - available by `gfortran-9` alias
 - GNU Fortran (Homebrew GCC 10.3.0) 10.3.0 - available by `gfortran-10` alias
 - GNU Fortran (Homebrew GCC 11.1.0_1) 11.1.0 - available by `gfortran-11` alias
-- Go 1.15.13
+- Go 1.15.14
 - julia 1.6.1
 - MSBuild 15.7.224.30163 (from /Library/Frameworks/Mono.framework/Versions/5.12.0/lib/mono/msbuild/15.0/bin/MSBuild.dll)
 - Node.js v8.17.0
@@ -167,8 +167,8 @@
 #### Go
 - 1.13.15
 - 1.14.15
-- 1.15.13
-- 1.16.5
+- 1.15.14
+- 1.16.6
 
 ### Rust Tools
 - Cargo 1.53.0

--- a/images/macos/macos-10.15-Readme.md
+++ b/images/macos/macos-10.15-Readme.md
@@ -21,7 +21,7 @@
 - GNU Fortran (Homebrew GCC 9.4.0) 9.4.0 - available by `gfortran-9` alias
 - GNU Fortran (Homebrew GCC 10.3.0) 10.3.0 - available by `gfortran-10` alias
 - GNU Fortran (Homebrew GCC 11.1.0_1) 11.1.0 - available by `gfortran-11` alias
-- Go 1.15.13
+- Go 1.15.14
 - julia 1.6.1
 - MSBuild 16.6.0.15801 (from /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/15.0/bin/MSBuild.dll)
 - Node.js v14.17.1
@@ -170,8 +170,8 @@
 #### Go
 - 1.13.15
 - 1.14.15
-- 1.15.13
-- 1.16.5
+- 1.15.14
+- 1.16.6
 
 ### Rust Tools
 - Cargo 1.53.0

--- a/images/macos/macos-11-Readme.md
+++ b/images/macos/macos-11-Readme.md
@@ -20,7 +20,7 @@
 - GNU Fortran (Homebrew GCC 9.4.0) 9.4.0 - available by `gfortran-9` alias
 - GNU Fortran (Homebrew GCC 10.3.0) 10.3.0 - available by `gfortran-10` alias
 - GNU Fortran (Homebrew GCC 11.1.0_1) 11.1.0 - available by `gfortran-11` alias
-- Go 1.15.13
+- Go 1.15.14
 - julia 1.6.1
 - MSBuild 16.6.0.15801 (from /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/15.0/bin/MSBuild.dll)
 - Node.js v14.17.3
@@ -157,8 +157,8 @@
 - 14.17.3
 
 #### Go
-- 1.15.13
-- 1.16.5
+- 1.15.14
+- 1.16.6
 
 ### Rust Tools
 - Cargo 1.53.0

--- a/images/win/Windows2016-Readme.md
+++ b/images/win/Windows2016-Readme.md
@@ -9,7 +9,7 @@
 ## Installed Software
 ### Language and Runtime
 - Bash 4.4.23(1)-release
-- Go 1.15.13
+- Go 1.15.14
 - Julia 1.6.1
 - Node 14.17.3
 - Perl 5.32.1
@@ -145,8 +145,8 @@ Note: MSYS2 is pre-installed on image but not added to PATH.
 | ------- | ------------ | -------------------- |
 | 1.13.15 | x64          | GOROOT_1_13_X64      |
 | 1.14.15 | x64          | GOROOT_1_14_X64      |
-| 1.15.13 (Default) | x64          | GOROOT_1_15_X64      |
-| 1.16.5  | x64          | GOROOT_1_16_X64      |
+| 1.15.14 (Default) | x64          | GOROOT_1_15_X64      |
+| 1.16.6  | x64          | GOROOT_1_16_X64      |
 
 
 #### Node

--- a/images/win/Windows2019-Readme.md
+++ b/images/win/Windows2019-Readme.md
@@ -12,7 +12,7 @@
 ## Installed Software
 ### Language and Runtime
 - Bash 4.4.23(1)-release
-- Go 1.15.13
+- Go 1.15.14
 - Julia 1.6.1
 - Node 14.17.3
 - Perl 5.32.1
@@ -151,8 +151,8 @@ Note: MSYS2 is pre-installed on image but not added to PATH.
 | ------- | ------------ | -------------------- |
 | 1.13.15 | x64          | GOROOT_1_13_X64      |
 | 1.14.15 | x64          | GOROOT_1_14_X64      |
-| 1.15.13 (Default) | x64          | GOROOT_1_15_X64      |
-| 1.16.5  | x64          | GOROOT_1_16_X64      |
+| 1.15.14 (Default) | x64          | GOROOT_1_15_X64      |
+| 1.16.6  | x64          | GOROOT_1_16_X64      |
 
 
 #### Node


### PR DESCRIPTION
# Description

Go versions have been outdated and actions/setup-go is unable to pull the latest patch version if a minor release is specified. This updates cached Go versions to 1.15.14 and 1.16.6. These releases addressed a CVE.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [X] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
