### PR TITLE
Install ghcup on windows

### DIFF
--- a/images/win/scripts/Installers/Install-Haskell.ps1
+++ b/images/win/scripts/Installers/Install-Haskell.ps1
@@ -33,3 +33,7 @@ Write-Host 'Installing cabal...'
 Choco-Install -PackageName cabal
 
 Invoke-PesterTests -TestFile 'Haskell'
+
+# install minimal ghcup, utilizing pre-installed msys2 at C:\msys64
+$bootstrapHaskell = Invoke-WebRequest https://www.haskell.org/ghcup/sh/bootstrap-haskell.ps1 -UseBasicParsing
+Invoke-Command -ScriptBlock ([ScriptBlock]::Create($bootstrapHaskell)) -ArgumentList $false, $true, $true, $false, $false, $false, $false, C:\, "", C:\msys64, C:\cabal


### PR DESCRIPTION
See https://github.com/actions/virtual-environments/pull/4016 for discussion and reasoning.

This just adds ghcup the binary to the installation. It still uses chocolatey for installation. I leave it open for discussion whether chocolatey or ghcup should be used. However, there have been some reports of chocolatey issues: https://github.com/haskell/actions/issues/70#issuecomment-913100373

I can't comment on the nature of them. I believe chocolatey is quite robust. It lacks a little bit behind in adding new GHC versions, but not significantly.

The main (or maybe only) difference between ghcup and chocolatey is the shimgen wrapper they use for emulating symlinks to `ghc.exe`:

1. Chocolatey uses a proprietary shimgen: https://github.com/chocolatey/shimgen#why-is-shimgen-closed-source
2. ghcup uses an open source shimgen: https://github.com/71/scoop-better-shimexe

Which one of those makes less problems, I don't know.