### PR TITLE
[macOS] Activate "Allow Remote Automation" Safari option during image generation

### DIFF
--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -2,12 +2,6 @@
 
 source ~/utils/utils.sh
 
-echo "Enabling safari driver..."
-# https://developer.apple.com/documentation/webkit/testing_with_webdriver_in_safari
-# Safari’s executable is located at /usr/bin/safaridriver
-# Configure Safari to Enable WebDriver Support
-sudo safaridriver --enable
-
 echo "Enabling developer mode..."
 sudo /usr/sbin/DevToolsSecurity --enable
 

--- a/images/macos/provision/core/safari.sh
+++ b/images/macos/provision/core/safari.sh
@@ -1,0 +1,14 @@
+echo "Enabling safari driver..."
+# https://developer.apple.com/documentation/webkit/testing_with_webdriver_in_safari
+# Safari’s executable is located at /usr/bin/safaridriver
+# Configure Safari to Enable WebDriver Support
+sudo safaridriver --enable
+
+echo "Enabling the 'Allow Remote Automation' option in Safari's Develop menu"
+mkdir -p $HOME/Library/WebDriver
+safari_plist="$HOME/Library/WebDriver/com.apple.Safari.plist"
+# "|| true" is needed to suppress exit code 1 in case if property or file doesn't exist 
+/usr/libexec/PlistBuddy -c 'delete AllowRemoteAutomation' $safari_plist || true
+/usr/libexec/PlistBuddy -c 'add AllowRemoteAutomation bool true' $safari_plist
+
+invoke_tests "Browsers" "Safari"

--- a/images/macos/provision/core/safari.sh
+++ b/images/macos/provision/core/safari.sh
@@ -1,3 +1,5 @@
+#!/bin/bash -e -o pipefail
+
 echo "Enabling safari driver..."
 # https://developer.apple.com/documentation/webkit/testing_with_webdriver_in_safari
 # Safari’s executable is located at /usr/bin/safaridriver

--- a/images/macos/templates/macOS-10.13.json
+++ b/images/macos/templates/macOS-10.13.json
@@ -171,6 +171,7 @@
                 "./provision/core/postgresql.sh",
                 "./provision/core/mongodb.sh",
                 "./provision/core/miniconda.sh",
+                "./provision/core/safari.sh",
                 "./provision/core/chrome.sh",
                 "./provision/core/edge.sh",
                 "./provision/core/firefox.sh",

--- a/images/macos/templates/macOS-10.14.json
+++ b/images/macos/templates/macOS-10.14.json
@@ -176,6 +176,7 @@
                 "./provision/core/postgresql.sh",
                 "./provision/core/mongodb.sh",
                 "./provision/core/audiodevice.sh",
+                "./provision/core/safari.sh",
                 "./provision/core/chrome.sh",
                 "./provision/core/edge.sh",
                 "./provision/core/firefox.sh",

--- a/images/macos/templates/macOS-10.15.json
+++ b/images/macos/templates/macOS-10.15.json
@@ -181,6 +181,7 @@
                 "./provision/core/audiodevice.sh",
                 "./provision/core/vcpkg.sh",
                 "./provision/core/miniconda.sh",
+                "./provision/core/safari.sh",
                 "./provision/core/chrome.sh",
                 "./provision/core/edge.sh",
                 "./provision/core/firefox.sh",

--- a/images/macos/templates/macOS-11.json
+++ b/images/macos/templates/macOS-11.json
@@ -185,6 +185,7 @@
                 "./provision/core/audiodevice.sh",
                 "./provision/core/vcpkg.sh",
                 "./provision/core/miniconda.sh",
+                "./provision/core/safari.sh",
                 "./provision/core/chrome.sh",
                 "./provision/core/edge.sh",
                 "./provision/core/firefox.sh",

--- a/images/macos/tests/Browsers.Tests.ps1
+++ b/images/macos/tests/Browsers.Tests.ps1
@@ -32,3 +32,14 @@ Describe "Firefox" {
         "geckodriver --version" | Should -ReturnZeroExitCode
     }
 }
+
+Describe "Safari" {
+    It "'Allow Remote Automation' option is activated" {
+        $plistPath = "$env:HOME/Library/WebDriver/com.apple.Safari.plist"
+        $command = "/usr/libexec/PlistBuddy -c 'print AllowRemoteAutomation' $plistPath"
+        $plistPath | Should -Exist
+        $commandResult = Get-CommandResult $command
+        $commandResult.ExitCode | Should -Be 0
+        $commandResult.Output | Should -Be "true"
+    }
+}


### PR DESCRIPTION
Previously, we had `Allow Remote Automation` option activate on our base image from which we generate images. We would like to move this step to image generation to avoid code debt.

# Description
New tool, Bug fixing, or Improvement?  
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.  
**For new tools, please provide total size and installation time.**

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
