### PR TITLE
[Windows] postdotnet: delete nuget.conf if exists

### DIFF
--- a/images/win/post-generation/Dotnet.ps1
+++ b/images/win/post-generation/Dotnet.ps1
@@ -8,5 +8,4 @@ if (-not $latestPath.Contains($dotnetPath))
 }
 
 # Recreate the config using the 'dotnet nuget list source command'
-# https://github.com/actions/virtual-environments/issues/3038
 dotnet nuget list source

--- a/images/win/post-generation/Dotnet.ps1
+++ b/images/win/post-generation/Dotnet.ps1
@@ -10,5 +10,9 @@ if (-not $latestPath.Contains($dotnetPath))
 # Delete empty nuget.config file created by choco and recreate the config using the 'dotnet nuget list source command'
 # before choco or powershell’s ancient embedded nuget does to prevent the issue with downloading packages from nuget.org
 # https://github.com/actions/virtual-environments/issues/3038
-Remove-Item $env:APPDATA\NuGet\NuGet.Config -Force
+$nugetPath = "$env:APPDATA\NuGet\NuGet.Config"
+if (Test-Path $nugetPath) 
+{
+    Remove-Item $nugetPath -Force
+}
 dotnet nuget list source

--- a/images/win/post-generation/Dotnet.ps1
+++ b/images/win/post-generation/Dotnet.ps1
@@ -7,12 +7,6 @@ if (-not $latestPath.Contains($dotnetPath))
     [System.Environment]::SetEnvironmentVariable('PATH', $latestPath, [System.EnvironmentVariableTarget]::Machine)
 }
 
-# Delete empty nuget.config file created by choco and recreate the config using the 'dotnet nuget list source command'
-# before choco or powershell’s ancient embedded nuget does to prevent the issue with downloading packages from nuget.org
+# Recreate the config using the 'dotnet nuget list source command'
 # https://github.com/actions/virtual-environments/issues/3038
-$nugetConfigPath = "$env:APPDATA\NuGet\NuGet.Config"
-if (Test-Path $nugetConfigPath) 
-{
-    Remove-Item $nugetConfigPath -Force
-}
 dotnet nuget list source

--- a/images/win/post-generation/Dotnet.ps1
+++ b/images/win/post-generation/Dotnet.ps1
@@ -10,9 +10,9 @@ if (-not $latestPath.Contains($dotnetPath))
 # Delete empty nuget.config file created by choco and recreate the config using the 'dotnet nuget list source command'
 # before choco or powershell’s ancient embedded nuget does to prevent the issue with downloading packages from nuget.org
 # https://github.com/actions/virtual-environments/issues/3038
-$nugetPath = "$env:APPDATA\NuGet\NuGet.Config"
-if (Test-Path $nugetPath) 
+$nugetConfigPath = "$env:APPDATA\NuGet\NuGet.Config"
+if (Test-Path $nugetConfigPath) 
 {
-    Remove-Item $nugetPath -Force
+    Remove-Item $nugetConfigPath -Force
 }
 dotnet nuget list source

--- a/images/win/scripts/Tests/ChocoPackages.Tests.ps1
+++ b/images/win/scripts/Tests/ChocoPackages.Tests.ps1
@@ -44,6 +44,9 @@ Describe "Nuget" {
     It "Nuget" {
        "nuget" | Should -ReturnZeroExitCode
     }
+    It "NuGet.Config not exists" {
+        "$env:APPDATA\NuGet\NuGet.Config" | Should -Not -Exist
+    }
 }
 
 Describe "OpenSSL" {


### PR DESCRIPTION
# Description
Remove NuGet.Config if exists.

https://docs.chocolatey.org/en-us/choco/release-notes
Fix - Prevent creation of empty nuget.config in user appdata folder - see #2233
