### PR TITLE
[Windows] Improve Visual Studio installation scripts to support Preview versions

### DIFF
--- a/images/win/post-generation/VSConfiguration.ps1
+++ b/images/win/post-generation/VSConfiguration.ps1
@@ -1,4 +1,4 @@
-$vsInstallRoot = Get-VisualStudioPath
+$vsInstallRoot = (Get-VisualStudioInstance).InstallationPath
 $devEnvPath = "$vsInstallRoot\Common7\IDE\devenv.exe"
 
 cmd.exe /c "`"$devEnvPath`" /updateconfiguration"

--- a/images/win/scripts/ImageHelpers/ImageHelpers.psm1
+++ b/images/win/scripts/ImageHelpers/ImageHelpers.psm1
@@ -34,11 +34,12 @@ Export-ModuleMember -Function @(
     'Get-EnvironmentVariable'
     'Invoke-PesterTests'
     'Get-VsCatalogJsonPath'
-    'Get-VisualStudioPath'
     'Install-AndroidSDKPackages'
     'Get-AndroidPackages'
     'Get-AndroidPackagesByName'
     'Get-AndroidPackagesByVersion'
+    'Get-VisualStudioInstance'
+    'Get-VisualStudioPath'
     'Get-VisualStudioPackages'
     'Get-VisualStudioComponents'
 )

--- a/images/win/scripts/ImageHelpers/ImageHelpers.psm1
+++ b/images/win/scripts/ImageHelpers/ImageHelpers.psm1
@@ -39,7 +39,5 @@ Export-ModuleMember -Function @(
     'Get-AndroidPackagesByName'
     'Get-AndroidPackagesByVersion'
     'Get-VisualStudioInstance'
-    'Get-VisualStudioPath'
-    'Get-VisualStudioPackages'
     'Get-VisualStudioComponents'
 )

--- a/images/win/scripts/ImageHelpers/VisualStudioHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/VisualStudioHelpers.ps1
@@ -78,16 +78,8 @@ function Get-VisualStudioInstance {
     $vsInstance | Select-VSSetupInstance -Product *
 }
 
-function Get-VisualStudioPath {
-    return (Get-VisualStudioInstance).InstallationPath
-}
-
-function Get-VisualStudioPackages {
-    return (Get-VisualStudioInstance).Packages
-}
-
 function Get-VisualStudioComponents {
-    Get-VisualStudioPackages | Where-Object type -in 'Component', 'Workload' |
+    (Get-VisualStudioInstance).Packages | Where-Object type -in 'Component', 'Workload' |
     Sort-Object Id, Version | Select-Object @{n = 'Package'; e = {$_.Id}}, Version |
     Where-Object { $_.Package -notmatch "[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}" }
 }

--- a/images/win/scripts/ImageHelpers/VisualStudioHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/VisualStudioHelpers.ps1
@@ -72,12 +72,18 @@ function Get-VsCatalogJsonPath {
     return Join-Path $instanceFolder.FullName "catalog.json"
 }
 
+function Get-VisualStudioInstance {
+    # Use -Prerelease and -All flags to make sure that Preview versions of VS are found correctly
+    $vsInstance = Get-VSSetupInstance -Prerelease -All | Where-Object { $_.DisplayName -match "Visual Studio" } | Select-Object -First 1
+    $vsInstance | Select-VSSetupInstance -Product *
+}
+
 function Get-VisualStudioPath {
-    return (Get-VSSetupInstance | Select-VSSetupInstance -Product *).InstallationPath
+    return (Get-VisualStudioInstance).InstallationPath
 }
 
 function Get-VisualStudioPackages {
-    return (Get-VSSetupInstance | Select-VSSetupInstance -Product *).Packages
+    return (Get-VisualStudioInstance).Packages
 }
 
 function Get-VisualStudioComponents {

--- a/images/win/scripts/Installers/Install-VS.ps1
+++ b/images/win/scripts/Installers/Install-VS.ps1
@@ -14,7 +14,8 @@ $workLoadsArgument = [String]::Join(" ", $workLoads)
 
 $releaseInPath = $toolset.visualStudio.edition
 $subVersion = $toolset.visualStudio.subversion
-$bootstrapperUrl = "https://aka.ms/vs/${subVersion}/release/vs_${releaseInPath}.exe"
+$channel = $toolset.visualStudio.channel
+$bootstrapperUrl = "https://aka.ms/vs/${subVersion}/${channel}/vs_${releaseInPath}.exe"
 
 # Install VS
 Install-VisualStudio -BootstrapperUrl $bootstrapperUrl -WorkLoads $workLoadsArgument

--- a/images/win/scripts/Installers/Install-VS.ps1
+++ b/images/win/scripts/Installers/Install-VS.ps1
@@ -31,7 +31,7 @@ if ($instanceFolders -is [array])
     exit 1
 }
 
-$vsInstallRoot = Get-VisualStudioPath
+$vsInstallRoot = (Get-VisualStudioInstance).InstallationPath
 
 # Initialize Visual Studio Experimental Instance
 & "$vsInstallRoot\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings /Command File.Exit

--- a/images/win/scripts/Installers/Install-WinAppDriver.ps1
+++ b/images/win/scripts/Installers/Install-WinAppDriver.ps1
@@ -10,4 +10,4 @@ $InstallerName = "WindowsApplicationDriver.msi"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Install-Binary -Url $InstallerUrl -Name $InstallerName
 
-Invoke-PesterTests -TestFile "WinAppDriver"
+Invoke-PesterTests -TestFile "WinAppDriver" -TestName "WinAppDriver"

--- a/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
@@ -1,9 +1,9 @@
 function Get-VisualStudioVersion {
-    $vsVersion = vswhere -format json | ConvertFrom-Json
+    $vsInstance = Get-VisualStudioInstance
     [PSCustomObject]@{
-        Name = $vsVersion.displayName
-        Version = $vsVersion.installationVersion
-        Path = $vsVersion.installationPath
+        Name = $vsInstance.DisplayName
+        Version = $vsInstance.InstallationVersion
+        Path = $vsInstance.InstallationPath
     }
 }
 

--- a/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
@@ -20,6 +20,8 @@ function Get-WDKVersion {
 }
 
 function Get-VisualStudioExtensions {
+    $vsPackages = (Get-VisualStudioInstance).Packages
+
     # Additional vsixs
     $toolset = Get-ToolsetContent
     $vsixUrls = $toolset.visualStudio.vsix
@@ -27,7 +29,8 @@ function Get-VisualStudioExtensions {
     {
         $vsixs = $vsixUrls | ForEach-Object {
             $vsix = Get-VsixExtenstionFromMarketplace -ExtensionMarketPlaceName $_
-            $vsixVersion = (Get-VisualStudioPackages | Where-Object {$_.Id -match $vsix.VsixId -and $_.type -eq 'vsix'}).Version
+            
+            $vsixVersion = ($vsPackages | Where-Object {$_.Id -match $vsix.VsixId -and $_.type -eq 'vsix'}).Version
             @{
                 Package = $vsix.ExtensionName
                 Version = $vsixVersion
@@ -52,7 +55,7 @@ function Get-VisualStudioExtensions {
     if (Test-IsWin16 -or Test-IsWin19) {
         # Wix
         $wixPackageVersion = Get-WixVersion
-        $wixExtensionVersion = (Get-VisualStudioPackages | Where-Object {$_.Id -match 'WixToolset.VisualStudioExtension.Dev' -and $_.type -eq 'vsix'}).Version
+        $wixExtensionVersion = ($vsPackages | Where-Object {$_.Id -match 'WixToolset.VisualStudioExtension.Dev' -and $_.type -eq 'vsix'}).Version
         $wixPackages = @(
             @{Package = 'WIX Toolset'; Version = $wixPackageVersion}
             @{Package = "WIX Toolset Studio $vs Extension"; Version = $wixExtensionVersion}

--- a/images/win/scripts/Tests/VisualStudio.Tests.ps1
+++ b/images/win/scripts/Tests/VisualStudio.Tests.ps1
@@ -5,7 +5,7 @@ Describe "Visual Studio" {
         }
 
         It "Devenv.exe" {
-            $vsInstallRoot = Get-VisualStudioPath
+            $vsInstallRoot = (Get-VisualStudioInstance).InstallationPath
             $devenvexePath = "${vsInstallRoot}\Common7\IDE\devenv.exe"
             $devenvexePath | Should -Exist
         }

--- a/images/win/scripts/Tests/Vsix.Tests.ps1
+++ b/images/win/scripts/Tests/Vsix.Tests.ps1
@@ -2,7 +2,7 @@ Describe "Vsix" {
     $toolset = Get-ToolsetContent
     $requiredVsixs = $toolset.visualStudio.vsix
 
-    $allPackages = Get-VisualStudioPackages
+    $allPackages = (Get-VisualStudioInstance).Packages
     $testCases = $requiredVsixs | ForEach-Object {
         $vsix = Get-VsixExtenstionFromMarketplace -ExtensionMarketPlaceName $_
         @{

--- a/images/win/scripts/Tests/Vsix.Tests.ps1
+++ b/images/win/scripts/Tests/Vsix.Tests.ps1
@@ -2,7 +2,7 @@ Describe "Vsix" {
     $toolset = Get-ToolsetContent
     $requiredVsixs = $toolset.visualStudio.vsix
 
-    $allPackages = (Get-VSSetupInstance | Select-VsSetupInstance -Product *).Packages
+    $allPackages = Get-VisualStudioPackages
     $testCases = $requiredVsixs | ForEach-Object {
         $vsix = Get-VsixExtenstionFromMarketplace -ExtensionMarketPlaceName $_
         @{

--- a/images/win/scripts/Tests/WinAppDriver.Tests.ps1
+++ b/images/win/scripts/Tests/WinAppDriver.Tests.ps1
@@ -2,7 +2,9 @@ Describe "WinAppDriver" {
   It "WinAppDriver directory exists" {
     Test-Path -Path "${env:ProgramFiles(x86)}\Windows Application Driver" | Should -BeTrue
   }
+}
 
+Describe "Developer Mode" {
   It "Developer Mode is enabled" {
     $path = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock";
     Get-ItemProperty -Path $path | Select-Object -ExpandProperty "AllowDevelopmentWithoutDevLicense" | Should -Be 1

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -260,6 +260,7 @@
         "version" : "2017",
         "subversion" : "15",
         "edition" : "Enterprise",
+        "channel": "release",
         "workloads": [
             "Microsoft.Net.Component.4.6.2.SDK",
             "Microsoft.Net.Component.4.6.2.TargetingPack",

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -258,6 +258,7 @@
         "version" : "2019",
         "subversion" : "16",
         "edition" : "Enterprise",
+        "channel": "release",
         "workloads": [
             "Component.Dotfuscator",
             "Component.Linux.CMake",

--- a/images/win/windows2016.json
+++ b/images/win/windows2016.json
@@ -154,11 +154,10 @@
                 3010
             ],
             "scripts": [
-                "{{ template_dir }}/scripts/Installers/Install-KubernetesTools.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-VS.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-KubernetesTools.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-NET48.ps1",
-                "{{ template_dir }}/scripts/Installers/Windows2016/Install-SSDT.ps1",
-                "{{ template_dir }}/scripts/Installers/Enable-DeveloperMode.ps1"
+                "{{ template_dir }}/scripts/Installers/Windows2016/Install-SSDT.ps1"
             ],
             "elevated_user": "{{user `install_user`}}",
             "elevated_password": "{{user `install_password`}}"
@@ -249,7 +248,8 @@
                 "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1",
                 "{{ template_dir }}/scripts/Installers/Configure-DynamicPort.ps1",
                 "{{ template_dir }}/scripts/Installers/Configure-GDIProcessHandleQuota.ps1",
-                "{{ template_dir }}/scripts/Installers/Configure-Shell.ps1"
+                "{{ template_dir }}/scripts/Installers/Configure-Shell.ps1",
+                "{{ template_dir }}/scripts/Installers/Enable-DeveloperMode.ps1"
             ],
             "elevated_user": "{{user `install_user`}}",
             "elevated_password": "{{user `install_password`}}"

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -161,10 +161,9 @@
                 3010
             ],
             "scripts": [
-                "{{ template_dir }}/scripts/Installers/Install-KubernetesTools.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-VS.ps1",
-                "{{ template_dir }}/scripts/Installers/Install-NET48.ps1",
-                "{{ template_dir }}/scripts/Installers/Enable-DeveloperMode.ps1"
+                "{{ template_dir }}/scripts/Installers/Install-KubernetesTools.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-NET48.ps1"
             ],
             "elevated_user": "{{user `install_user`}}",
             "elevated_password": "{{user `install_password`}}"
@@ -258,7 +257,8 @@
                 "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1",
                 "{{ template_dir }}/scripts/Installers/Configure-DynamicPort.ps1",
                 "{{ template_dir }}/scripts/Installers/Configure-GDIProcessHandleQuota.ps1",
-                "{{ template_dir }}/scripts/Installers/Configure-Shell.ps1"
+                "{{ template_dir }}/scripts/Installers/Configure-Shell.ps1",
+                "{{ template_dir }}/scripts/Installers/Enable-DeveloperMode.ps1"
             ],
             "elevated_user": "{{user `install_user`}}",
             "elevated_password": "{{user `install_password`}}"


### PR DESCRIPTION
# Description
1) Set channel via toolset (`release` or `pre`)
2) Invoke `Get-VSSetupInstance` with flags `-Prerelease -All` everywhere to find VS properly
3) Switch `vswhere` using to `Get-VSSetupInstance` because of better handling of preview