### PR TITLE
[macOS] Change .NET SDK pre-installation policy

### DIFF
--- a/images/macos/provision/core/dotnet.sh
+++ b/images/macos/provision/core/dotnet.sh
@@ -26,14 +26,16 @@ for DOTNET_VERSION in "${DOTNET_VERSIONS[@]}"; do
     # https://rider-support.jetbrains.com/hc/en-us/articles/360004180039
     if is_Less_Catalina; then
         ARGS_LIST+=(
-        $(curl -s "$RELEASE_URL" | \
-        jq -r '.releases[].sdk."version"' | grep -v -E '\-(preview|rc)\d*' | grep -v -E '2.1.[6-9]\d*')
-    )
+            $(curl -s "$RELEASE_URL" | \
+            jq -r '.releases[].sdk."version"' | grep -v -E '\-(preview|rc)\d*' | grep -v -E '2.1.[6-9]\d*' | \
+            sort -r | rev | uniq -s 2 | rev)
+        )
     else
         ARGS_LIST+=(
-        $(curl -s "$RELEASE_URL" | \
-        jq -r '.releases[].sdk."version"' | grep -v -E '\-(preview|rc)\d*')
-    )
+            $(curl -s "$RELEASE_URL" | \
+            jq -r '.releases[].sdk."version"' | grep -v -E '\-(preview|rc)\d*' | \
+            sort -r | rev | uniq -s 2 | rev)
+        )
     fi
 done
 


### PR DESCRIPTION
# Description
Currently, we install all available and supported versions of .NET SDK. In scope of this PR, we change this approach in favor of installing the latest patch version for every feature version.

#### Related issue: #3809 

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
