### PR TITLE
[Windows] doc: add wsl info section for win22

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -21,7 +21,7 @@ $markdown += New-MDList -Style Unordered -Lines @(
     "Image Version: $env:IMAGE_VERSION"
 )
 
-if (Test-IsWin19)
+if ((Test-IsWin19) -or (Test-IsWin22))
 {
     $markdown += New-MDHeader "Enabled windows optional features" -Level 2
     $markdown += New-MDList -Style Unordered -Lines @(


### PR DESCRIPTION
# Description
We should include WSLv1 section in Windows Server 2022 doc file.