### PR TITLE
Revert "[Windows] Stick mongodb version to 4.4.7"

### DIFF
--- a/images/win/scripts/Installers/Install-MongoDB.ps1
+++ b/images/win/scripts/Installers/Install-MongoDB.ps1
@@ -3,7 +3,7 @@
 ##  Desc:  Install MongoDB
 ####################################################################################
 
-Choco-Install -PackageName mongodb -ArgumentList "--version=4.4.7"
+Choco-Install -PackageName mongodb
 $mongoPath = (Get-CimInstance Win32_Service -Filter "Name LIKE 'mongodb'").PathName
 $mongoBin = Split-Path -Path $mongoPath.split('"')[1]
 Add-MachinePathItem "$mongoBin"


### PR DESCRIPTION
# Description
We have announced upgrading to version 5 thus can remove the workaround to instal 4.4.7.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3749

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
