### PR TITLE
[macOS] Fix xcode installation script if there is only one Xcode version to install

### DIFF
--- a/images/macos/provision/core/xcode.ps1
+++ b/images/macos/provision/core/xcode.ps1
@@ -17,7 +17,10 @@ $env:SPACESHIP_SKIP_2FA_UPGRADE = 1
 $os = Get-OSVersion
 $xcodeVersions = Get-ToolsetValue "xcode.versions"
 $defaultXcode = Get-ToolsetValue "xcode.default"
-[Array]::Reverse($xcodeVersions)
+if ($xcodeVersions.Count -gt 1)
+{
+    [Array]::Reverse($xcodeVersions)
+}
 $threadCount = "5"
 
 Write-Host "Installing Xcode versions..."
@@ -36,8 +39,8 @@ if ($os.IsLessThanCatalina) {
     $latestXcodeVersion = $xcodeVersions | Select-Object -Last 1 -ExpandProperty link
     Install-XcodeAdditionalPackages -Version $latestXcodeVersion
 }
-$xcodeVersions | ForEach-Object { 
-    Invoke-XcodeRunFirstLaunch -Version $_.link 
+$xcodeVersions | ForEach-Object {
+    Invoke-XcodeRunFirstLaunch -Version $_.link
 }
 Invoke-XcodeRunFirstLaunch -Version $defaultXcode
 

--- a/images/macos/provision/core/xcode.ps1
+++ b/images/macos/provision/core/xcode.ps1
@@ -15,12 +15,9 @@ if ([string]::IsNullOrEmpty($env:XCODE_INSTALL_USER) -or [string]::IsNullOrEmpty
 $env:SPACESHIP_SKIP_2FA_UPGRADE = 1
 
 $os = Get-OSVersion
-$xcodeVersions = Get-ToolsetValue "xcode.versions"
+[Array]$xcodeVersions = Get-ToolsetValue "xcode.versions"
 $defaultXcode = Get-ToolsetValue "xcode.default"
-if ($xcodeVersions.Count -gt 1)
-{
-    [Array]::Reverse($xcodeVersions)
-}
+[Array]::Reverse($xcodeVersions)
 $threadCount = "5"
 
 Write-Host "Installing Xcode versions..."


### PR DESCRIPTION
# Description
There is an exception when we try to reverse 1 element array:
`MethodException: Cannot find an overload for "Reverse" and the argument count: "1"`
This PR fixes it by reversing arrays with more than 1 element.

#### Related issue:
n\a

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
