### PR TITLE
Revert "[Ubuntu] Install cargo-audit 0.14.1 as 0.15.0 is broken"

### DIFF
--- a/images/linux/scripts/installers/rust.sh
+++ b/images/linux/scripts/installers/rust.sh
@@ -17,9 +17,7 @@ source $CARGO_HOME/env
 
 # Install common tools
 rustup component add rustfmt clippy
-cargo install --locked bindgen cbindgen cargo-outdated
-# Temporary hardcode cargo-audit 0.14.1 as 0.15.0 is broken https://docs.rs/crate/cargo-audit/0.15.0
-cargo install cargo-audit --version 0.14.1
+cargo install --locked bindgen cbindgen cargo-audit cargo-outdated
 
 # Permissions
 chmod -R 777 $(dirname $RUSTUP_HOME)


### PR DESCRIPTION
The issue has been fixed - https://github.com/rustsec/rustsec/issues/429
https://docs.rs/crate/cargo-audit/0.15.2 - the last successful build
