### PR TITLE
[Ubuntu] Add HOMEBREW_SHELLENV_PREFIX env

### DIFF
--- a/images/linux/scripts/installers/homebrew.sh
+++ b/images/linux/scripts/installers/homebrew.sh
@@ -15,9 +15,10 @@ eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
 
 # Update /etc/environemnt
 ## Put HOMEBREW_* variables
-brew shellenv|grep 'export HOMEBREW'|sed -E 's/^export (.*);$/\1/' | sudo tee -a /etc/environment
+## The variable `HOMEBREW_SHELLENV_PREFIX` will be exported to avoid adding duplicate entries to the environment variables.
+HOMEBREW_SHELLENV_PREFIX='' brew shellenv | grep 'export HOMEBREW'| sed -E 's/^export (.*);$/\1/' | sudo tee -a /etc/environment
 # add brew executables locations to PATH
-brew_path=$(brew shellenv|grep  '^export PATH' |sed -E 's/^export PATH="([^$]+)\$.*/\1/')
+brew_path=$(HOMEBREW_SHELLENV_PREFIX='' brew shellenv | grep '^export PATH' | sed -E 's/^export PATH="([^$]+)\$.*/\1/')
 prependEtcEnvironmentPath "$brew_path"
 setEtcEnvironmentVariable HOMEBREW_NO_AUTO_UPDATE 1
 setEtcEnvironmentVariable HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS 3650


### PR DESCRIPTION
# Description
The new behavior has been introduced in  https://github.com/Homebrew/brew/pull/11789 PR . After eval statement has been completed, the `brew shellenv` checks HOMEBREW_SHELLENV_PREFIX env and returns empty.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2601

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
