### PR TITLE
[Linux] install.sh: make the IsPackageInstalled function definition consistent

### DIFF
--- a/images/linux/scripts/helpers/install.sh
+++ b/images/linux/scripts/helpers/install.sh
@@ -48,7 +48,7 @@ download_with_retries() {
 ## if ! IsPackageInstalled packageName; then
 ##     echo "packageName is not installed!"
 ## fi
-IsPackageInstalled {
+IsPackageInstalled() {
     dpkg -S $1 &> /dev/null
 }
 

--- a/images/linux/scripts/helpers/install.sh
+++ b/images/linux/scripts/helpers/install.sh
@@ -48,7 +48,7 @@ download_with_retries() {
 ## if ! IsPackageInstalled packageName; then
 ##     echo "packageName is not installed!"
 ## fi
-function IsPackageInstalled {
+IsPackageInstalled {
     dpkg -S $1 &> /dev/null
 }
 


### PR DESCRIPTION

# Description
According to the [bash manual](http://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Shell-Functions) the `function` keyword is not really mandatory, other functions defined in the file have no this keyword as well.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: n/a

## Check list
- [n/a ] Related issue / work item is attached
- [n/a ] Tests are written (if applicable)
- [n/a ] Documentation is updated (if applicable)
- [n/a ] Changes are tested and related VM images are successfully generated
