### PR TITLE
Update windows-2019 image to use 20348 SDK & WDK

### DIFF
--- a/images/win/scripts/Installers/Install-WDK.ps1
+++ b/images/win/scripts/Installers/Install-WDK.ps1
@@ -6,8 +6,8 @@
 # Requires Windows SDK with the same version number as the WDK
 if (Test-IsWin19)
 {
-    $winSdkUrl = "https://go.microsoft.com/fwlink/p/?linkid=2120843"
-    $wdkUrl = "https://go.microsoft.com/fwlink/?linkid=2128854"
+    $winSdkUrl = "https://go.microsoft.com/fwlink/?linkid=2164145"
+    $wdkUrl = "https://go.microsoft.com/fwlink/?linkid=2164149"
     $FilePath = "C:\Program Files (x86)\Windows Kits\10\Vsix\VS2019\WDK.vsix"
     $VSver = "2019"
 }

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -327,6 +327,7 @@
             "Microsoft.VisualStudio.Component.Windows10SDK.17763",
             "Microsoft.VisualStudio.Component.Windows10SDK.18362",
             "Microsoft.VisualStudio.Component.Windows10SDK.19041",
+            "Microsoft.VisualStudio.Component.Windows10SDK.20348",
             "Microsoft.VisualStudio.Component.WinXP",
             "Microsoft.VisualStudio.Component.Workflow",
             "Microsoft.VisualStudio.ComponentGroup.Azure.CloudServices",

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -173,6 +173,7 @@
             "Microsoft.VisualStudio.Component.VC.v141.MFC",
             "Microsoft.VisualStudio.Component.VC.v141.MFC.Spectre",
             "Microsoft.VisualStudio.Component.Windows10SDK.19041",
+            "Microsoft.VisualStudio.Component.Windows10SDK.20348",
             "Microsoft.VisualStudio.Component.Workflow",
             "Microsoft.VisualStudio.ComponentGroup.Azure.CloudServices",
             "Microsoft.VisualStudio.ComponentGroup.Azure.ResourceManager.Tools",


### PR DESCRIPTION
# Description
Need more recent Windows SDK to compile against new GraphicsCaptureAccess class. Also updated WDK because of the comment that they need to be on the same version.

Verified correct version of SDK, WDK, and WDK VS extension were all installed to a generated VM. My application compiles successfully.

I more or less did the same things as the previous upgrade to 19041: #935

#### Related issue:
Someone opened issue #3641 a couple months ago, and it was closed, but I'm hoping this is fine since the PR is similar to the previous one.

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated