### PR TITLE
[Windows] pester: remove Nuget.Config test

### DIFF
--- a/images/win/scripts/Tests/ChocoPackages.Tests.ps1
+++ b/images/win/scripts/Tests/ChocoPackages.Tests.ps1
@@ -44,9 +44,6 @@ Describe "Nuget" {
     It "Nuget" {
        "nuget" | Should -ReturnZeroExitCode
     }
-    It "NuGet.Config not exists" {
-        "$env:APPDATA\NuGet\NuGet.Config" | Should -Not -Exist
-    }
 }
 
 Describe "OpenSSL" {


### PR DESCRIPTION
# Description
Remove validation Nuget.Config test and move to canary.