### PR TITLE
[Ubuntu] homebrew: remove double quotes around env vars

### DIFF
--- a/images/linux/scripts/installers/homebrew.sh
+++ b/images/linux/scripts/installers/homebrew.sh
@@ -15,7 +15,7 @@ brew_shellenv="/home/linuxbrew/.linuxbrew/bin/brew shellenv"
 
 # Update /etc/environment
 ## Put HOMEBREW_* variables.
-$brew_shellenv | grep 'export HOMEBREW' | sed -E 's/^export (.*);$/\1/' | sudo tee -a /etc/environment
+$brew_shellenv | grep 'export HOMEBREW' | sed -E 's/^export (.*);$/\1/' | tr -d '"' | sudo tee -a /etc/environment
 # add brew executables locations to PATH
 brew_path=$($brew_shellenv | grep '^export PATH' | sed -E 's/^export PATH="([^$]+)\$.*/\1/')
 prependEtcEnvironmentPath "$brew_path"


### PR DESCRIPTION
# Description
Remove double quotes around env vars.

Before:
```
HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew"
HOMEBREW_CELLAR="/home/linuxbrew/.linuxbrew/Cellar"
HOMEBREW_REPOSITORY="/home/linuxbrew/.linuxbrew/Homebrew
```
Expected:
```
HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew
HOMEBREW_CELLAR=/home/linuxbrew/.linuxbrew/Cellar
HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew/Homebrew
```

#### Related issue:
https://github.com/actions/virtual-environments/issues/3981

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
