### PR TITLE
[MacOS] Add SBT to MacOS 10.14, 10.15 and 11

### DIFF
--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -512,6 +512,11 @@ function Get-KotlinVersion {
     return "Kotlin $kotlinVersion"
 }
 
+function Get-SbtVersion {
+    $sbtVersion = (sbt -version) -match "sbt script version:" -replace "script version: "
+    return "$sbtVersion"
+}
+
 function Build-PackageManagementEnvironmentTable {
     return @(
         @{

--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -513,8 +513,8 @@ function Get-KotlinVersion {
 }
 
 function Get-SbtVersion {
-    $sbtVersion = (sbt -version) -match "sbt script version:" -replace "script version: "
-    return "$sbtVersion"
+    $sbtVersion = Run-Command "sbt -version" | Take-Part -Part 3
+    return "Sbt $sbtVersion"
 }
 
 function Build-PackageManagementEnvironmentTable {

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -99,7 +99,8 @@ $markdown += New-MDHeader "Project Management" -Level 3
 $markdown += New-MDList -Style Unordered -Lines (@(
     (Get-MavenVersion),
     (Get-GradleVersion),
-    (Get-ApacheAntVersion)
+    (Get-ApacheAntVersion),
+    (Get-SbtVersion)
     ) | Sort-Object
 )
 

--- a/images/macos/tests/BasicTools.Tests.ps1
+++ b/images/macos/tests/BasicTools.Tests.ps1
@@ -176,3 +176,9 @@ Describe "Kotlin" {
         "$toolName -version" | Should -ReturnZeroExitCode
     }
 }
+
+Describe "sbt" {
+    It "sbt" {
+        "sbt --version" | Should -ReturnZeroExitCode
+    }
+}

--- a/images/macos/tests/BasicTools.Tests.ps1
+++ b/images/macos/tests/BasicTools.Tests.ps1
@@ -179,6 +179,6 @@ Describe "Kotlin" {
 
 Describe "sbt" {
     It "sbt" {
-        "sbt --version" | Should -ReturnZeroExitCode
+        "sbt -version" | Should -ReturnZeroExitCode
     }
 }

--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -261,6 +261,7 @@
             "packer",
             "parallel",
             "perl",
+            "sbt",
             "subversion",
             "swiftformat",
             "swig",

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -212,6 +212,7 @@
             "packer",
             "parallel",
             "perl",
+            "sbt",
             "subversion",
             "swiftformat",
             "swig",

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -157,6 +157,7 @@
             "p7zip",
             "packer",
             "perl",
+            "sbt",
             "subversion",
             "swiftformat",
             "swig",


### PR DESCRIPTION
# Description
This PR adds SBT tool to MacOS 10.14, 10.15 and 11 images.

#### Related issue: https://github.com/actions/virtual-environments/issues/4065

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
