### PR TITLE
[macOS 11] Change default Xcode version to 12.5.1

### DIFF
--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -1,6 +1,6 @@
 {
     "xcode": {
-        "default": "12.5",
+        "default": "12.5.1",
         "versions": [
             { "link": "13.0", "version": "13.0.0"},
             { "link": "12.5.1", "version": "12.5.1"},


### PR DESCRIPTION
# Description
It's time to change default Xcode version to 12.5.1

#### Related issue:
--

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
