### PR TITLE
[macOS] Move global npm packages to toolsets

### DIFF
--- a/images/macos/provision/core/node.sh
+++ b/images/macos/provision/core/node.sh
@@ -1,11 +1,6 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
 
-node_modules=(
-  appcenter-cli
-  newman
-)
-
 if is_Less_Catalina; then
   echo Installing the latest Node JS 8...
   TMP_FILE=/tmp/node-v8.17.0.pkg
@@ -14,33 +9,19 @@ if is_Less_Catalina; then
   sudo installer -pkg "${TMP_FILE}" -target /
   rm -rf "${TMP_FILE}"
   sudo chown -R $USER "/usr/local/lib/node_modules"
-
-  echo Installing NPM 3.x.x...
-  npm install -g npm@3
-
-  # This step is required to install App Center CLI
-  echo Installing Omelette...
-  npm install -g omelette@0.4.14
-
-  echo Installing App Center CLI...
-  npm install -g appcenter-cli@^1.0.0
 else
   # Install Node.js 14 for macOS >= 10.15
   brew_smart_install "node@14"
   brew link node@14 --force
-
-  for module in ${node_modules[@]}; do
-    echo "Install $module"
-    npm install -g $module
-  done
 fi
 
 echo Installing yarn...
 curl -o- -L https://yarnpkg.com/install.sh | bash
 
-if is_Less_BigSur; then
-  echo "Install node-gyp"
-  npm install -g node-gyp
-fi
+npm_global_packages=$(get_toolset_value '.npm.global_packages[].name')
+for module in ${npm_global_packages[@]}; do
+  echo "Install $module"
+  npm install -g $module
+done
 
 invoke_tests "Node" "Node.js"

--- a/images/macos/tests/Node.Tests.ps1
+++ b/images/macos/tests/Node.Tests.ps1
@@ -51,14 +51,12 @@ Describe "nvm" {
     }
 }
 
-Describe "AppCenterCLI" {
-    It "App Center CLI" {
-        "appcenter --version" | Should -ReturnZeroExitCode
+Describe "Global NPM Packages" {
+    $globalNpmPackages = Get-ToolsetValue "npm.global_packages"
+    $globalNpmPackagesWithTests = $globalNpmPackages | Where-Object { $_.test } | ForEach-Object { @{ Name = $_.name; Test = $_.test } }
+
+    It "<Name>" -TestCases $globalNpmPackagesWithTests {
+        $Test | Should -ReturnZeroExitCode
     }
 }
 
-Describe "Newman" -Skip:($os.IsHighSierra -or $os.IsMojave) {
-    It "Newman" {
-        "newman --version" | Should -ReturnZeroExitCode
-    }
-}

--- a/images/macos/toolsets/toolset-10.13.json
+++ b/images/macos/toolsets/toolset-10.13.json
@@ -209,6 +209,14 @@
         {"name": "Pester"},
         {"name": "PSScriptAnalyzer"}
     ],
+    "npm": {
+        "global_packages": [
+            { "name": "npm@3" },
+            { "name": "omelette@0.4.14" },
+            { "name": "appcenter-cli@^1.0.0", "test": "appcenter --version" },
+            { "name": "node-gyp" }
+        ]
+    },
     "brew": {
         "common_packages": [
             "aliyun-cli",

--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -230,6 +230,14 @@
         {"name": "Pester"},
         {"name": "PSScriptAnalyzer"}
     ],
+    "npm": {
+        "global_packages": [
+            { "name": "npm@3" },
+            { "name": "omelette@0.4.14" },
+            { "name": "appcenter-cli@^1.0.0", "test": "appcenter --version" },
+            { "name": "node-gyp" }
+        ]
+    },
     "brew": {
         "common_packages": [
             "aliyun-cli",

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -182,6 +182,13 @@
         {"name": "Pester"},
         {"name": "PSScriptAnalyzer"}
     ],
+    "npm": {
+        "global_packages": [
+            { "name": "appcenter-cli", "test": "appcenter --version" },
+            { "name": "newman", "test": "newman --version" },
+            { "name": "node-gyp" }
+        ]
+    },
     "brew": {
         "common_packages": [
             "aliyun-cli",

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -130,6 +130,12 @@
         {"name": "Pester"},
         {"name": "PSScriptAnalyzer"}
     ],
+    "npm": {
+        "global_packages": [
+            { "name": "appcenter-cli", "test": "appcenter --version" },
+            { "name": "newman", "test": "newman --version" }
+        ]
+    },
     "brew": {
         "common_packages": [
             "aliyun-cli",


### PR DESCRIPTION
# Description
Currently we install global `npm` modules in `node.sh`. In scope of this pull request we move global `npm` packages to the toolset.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
