### PR TITLE
[Windows] Change .NET SDK pre-installation policy

### DIFF
--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -28,14 +28,9 @@ function Get-SDKVersionsToInstall (
         $sdks += $release.'sdks'
     }
 
-    $sortedSdkVersions = $sdks.version | Sort-Object { [Version] $_ } -Unique
-
-    if (Test-IsWin22)
-    {
-        return $sortedSdkVersions | Group-Object { $_.Substring(0, $_.LastIndexOf('.') + 2) } | Foreach-Object { $_.Group[-1] }
-    }
-
-    return $sortedSdkVersions
+    return $sdks.version | Sort-Object { [Version] $_ } -Unique `
+                         | Group-Object { $_.Substring(0, $_.LastIndexOf('.') + 2) } `
+                         | Foreach-Object { $_.Group[-1] }
 }
 
 function Invoke-Warmup (


### PR DESCRIPTION
# Description
Currently, we install all available and supported versions of .NET SDK. In scope of this PR, we change this approach in favor of installing the latest patch version for every feature version.

#### Related issue: #3809 

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
