### PR TITLE
[Ubuntu] Correct variable to print only tool name

### DIFF
--- a/images/linux/scripts/installers/Install-Toolset.ps1
+++ b/images/linux/scripts/installers/Install-Toolset.ps1
@@ -50,5 +50,5 @@ foreach ($tool in $tools) {
             exit 1
         }
     }
-    chown -R "$($env:SUDO_USER):$($env:SUDO_USER)" /opt/hostedtoolcache/$tool
+    chown -R "$($env:SUDO_USER):$($env:SUDO_USER)" "/opt/hostedtoolcache/$($tool.name)"
 }


### PR DESCRIPTION
it was broken in #3701

It can be seen here: https://github.visualstudio.com/virtual-environments/_build/results?buildId=113761&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=5431112d-2b61-5a5f-7042-ef698f761043&l=19972

```
    azure-arm: Successfully installed pip-21.1.3
    azure-arm: Create complete file
==> azure-arm: /bin/chown: cannot access '/opt/hostedtoolcache/@{name=Python; url=https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json; platform=linux; platform_version=18.04; arch=x64; versions=System.Object[]}': No such file or directory
    azure-arm: Installing node 10.* x64...
    azure-arm: Download node-10.24.1-linux-x64.tar.gz
```

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
