### PR TITLE
[Ubuntu] Remove platform-tools from toolset

### DIFF
--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -91,8 +91,7 @@
         ],
         "additional_tools": [
             "cmake;3.10.2.4988404",
-            "cmake;3.18.1",
-            "platform-tools"
+            "cmake;3.18.1"
         ],
         "ndk": {
             "lts": "21"

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -87,8 +87,7 @@
         ],
         "additional_tools": [
             "cmake;3.10.2.4988404",
-            "cmake;3.18.1",
-            "platform-tools"
+            "cmake;3.18.1"
         ],
         "ndk": {
             "lts": "21",


### PR DESCRIPTION
# Description
Android `platform-tools` are installed along with any version of `build-tools` and this, sometimes, causes issues when the simultaneous installation of `build-tools` and `platform-tools` runs — as a result, two `platform-tools` installations exist on the image.  
This PR removes additional `platform-tools` installation as they are installed with the `build-tools` anyway.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2441

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
