### PR TITLE
[ubuntu] fix: escape tilde operator in package version

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -353,6 +353,8 @@ function Get-AptPackages {
         if ($Null -eq $version) {
             $version = $(dpkg-query -W -f '${Version}' "$pkg*")
         }
+        
+        $version = $version -replace '~','\~'
 
         $output += [PSCustomObject] @{
             Name    = $pkg


### PR DESCRIPTION
# Description

Prevents markdown to interpret it as strike-through style when 2 or more tilde operators appear
example:
https://github.com/actions/virtual-environments/blob/b56230f3423cc8fa24bae454cacf7e841b22fb6b/images/linux/Ubuntu2004-README.md#L305

| Name                   | Version                           |
| ---------------------- | --------------------------------- |
| fonts-noto-color-emoji | 0~20200916-1~ubuntu20.04.1        |

#### Related issue:
n/a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
