### PR TITLE
[Ubuntu] Add android NDK r23

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -156,7 +156,13 @@ function Get-AndroidGoogleAPIsVersions {
 function Get-AndroidNDKVersions {
     $ndkFolderPath = Join-Path (Get-AndroidSDKRoot) "ndk"
     $versions = Get-ChildItem -Path $ndkFolderPath -Name
-    return ($versions -Join "<br>")
+    $ndkDefaultVersion = Get-ToolsetValue "android.ndk.default"
+    $ndkDefaultFullVersion = Get-ChildItem "$env:ANDROID_HOME/ndk/$ndkDefaultVersion.*" -Name | Select-Object -Last 1
+
+    return ($versions | ForEach-Object {
+        $defaultPostfix = ( $_ -eq $ndkDefaultFullVersion ) ? " (default)" : ""
+        $_ + $defaultPostfix
+    } | Join-String -Separator "<br>")
 }
 
 function Build-AndroidEnvironmentTable {

--- a/images/linux/scripts/installers/android.sh
+++ b/images/linux/scripts/installers/android.sh
@@ -72,22 +72,25 @@ minimumPlatformVersion=$(get_toolset_value '.android.platform_min_version')
 extras=$(get_toolset_value '.android.extra_list[]|"extras;" + .')
 addons=$(get_toolset_value '.android.addon_list[]|"add-ons;" + .')
 additional=$(get_toolset_value '.android.additional_tools[]')
-ANDROID_NDK_MAJOR_LTS=($(get_toolset_value '.android.ndk.lts'))
-ndkLTSFullVersion=$(get_full_ndk_version $ANDROID_NDK_MAJOR_LTS)
+ANDROID_NDK_MAJOR_VERSIONS=($(get_toolset_value '.android.ndk."versions[]"'))
+ANDROID_NDK_MAJOR_DEFAULT=($(get_toolset_value '.android.ndk.default'))
+ndkDefaultFullVersion=$(get_full_ndk_version $ANDROID_NDK_MAJOR_DEFAULT)
 
-components=("${extras[@]}" "${addons[@]}" "${additional[@]}" "ndk;$ndkLTSFullVersion")
-if isUbuntu20; then
-    ANDROID_NDK_MAJOR_LATEST=($(get_toolset_value '.android.ndk.latest'))
-    ndkLatestFullVersion=$(get_full_ndk_version $ANDROID_NDK_MAJOR_LATEST)
-    components+=("ndk;$ndkLatestFullVersion")
-fi
+components=("${extras[@]}" "${addons[@]}" "${additional[@]}")
+for ndk_version in "${ANDROID_NDK_MAJOR_VERSIONS[@]}"
+do
+    ndk_full_version=$(get_full_ndk_version $ndk_version)
+    components+=("ndk;$ndk_full_version")
+done
 
 # This changes were added due to incompatibility with android ndk-bundle (ndk;22.0.7026061).
 # Link issue virtual-environments: https://github.com/actions/virtual-environments/issues/2481
 # Link issue xamarin-android: https://github.com/xamarin/xamarin-android/issues/5526
-ln -s $ANDROID_SDK_ROOT/ndk/$ndkLTSFullVersion $ANDROID_NDK_ROOT
+ln -s $ANDROID_SDK_ROOT/ndk/$ndkDefaultFullVersion $ANDROID_NDK_ROOT
 
 if isUbuntu20; then
+    ANDROID_NDK_MAJOR_LATEST=(${ANDROID_NDK_MAJOR_VERSIONS[-1]})
+    ndkLatest=$(get_full_ndk_version $ANDROID_NDK_MAJOR_LATEST)
     echo "ANDROID_NDK_LATEST_HOME=$ANDROID_SDK_ROOT/ndk/$ndkLatestFullVersion" | tee -a /etc/environment
 fi
 

--- a/images/linux/scripts/installers/android.sh
+++ b/images/linux/scripts/installers/android.sh
@@ -73,7 +73,7 @@ extras=$(get_toolset_value '.android.extra_list[]|"extras;" + .')
 addons=$(get_toolset_value '.android.addon_list[]|"add-ons;" + .')
 additional=$(get_toolset_value '.android.additional_tools[]')
 ANDROID_NDK_MAJOR_VERSIONS=($(get_toolset_value '.android.ndk.versions[]'))
-ANDROID_NDK_MAJOR_DEFAULT=($(get_toolset_value '.android.ndk.default'))
+ANDROID_NDK_MAJOR_DEFAULT=$(get_toolset_value '.android.ndk.default')
 ndkDefaultFullVersion=$(get_full_ndk_version $ANDROID_NDK_MAJOR_DEFAULT)
 
 components=("${extras[@]}" "${addons[@]}" "${additional[@]}")

--- a/images/linux/scripts/installers/android.sh
+++ b/images/linux/scripts/installers/android.sh
@@ -90,7 +90,7 @@ ln -s $ANDROID_SDK_ROOT/ndk/$ndkDefaultFullVersion $ANDROID_NDK_ROOT
 
 if isUbuntu20; then
     ANDROID_NDK_MAJOR_LATEST=(${ANDROID_NDK_MAJOR_VERSIONS[-1]})
-    ndkLatest=$(get_full_ndk_version $ANDROID_NDK_MAJOR_LATEST)
+    ndkLatestFullVersion=$(get_full_ndk_version $ANDROID_NDK_MAJOR_LATEST)
     echo "ANDROID_NDK_LATEST_HOME=$ANDROID_SDK_ROOT/ndk/$ndkLatestFullVersion" | tee -a /etc/environment
 fi
 

--- a/images/linux/scripts/installers/android.sh
+++ b/images/linux/scripts/installers/android.sh
@@ -72,7 +72,7 @@ minimumPlatformVersion=$(get_toolset_value '.android.platform_min_version')
 extras=$(get_toolset_value '.android.extra_list[]|"extras;" + .')
 addons=$(get_toolset_value '.android.addon_list[]|"add-ons;" + .')
 additional=$(get_toolset_value '.android.additional_tools[]')
-ANDROID_NDK_MAJOR_VERSIONS=($(get_toolset_value '.android.ndk."versions[]"'))
+ANDROID_NDK_MAJOR_VERSIONS=($(get_toolset_value '.android.ndk.versions[]'))
 ANDROID_NDK_MAJOR_DEFAULT=($(get_toolset_value '.android.ndk.default'))
 ndkDefaultFullVersion=$(get_full_ndk_version $ANDROID_NDK_MAJOR_DEFAULT)
 

--- a/images/linux/scripts/tests/Android.Tests.ps1
+++ b/images/linux/scripts/tests/Android.Tests.ps1
@@ -20,7 +20,7 @@ Describe "Android" {
         (Get-ToolsetValue "android.extra_list" | ForEach-Object { "extras/${_}" }),
         (Get-ToolsetValue "android.addon_list" | ForEach-Object { "add-ons/${_}" }),
         (Get-ToolsetValue "android.additional_tools" | ForEach-Object { "${_}" }),
-        $ndkFullVersions | ForEach-Object { "ndk/${_}" }
+        ($ndkFullVersions | ForEach-Object { "ndk/${_}" })
     )
 
     [string]$ndkLatestVersion = Get-ToolsetValue "android.ndk.latest"

--- a/images/linux/scripts/tests/Android.Tests.ps1
+++ b/images/linux/scripts/tests/Android.Tests.ps1
@@ -25,12 +25,6 @@ Describe "Android" {
         (Get-ToolsetValue "android.additional_tools" | ForEach-Object { "${_}" })
     )
 
-    [string]$ndkLatestVersion = Get-ToolsetValue "android.ndk.latest"
-    if ($ndkLatestVersion) {
-        $ndkLatestFullVersion = (Get-ChildItem "/usr/local/lib/android/sdk/ndk/$ndkLatestVersion.*" | Select-Object -Last 1).Name
-        $androidPackages += @("ndk/$ndkLatestFullVersion")
-    }
-
     $androidPackages = $androidPackages | ForEach-Object { $_ }
 
     BeforeAll {

--- a/images/linux/scripts/tests/Android.Tests.ps1
+++ b/images/linux/scripts/tests/Android.Tests.ps1
@@ -5,7 +5,7 @@ Describe "Android" {
     [string]$ndkDefaultVersion = Get-ToolsetValue "android.ndk.default"
     [array]$ndkVersions = Get-ToolsetValue "android.ndk.versions"
     $ndkDefaultFullVersion = Get-ChildItem "$env:ANDROID_HOME/ndk/$ndkDefaultVersion.*" -Name | Select-Object -Last 1
-    $ndkFullVersions = $ndkVersions | ForEach-Object { (Get-ChildItem "/usr/local/lib/android/sdk/ndk/${_}.*" | Select-Object -Last 1).Name }
+    $ndkFullVersions = $ndkVersions | ForEach-Object { (Get-ChildItem "/usr/local/lib/android/sdk/ndk/${_}.*" | Select-Object -Last 1).Name } | ForEach-Object { "ndk/${_}" }
 
     $platformVersionsList = ($androidSdkManagerPackages | Where-Object { "$_".StartsWith("platforms;") }) -replace 'platforms;android-', ''
     $platformNumericList = $platformVersionsList | Where-Object { $_ -match "\d+" } | Where-Object { [int]$_ -ge $platformMinVersion } | Sort-Object -Unique

--- a/images/linux/scripts/tests/Android.Tests.ps1
+++ b/images/linux/scripts/tests/Android.Tests.ps1
@@ -2,8 +2,8 @@ Describe "Android" {
     $androidSdkManagerPackages = Get-AndroidPackages
     [int]$platformMinVersion = Get-ToolsetValue "android.platform_min_version"
     [version]$buildToolsMinVersion = Get-ToolsetValue "android.build_tools_min_version"
-    [string]$ndkLTSVersion = Get-ToolsetValue "android.ndk.lts"
-    $ndkLTSFullVersion = (Get-ChildItem "/usr/local/lib/android/sdk/ndk/$ndkLTSVersion.*" | Select-Object -Last 1).Name
+    [array]$ndkVersions = Get-ToolsetValue "android.ndk.versions"
+    $ndkFullVersions = $ndkVersions | ForEach-Object { (Get-ChildItem "/usr/local/lib/android/sdk/ndk/${_}.*" | Select-Object -Last 1).Name }
 
     $platformVersionsList = ($androidSdkManagerPackages | Where-Object { "$_".StartsWith("platforms;") }) -replace 'platforms;android-', ''
     $platformNumericList = $platformVersionsList | Where-Object { $_ -match "\d+" } | Where-Object { [int]$_ -ge $platformMinVersion } | Sort-Object -Unique
@@ -20,7 +20,7 @@ Describe "Android" {
         (Get-ToolsetValue "android.extra_list" | ForEach-Object { "extras/${_}" }),
         (Get-ToolsetValue "android.addon_list" | ForEach-Object { "add-ons/${_}" }),
         (Get-ToolsetValue "android.additional_tools" | ForEach-Object { "${_}" }),
-        "ndk/$ndkLTSFullVersion"
+        $ndkFullVersions | ForEach-Object { "ndk/${_}" }
     )
 
     [string]$ndkLatestVersion = Get-ToolsetValue "android.ndk.latest"

--- a/images/linux/scripts/tests/Android.Tests.ps1
+++ b/images/linux/scripts/tests/Android.Tests.ps1
@@ -2,7 +2,9 @@ Describe "Android" {
     $androidSdkManagerPackages = Get-AndroidPackages
     [int]$platformMinVersion = Get-ToolsetValue "android.platform_min_version"
     [version]$buildToolsMinVersion = Get-ToolsetValue "android.build_tools_min_version"
+    [string]$ndkDefaultVersion = Get-ToolsetValue "android.ndk.default"
     [array]$ndkVersions = Get-ToolsetValue "android.ndk.versions"
+    $ndkDefaultFullVersion = Get-ChildItem "$env:ANDROID_HOME/ndk/$ndkDefaultVersion.*" -Name | Select-Object -Last 1
     $ndkFullVersions = $ndkVersions | ForEach-Object { (Get-ChildItem "/usr/local/lib/android/sdk/ndk/${_}.*" | Select-Object -Last 1).Name }
 
     $platformVersionsList = ($androidSdkManagerPackages | Where-Object { "$_".StartsWith("platforms;") }) -replace 'platforms;android-', ''
@@ -17,10 +19,10 @@ Describe "Android" {
     $androidPackages = @(
         $platforms,
         $buildTools,
+        $ndkFullVersions,
         (Get-ToolsetValue "android.extra_list" | ForEach-Object { "extras/${_}" }),
         (Get-ToolsetValue "android.addon_list" | ForEach-Object { "add-ons/${_}" }),
-        (Get-ToolsetValue "android.additional_tools" | ForEach-Object { "${_}" }),
-        ($ndkFullVersions | ForEach-Object { "ndk/${_}" })
+        (Get-ToolsetValue "android.additional_tools" | ForEach-Object { "${_}" })
     )
 
     [string]$ndkLatestVersion = Get-ToolsetValue "android.ndk.latest"
@@ -67,10 +69,17 @@ Describe "Android" {
 
     Context "Packages" {
         $testCases = $androidPackages | ForEach-Object { @{ PackageName = $_ } }
+        $defaultNdkTestCase = @{ NdkDefaultFullVersion = $ndkDefaultFullVersion }
 
         It "<PackageName>" -TestCases $testCases {
             param ([string] $PackageName)
             Validate-AndroidPackage $PackageName
+        }
+
+        It "ndk-bundle points to the default NDK version" -TestCases $defaultNdkTestCase {
+            $ndkLinkTarget = (Get-Item $env:ANDROID_NDK_HOME).Target
+            $ndkVersion = Split-Path -Path $ndkLinkTarget -Leaf
+            $ndkVersion | Should -BeExactly $NdkDefaultFullVersion
         }
     }
 }

--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -98,10 +98,7 @@
             "platform-tools"
         ],
         "ndk": {
-            "default": "21",
-            "versions": [
-                "21", "23"
-            ]
+            "lts": "21"
         }
     },
     "powershellModules": [

--- a/images/linux/toolsets/toolset-1604.json
+++ b/images/linux/toolsets/toolset-1604.json
@@ -98,7 +98,10 @@
             "platform-tools"
         ],
         "ndk": {
-            "lts": "21"
+            "default": "21",
+            "versions": [
+                "21", "23"
+            ]
         }
     },
     "powershellModules": [

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -93,7 +93,10 @@
             "cmake;3.18.1"
         ],
         "ndk": {
-            "lts": "21"
+            "default": "21",
+            "versions": [
+                "21", "23"
+            ]
         }
     },
     "powershellModules": [

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -89,8 +89,10 @@
             "cmake;3.18.1"
         ],
         "ndk": {
-            "lts": "21",
-            "latest": "22"
+            "default": "21",
+            "versions": [
+                "21", "22", "23"
+            ]
         }
     },
     "powershellModules": [


### PR DESCRIPTION
# Description
In scope of this PR we have added Android NDK r23 to Ubuntu images and leave the current LTS version (r21) as default.
Also, we've reworked the `android.ndk` toolset section:

- The `android.ndk.versions` field is a manually sorted list of all versions that will be installed on the image
- The `android.ndk.lts` field has been renamed to `android.ndk.default`. It will allow us, if necessary, to set a non-LTS NDK version as default.
- The `android.ndk.latest` field has been removed and its value will be taken from the end of `android.ndk.versions` list

#### Related issue: [Update/Add Android NDK r23 LTS #3894](https://github.com/actions/virtual-environments/issues/3894)


## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated: [Ubuntu 18.04](https://github.visualstudio.com/virtual-environments/_build/results?buildId=116532&view=results), [Ubuntu 20.04](https://github.visualstudio.com/virtual-environments/_build/results?buildId=116531&view=results)
