### PR TITLE
[Windows] Implement minor improvements, rev 2

### DIFF
--- a/images/win/scripts/Installers/Install-Msys2.ps1
+++ b/images/win/scripts/Installers/Install-Msys2.ps1
@@ -70,7 +70,6 @@ function Install-MingwPackages($Packages) {
   }
 }
 
-
 Install-Msys2
 
 # Add msys2 bin tools folders to PATH temporary

--- a/images/win/scripts/Installers/Install-Msys2.ps1
+++ b/images/win/scripts/Installers/Install-Msys2.ps1
@@ -10,19 +10,68 @@
 $dash = "-" * 40
 $origPath = $env:PATH
 
-$msys2_release = "https://api.github.com/repos/msys2/msys2-installer/releases/latest"
-$msys2Uri = ((Invoke-RestMethod $msys2_release).assets | Where-Object {
-  $_.name -match "^msys2-x86_64" -and $_.name.EndsWith(".exe") }).browser_download_url
+function Install-Msys2 {
+  $msys2_release = "https://api.github.com/repos/msys2/msys2-installer/releases/latest"
+  $msys2Uri = ((Invoke-RestMethod $msys2_release).assets | Where-Object {
+    $_.name -match "^msys2-x86_64" -and $_.name.EndsWith(".exe") }).browser_download_url
 
-# Download the latest msys2 x86_64, filename includes release date
-Write-Host "Starting msys2 download using $($msys2Uri.split('/')[-1])"
-$msys2File = Start-DownloadWithRetry -Url $msys2Uri
-Write-Host "Finished download"
+  # Download the latest msys2 x86_64, filename includes release date
+  Write-Host "Starting msys2 download using $($msys2Uri.split('/')[-1])"
+  $msys2File = Start-DownloadWithRetry -Url $msys2Uri
+  Write-Host "Finished download"
 
-# extract tar.xz to C:\
-Write-Host "Starting msys2 installation"
-& $msys2File in --confirm-command --accept-messages --root C:/msys64
-Remove-Item $msys2File
+  # extract tar.xz to C:\
+  Write-Host "Starting msys2 installation"
+  & $msys2File in --confirm-command --accept-messages --root C:/msys64
+  Remove-Item $msys2File
+}
+
+function Install-Msys2Packages($Packages) {
+  if (-not $Packages) {
+    return
+  }
+
+  Write-Host "`n$dash Install msys2 packages"
+  pacman.exe -S --noconfirm --needed --noprogressbar $Packages
+  taskkill /f /fi "MODULES eq msys-2.0.dll"
+
+  Write-Host "`n$dash Remove p7zip/7z package due to conflicts"
+  pacman.exe -R --noconfirm --noprogressbar p7zip
+}
+
+function Install-MingwPackages($Packages) {
+  if (-not $Packages) {
+    return
+  }
+
+  Write-Host "`n$dash Install mingw packages"
+  $archs = $Packages.arch
+
+  foreach ($arch in $archs) {
+    Write-Host "Installing $arch packages"
+    $archPackages = $toolsetContent.mingw | Where-Object { $_.arch -eq $arch }
+    $runtimePackages = $archPackages.runtime_packages.name | ForEach-Object { "${arch}-$_" }
+    $additionalPackages = $archPackages.additional_packages | ForEach-Object { "${arch}-$_" }
+    $packagesToInstall = $runtimePackages + $additionalPackages
+    Write-Host "The following packages will be installed: $packagesToInstall"
+    pacman.exe -S --noconfirm --needed --noprogressbar $packagesToInstall
+  }
+
+  # clean all packages to decrease image size
+  Write-Host "`n$dash Clean packages"
+  pacman.exe -Scc --noconfirm
+
+  $pkgs = pacman.exe -Q
+
+  foreach ($arch in $archs)
+  {
+    Write-Host "`n$dash Installed $arch packages"
+    $pkgs | grep ^${arch}-
+  }
+}
+
+
+Install-Msys2
 
 # Add msys2 bin tools folders to PATH temporary
 $env:PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$origPath"
@@ -35,38 +84,8 @@ pacman.exe -Syuu  --noconfirm
 taskkill /f /fi "MODULES eq msys-2.0.dll"
 
 $toolsetContent = (Get-ToolsetContent).MsysPackages
