### PR TITLE
[Windows] Add Microsoft.VisualStudio.Component.VC.Tools.ARM and Microsoft.VisualStudio.Component.VC.Tools.ARM64 components to Win 2022

### DIFF
--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -177,6 +177,8 @@
             "Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre",
             "Microsoft.VisualStudio.Component.VC.TestAdapterForBoostTest",
             "Microsoft.VisualStudio.Component.VC.TestAdapterForGoogleTest",
+            "Microsoft.VisualStudio.Component.VC.Tools.ARM",
+            "Microsoft.VisualStudio.Component.VC.Tools.ARM64",
             "Microsoft.VisualStudio.Component.VC.v141.x86.x64",
             "Microsoft.VisualStudio.Component.VC.v141.x86.x64.Spectre",
             "Microsoft.VisualStudio.Component.VC.v141.MFC",


### PR DESCRIPTION
# Description
This PR adds Microsoft.VisualStudio.Component.VC.Tools.ARM and Microsoft.VisualStudio.Component.VC.Tools.ARM64 components to VisualStudio of Windows 2022 image.

#### Related issue: https://github.com/actions/virtual-environments/issues/4051

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
