### PR TITLE
Measure and output installing and downloading durations

### DIFF
--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -31,6 +31,7 @@ function Install-Binary
         [String[]] $ArgumentList
     )
 
+    $installStartTime = Get-Date
     if ($PSCmdlet.ParameterSetName -eq "LocalPath")
     {
         $name = Split-Path -Path $FilePath -Leaf
@@ -57,7 +58,8 @@ function Install-Binary
         $exitCode = $process.ExitCode
         if ($exitCode -eq 0 -or $exitCode -eq 3010)
         {
-            Write-Host "Installation successful"
+            $installCompleteTime = [math]::Round(($(Get-Date) - $installStartTime).TotalSeconds, 2)
+            Write-Host "Installation successful in $($installCompleteTime) seconds"
         }
         else
         {
@@ -179,18 +181,21 @@ function Start-DownloadWithRetry
 
     $filePath = Join-Path -Path $DownloadPath -ChildPath $Name
 
-    #Default retry logic for the package.
+    # Default retry logic for the package.
     while ($Retries -gt 0)
     {
         try
         {
+            $downloadStartTime = Get-Date
             Write-Host "Downloading package from: $Url to path $filePath ."
             (New-Object System.Net.WebClient).DownloadFile($Url, $filePath)
             break
         }
         catch
         {
+            $failTime = [math]::Round(($(Get-Date) - $downloadStartTime).TotalSeconds, 2)
             Write-Host "There is an error during package downloading:`n $_"
+            Write-Host "Total time elapsed $($failTime)"
             $Retries--
 
             if ($Retries -eq 0)
@@ -204,6 +209,8 @@ function Start-DownloadWithRetry
         }
     }
 
+    $downloadCompleteTime = [math]::Round(($(Get-Date) - $downloadStartTime).TotalSeconds, 2)
+    Write-Host "Package downloaded successfully in $($downloadCompleteTime) seconds"
     return $filePath
 }
 

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -199,12 +199,12 @@ function Start-DownloadWithRetry
             $failTime = [math]::Round(($(Get-Date) - $downloadStartTime).TotalSeconds, 2)
             $attemptTime = [math]::Round(($(Get-Date) - $downloadAttemptStartTime).TotalSeconds, 2)
             Write-Host "There is an error encounterd after $attemptTime seconds during package downloading:`n $_"
-            Write-Host "Total time elapsed $failTime"
             $Retries--
 
             if ($Retries -eq 0)
             {
                 Write-Host "File can't be downloaded. Please try later or check that file exists by url: $Url"
+                Write-Host "Total time elapsed $failTime"
                 exit 1
             }
 

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -31,7 +31,6 @@ function Install-Binary
         [String[]] $ArgumentList
     )
 
-    $installStartTime = Get-Date
     if ($PSCmdlet.ParameterSetName -eq "LocalPath")
     {
         $name = Split-Path -Path $FilePath -Leaf
@@ -50,26 +49,29 @@ function Install-Binary
         $filePath = "msiexec.exe"
     }
 
+    $installStartTime = Get-Date
     try
     {
         Write-Host "Starting Install $Name..."
         $process = Start-Process -FilePath $filePath -ArgumentList $ArgumentList -Wait -PassThru
-
         $exitCode = $process.ExitCode
+        $installCompleteTime = [math]::Round(($(Get-Date) - $installStartTime).TotalSeconds, 2)
         if ($exitCode -eq 0 -or $exitCode -eq 3010)
         {
-            $installCompleteTime = [math]::Round(($(Get-Date) - $installStartTime).TotalSeconds, 2)
             Write-Host "Installation successful in $($installCompleteTime) seconds"
         }
         else
         {
             Write-Host "Non zero exit code returned by the installation process: $exitCode"
+            Write-Host "Total time elapsed: $($installCompleteTime) seconds"
             exit $exitCode
         }
     }
     catch
     {
+        $installCompleteTime = [math]::Round(($(Get-Date) - $installStartTime).TotalSeconds, 2)
         Write-Host "Failed to install the $fileExtension ${Name}: $($_.Exception.Message)"
+        Write-Host "Installation failed after $($installCompleteTime) seconds"
         exit 1
     }
 }

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -49,21 +49,21 @@ function Install-Binary
         $filePath = "msiexec.exe"
     }
 
-    $installStartTime = Get-Date
     try
     {
+        $installStartTime = Get-Date
         Write-Host "Starting Install $Name..."
         $process = Start-Process -FilePath $filePath -ArgumentList $ArgumentList -Wait -PassThru
         $exitCode = $process.ExitCode
         $installCompleteTime = [math]::Round(($(Get-Date) - $installStartTime).TotalSeconds, 2)
         if ($exitCode -eq 0 -or $exitCode -eq 3010)
         {
-            Write-Host "Installation successful in $($installCompleteTime) seconds"
+            Write-Host "Installation successful in $installCompleteTime seconds"
         }
         else
         {
             Write-Host "Non zero exit code returned by the installation process: $exitCode"
-            Write-Host "Total time elapsed: $($installCompleteTime) seconds"
+            Write-Host "Total time elapsed: $installCompleteTime seconds"
             exit $exitCode
         }
     }
@@ -71,7 +71,7 @@ function Install-Binary
     {
         $installCompleteTime = [math]::Round(($(Get-Date) - $installStartTime).TotalSeconds, 2)
         Write-Host "Failed to install the $fileExtension ${Name}: $($_.Exception.Message)"
-        Write-Host "Installation failed after $($installCompleteTime) seconds"
+        Write-Host "Installation failed after $installCompleteTime seconds"
         exit 1
     }
 }
@@ -182,13 +182,14 @@ function Start-DownloadWithRetry
     }
 
     $filePath = Join-Path -Path $DownloadPath -ChildPath $Name
-
+    $downloadStartTime = Get-Date
+    
     # Default retry logic for the package.
     while ($Retries -gt 0)
     {
         try
         {
-            $downloadStartTime = Get-Date
+            $downloadAttemptStartTime = Get-Date
             Write-Host "Downloading package from: $Url to path $filePath ."
             (New-Object System.Net.WebClient).DownloadFile($Url, $filePath)
             break
@@ -196,8 +197,9 @@ function Start-DownloadWithRetry
         catch
         {
             $failTime = [math]::Round(($(Get-Date) - $downloadStartTime).TotalSeconds, 2)
-            Write-Host "There is an error during package downloading:`n $_"
-            Write-Host "Total time elapsed $($failTime)"
+            $attemptTime = [math]::Round(($(Get-Date) - $downloadAttemptStartTime).TotalSeconds, 2)
+            Write-Host "There is an error encounterd after $attemptTime seconds during package downloading:`n $_"
+            Write-Host "Total time elapsed $failTime"
             $Retries--
 
             if ($Retries -eq 0)
@@ -212,7 +214,7 @@ function Start-DownloadWithRetry
     }
 
     $downloadCompleteTime = [math]::Round(($(Get-Date) - $downloadStartTime).TotalSeconds, 2)
-    Write-Host "Package downloaded successfully in $($downloadCompleteTime) seconds"
+    Write-Host "Package downloaded successfully in $downloadCompleteTime seconds"
     return $filePath
 }
 


### PR DESCRIPTION
# Description
Improving output for "Install-Binary" and "Start-DownloadWithRetry" functions with additional measuring and logging of installing and downloading durations.

### Test run:
https://github.visualstudio.com/virtual-environments/_build/results?buildId=116599&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=5431112d-2b61-5a5f-7042-ef698f761043&l=5552

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