-Write-Host "`n$dash Install msys2 packages"
-$msys2Packages = $toolsetContent.msys2
-pacman.exe -S --noconfirm --needed --noprogressbar $msys2Packages
-taskkill /f /fi "MODULES eq msys-2.0.dll"
-
-Write-Host "`n$dash Remove p7zip/7z package due to conflicts"
-pacman.exe -R --noconfirm --noprogressbar p7zip
-
-# install mingw packages
-$archs = $toolsetContent.mingw.arch
-foreach ($arch in $archs)
-{
-  Write-Host "Installing $arch packages"
-  $archPackages = $toolsetContent.mingw | Where-Object { $_.arch -eq $arch }
-  $runtimePackages = $archPackages.runtime_packages.name | ForEach-Object { "${arch}-$_" }
-  $additionalPackages = $archPackages.additional_packages | ForEach-Object { "${arch}-$_" }
-  $packagesToInstall = $runtimePackages + $additionalPackages
-  Write-Host "The following packages will be installed: $packagesToInstall"
-  pacman.exe -S --noconfirm --needed --noprogressbar $packagesToInstall
-}
-
-# clean all packages to decrease image size
-Write-Host "`n$dash Clean packages"
-pacman.exe -Scc --noconfirm
-
-$pkgs = pacman.exe -Q
-
-foreach ($arch in $archs)
-{
-  Write-Host "`n$dash Installed $arch packages"
-  $pkgs | grep ^${arch}-
-}
+Install-Msys2Packages -Packages $toolsetContent.msys2
+Install-MingwPackages -Packages $toolsetContent.mingw
 
 $env:PATH = $origPath
 Write-Host "`nMSYS2 installation completed"

--- a/images/win/scripts/Installers/Install-WDK.ps1
+++ b/images/win/scripts/Installers/Install-WDK.ps1
@@ -18,6 +18,10 @@ elseif (Test-IsWin16)
     $FilePath = "C:\Program Files (x86)\Windows Kits\10\Vsix\WDK.vsix"
     $VSver = "2017"
 }
+else
+{
+    throw "Invalid version of Visual Studio is found. Either 2017 or 2019 are required"
+}
 
 $argumentList = ("/features", "+", "/quiet")
 

--- a/images/win/scripts/Installers/Install-WDK.ps1
+++ b/images/win/scripts/Installers/Install-WDK.ps1
@@ -11,7 +11,7 @@ if (Test-IsWin19)
     $FilePath = "C:\Program Files (x86)\Windows Kits\10\Vsix\VS2019\WDK.vsix"
     $VSver = "2019"
 }
