### PR TITLE
[Ubuntu] Install yq to /usr/bin

### DIFF
--- a/images/linux/scripts/installers/yq.sh
+++ b/images/linux/scripts/installers/yq.sh
@@ -11,6 +11,6 @@ echo "Downloading latest yq from $YQ_URL"
 
 download_with_retries "$YQ_URL" "/tmp" "${YQ_BINARY}.tar.gz"
 tar xzf "/tmp/${YQ_BINARY}.tar.gz" -C "/tmp"
-mv /tmp/${YQ_BINARY} /usr/local/bin/yq
+mv /tmp/${YQ_BINARY} /usr/bin/yq
 
 invoke_tests "Tools" "yq"


### PR DESCRIPTION
# Description
It turned out that installation to /usr/local/bin can break some workflows as well as installation from PPAs such as https://launchpad.net/~rmescandon/+archive/ubuntu/yq/+packages because yq is usually installed in `/usr/bin`, but we have it in the `/usr/local/bin`that is later in the `$PATH` thus overrides yq from the `/usr/bin.`
https://github.com/actions/virtual-environments/pull/3646#pullrequestreview-711489340
 
#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2472

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
