### PR TITLE
[Windows][Ubuntu] Upgrade Maven version to 3.8.2

### DIFF
--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -73,7 +73,7 @@
         "versions": [
             "8", "11", "12"
         ],
-        "maven": "3.8.1"
+        "maven": "3.8.2"
     },
     "android": {
         "platform_min_version": "23",

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -73,7 +73,7 @@
         "versions": [
             "8", "11", "12"
         ],
-        "maven": "3.8.1"
+        "maven": "3.8.2"
     },
     "android": {
         "platform_min_version": "23",

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -73,7 +73,7 @@
         "versions": [
             "8", "11"
         ],
-        "maven": "3.8.1"
+        "maven": "3.8.2"
     },
     "android": {
         "platform_min_version": "27",

--- a/images/win/scripts/Installers/Install-JavaTools.ps1
+++ b/images/win/scripts/Installers/Install-JavaTools.ps1
@@ -103,7 +103,7 @@ foreach ($jdkVersion in $jdkVersions) {
 # Install Java tools
 # Force chocolatey to ignore dependencies on Ant and Maven or else they will download the Oracle JDK
 Choco-Install -PackageName ant -ArgumentList "-i"
-Choco-Install -PackageName maven -ArgumentList "-i", "--version=3.8.1"
+Choco-Install -PackageName maven -ArgumentList "-i", "--version=3.8.2"
 Choco-Install -PackageName gradle
 
 # Move maven variables to Machine. They may not be in the environment for this script so we need to read them from the registry.


### PR DESCRIPTION
# Description
According to the latest Maven releases, we have Maven 3.8.2 preinstalled on Macos images, but on Ubuntu and Windows 3.8.1. I guess we need to upgrade version to 3.8.2
https://maven.apache.org/docs/history.html

#### Related issue:
https://github.com/actions/virtual-environments/issues/3969

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
