### PR TITLE
[Ubuntu] Remove alpine:3.11 docker image from Ubuntu 18.04 and 20.04

### DIFF
--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -201,7 +201,6 @@
     ],
     "docker": {
         "images": [
-            "alpine:3.11",
             "alpine:3.12",
             "alpine:3.13",
             "alpine:3.14",

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -200,7 +200,6 @@
     ],
     "docker": {
         "images": [
-            "alpine:3.11",
             "alpine:3.12",
             "alpine:3.13",
             "alpine:3.14",


### PR DESCRIPTION
# Description
This PR removes alpine:3.11 docker image from the list of pre-cached images on Ubuntu 18.04 and 20.04 VMs

#### Related issue: https://github.com/actions/virtual-environments/issues/4042

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
