### PR TITLE
[Windows] edge: skip edge installation for windows-2022

### DIFF
--- a/images/win/scripts/Installers/Install-Edge.ps1
+++ b/images/win/scripts/Installers/Install-Edge.ps1
@@ -3,7 +3,10 @@
 ##  Desc:  Install latest stable version of Microsoft Edge browser
 ################################################################################
 
-Choco-Install -PackageName microsoft-edge
+# Installed by default on Windows Server 2022
+if (-not (Test-IsWin22)) {
+    Choco-Install -PackageName microsoft-edge
+}
 
 # Install Microsoft Edge WebDriver
 Write-Host "Install Edge WebDriver..."
@@ -24,13 +27,6 @@ $EdgeDriverVersionFile = Start-DownloadWithRetry -Url $EdgeDriverVersionUrl -Nam
 Write-Host "Download Microsoft Edge WebDriver..."
 $EdgeDriverLatestVersion = Get-Content -Path $EdgeDriverVersionFile
 $EdgeDriverArchName = "edgedriver_win64.zip"
-# A temporary workaround to install the previous driver version because 85.0.564.60 for win64 doesn't exist
-if ($EdgeDriverLatestVersion -eq "85.0.564.60")
-{
-    $EdgeDriverLatestVersion = "85.0.564.51"
-    Set-Content -Path $EdgeDriverVersionFile -Value $EdgeDriverLatestVersion
-}
-
 $EdgeDriverDownloadUrl = "https://msedgedriver.azureedge.net/${EdgeDriverLatestVersion}/${EdgeDriverArchName}"
 
 $EdgeDriverArchPath = Start-DownloadWithRetry -Url $EdgeDriverDownloadUrl -Name $EdgeDriverArchName


### PR DESCRIPTION
# Description
Edge browser is already pre-installed on Windows Server 2022 that's why msi installation fails with exit code 1603.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2689

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
