### PR TITLE
[Ubuntu] Use python3 to install aws-cli V1

### DIFF
--- a/images/linux/scripts/installers/aws.sh
+++ b/images/linux/scripts/installers/aws.sh
@@ -15,10 +15,11 @@ if isUbuntu20 ; then
     /tmp/aws/install -i /usr/local/aws-cli -b /usr/local/bin
 fi
 
+# The installation should be run after python3 is installed as aws-cli V1 dropped python2 support
 if isUbuntu16 || isUbuntu18 ; then
     download_with_retries "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" "/tmp" "awscli-bundle.zip"
     unzip -qq /tmp/awscli-bundle.zip -d /tmp
-    /tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+    python3 /tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
 fi
 
 download_with_retries "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" "/tmp" "session-manager-plugin.deb"

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -199,7 +199,6 @@
                 "{{template_dir}}/scripts/installers/bicep.sh",
                 "{{template_dir}}/scripts/installers/aliyun-cli.sh",
                 "{{template_dir}}/scripts/installers/apache.sh",
-                "{{template_dir}}/scripts/installers/aws.sh",
                 "{{template_dir}}/scripts/installers/clang.sh",
                 "{{template_dir}}/scripts/installers/swift.sh",
                 "{{template_dir}}/scripts/installers/cmake.sh",
@@ -250,7 +249,8 @@
                 "{{template_dir}}/scripts/installers/android.sh",
                 "{{template_dir}}/scripts/installers/yq.sh",
                 "{{template_dir}}/scripts/installers/pypy.sh",
-                "{{template_dir}}/scripts/installers/python.sh"
+                "{{template_dir}}/scripts/installers/python.sh",
+                "{{template_dir}}/scripts/installers/aws.sh"
             ],
             "environment_vars": [
                 "HELPER_SCRIPTS={{user `helper_script_folder`}}",


### PR DESCRIPTION
# Description
Image generation for Ubuntu 18 is broken because Aws-cli V1 dropped python 2.7 support starting from version 1.20
https://github.com/aws/aws-cli/blob/develop/CHANGELOG.rst#1200
```
==> azure-arm: Unsupported Python version detected: Python 2.7
==> azure-arm: To continue using this installer you must use Python 3.6 or later.
==> azure-arm: For more information see the following blog post: https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/
==> azure-arm:
==> azure-arm: Provisioning step had errors: Running the cleanup provisioner, if present...
```
This PR switches V1 installation to use python3.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2456

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
