### PR TITLE
[Ubuntu] Fix GraalVM installation

### DIFF
--- a/images/linux/scripts/installers/graalvm.sh
+++ b/images/linux/scripts/installers/graalvm.sh
@@ -7,7 +7,10 @@ source $HELPER_SCRIPTS/etc-environment.sh
 GRAALVM_ROOT=/usr/local/graalvm
 export GRAALVM_11_ROOT=$GRAALVM_ROOT/graalvm-ce-java11*
 
-url=$(curl -s https://api.github.com/repos/graalvm/graalvm-ce-builds/releases/latest | jq -r '.assets[].browser_download_url | select(contains("graalvm-ce-java11-linux-amd64") and endswith("tar.gz"))')
+json=$(curl -s "json=$(curl -s https://api.github.com/repos/graalvm/graalvm-ce-builds/releases)")
+latest_tag=$(echo $json | jq -r '.[] | select(.prerelease==false).tag_name' | sort --unique --version-sort | tail -1)
+url=$(echo $json | jq -r ".[] | select(.tag_name==\"${latest_tag}\").assets[].browser_download_url | select(contains(\"graalvm-ce-java11-linux-amd64\") and endswith(\"tar.gz\"))")
+
 download_with_retries "$url" "/tmp" "graalvm-archive.tar.gz"
 mkdir $GRAALVM_ROOT
 tar -xzf "/tmp/graalvm-archive.tar.gz" -C $GRAALVM_ROOT

--- a/images/linux/scripts/installers/graalvm.sh
+++ b/images/linux/scripts/installers/graalvm.sh
@@ -7,7 +7,7 @@ source $HELPER_SCRIPTS/etc-environment.sh
 GRAALVM_ROOT=/usr/local/graalvm
 export GRAALVM_11_ROOT=$GRAALVM_ROOT/graalvm-ce-java11*
 
-json=$(curl -s "json=$(curl -s https://api.github.com/repos/graalvm/graalvm-ce-builds/releases)")
+json=$(curl -s "https://api.github.com/repos/graalvm/graalvm-ce-builds/releases")
 latest_tag=$(echo $json | jq -r '.[] | select(.prerelease==false).tag_name' | sort --unique --version-sort | tail -1)
 url=$(echo $json | jq -r ".[] | select(.tag_name==\"${latest_tag}\").assets[].browser_download_url | select(contains(\"graalvm-ce-java11-linux-amd64\") and endswith(\"tar.gz\"))")
 


### PR DESCRIPTION
# Description
GraalVM got downgraded https://github.com/actions/virtual-environments/pull/3829/files#diff-6be9f9ce03ba57ca01e4ae937d5c2bb04893520fdf391ea87eb46acbc43ecdc5R123 because we get the latest release by URL https://api.github.com/repos/graalvm/graalvm-ce-builds/releases/latest and the latest release happened for 21.0.0.2.
In scope of this PR we are changing the logic of installing the latest version.

#### Related issue: [#2525](https://github.com/actions/virtual-environments-internal/issues/2525)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
