### PR TITLE
Revert "[macOS] Install cargo-audit 0.14.1 as 0.15.0 is broken"

### DIFF
--- a/images/macos/provision/core/rust.sh
+++ b/images/macos/provision/core/rust.sh
@@ -12,9 +12,7 @@ CARGO_HOME=$HOME/.cargo
 
 echo Install common tools...
 rustup component add rustfmt clippy
-cargo install --locked bindgen cbindgen cargo-outdated
-# Temporary hardcode cargo-audit 0.14.1 as 0.15.0 is broken https://docs.rs/crate/cargo-audit/0.15.0
-cargo install cargo-audit --version 0.14.1
+cargo install --locked bindgen cbindgen cargo-audit cargo-outdated
 
 echo Cleanup Cargo registry cached data...
 rm -rf $CARGO_HOME/registry/*


### PR DESCRIPTION
The issue has been fixed - https://github.com/rustsec/rustsec/issues/429
https://docs.rs/crate/cargo-audit/0.15.2 - the last successful build
