### PR TITLE
[macOS] doc: rename kotlin to Kotlin

### DIFF
--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -509,7 +509,7 @@ function Get-BicepVersion {
 
 function Get-KotlinVersion {
     $kotlinVersion = Run-Command "kotlin -version" | Take-Part -Part 2
-    return "kotlin $kotlinVersion"
+    return "Kotlin $kotlinVersion"
 }
 
 function Build-PackageManagementEnvironmentTable {


### PR DESCRIPTION
# Description
We should use the same name style in macOS doc for Kotlin which we use in Windows and Ubuntu docs.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
