### PR TITLE
[Windows] Remove exact Maven version to install

### DIFF
--- a/images/win/scripts/Installers/Install-JavaTools.ps1
+++ b/images/win/scripts/Installers/Install-JavaTools.ps1
@@ -103,7 +103,7 @@ foreach ($jdkVersion in $jdkVersions) {
 # Install Java tools
 # Force chocolatey to ignore dependencies on Ant and Maven or else they will download the Oracle JDK
 Choco-Install -PackageName ant -ArgumentList "-i"
-Choco-Install -PackageName maven -ArgumentList "-i", "--version=3.8.1"
+Choco-Install -PackageName maven -ArgumentList "-i"
 Choco-Install -PackageName gradle
 
 # Move maven variables to Machine. They may not be in the environment for this script so we need to read them from the registry.


### PR DESCRIPTION
# Description
Currently we install specific version of Maven on Windows images. In scope of this PR we are removing exact Maven version to install in favor to install latest available version.

#### Related issue: [#3969 ](https://github.com/actions/virtual-environments/issues/3969)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
