### PR TITLE
[Windows] winpacker: add extra reboot step

### DIFF
--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -130,6 +130,10 @@
             "execution_policy": "unrestricted"
         },
         {
+            "type": "windows-restart",
+            "restart_timeout": "30m"
+        },
+        {
             "type": "powershell",
             "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1"


### PR DESCRIPTION
# Description
Add extra reboot command before running the `Install-WindowsUpdates.ps1` script.

#### Related issue:
https://github.com/actions/virtual-environments/issues/4026

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
