### PR TITLE
[MacOS] fix python installation order

### DIFF
--- a/images/macos/provision/core/powershell.sh
+++ b/images/macos/provision/core/powershell.sh
@@ -1,14 +1,8 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
 
-echo Installing Azure CLI...
-brew_smart_install "azure-cli"
-
 echo Installing PowerShell...
 brew install --cask powershell
-
-# A dummy call of `az` to initialize ~/.azure directory before the modules are installed
-az -v
 
 # Install PowerShell modules
 psModules=$(get_toolset_value '.powershellModules[].name')
@@ -30,8 +24,5 @@ pwsh -command "& {Import-Module Az}"
 
 # powershell link was removed in powershell-6.0.0-beta9
 sudo ln -s /usr/local/bin/pwsh /usr/local/bin/powershell
-
-# fix ~/.azure directory permissions
-sudo chown -R ${USER}: $HOME/.azure
 
 invoke_tests "Powershell"

--- a/images/macos/tests/BasicTools.Tests.ps1
+++ b/images/macos/tests/BasicTools.Tests.ps1
@@ -1,5 +1,11 @@
 $os = Get-OSVersion
 
+Describe "Azure CLI" {
+    It "Azure CLI" {
+        "az -v" | Should -ReturnZeroExitCode
+    }
+}
+
 Describe "Carthage" {
     It "Carthage" {
         "carthage version" | Should -ReturnZeroExitCode

--- a/images/macos/tests/Powershell.Tests.ps1
+++ b/images/macos/tests/Powershell.Tests.ps1
@@ -40,10 +40,4 @@ Describe "Powershell" {
             }
         }
     }
-    
-    Context "Azure CLI" {
-        It "Azure CLI" {
-            "az -v" | Should -ReturnZeroExitCode
-        }
-    }
 }

--- a/images/macos/tests/Python.Tests.ps1
+++ b/images/macos/tests/Python.Tests.ps1
@@ -41,4 +41,9 @@ Describe "Python" {
         $python3Path = Split-Path (readlink (which python3))
         $pip3Path | Should -BeExactly $python3Path
     }
+
+    It "2to3 symlink does not point to Python 2" {
+        $2to3path = (Get-ChildItem (Get-Command 2to3).Path).Target
+        $2to3path | Should -Not -BeLike '/Frameworks/Python.framework/Versions/2.*'
+    }
 }

--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -235,6 +235,7 @@
             "aliyun-cli",
             "ant",
             "aria2",
+            "azure-cli",
             "bats",
             "bazelisk",
             "carthage",

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -187,6 +187,7 @@
             "aliyun-cli",
             "ant",
             "aria2",
+            "azure-cli",
             "bats",
             "bazelisk",
             "carthage",

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -135,6 +135,7 @@
             "aliyun-cli",
             "ant",
             "aria2",
+            "azure-cli",
             "bazelisk",
             "carthage",
             "cmake",


### PR DESCRIPTION
# Description

The `azure-cli` package pulls python3.9 as a dependency from within the `powershell.sh` installer, which is being called before the actual python installer.  In our `python.sh` script we are installing both python2 from the upstream `.pkg` file and python3 from brew. python2 installation overrides the previously created `/usr/local/bin/2to3` symlink to its own internal path -`/Library/Frameworks/Python.framework/Versions/2.7/bin/2to3`, in the meantime python3 installation attempt is being ignored (as well as the `brew link --overwrite python@3.` call) as it had already been installed by azure cli. To prevent this azure-cli installation has been moved from `powershell.sh` to `commonutils.sh` to fix the installation order.

Apart from that:

- A test has been written to make sure that `2to3` symlink points to the correct place
- `az -v` and the `~/.azure` directory owner fix have been removed (it was figured that they are not needed anymore)

Interesting side effect:

 - Whenever you call `az -v` and then `pwsh -command "& {Import-Module Az}"` the `~/.azure` directory will be created and files created after `Import-Module Az` will be placed there as well
 
This works both ways:

- Whenever you call `pwsh -command "& {Import-Module Az}"` the `~/.Azure` directory will be created and files created after `az -v` call will be placed there.

#### Related issue: https://github.com/actions/virtual-environments/issues/4020

## Check list
- [X] Related issue / work item is attached
- [X] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [X] Changes are tested and related VM images are successfully generated
