### PR TITLE
[macOS] Install Xcode 13 beta along with 13 stable

### DIFF
--- a/images/macos/provision/core/xcode.ps1
+++ b/images/macos/provision/core/xcode.ps1
@@ -45,8 +45,8 @@ Write-Host "Configuring Xcode symlinks..."
 $xcodeVersions | ForEach-Object {
     Build-XcodeSymlinks -Version $_.link -Symlinks $_.symlinks
 
-    # Temporary solution to install Xcode 13 beta along with 13 stable
-    if ($_.link -ne "13.0_beta") {
+    # Skip creating symlink to install multiple releases of the same Xcode version side-by-side
+    if ($_."skip-symlink" -ne "true") {
         Build-ProvisionatorSymlink -Version $_.link
     }
 }

--- a/images/macos/provision/core/xcode.ps1
+++ b/images/macos/provision/core/xcode.ps1
@@ -44,7 +44,11 @@ Invoke-XcodeRunFirstLaunch -Version $defaultXcode
 Write-Host "Configuring Xcode symlinks..."
 $xcodeVersions | ForEach-Object {
     Build-XcodeSymlinks -Version $_.link -Symlinks $_.symlinks
-    Build-ProvisionatorSymlink -Version $_.link
+
+    # Temporary solution to install Xcode 13 beta along with 13 stable
+    if ($_.link -ne "13.0_beta") {
+        Build-ProvisionatorSymlink -Version $_.link
+    }
 }
 
 Write-Host "Setting default Xcode to $defaultXcode"

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -3,7 +3,7 @@
         "default": "12.5.1",
         "versions": [
             { "link": "13.0", "version": "13.0.0"},
-            { "link": "13.0_beta", "version": "13 beta 5"},
+            { "link": "13.0_beta", "version": "13 beta 5", "skip-symlink": "true"},
             { "link": "12.5.1", "version": "12.5.1"},
             { "link": "12.5", "version": "12.5.0"},
             { "link": "12.4", "version": "12.4.0"},

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -3,6 +3,7 @@
         "default": "12.5.1",
         "versions": [
             { "link": "13.0", "version": "13.0.0"},
+            { "link": "13.0_beta", "version": "13 beta 5"},
             { "link": "12.5.1", "version": "12.5.1"},
             { "link": "12.5", "version": "12.5.0"},
             { "link": "12.4", "version": "12.4.0"},


### PR DESCRIPTION
# Description
It turned out Xcode 13 RC doesn't contain macOS-12 SDK so we decided to keep Xcode 13 beta version on the images for now.

This PR introduces the following changes:
- Location of the Xcode 13 is `/Applications/Xcode_13.0.app`. The `/Applications/Xcode_13.0.0.app` symlink will be created for this version.
- Location of the Xcode 13 beta is `/Applications/Xcode_13.0_beta.app`. There are no symlinks for this version.

#### Related issue: [2727](https://github.com/actions/virtual-environments-internal/issues/2727)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
