### PR TITLE
[Ubuntu] Disable schedule builds for Ubuntu16

### DIFF
--- a/images.CI/linux-and-win/azure-pipelines/ubuntu1604.yml
+++ b/images.CI/linux-and-win/azure-pipelines/ubuntu1604.yml
@@ -1,11 +1,3 @@
-schedules:
-- cron: "0 0 * * *"
-  displayName: Daily
-  branches:
-    include:
-    - main
-  always: true
-
 trigger: none
 pr:
   autoCancel: true


### PR DESCRIPTION
# Description
Ubuntu16 is in the deprecation process, we don't need to build it daily.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3287

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
