### PR TITLE
[Windows2022] fix for missing from GenerateResourceandImages.ps1

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -3,9 +3,10 @@ $ErrorActionPreference = 'Stop'
 enum ImageType {
     Windows2016 = 0
     Windows2019 = 1
-    Ubuntu1604 = 2
-    Ubuntu1804 = 3
-    Ubuntu2004 = 4
+    Windows2022 = 2
+    Ubuntu1604 = 3
+    Ubuntu1804 = 4
+    Ubuntu2004 = 5
 }
 
 Function Get-PackerTemplatePath {
@@ -22,6 +23,9 @@ Function Get-PackerTemplatePath {
         }
         ([ImageType]::Windows2019) {
             $relativeTemplatePath = Join-Path "win" "windows2019.json"
+        }
+        ([ImageType]::Windows2022) {
+            $relativeTemplatePath = Join-Path "win" "windows2022.json"
         }
         ([ImageType]::Ubuntu1604) {
             $relativeTemplatePath = Join-Path "linux" "ubuntu1604.json"


### PR DESCRIPTION
# Description
GenerateResourceandImages.ps1 script does not contain Windows 2022 image type. So, let's include it as well.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3959

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
