### PR TITLE
[macOS 11] fix for invalid link to release and software report

### DIFF
--- a/images/macos/provision/configuration/preimagedata.sh
+++ b/images/macos/provision/configuration/preimagedata.sh
@@ -8,6 +8,9 @@ os_name=$(sw_vers -productName)
 os_version=$(sw_vers -productVersion)
 os_build=$(sw_vers -buildVersion)
 label_version=$(echo $os_version | cut -d. -f1,2)
+if is_BigSur; then
+  label_version=$(echo $os_version | cut -d. -f1)
+fi
 image_label="macos-${label_version}"
 release_label="macOS-${label_version}"
 software_url="https://github.com/actions/virtual-environments/blob/${release_label}/${image_version}/images/macos/${image_label}-Readme.md"

--- a/images/macos/provision/configuration/preimagedata.sh
+++ b/images/macos/provision/configuration/preimagedata.sh
@@ -8,8 +8,10 @@ os_name=$(sw_vers -productName)
 os_version=$(sw_vers -productVersion)
 os_build=$(sw_vers -buildVersion)
 label_version=$(echo $os_version | cut -d. -f1,2)
-if is_BigSur; then
-  label_version=$(echo $os_version | cut -d. -f1)
+if is_Less_BigSur; then
+    label_version=$(echo $os_version | cut -d. -f1,2)
+else
+    label_version=$(echo $os_version | cut -d. -f1)
 fi
 image_label="macos-${label_version}"
 release_label="macOS-${label_version}"


### PR DESCRIPTION
# Description
Environment and links contain macos-11.5 term. It is invalid and all links are broken due to that.
The correct environment should be macos-11.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3953

## Check list
- [+] Related issue / work item is attached
- [+] Tests are written (if applicable)
