### PR TITLE
[Ubuntu] scripts: move invoke_tests at the bottom

### DIFF
--- a/images/linux/scripts/installers/erlang.sh
+++ b/images/linux/scripts/installers/erlang.sh
@@ -23,7 +23,7 @@ download_with_retries $rebar3DownloadUrl "/tmp"
 mv /tmp/rebar3 /usr/local/bin/rebar3
 chmod +x /usr/local/bin/rebar3
 
-invoke_tests "Tools" "erlang"
-
 # Clean up source list
 rm $source_list
+
+invoke_tests "Tools" "erlang"

--- a/images/linux/scripts/installers/nvm.sh
+++ b/images/linux/scripts/installers/nvm.sh
@@ -12,7 +12,7 @@ echo 'NVM_DIR=$HOME/.nvm' | tee -a /etc/environment
 echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm' | tee -a /etc/skel/.bash_profile
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
+invoke_tests "Tools" "nvm"
+
 # set system node.js as default one
 nvm alias default system
-
-invoke_tests "Tools" "nvm"

--- a/images/linux/scripts/installers/nvm.sh
+++ b/images/linux/scripts/installers/nvm.sh
@@ -12,7 +12,7 @@ echo 'NVM_DIR=$HOME/.nvm' | tee -a /etc/environment
 echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm' | tee -a /etc/skel/.bash_profile
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
-invoke_tests "Tools" "nvm"
-
 # set system node.js as default one
 nvm alias default system
+
+invoke_tests "Tools" "nvm"


### PR DESCRIPTION
# Description
Sometimes bash ignores `set -e` option for subshells commands and will continue to invoke the next script. We should move invoke_tests call to the bottom of a script not to override the last exit code.
https://github.visualstudio.com/virtual-environments/_build/results?buildId=115326&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=5431112d-2b61-5a5f-7042-ef698f761043

Before:
```
==> azure-arm: Exception: /imagegeneration/helpers/Tests.Helpers.psm1:41
==> azure-arm: Line |
==> azure-arm:   41 |          throw "Test run has failed"
==> azure-arm:      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~
==> azure-arm:      | Test run has failed
==> azure-arm: 
==> azure-arm: Provisioning with shell script: C:\agent\_work\6\s\images\linux/scripts/installers/firefox.sh
```

After:
```
==> azure-arm: Exception: /imagegeneration/helpers/Tests.Helpers.psm1:41
==> azure-arm: Line |
==> azure-arm:   41 |          throw "Test run has failed"
==> azure-arm:      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~
==> azure-arm:      | Test run has failed
==> azure-arm: 
==> azure-arm: Provisioning step had errors: Running the cleanup provisioner, if present...
==> azure-arm: 
==> azure-arm: Deleting individual resources ...

```