### PR TITLE
[macOS] Disable App Nap System Wide

### DIFF
--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -15,6 +15,9 @@ sudo /usr/sbin/DevToolsSecurity --enable
 sudo pmset hibernatemode 0
 sudo rm -f /var/vm/sleepimage
 
+# Disable App Nap System Wide
+defaults write NSGlobalDomain NSAppSleepDisabled -bool YES
+
 # Change screen resolution to the maximum supported for 4Mb video memory
 sudo "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1176 885
 


### PR DESCRIPTION
# Description
App Nap is an energy feature  that causes inactive applications to go into a paused state, helping to reduce power usage. Applications should not go to sleep.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
