### PR TITLE
[Windows] win: add validation InstalledSoftware.md and testResults.xml files

### DIFF
--- a/images/win/scripts/ImageHelpers/TestsHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/TestsHelpers.ps1
@@ -53,6 +53,10 @@ function Invoke-PesterTests {
     if ($TestName) {
         $configuration.Filter.FullName = $TestName
     }
+    if ($TestFile -eq "*") {
+        $configuration.TestResult.Enabled = $true
+        $configuration.TestResult.OutputPath = "C:\image\Tests\testResults.xml"
+    }
 
     # Update environment variables without reboot
     Update-Environment

--- a/images/win/scripts/Installers/Install-WindowsUpdates.ps1
+++ b/images/win/scripts/Installers/Install-WindowsUpdates.ps1
@@ -5,4 +5,10 @@
 ################################################################################
 
 Write-Host "Run windows updates"
+# KB5005030 causes Windows Server 2019 virtual machine issues with running tests
+if (Test-IsWin19) {
+    Get-WUInstall -MicrosoftUpdate
+    Write-Host "Hide update KB5005030"
+    Hide-WindowsUpdate -Confirm:$false -KBArticleID "KB5005030"
+}
 Get-WUInstall -MicrosoftUpdate -AcceptAll -Install -IgnoreUserInput -IgnoreReboot

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -271,8 +271,7 @@ function Get-VisualCPPComponents {
 }
 
 function Get-DacFxVersion {
-    cd "C:\Program Files\Microsoft SQL Server\150\DAC\bin\"
-    $dacfxversion = (./sqlpackage.exe /version)
+    $dacfxversion = & "$env:ProgramFiles\Microsoft SQL Server\150\DAC\bin\sqlpackage.exe" /version
     return "DacFx $dacfxversion"
 }
 

--- a/images/win/scripts/SoftwareReport/SoftwareReport.WebServers.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.WebServers.psm1
@@ -13,8 +13,8 @@ function Get-ApacheVersion {
 }
 
 function Get-NginxVersion {
-    $nginxBinPath = Join-Path (Get-NginxPath) "\nginx"
-    (. $nginxBinPath -v 2>&1 | Select-String -Pattern "nginx/") -match "nginx/(?<version>\d+\.\d+\.\d+)" | Out-Null
+    $nginxBinPath = Join-Path (Get-NginxPath) "nginx"
+    (cmd /c "$nginxBinPath -v 2>&1") -match "nginx/(?<version>\d+\.\d+\.\d+)" | Out-Null
     return $Matches.Version
 }
 

--- a/images/win/scripts/Tests/Nginx.Tests.ps1
+++ b/images/win/scripts/Tests/Nginx.Tests.ps1
@@ -1,7 +1,7 @@
 Describe "Nginx" {
     Context "Path" {
         It "Nginx" {
-            $nginxPath = Join-Path (Join-Path "C:\tools\" (Get-Item C:\tools\nginx*).Name) "\nginx"
+            $nginxPath = Join-Path (Join-Path "C:\tools\" (Get-Item C:\tools\nginx*).Name) "nginx"
             "$nginxPath -v" | Should -ReturnZeroExitCode
         }
     }

--- a/images/win/windows2016.json
+++ b/images/win/windows2016.json
@@ -267,7 +267,8 @@
         {
             "type": "powershell",
             "inline": [
-                "pwsh -File '{{user `image_folder`}}\\SoftwareReport\\SoftwareReport.Generator.ps1'"
+                "pwsh -File '{{user `image_folder`}}\\SoftwareReport\\SoftwareReport.Generator.ps1'",
+                "if (-not (Test-Path C:\\InstalledSoftware.md)) { throw 'C:\\InstalledSoftware.md is not found'}"
             ],
             "environment_vars": [
                 "IMAGE_VERSION={{user `image_version`}}"

--- a/images/win/windows2016.json
+++ b/images/win/windows2016.json
@@ -260,8 +260,9 @@
         },
         {
             "type": "powershell",
-            "scripts": [
-                "{{ template_dir }}/scripts/Tests/RunAll-Tests.ps1"
+            "inline": [
+                "& {{ template_dir }}/scripts/Tests/RunAll-Tests.ps1",
+                "if (-not (Test-Path C:\\InstalledSoftware.md)) { throw 'C:\\image\\Tests\\testResults.xml not found'}"
             ]
         },
         {

--- a/images/win/windows2016.json
+++ b/images/win/windows2016.json
@@ -268,7 +268,7 @@
             "type": "powershell",
             "inline": [
                 "pwsh -File '{{user `image_folder`}}\\SoftwareReport\\SoftwareReport.Generator.ps1'",
-                "if (-not (Test-Path C:\\InstalledSoftware.md)) { throw 'C:\\InstalledSoftware.md is not found'}"
+                "if (-not (Test-Path C:\\InstalledSoftware.md)) { throw 'C:\\InstalledSoftware.md not found'}"
             ],
             "environment_vars": [
                 "IMAGE_VERSION={{user `image_version`}}"

--- a/images/win/windows2016.json
+++ b/images/win/windows2016.json
@@ -262,7 +262,7 @@
             "type": "powershell",
             "inline": [
                 "& {{ template_dir }}/scripts/Tests/RunAll-Tests.ps1",
-                "if (-not (Test-Path C:\\InstalledSoftware.md)) { throw 'C:\\image\\Tests\\testResults.xml not found'}"
+                "if (-not (Test-Path C:\\image\\Tests\\testResults.xml)) { throw 'C:\\image\\Tests\\testResults.xml not found'}"
             ]
         },
         {

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -269,7 +269,7 @@
             "type": "powershell",
             "inline": [
                 "pwsh -File '{{user `image_folder`}}\\SoftwareReport\\SoftwareReport.Generator.ps1'",
-                "if (-not (Test-Path C:\\InstalledSoftware.md)) { throw 'C:\\InstalledSoftware.md is not found'}"
+                "if (-not (Test-Path C:\\InstalledSoftware.md)) { throw 'C:\\InstalledSoftware.md not found'}"
             ],
             "environment_vars": [
                 "IMAGE_VERSION={{user `image_version`}}"

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -263,14 +263,14 @@
             "type": "powershell",
             "inline": [
                 "& {{ template_dir }}/scripts/Tests/RunAll-Tests.ps1",
-                "if (-not (Test-Path C:\\InstalledSoftware.md)) { throw 'C:\\image\\Tests\\testResults.xml not found'}"
+                "if (-not (Test-Path C:\\InstalledSoftware.md)) { throw 'C:\\image\\Tests\\testResults.xml not found' }"
             ]
         },
         {
             "type": "powershell",
             "inline": [
                 "pwsh -File '{{user `image_folder`}}\\SoftwareReport\\SoftwareReport.Generator.ps1'",
-                "if (-not (Test-Path C:\\InstalledSoftware.md)) { throw 'C:\\InstalledSoftware.md not found'}"
+                "if (-not (Test-Path C:\\InstalledSoftware.md)) { throw 'C:\\InstalledSoftware.md not found' }"
             ],
             "environment_vars": [
                 "IMAGE_VERSION={{user `image_version`}}"

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -261,8 +261,9 @@
         },
         {
             "type": "powershell",
-            "scripts": [
-                "{{ template_dir }}/scripts/Tests/RunAll-Tests.ps1"
+            "inline": [
+                "& {{ template_dir }}/scripts/Tests/RunAll-Tests.ps1",
+                "if (-not (Test-Path C:\\InstalledSoftware.md)) { throw 'C:\\image\\Tests\\testResults.xml not found'}"
             ]
         },
         {

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -268,7 +268,8 @@
         {
             "type": "powershell",
             "inline": [
-                "pwsh -File '{{user `image_folder`}}\\SoftwareReport\\SoftwareReport.Generator.ps1'"
+                "pwsh -File '{{user `image_folder`}}\\SoftwareReport\\SoftwareReport.Generator.ps1'",
+                "if (-not (Test-Path C:\\InstalledSoftware.md)) { throw 'C:\\InstalledSoftware.md is not found'}"
             ],
             "environment_vars": [
                 "IMAGE_VERSION={{user `image_version`}}"

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -263,7 +263,7 @@
             "type": "powershell",
             "inline": [
                 "& {{ template_dir }}/scripts/Tests/RunAll-Tests.ps1",
-                "if (-not (Test-Path C:\\InstalledSoftware.md)) { throw 'C:\\image\\Tests\\testResults.xml not found' }"
+                "if (-not (Test-Path C:\\image\\Tests\\testResults.xml)) { throw 'C:\\image\\Tests\\testResults.xml not found' }"
             ]
         },
         {

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -246,7 +246,7 @@
             "type": "powershell",
             "inline": [
                 "& {{ template_dir }}/scripts/Tests/RunAll-Tests.ps1",
-                "if (-not (Test-Path C:\\InstalledSoftware.md)) { throw 'C:\\image\\Tests\\testResults.xml not found'}"
+                "if (-not (Test-Path C:\\image\\Tests\\testResults.xml)) { throw 'C:\\image\\Tests\\testResults.xml not found'}"
             ]
         },
         {

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -251,7 +251,8 @@
         {
             "type": "powershell",
             "inline": [
-                "pwsh -File '{{user `image_folder`}}\\SoftwareReport\\SoftwareReport.Generator.ps1'"
+                "pwsh -File '{{user `image_folder`}}\\SoftwareReport\\SoftwareReport.Generator.ps1'",
+                "if (-not (Test-Path C:\\InstalledSoftware.md)) { throw 'C:\\InstalledSoftware.md is not found'}"
             ],
             "environment_vars": [
                 "IMAGE_VERSION={{user `image_version`}}"

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -244,8 +244,9 @@
         },
         {
             "type": "powershell",
-            "scripts": [
-                "{{ template_dir }}/scripts/Tests/RunAll-Tests.ps1"
+            "inline": [
+                "& {{ template_dir }}/scripts/Tests/RunAll-Tests.ps1",
+                "if (-not (Test-Path C:\\InstalledSoftware.md)) { throw 'C:\\image\\Tests\\testResults.xml not found'}"
             ]
         },
         {

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -252,7 +252,7 @@
             "type": "powershell",
             "inline": [
                 "pwsh -File '{{user `image_folder`}}\\SoftwareReport\\SoftwareReport.Generator.ps1'",
-                "if (-not (Test-Path C:\\InstalledSoftware.md)) { throw 'C:\\InstalledSoftware.md is not found'}"
+                "if (-not (Test-Path C:\\InstalledSoftware.md)) { throw 'C:\\InstalledSoftware.md not found'}"
             ],
             "environment_vars": [
                 "IMAGE_VERSION={{user `image_version`}}"


### PR DESCRIPTION
# Description
Currently, if  tests are not passed or InstalledSoftware.md is missing the result status is green:
- Add validation InstalledSoftware.md
- Add validation testResults.xml 
- Exclude KB5005030
- Fix nginx test

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
