### PR TITLE
[Ubuntu] fix: add aria2 to toolset

### DIFF
--- a/images/linux/scripts/base/apt.sh
+++ b/images/linux/scripts/base/apt.sh
@@ -25,8 +25,8 @@ echo 'APT sources limited to the actual architectures'
 cat /etc/apt/sources.list
 
 apt-get update
-# Install aria2 , jq
-apt-get install aria2 jq
+# Install jq
+apt-get install jq
 
 # Install apt-fast using quick-install.sh
 # https://github.com/ilikenwf/apt-fast

--- a/images/linux/scripts/tests/Apt.Tests.ps1
+++ b/images/linux/scripts/tests/Apt.Tests.ps1
@@ -14,6 +14,11 @@ Describe "Apt" {
             $toolName = "getfacl"
         }
 
+        if ($toolName -eq "aria2")
+        {
+            $toolName = "aria2c"
+        }
+
         if ($toolName -eq "p7zip-full")
         {
             $toolName = "p7zip"

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -158,6 +158,7 @@
             "zsync"
         ],
         "cmd_packages": [
+            "aria2",
             "binutils",
             "bison",
             "brotli",

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -158,6 +158,7 @@
         ],
         "cmd_packages": [
             "acl",
+            "aria2",
             "binutils",
             "bison",
             "brotli",


### PR DESCRIPTION
# Description
`aria2` is already installed as part of https://github.com/actions/virtual-environments/blob/133db654885e1796cc158ab04f9217826294857a/images/linux/scripts/base/apt.sh#L29
This change will add `aria2` to list of apt packages in generated README the same way `jq` is already done 

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: https://github.com/actions/virtual-environments/issues/970#issuecomment-900410042

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
