### PR TITLE
[Ubuntu] Expand oc only

### DIFF
--- a/images/linux/scripts/installers/oc.sh
+++ b/images/linux/scripts/installers/oc.sh
@@ -10,6 +10,6 @@ source $HELPER_SCRIPTS/install.sh
 DOWNLOAD_URL="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz"
 PACKAGE_TAR_NAME="oc.tar.gz"
 download_with_retries $DOWNLOAD_URL "/tmp" $PACKAGE_TAR_NAME
-tar xzf "/tmp/$PACKAGE_TAR_NAME" -C "/usr/local/bin"
+tar xzf "/tmp/$PACKAGE_TAR_NAME" -C "/usr/local/bin" oc
 
 invoke_tests "CLI.Tools" "OC CLI"


### PR DESCRIPTION
# Description
The `openshift-client-linux.tar.gz` archive contains kubectl binary which replace the pervious one installed in the `images\linux\scripts\installers\kubernetes-tools.sh` script.

```
:~$ tar -ztf /tmp/oc.tar.gz
README.md
oc
kubectl

:~$ md5sum /usr/local/bin/oc
8a636bbf530bd2cf8bd2cfbe58d6cd38  /usr/local/bin/oc
:~$ md5sum /usr/local/bin/kubectl
8a636bbf530bd2cf8bd2cfbe58d6cd38  /usr/local/bin/kubectl
```
## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