-else
+elseif (Test-IsWin16)
 {
     $winSdkUrl = "https://go.microsoft.com/fwlink/p/?LinkID=2023014"
     $wdkUrl = "https://go.microsoft.com/fwlink/?linkid=2026156"

--- a/images/win/scripts/Installers/Install-Wix.ps1
+++ b/images/win/scripts/Installers/Install-Wix.ps1
@@ -5,18 +5,23 @@
 
 Choco-Install -PackageName wixtoolset -ArgumentList "--force"
 
-if(Test-IsWin19)
+if (Test-IsWin19)
 {
     $extensionUrl = "https://wixtoolset.gallerycdn.vsassets.io/extensions/wixtoolset/wixtoolsetvisualstudio2019extension/1.0.0.4/1563296438961/Votive2019.vsix"
     $VSver = "2019"
 }
-else
+elseif (Test-IsWin16)
 {
     $extensionUrl = "https://robmensching.gallerycdn.vsassets.io/extensions/robmensching/wixtoolsetvisualstudio2017extension/0.9.21.62588/1494013210879/250616/4/Votive2017.vsix"
     $VSver = "2017"
 }
+else
+{
+    throw "Invalid version of Visual Studio is found. Either 2017 or 2019 are required"
+}
 
 $extensionName = "Votive$VSver.vsix"
+
 #Installing VS extension 'Wix Toolset Visual Studio Extension'
 Install-VsixExtension -Url $extensionUrl -Name $extensionName -VSversion $VSver
 

--- a/images/win/scripts/Installers/Update-DotnetTLS.ps1
+++ b/images/win/scripts/Installers/Update-DotnetTLS.ps1
@@ -14,6 +14,3 @@ $registryPath = "HKLM:\SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v4.0.30319"
 if(Test-Path $registryPath){
     Set-ItemProperty -Path $registryPath -Name $name -Value $value -Type DWORD
 }
-
-Invoke-PesterTests -TestFile "Tools" -TestName "DotnetTLS"
-

--- a/images/win/scripts/Installers/Update-ImageData.ps1
+++ b/images/win/scripts/Installers/Update-ImageData.ps1
@@ -7,18 +7,16 @@ $imageVersion = $env:IMAGE_VERSION
 $imageDataFile = $env:IMAGEDATA_FILE
 $githubUrl="https://github.com/actions/virtual-environments/blob"
 
-if ($caption -match "2019")
-{
+if (Test-IsWin19) {
     $imageLabel = "windows-2019"
     $softwareUrl = "${githubUrl}/win19/${imageVersion}/images/win/Windows2019-Readme.md"
     $releaseUrl="https://github.com/actions/virtual-environments/releases/tag/win19%2F${imageVersion}"
-}
-
-if ($caption -match "2016")
-{
+} elseif (Test-IsWin16) {
     $imageLabel = "windows-2016"
     $softwareUrl = "${githubUrl}/win16/${imageVersion}/images/win/Windows2016-Readme.md"
     $releaseUrl="https://github.com/actions/virtual-environments/releases/tag/win16%2F${imageVersion}"
+} else {
+    throw "Invalid platform version is found. Either Windows Server 2016 or 2019 or 2022 are required"
 }
 
 $json = @"

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -273,8 +273,11 @@ $markdown += Build-AndroidEnvironmentTable | New-MDTable
 $markdown += New-MDNewLine
 
 # Docker images section
-$markdown += New-MDHeader "Cached Docker images" -Level 3
-$markdown += Get-CachedDockerImagesTableData | New-MDTable
-$markdown += New-MDNewLine
+$cachedImages = Get-CachedDockerImagesTableData
+if ($cachedImages) {
+    $markdown += New-MDHeader "Cached Docker images" -Level 3
+    $markdown += $cachedImages | New-MDTable
+    $markdown += New-MDNewLine
+}
 
 $markdown | Out-File -FilePath "C:\InstalledSoftware.md"

--- a/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
@@ -37,7 +37,7 @@ function Get-VisualStudioExtensions {
 
     # SSDT extensions for VS2017
     $vs = (Get-VisualStudioVersion).Name.Split()[-1]
-    if ($vs -eq "2017")
+    if (Test-IsWin16)
     {
         $analysisPackageVersion = Get-VSExtensionVersion -packageName '04a86fc2-dbd5-4222-848e-911638e487fe'
         $reportingPackageVersion = Get-VSExtensionVersion -packageName '717ad572-c4b7-435c-c166-c2969777f718'
@@ -49,21 +49,30 @@ function Get-VisualStudioExtensions {
         )
     }
 
-    # Wix
-    $wixPackageVersion = Get-WixVersion
-    $wixExtensionVersion = (Get-VisualStudioPackages | Where-Object {$_.Id -match 'WixToolset.VisualStudioExtension.Dev' -and $_.type -eq 'vsix'}).Version
+    if (Test-IsWin16 -or Test-IsWin19) {
+        # Wix
+        $wixPackageVersion = Get-WixVersion
+        $wixExtensionVersion = (Get-VisualStudioPackages | Where-Object {$_.Id -match 'WixToolset.VisualStudioExtension.Dev' -and $_.type -eq 'vsix'}).Version
+        $wixPackages = @(
+            @{Package = 'WIX Toolset'; Version = $wixPackageVersion}
+            @{Package = "WIX Toolset Studio $vs Extension"; Version = $wixExtensionVersion}
+        )
 
-    # WDK
-    $wdkPackageVersion = Get-VSExtensionVersion -packageName 'Microsoft.Windows.DriverKit'
-    $wdkExtensionVersion = Get-WDKVersion
+        # WDK
+        $wdkPackageVersion = Get-VSExtensionVersion -packageName 'Microsoft.Windows.DriverKit'
+        $wdkExtensionVersion = Get-WDKVersion
+        $wdkPackages = @(
+            @{Package = 'Windows Driver Kit'; Version = $wdkPackageVersion}
+            @{Package = 'Windows Driver Kit Visual Studio Extension'; Version = $wdkExtensionVersion}
+        )
+    }
+    
 
     $extensions = @(
         $vsixs
         $ssdtPackages
-        @{Package = 'Windows Driver Kit'; Version = $wdkPackageVersion}
-        @{Package = 'Windows Driver Kit Visual Studio Extension'; Version = $wdkExtensionVersion}
-        @{Package = 'WIX Toolset'; Version = $wixPackageVersion}
-        @{Package = "WIX Toolset Studio $vs Extension"; Version = $wixExtensionVersion}
+        $wixPackages
+        $wdkPackages
     )
 
     $extensions | Foreach-Object {


### PR DESCRIPTION
# Description
This PR brings minor improvements to Windows image generation:
1) Make sure that `MSYS2` installation works correctly if no mingw, msys packages are specified in toolset
2) `Install-WDK.ps1` and `Install-Wix.ps1`  should fail on different platforms because they are not compatible with them
3) Don't run TLS tests in scope of `images/win/scripts/Installers/Update-DotnetTLS.ps1` because changes are not applied immediately
4) Exclude `Cached Docker images` section from docs if no containers are cached

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
