### PR TITLE
Add LLVM via choco

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -94,6 +94,11 @@ function Get-JuliaVersion {
     return "Julia $juliaVersion"
 }
 
+function Get-LLVMVersion {
+    $llvmVersion = [regex]::matches($(clang --version), "\d+\.\d+\.\d+").Value
+    return "LLVM $llvmVersion"
+}
+
 function Get-PerlVersion {
     ($(perl --version) | Out-String) -match "\(v(?<version>\d+\.\d+\.\d+)\)" | Out-Null
     $perlVersion = $Matches.Version

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -35,6 +35,7 @@ $languageTools = @(
     (Get-BashVersion),
     (Get-GoVersion),
     (Get-JuliaVersion),
+    (Get-LLVMVersion),
     (Get-NodeVersion),
     (Get-PHPVersion),
     (Get-PythonVersion),

--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -81,6 +81,15 @@ Describe "KubernetesTools" {
     }
 }
 
+Describe "LLVM" {
+    It "<ToolName>" -TestCases @(
+        @{ ToolName = "clang" }
+        @{ ToolName = "clang++" }
+    ) {
+        "$ToolName --version" | Should -ReturnZeroExitCode
+    }
+}
+
 Describe "Mingw64" {
     It "<ToolName>" -TestCases @(
         @{ ToolName = "gcc" }

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -390,6 +390,7 @@
             { "name": "gitversion.portable" },
             { "name": "innosetup" },
             { "name": "jq" },
+            { "name": "llvm" },
             { "name": "NuGet.CommandLine" },
             {
                 "name": "openssl.light",

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -420,6 +420,7 @@
             { "name": "gitversion.portable" },
             { "name": "innosetup" },
             { "name": "jq" },
+            { "name": "llvm" },
             { "name": "NuGet.CommandLine" },
             {
                 "name": "openssl.light",

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -245,6 +245,7 @@
             { "name": "azcopy10" },
             { "name": "Bicep" },
             { "name": "jq" },
+            { "name": "llvm" },
             { "name": "NuGet.CommandLine" },
             {
                 "name": "openssl.light",


### PR DESCRIPTION
# Description

This adds Clang, LLD, compiler-rt, various LLVM tools

Install time is ~ 3.5 minutes

I've manually tested windows 2016/2019 and 2022 images generated. 

#### Related issue:

https://github.com/actions/virtual-environments/issues/2530

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated