### PR TITLE
[Windows] Use default msys2 installer

### DIFF
--- a/images/win/scripts/Installers/Install-Rust.ps1
+++ b/images/win/scripts/Installers/Install-Rust.ps1
@@ -20,7 +20,8 @@ $env:Path = Get-MachinePath
 
 # Install common tools
 rustup component add rustfmt clippy
-cargo install --locked bindgen cbindgen cargo-audit cargo-outdated
+# Temporary hardcode cargo-audit 0.14.1 as 0.15.0 is broken https://docs.rs/crate/cargo-audit/0.15.0
+cargo install --locked bindgen cbindgen cargo-audit --version 0.14.1 cargo-outdated
 
 # Run script at startup for all users
 $cmdRustSymScript = @"

--- a/images/win/scripts/Installers/Install-Rust.ps1
+++ b/images/win/scripts/Installers/Install-Rust.ps1
@@ -20,8 +20,7 @@ $env:Path = Get-MachinePath
 
 # Install common tools
 rustup component add rustfmt clippy
-# Temporary hardcode cargo-audit 0.14.1 as 0.15.0 is broken https://docs.rs/crate/cargo-audit/0.15.0
-cargo install --locked bindgen cbindgen cargo-audit --version 0.14.1 cargo-outdated
+cargo install --locked bindgen cbindgen cargo-audit cargo-outdated
 
 # Run script at startup for all users
 $cmdRustSymScript = @"


### PR DESCRIPTION
# Description
Installation msys2 failed with:
```
    vhd: :: Import PGP key 5F944B027F7FE2091985AA2EFA11531AA0AA7F57? [Y/n]
    vhd: :: Synchronizing package databases...
==> vhd: error: mingw32: signature from "Christoph Reiter (MSYS2 development key) <reiter.christoph@gmail.com>" is unknown trust
==> vhd: error: mingw64: signature from "Christoph Reiter (MSYS2 development key) <reiter.christoph@gmail.com>" is unknown trust
==> vhd: error: ucrt64: signature from "Christoph Reiter (MSYS2 development key) <reiter.christoph@gmail.com>" is unknown trust
==> vhd: error: clang64: signature from "Christoph Reiter (MSYS2 development key) <reiter.christoph@gmail.com>" is unknown trust
==> vhd: error: msys: signature from "Christoph Reiter (MSYS2 development key) <reiter.christoph@gmail.com>" is unknown trust
```

Use default installation - https://github.com/msys2/msys2-installer/actions/runs/1077166627/workflow

#### Related issue:
https://github.com/actions/virtual-environments/issues/3810

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
