### PR TITLE
[Ubuntu] Reworked clang installation to use default Ubuntu repo

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -47,8 +47,7 @@ function Get-ClangVersions {
 function Get-LLVMInfo {
     $clangVersions = Get-ClangToolVersions -ToolName "clang"
     $clangFormatVersions = Get-ClangToolVersions -ToolName "clang-format"
-    $aptSourceRepo = Get-AptSourceRepository -PackageName "llvm"
-    return "LLVM components: Clang $clangFormatVersions, Clang-format $clangFormatVersions (apt source: $aptSourceRepo)"
+    return "LLVM components: Clang $clangVersions, Clang-format $clangFormatVersions"
 }
 
 function Get-ClangFormatVersions {

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -44,12 +44,6 @@ function Get-ClangVersions {
     return "Clang " + $clangVersions
 }
 
-function Get-LLVMInfo {
-    $clangVersions = Get-ClangToolVersions -ToolName "clang"
-    $clangFormatVersions = Get-ClangToolVersions -ToolName "clang-format"
-    return "LLVM components: Clang $clangVersions, Clang-format $clangFormatVersions"
-}
-
 function Get-ClangFormatVersions {
     $clangFormatVersions = Get-ClangToolVersions -ToolName "clang-format"
     return "Clang-format " + $clangFormatVersions

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -50,15 +50,10 @@ $runtimesList = @(
         (Get-RubyVersion),
         (Get-SwiftVersion),
         (Get-JuliaVersion),
-        (Get-KotlinVersion)
+        (Get-KotlinVersion),
+        (Get-ClangVersions),
+        (Get-ClangFormatVersions)
         ) 
-
-if (Test-IsUbuntu20) {
-    $runtimesList += (Get-LLVMInfo)
-} else {
-    $runtimesList += (Get-ClangVersions)
-    $runtimesList += (Get-ClangFormatVersions)
-}
 
 $markdown += New-MDList -Style Unordered -Lines ($runtimesList | Sort-Object)
 

--- a/images/linux/scripts/installers/clang.sh
+++ b/images/linux/scripts/installers/clang.sh
@@ -12,14 +12,7 @@ function InstallClang {
     local version=$1
 
     echo "Installing clang-$version..."
-    if [[ $version =~ 9 ]] && isUbuntu16 || [[ $version =~ 12 ]]; then
-        ./llvm.sh $version
-        apt-get install -y "clang-format-$version"
-	llvm_repo=$(grep '^deb.*apt.llvm.org\/' /etc/apt/sources.list)
-	echo "llvm $llvm_repo" >> $HELPER_SCRIPTS/apt-sources.txt
-    else
-        apt-get install -y "clang-$version" "lldb-$version" "lld-$version" "clang-format-$version"
-    fi    
+    apt-get install -y "clang-$version" "lldb-$version" "lld-$version" "clang-format-$version" 
 }
 
 function SetDefaultClang {
@@ -31,10 +24,6 @@ function SetDefaultClang {
     update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-${version} 100
 }
 
-# Download script for automatic installation
-download_with_retries https://apt.llvm.org/llvm.sh
-chmod +x llvm.sh
-
 versions=$(get_toolset_value '.clang.versions[]')
 default_clang_version=$(get_toolset_value '.clang.default_version')
 
@@ -43,9 +32,8 @@ for version in ${versions[*]}; do
         InstallClang $version
     fi
 done
-InstallClang $default_clang_version
 
+InstallClang $default_clang_version
 SetDefaultClang $default_clang_version
-rm llvm.sh
 
 invoke_tests "Tools" "clang"

--- a/images/linux/scripts/installers/clang.sh
+++ b/images/linux/scripts/installers/clang.sh
@@ -5,7 +5,6 @@
 ################################################################################
 
 # Source the helpers for use with the script
-source $HELPER_SCRIPTS/os.sh
 source $HELPER_SCRIPTS/install.sh
 
 function InstallClang {


### PR DESCRIPTION
# Description
Previously clang 12 installation used a custom PPA as the packages source because default Ubuntu repos did not contain appropriate packages. They are available now and installation script rework to use default repos instead of PPA.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: #3827

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
