### PR TITLE
feat: add Oracle Cloud Infrastructure CLI via pipx

### DIFF
--- a/images/linux/Ubuntu1804-README.md
+++ b/images/linux/Ubuntu1804-README.md
@@ -105,8 +105,9 @@
 - GitHub CLI 1.14.0
 - Google Cloud SDK 351.0.0 (apt source repository: https://packages.cloud.google.com/apt)
 - Hub CLI 2.14.2
-- Netlify CLI 6.0.9
-- OpenShift CLI 4.8.4
+- Netlify CLI 5.4.9
+- OpenShift CLI 4.8.3
+- Oracle Cloud Infrastructure CLI 3.0.0
 - ORAS CLI 0.12.0
 - Vercel CLI 23.1.2
 
@@ -354,5 +355,3 @@
 | xz-utils          | 5.2.2-1.3                         |
 | zip               | 3.0-11build1                      |
 | zsync             | 0.6.2-3ubuntu1                    |
-
-

--- a/images/linux/Ubuntu2004-README.md
+++ b/images/linux/Ubuntu2004-README.md
@@ -109,6 +109,7 @@
 - Hub CLI 2.14.2
 - Netlify CLI 6.0.9
 - OpenShift CLI 4.8.3
+- Oracle Cloud Infrastructure CLI 3.0.0
 - ORAS CLI 0.12.0
 - Vercel CLI 23.1.2
 
@@ -364,5 +365,3 @@
 | xz-utils               | 5.2.4-1ubuntu1                    |
 | zip                    | 3.0-11build1                      |
 | zsync                  | 0.6.2-3ubuntu1                    |
-
-

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -225,6 +225,10 @@
         {
             "package": "ansible-core",
             "cmd": "ansible"
+        },
+        {
+            "package": "oci-cli",
+            "cmd": "oci"
         }
     ],
     "dotnet": {

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -225,6 +225,10 @@
         {
             "package": "ansible-core",
             "cmd": "ansible"
+        },
+        {
+            "package": "oci-cli",
+            "cmd": "oci"
         }
     ],
     "dotnet": {

--- a/images/win/Windows2016-Readme.md
+++ b/images/win/Windows2016-Readme.md
@@ -90,6 +90,7 @@
 - Cloud Foundry CLI 6.53.0
 - GitHub CLI 1.14.0
 - Hub CLI 2.14.2
+- Oracle Cloud Infrastructure CLI 3.0.0
 
 ### Rust Tools
 - Cargo 1.54.0
@@ -576,6 +577,3 @@ All other versions are saved but not installed.
 | mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2016     | sha256:65d94ee17565554801c4ba0a9b153ee90b6a25bcdb5395356d8f0c452c002203  | 2021-07-13 |
 | mcr.microsoft.com/windows/nanoserver:10.0.14393.953                       | sha256:fc60bd5ae0e61b334ce1cf1bcbf20c10c36b4c5482a01da319c9c989f9e6e268  | 2017-03-08 |
 | mcr.microsoft.com/windows/servercore:ltsc2016                             | sha256:c6b1c3fecf651e7629f96874393476ba00cda2a1c2090314fdfe384267cd584f  | 2021-07-09 |
-
-
-

--- a/images/win/Windows2019-Readme.md
+++ b/images/win/Windows2019-Readme.md
@@ -93,6 +93,7 @@
 - Cloud Foundry CLI 6.53.0
 - GitHub CLI 1.14.0
 - Hub CLI 2.14.2
+- Oracle Cloud Infrastructure CLI 3.0.0
 
 ### Rust Tools
 - Cargo 1.54.0
@@ -567,6 +568,3 @@ All other versions are saved but not installed.
 | mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019     | sha256:c6e9c591b9e80e2cb0f8bcb736008ebbc3e3ed23de045523847ef0f9778dbaa6  | 2021-07-13 |
 | mcr.microsoft.com/windows/nanoserver:1809                                 | sha256:0cfbe14b2bcb1bd1af2bdc1603f9b60e63effaf25bce3fbab9ceb23e02b2b97f  | 2021-07-06 |
 | mcr.microsoft.com/windows/servercore:ltsc2019                             | sha256:cc8a0215d2d19516c23b5f8a8e04799631c5ff2fb9a3c509fbd46f7ef7057877  | 2021-07-06 |
-
-
-

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -347,6 +347,10 @@
         {
             "package": "yamllint",
             "cmd": "yamllint --version"
+        },
+        {
+            "package": "oci-cli",
+            "cmd": "oci --version"
         }
     ],
     "npm": {

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -373,6 +373,10 @@
         {
             "package": "yamllint",
             "cmd": "yamllint --version"
+        },
+        {
+            "package": "oci-cli",
+            "cmd": "oci --version"
         }
     ],
     "npm": {


### PR DESCRIPTION
Signed-off-by: Avi Miller <avi.miller@oracle.com>

# Description
New tool: Oracle Cloud Infrastructure CLI 3.0.0

Adds the OCI CLI tool to enable interoperability with OCI in GitHub Actions. Installed using `pipx` on Ubuntu and Windows instances and consumes about 255MB. 

#### Related issue:

Resolves #3909 

####  Check list
- [X] Related issue / work item is attached
- [X] Tests are written (if applicable)
- [X] Documentation is updated (if applicable)
- [X] Changes are tested and related VM images are successfully generated
