### PR TITLE
[macOS] Add Android NDK r23

### DIFF
--- a/images/macos/provision/core/android-toolsets.sh
+++ b/images/macos/provision/core/android-toolsets.sh
@@ -31,7 +31,7 @@ ANDROID_BUILD_TOOL=($(get_toolset_value '.android.build_tools_min_version'))
 ANDROID_EXTRA_LIST=($(get_toolset_value '.android."extra-list"[]'))
 ANDROID_ADDON_LIST=($(get_toolset_value '.android."addon-list"[]'))
 ANDROID_ADDITIONAL_TOOLS=($(get_toolset_value '.android."additional-tools"[]'))
-ANDROID_NDK_MAJOR_VERSIONS=($(get_toolset_value '.android.ndk."versions[]"'))
+ANDROID_NDK_MAJOR_VERSIONS=($(get_toolset_value '.android.ndk."versions"[]'))
 ANDROID_NDK_MAJOR_DEFAULT=($(get_toolset_value '.android.ndk.default'))
 ANDROID_NDK_MAJOR_LATEST=(${ANDROID_NDK_MAJOR_VERSIONS[${#ANDROID_NDK_MAJOR_VERSIONS[@]}-1]})
 # Get the latest command line tools from https://developer.android.com/studio#cmdline-tools

--- a/images/macos/provision/core/android-toolsets.sh
+++ b/images/macos/provision/core/android-toolsets.sh
@@ -31,8 +31,9 @@ ANDROID_BUILD_TOOL=($(get_toolset_value '.android.build_tools_min_version'))
 ANDROID_EXTRA_LIST=($(get_toolset_value '.android."extra-list"[]'))
 ANDROID_ADDON_LIST=($(get_toolset_value '.android."addon-list"[]'))
 ANDROID_ADDITIONAL_TOOLS=($(get_toolset_value '.android."additional-tools"[]'))
-ANDROID_NDK_MAJOR_LTS=($(get_toolset_value '.android.ndk.lts'))
-ANDROID_NDK_MAJOR_LATEST=($(get_toolset_value '.android.ndk.latest'))
+ANDROID_NDK_MAJOR_VERSIONS=($(get_toolset_value '.android.ndk."versions[]"'))
+ANDROID_NDK_MAJOR_DEFAULT=($(get_toolset_value '.android.ndk.default'))
+ANDROID_NDK_MAJOR_LATEST=(${ANDROID_NDK_MAJOR_VERSIONS[${#ANDROID_NDK_MAJOR_VERSIONS[@]}-1]})
 # Get the latest command line tools from https://developer.android.com/studio#cmdline-tools
 ANDROID_OSX_SDK_URL="https://dl.google.com/android/repository/commandlinetools-mac-7302050_latest.zip"
 ANDROID_HOME=$HOME/Library/Android/sdk
@@ -59,13 +60,17 @@ echo "Installing latest tools & platform tools..."
 echo y | $SDKMANAGER "tools" "platform-tools"
 
 echo "Installing latest ndk..."
-ndkLtsLatest=$(get_full_ndk_version  $ANDROID_NDK_MAJOR_LTS)
-ndkLatest=$(get_full_ndk_version  $ANDROID_NDK_MAJOR_LATEST)
-echo y | $SDKMANAGER  "ndk;$ndkLtsLatest" "ndk;$ndkLatest"
+ndkDefault=$(get_full_ndk_version $ANDROID_NDK_MAJOR_DEFAULT)
+ndkLatest=$(get_full_ndk_version $ANDROID_NDK_MAJOR_LATEST)
+for ndk_version in "${ANDROID_NDK_MAJOR_VERSIONS[@]}"
+do
+    ndk_full_version=$(get_full_ndk_version $ndk_version)
+    echo y | $SDKMANAGER "ndk;$ndk_full_version"
+done
 # This changes were added due to incompatibility with android ndk-bundle (ndk;22.0.7026061).
 # Link issue virtual-environments: https://github.com/actions/virtual-environments/issues/2481
 # Link issue xamarin-android: https://github.com/xamarin/xamarin-android/issues/5526
-ln -s $ANDROID_HOME/ndk/$ndkLtsLatest $ANDROID_HOME/ndk-bundle
+ln -s $ANDROID_HOME/ndk/$ndkDefault $ANDROID_HOME/ndk-bundle
 ANDROID_NDK_LATEST_HOME=$ANDROID_HOME/ndk/$ndkLatest
 echo "export ANDROID_NDK_LATEST_HOME=$ANDROID_NDK_LATEST_HOME" >> "${HOME}/.bashrc"
 

--- a/images/macos/provision/core/android-toolsets.sh
+++ b/images/macos/provision/core/android-toolsets.sh
@@ -60,8 +60,6 @@ echo "Installing latest tools & platform tools..."
 echo y | $SDKMANAGER "tools" "platform-tools"
 
 echo "Installing latest ndk..."
-ndkDefault=$(get_full_ndk_version $ANDROID_NDK_MAJOR_DEFAULT)
-ndkLatest=$(get_full_ndk_version $ANDROID_NDK_MAJOR_LATEST)
 for ndk_version in "${ANDROID_NDK_MAJOR_VERSIONS[@]}"
 do
     ndk_full_version=$(get_full_ndk_version $ndk_version)
@@ -70,6 +68,8 @@ done
 # This changes were added due to incompatibility with android ndk-bundle (ndk;22.0.7026061).
 # Link issue virtual-environments: https://github.com/actions/virtual-environments/issues/2481
 # Link issue xamarin-android: https://github.com/xamarin/xamarin-android/issues/5526
+ndkDefault=$(get_full_ndk_version $ANDROID_NDK_MAJOR_DEFAULT)
+ndkLatest=$(get_full_ndk_version $ANDROID_NDK_MAJOR_LATEST)
 ln -s $ANDROID_HOME/ndk/$ndkDefault $ANDROID_HOME/ndk-bundle
 ANDROID_NDK_LATEST_HOME=$ANDROID_HOME/ndk/$ndkLatest
 echo "export ANDROID_NDK_LATEST_HOME=$ANDROID_NDK_LATEST_HOME" >> "${HOME}/.bashrc"

--- a/images/macos/provision/core/android-toolsets.sh
+++ b/images/macos/provision/core/android-toolsets.sh
@@ -26,14 +26,14 @@ function get_full_ndk_version {
 
 components=()
 
-ANDROID_PLATFORM=($(get_toolset_value '.android.platform_min_version'))
-ANDROID_BUILD_TOOL=($(get_toolset_value '.android.build_tools_min_version'))
+ANDROID_PLATFORM=$(get_toolset_value '.android.platform_min_version')
+ANDROID_BUILD_TOOL=$(get_toolset_value '.android.build_tools_min_version')
 ANDROID_EXTRA_LIST=($(get_toolset_value '.android."extra-list"[]'))
 ANDROID_ADDON_LIST=($(get_toolset_value '.android."addon-list"[]'))
 ANDROID_ADDITIONAL_TOOLS=($(get_toolset_value '.android."additional-tools"[]'))
 ANDROID_NDK_MAJOR_VERSIONS=($(get_toolset_value '.android.ndk."versions"[]'))
-ANDROID_NDK_MAJOR_DEFAULT=($(get_toolset_value '.android.ndk.default'))
-ANDROID_NDK_MAJOR_LATEST=(${ANDROID_NDK_MAJOR_VERSIONS[${#ANDROID_NDK_MAJOR_VERSIONS[@]}-1]})
+ANDROID_NDK_MAJOR_DEFAULT=$(get_toolset_value '.android.ndk.default')
+ANDROID_NDK_MAJOR_LATEST=$(get_toolset_value '.android.ndk."versions"[-1]')
 # Get the latest command line tools from https://developer.android.com/studio#cmdline-tools
 ANDROID_OSX_SDK_URL="https://dl.google.com/android/repository/commandlinetools-mac-7302050_latest.zip"
 ANDROID_HOME=$HOME/Library/Android/sdk

--- a/images/macos/software-report/SoftwareReport.Android.psm1
+++ b/images/macos/software-report/SoftwareReport.Android.psm1
@@ -186,9 +186,10 @@ function Get-AndroidNDKVersions {
     $ndkFolderPath = Join-Path (Get-AndroidSDKRoot) "ndk"
     $versions += Get-ChildItem -Path $ndkFolderPath -Name
     $ndkDefaultVersion = Get-ToolsetValue "android.ndk.default"
+    $ndkDefaultFullVersion = Get-ChildItem "$env:ANDROID_HOME/ndk/$ndkDefaultVersion.*" -Name | Select-Object -Last 1
 
     return ($versions | ForEach-Object {
-        $defaultPostfix = ( $_ -eq $ndkDefaultVersion ) ? " (default)" : ""
+        $defaultPostfix = ( $_ -eq $ndkDefaultFullVersion ) ? " (default)" : ""
         $_ + $defaultPostfix
     } | Join-String -Separator "<br>")
 }

--- a/images/macos/software-report/SoftwareReport.Android.psm1
+++ b/images/macos/software-report/SoftwareReport.Android.psm1
@@ -1,4 +1,5 @@
 Import-Module "$PSScriptRoot/../helpers/SoftwareReport.Helpers.psm1" -DisableNameChecking
+Import-Module "$PSScriptRoot/../helpers/Common.Helpers.psm1"
 
 function Split-TableRowByColumns {
     param(
@@ -184,8 +185,12 @@ function Get-AndroidNDKVersions {
 
     $ndkFolderPath = Join-Path (Get-AndroidSDKRoot) "ndk"
     $versions += Get-ChildItem -Path $ndkFolderPath -Name
+    $ndkDefaultVersion = Get-ToolsetValue "android.ndk.default"
 
-    return ($versions -Join "<br>")
+    return ($versions | ForEach-Object {
+        $defaultPostfix = ( $_ -eq $ndkDefaultVersion ) ? " (default)" : ""
+        $_ + $defaultPostfix
+    } | Join-String -Separator "<br>")
 }
 
 function Get-IntelHaxmVersion {

--- a/images/macos/tests/Android.Tests.ps1
+++ b/images/macos/tests/Android.Tests.ps1
@@ -8,10 +8,8 @@ Describe "Android" {
     $androidSdkManagerPackages = Get-AndroidPackages
     [int]$platformMinVersion = Get-ToolsetValue "android.platform_min_version"
     [version]$buildToolsMinVersion = Get-ToolsetValue "android.build_tools_min_version"
-    [string]$ndkLatestVersion = Get-ToolsetValue "android.ndk.latest"
-    [string]$ndkLtsVersion = Get-ToolsetValue "android.ndk.lts"
-    $ndkLatestFullVersion = (Get-ChildItem "$env:ANDROID_HOME/ndk/$ndkLatestVersion.*" | Select-Object -Last 1).Name
-    $ndkLtsFullVersion = (Get-ChildItem "$env:ANDROID_HOME/ndk/$ndkLtsVersion.*" | Select-Object -Last 1).Name
+    [array]$ndkVersions = Get-ToolsetValue "android.ndk.versions"
+    $ndkFullVersions = $ndkVersions | ForEach-Object { (Get-ChildItem "$env:ANDROID_HOME/ndk/${_}.*" | Select-Object -Last 1).Name }
 
     $platformVersionsList = ($androidSdkManagerPackages | Where-Object { "$_".StartsWith("platforms;") }) -replace 'platforms;android-', ''
     $platformNumericList = $platformVersionsList | Where-Object { $_ -match "\d+" } | Where-Object { [int]$_ -ge $platformMinVersion } | Sort-Object -Unique
@@ -28,10 +26,9 @@ Describe "Android" {
         "tools/proguard",
         "ndk-bundle",
         "cmake",
-        "ndk/$ndkLatestFullVersion",
-        "ndk/$ndkLtsFullVersion",
         $platforms,
         $buildTools,
+        $ndkFullVersions | ForEach-Object { "ndk/${_}" },
         (Get-ToolsetValue "android.extra-list" | ForEach-Object { "extras/${_}" }),
         (Get-ToolsetValue "android.addon-list" | ForEach-Object { "add-ons/${_}" }),
         (Get-ToolsetValue "android.additional-tools")

--- a/images/macos/tests/Android.Tests.ps1
+++ b/images/macos/tests/Android.Tests.ps1
@@ -9,7 +9,9 @@ Describe "Android" {
     [int]$platformMinVersion = Get-ToolsetValue "android.platform_min_version"
     [version]$buildToolsMinVersion = Get-ToolsetValue "android.build_tools_min_version"
     [array]$ndkVersions = Get-ToolsetValue "android.ndk.versions"
+    [string]$ndkDefaultVersion = Get-ToolsetValue "android.ndk.default"
     $ndkFullVersions = $ndkVersions | ForEach-Object { Get-ChildItem "$env:ANDROID_HOME/ndk/${_}.*" -Name | Select-Object -Last 1} | ForEach-Object { "ndk/${_}" }
+    $ndkDefaultFullVersion = Get-ChildItem "$env:ANDROID_HOME/ndk/$ndkDefaultVersion.*" -Name | Select-Object -Last 1
 
     $platformVersionsList = ($androidSdkManagerPackages | Where-Object { "$_".StartsWith("platforms;") }) -replace 'platforms;android-', ''
     $platformNumericList = $platformVersionsList | Where-Object { $_ -match "\d+" } | Where-Object { [int]$_ -ge $platformMinVersion } | Sort-Object -Unique
@@ -77,6 +79,12 @@ Describe "Android" {
         It "<PackageName>" -TestCases $testCases {
             param ([string] $PackageName)
             Validate-AndroidPackage $PackageName
+        }
+
+        It "ndk-bundle points to the default NDK version" {
+            $ndkLinkTarget = (Get-Item $env:ANDROID_NDK_HOME).Target
+            $ndkVersion = Split-Path -Path $ndkLinkTarget -Leaf
+            $ndkVersion | Should -BeExactly $ndkDefaultFullVersion
         }
     }
 

--- a/images/macos/tests/Android.Tests.ps1
+++ b/images/macos/tests/Android.Tests.ps1
@@ -9,7 +9,7 @@ Describe "Android" {
     [int]$platformMinVersion = Get-ToolsetValue "android.platform_min_version"
     [version]$buildToolsMinVersion = Get-ToolsetValue "android.build_tools_min_version"
     [array]$ndkVersions = Get-ToolsetValue "android.ndk.versions"
-    $ndkFullVersions = $ndkVersions | ForEach-Object { (Get-ChildItem "$env:ANDROID_HOME/ndk/${_}.*" | Select-Object -Last 1).Name }
+    $ndkFullVersions = $ndkVersions | ForEach-Object { Get-ChildItem "$env:ANDROID_HOME/ndk/${_}.*" -Name | Select-Object -Last 1} | ForEach-Object { "ndk/${_}" }
 
     $platformVersionsList = ($androidSdkManagerPackages | Where-Object { "$_".StartsWith("platforms;") }) -replace 'platforms;android-', ''
     $platformNumericList = $platformVersionsList | Where-Object { $_ -match "\d+" } | Where-Object { [int]$_ -ge $platformMinVersion } | Sort-Object -Unique
@@ -28,7 +28,7 @@ Describe "Android" {
         "cmake",
         $platforms,
         $buildTools,
-        ($ndkFullVersions | ForEach-Object { "ndk/${_}" }),
+        $ndkFullVersions,
         (Get-ToolsetValue "android.extra-list" | ForEach-Object { "extras/${_}" }),
         (Get-ToolsetValue "android.addon-list" | ForEach-Object { "add-ons/${_}" }),
         (Get-ToolsetValue "android.additional-tools")

--- a/images/macos/tests/Android.Tests.ps1
+++ b/images/macos/tests/Android.Tests.ps1
@@ -75,16 +75,17 @@ Describe "Android" {
 
     Context "Packages" {
         $testCases = $androidPackages | ForEach-Object { @{ PackageName = $_ } }
+        $defaultNdkTestCase = @{ NdkDefaultFullVersion = $ndkDefaultFullVersion }
 
         It "<PackageName>" -TestCases $testCases {
             param ([string] $PackageName)
             Validate-AndroidPackage $PackageName
         }
 
-        It "ndk-bundle points to the default NDK version" {
+        It "ndk-bundle points to the default NDK version" -TestCases $defaultNdkTestCase {
             $ndkLinkTarget = (Get-Item $env:ANDROID_NDK_HOME).Target
             $ndkVersion = Split-Path -Path $ndkLinkTarget -Leaf
-            $ndkVersion | Should -BeExactly $ndkDefaultFullVersion
+            $ndkVersion | Should -BeExactly $NdkDefaultFullVersion
         }
     }
 

--- a/images/macos/tests/Android.Tests.ps1
+++ b/images/macos/tests/Android.Tests.ps1
@@ -28,7 +28,7 @@ Describe "Android" {
         "cmake",
         $platforms,
         $buildTools,
-        $ndkFullVersions | ForEach-Object { "ndk/${_}" },
+        ($ndkFullVersions | ForEach-Object { "ndk/${_}" }),
         (Get-ToolsetValue "android.extra-list" | ForEach-Object { "extras/${_}" }),
         (Get-ToolsetValue "android.addon-list" | ForEach-Object { "add-ons/${_}" }),
         (Get-ToolsetValue "android.additional-tools")

--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -215,8 +215,10 @@
             "cmake;3.18.1"
         ],
         "ndk": {
-            "lts": "21",
-            "latest": "22"
+            "default": "21",
+            "versions": [
+                "21", "22", "23"
+            ]
         }
     },
     "powershellModules": [

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -167,8 +167,10 @@
             "cmake;3.18.1"
         ],
         "ndk": {
-            "lts": "21",
-            "latest": "22"
+            "default": "21",
+            "versions": [
+                "21", "22", "23"
+            ]
         }
     },
     "powershellModules": [

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -115,8 +115,10 @@
             "cmake;3.18.1"
         ],
         "ndk": {
-            "lts": "21",
-            "latest": "22"
+            "default": "21",
+            "versions": [
+                "21", "22", "23"
+            ]
         }
     },
     "powershellModules": [


### PR DESCRIPTION
# Description
In scope of this PR we have added Android NDK r23 to macOS images and leave the current LTS version (r21) as default.
Also, we've reworked the `android.ndk` toolset section:
- The `android.ndk.versions` field  is a manually sorted list of all versions that will be installed on the image
- The `android.ndk.lts` field has been renamed to `android.ndk.default`. It will allow us, if necessary, to set a non-LTS NDK version as default.
- The `android.ndk.latest` field has been removed and its value will be taken from the end of `android.ndk.versions` list



#### Related issue: [Update/Add Android NDK r23 LTS #3894](https://github.com/actions/virtual-environments/issues/3894)
## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated: [macOS 10.14](https://github.visualstudio.com/virtual-environments/_build/results?buildId=116323&view=results), [macOS 10.15](https://github.visualstudio.com/virtual-environments/_build/results?buildId=116324&view=results), [macOS 11](https://github.visualstudio.com/virtual-environments/_build/results?buildId=116322&view=results)
