### PR TITLE
[windows] Install cargo-audit 0.14.1 as 0.15.0 is broken (fix)

### DIFF
--- a/images/win/scripts/Installers/Install-Rust.ps1
+++ b/images/win/scripts/Installers/Install-Rust.ps1
@@ -20,7 +20,8 @@ $env:Path = Get-MachinePath
 
 # Install common tools
 rustup component add rustfmt clippy
-cargo install --locked bindgen cbindgen cargo-audit cargo-outdated
+# Temporary hardcode cargo-audit 0.14.1 as 0.15.0 is broken https://docs.rs/crate/cargo-audit/0.15.0
+cargo install --locked bindgen cbindgen cargo-audit --version 0.14.1 cargo-outdated
 
 # Run script at startup for all users
 $cmdRustSymScript = @"

--- a/images/win/scripts/Installers/Install-Rust.ps1
+++ b/images/win/scripts/Installers/Install-Rust.ps1
@@ -21,7 +21,9 @@ $env:Path = Get-MachinePath
 # Install common tools
 rustup component add rustfmt clippy
 # Temporary hardcode cargo-audit 0.14.1 as 0.15.0 is broken https://docs.rs/crate/cargo-audit/0.15.0
-cargo install --locked bindgen cbindgen cargo-audit --version 0.14.1 cargo-outdated
+cargo install --locked bindgen cbindgen cargo-outdated
+cargo install cargo-audit --version 0.14.1
+
 
 # Run script at startup for all users
 $cmdRustSymScript = @"


### PR DESCRIPTION
# Description
The previous PR https://github.com/actions/virtual-environments/pull/3822 was not helped, need to install cargo-audit separately.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2508
https://github.com/actions/virtual-environments/issues/3817

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
