### PR TITLE
Revert "[windows] Install cargo-audit 0.14.1 as 0.15.0 is broken (fix)"

### DIFF
--- a/images/win/scripts/Installers/Install-Rust.ps1
+++ b/images/win/scripts/Installers/Install-Rust.ps1
@@ -21,9 +21,7 @@ $env:Path = Get-MachinePath
 # Install common tools
 rustup component add rustfmt clippy
 # Temporary hardcode cargo-audit 0.14.1 as 0.15.0 is broken https://docs.rs/crate/cargo-audit/0.15.0
-cargo install --locked bindgen cbindgen cargo-outdated
-cargo install cargo-audit --version 0.14.1
-
+cargo install --locked bindgen cbindgen cargo-audit --version 0.14.1 cargo-outdated
 
 # Run script at startup for all users
 $cmdRustSymScript = @"


### PR DESCRIPTION
The issue has been fixed - https://github.com/rustsec/rustsec/issues/429
https://docs.rs/crate/cargo-audit/0.15.2 - the last successful build