### PR TITLE
[Ubuntu] Install cargo-audit 0.14.1 as 0.15.0 is broken

### DIFF
--- a/images/linux/scripts/installers/rust.sh
+++ b/images/linux/scripts/installers/rust.sh
@@ -17,8 +17,9 @@ source $CARGO_HOME/env
 
 # Install common tools
 rustup component add rustfmt clippy
+cargo install --locked bindgen cbindgen cargo-outdated
 # Temporary hardcode cargo-audit 0.14.1 as 0.15.0 is broken https://docs.rs/crate/cargo-audit/0.15.0
-cargo install --locked bindgen cbindgen cargo-audit --version 0.14.1 cargo-outdated
+cargo install cargo-audit --version 0.14.1
 
 # Permissions
 chmod -R 777 $(dirname $RUSTUP_HOME)

--- a/images/linux/scripts/installers/rust.sh
+++ b/images/linux/scripts/installers/rust.sh
@@ -17,7 +17,8 @@ source $CARGO_HOME/env
 
 # Install common tools
 rustup component add rustfmt clippy
-cargo install --locked bindgen cbindgen cargo-audit cargo-outdated
+# Temporary hardcode cargo-audit 0.14.1 as 0.15.0 is broken https://docs.rs/crate/cargo-audit/0.15.0
+cargo install --locked bindgen cbindgen cargo-audit --version 0.14.1 cargo-outdated
 
 # Permissions
 chmod -R 777 $(dirname $RUSTUP_HOME)


### PR DESCRIPTION
# Description
cargo-audit package 0.15.0 is broken so we have to temporarily stick to 0.14.1
https://docs.rs/crate/cargo-audit/0.15.0
![image](https://user-images.githubusercontent.com/48208649/127626569-d44b39eb-32d0-4b54-9262-8e58928a1a6e.png)

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2508
https://github.com/actions/virtual-environments/issues/3817

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
