### PR TITLE
[MacOS] Add Adoptium to Java installer

### DIFF
--- a/images/macos/provision/core/openjdk.sh
+++ b/images/macos/provision/core/openjdk.sh
@@ -1,52 +1,89 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
 
-JAVA_TOOLCACHE_PATH=$AGENT_TOOLSDIRECTORY/Java_Adopt_jdk
-
 createEnvironmentVariable() {
     local JAVA_VERSION=$1
-    local JAVA_PATH=$2
+    local VENDOR_NAME=$2
+    local DEFAULT=$3
 
-    local JAVA_HOME_PATH=$JAVA_PATH/Contents/Home
-    if [[ $JAVA_VERSION == $JAVA_DEFAULT ]]; then
-        echo "export JAVA_HOME=${JAVA_HOME_PATH}" >> "${HOME}/.bashrc"
+    INSTALL_PATH_PATTERN=$(echo ${AGENT_TOOLSDIRECTORY}/Java_${VENDOR_NAME}_jdk/${JAVA_VERSION}*/x64/Contents/Home/)
+
+    if [[ ${DEFAULT} == "True" ]]; then
+        echo "Setting up JAVA_HOME variable to ${INSTALL_PATH_PATTERN}"
+        echo "export JAVA_HOME=${INSTALL_PATH_PATTERN}" >> "${HOME}/.bashrc"
     fi
-    echo "export JAVA_HOME_${JAVA_VERSION}_X64=${JAVA_HOME_PATH}" >> "${HOME}/.bashrc"
+
+    echo "Setting up JAVA_HOME_${JAVA_VERSION}_X64 variable to ${INSTALL_PATH_PATTERN}"
+    echo "export JAVA_HOME_${JAVA_VERSION}_X64=${INSTALL_PATH_PATTERN}" >> "${HOME}/.bashrc"
 }
 
-installJavaFromAdoptOpenJDK() {
+installOpenJDK() {
     local JAVA_VERSION=$1
+    local VENDOR_NAME=$2
 
     # Get link for Java binaries and Java version
-    assetUrl=$(curl -s "https://api.adoptopenjdk.net/v3/assets/latest/${JAVA_VERSION}/hotspot")
-    asset=$(echo $assetUrl | jq -r '.[] | select(.binary.os=="mac" and .binary.image_type=="jdk" and .binary.architecture=="x64")')
-    archivePath=$(echo $asset | jq -r '.binary.package.link')
-    fullVersion=$(echo $asset | jq -r '.version.semver' | tr '+' '-')
+    if [[ ${VENDOR_NAME} == "Temurin-Hotspot" ]]; then
+        assetUrl=$(curl -s "https://api.adoptium.net/v3/assets/latest/${JAVA_VERSION}/hotspot")
+    elif [[ ${VENDOR_NAME} == "Adopt" ]]; then
+        assetUrl=$(curl -s "https://api.adoptopenjdk.net/v3/assets/latest/${JAVA_VERSION}/hotspot")
+    else
+        echo "${VENDOR_NAME} is invalid, valid names are: Temurin-Hotspot and Adopt"
+        exit 1
+    fi
 
-    javaToolcacheVersionPath=$JAVA_TOOLCACHE_PATH/$fullVersion
-    javaToolcacheVersionArchPath=$javaToolcacheVersionPath/x64
+    asset=$(echo ${assetUrl} | jq -r '.[] | select(.binary.os=="mac" and .binary.image_type=="jdk" and .binary.architecture=="x64")')
+    archivePath=$(echo ${asset} | jq -r '.binary.package.link')
+    fullVersion=$(echo ${asset} | jq -r '.version.semver' | tr '+' '-')
+
+    JAVA_TOOLCACHE_PATH=${AGENT_TOOLSDIRECTORY}/Java_${VENDOR_NAME}_jdk
+
+    javaToolcacheVersionPath=$JAVA_TOOLCACHE_PATH/${fullVersion}
+    javaToolcacheVersionArchPath=${javaToolcacheVersionPath}/x64
 
     # Download and extract Java binaries
-    download_with_retries $archivePath /tmp OpenJDK${JAVA_VERSION}.tar.gz
-    mkdir -p $javaToolcacheVersionArchPath
-    tar -xzf /tmp/OpenJDK${JAVA_VERSION}.tar.gz -C $javaToolcacheVersionArchPath --strip-components=1
-    # Create complete file
-    touch $javaToolcacheVersionPath/x64.complete
+    download_with_retries ${archivePath} /tmp OpenJDK-${VENDOR_NAME}-${fullVersion}.tar.gz
+    
+    echo "Creating ${javaToolcacheVersionArchPath} directory"
+    mkdir -p ${javaToolcacheVersionArchPath}
 
-    createEnvironmentVariable $JAVA_VERSION $javaToolcacheVersionArchPath
+    tar -xf /tmp/OpenJDK-${VENDOR_NAME}-${fullVersion}.tar.gz -C ${javaToolcacheVersionArchPath} --strip-components=1
+    # Create complete file
+    touch ${javaToolcacheVersionPath}/x64.complete
 
     # Create a symlink to '/Library/Java/JavaVirtualMachines'
     # so '/usr/libexec/java_home' will be able to find Java
-    sudo ln -sf $javaToolcacheVersionArchPath /Library/Java/JavaVirtualMachines/adoptopenjdk-${JAVA_VERSION}.jdk
+    sudo ln -sf ${javaToolcacheVersionArchPath} /Library/Java/JavaVirtualMachines/${VENDOR_NAME}-${JAVA_VERSION}.jdk
 }
 
-JAVA_VERSIONS_LIST=($(get_toolset_value '.java.versions | .[]'))
-JAVA_DEFAULT=$(get_toolset_value '.java.default')
+defaultVersion=$(get_toolset_value '.java.default')
+defaultVendor=$(get_toolset_value '.java.default_vendor')
+jdkVendors=($(get_toolset_value '.java.vendors[].name'))
 
-for JAVA_VERSION in "${JAVA_VERSIONS_LIST[@]}"
-do
-    installJavaFromAdoptOpenJDK $JAVA_VERSION 
+for jdkVendor in ${jdkVendors[@]}; do
+
+     # get vendor-specific versions
+     jdkVersionsToInstall=($(get_toolset_value ".java.vendors[] | select (.name==\"${jdkVendor}\") | .versions[]"))
+
+     for jdkVersionToInstall in ${jdkVersionsToInstall[@]}; do
+
+        installOpenJDK ${jdkVersionToInstall} ${jdkVendor}
+
+        isDefaultVersion=False; [[ ${jdkVersionToInstall} == ${defaultVersion} ]] && isDefaultVersion=True
+
+        if [[ ${jdkVendor} == ${defaultVendor} ]]; then
+            createEnvironmentVariable ${jdkVersionToInstall} ${jdkVendor} ${isDefaultVersion}
+        fi
+
+    done
 done
+
+# Big Sur or newer does not have these versions of Adopt.
+# Also hardcode these versions as they only exist for Adopt
+if is_Less_BigSur; then
+    for adoptVersionToInstall in 12 13 14; do
+        createEnvironmentVariable ${adoptVersionToInstall} "Adopt"
+    done
+fi
 
 echo Installing Maven...
 brew_smart_install "maven"

--- a/images/macos/software-report/SoftwareReport.Java.psm1
+++ b/images/macos/software-report/SoftwareReport.Java.psm1
@@ -12,10 +12,11 @@ function Get-JavaVersions {
         $version = $javaPath.split('/')[5]
         $fullVersion = $version.Replace('-', '+')
         $defaultPostfix = ($javaPath -eq $defaultJavaPath) ? " (default)" : ""
+        $vendorName = ($javaPath -like '*Java_Adopt_jdk*') ? "Adopt OpenJDK" :  "Eclipse Temurin"
 
         [PSCustomObject] @{
             "Version" = $fullVersion + $defaultPostfix
-            "Vendor" = "Adopt OpenJDK"
+            "Vendor" = $vendorName
             "Environment Variable" = $_.Name
         }
     }

--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -197,8 +197,16 @@
     },
     "java": {
         "default": "8",
-        "versions": [
-            "8", "11", "12", "13", "14"
+        "default_vendor": "Temurin-Hotspot",
+        "vendors": [
+            {
+                "name": "Temurin-Hotspot",
+                "versions": [ "8", "11" ]
+            },
+            {
+                "name": "Adopt",
+                "versions": [ "8", "11", "12", "13", "14" ]
+            }
         ]
     },
     "android": {

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -149,8 +149,16 @@
     },
     "java": {
         "default": "8",
-        "versions": [
-            "8", "11", "12", "13", "14"
+        "default_vendor": "Temurin-Hotspot",
+        "vendors": [
+            {
+                "name": "Temurin-Hotspot",
+                "versions": [ "8", "11" ]
+            },
+            {
+                "name": "Adopt",
+                "versions": [ "8", "11", "12", "13", "14" ]
+            }
         ]
     },
     "android": {

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -100,8 +100,16 @@
     },
     "java": {
         "default": "8",
-        "versions": [
-            "8", "11"
+        "default_vendor": "Temurin-Hotspot",
+        "vendors": [
+            {
+                "name": "Temurin-Hotspot",
+                "versions": [ "8", "11" ]
+            },
+            {
+                "name": "Adopt",
+                "versions": [ "8", "11" ]
+            }
         ]
     },
     "android": {


### PR DESCRIPTION
# Description

Another round of Adoptium (Temurin-Hotspot) addition. The script attempts to emulate the same behaviour as the Windows installer has (taking into account all the limitations bash has). Toolset parsing is a little bit flaky as our `get_toolset_value` function does not have the `--arg` passed (for obvious reason) to use `jq` output in the loops (suggestions are welcome!).

 * Pester tests have been updated to make sure all Adopt's versions can be found in the paths we expect them to be installed to
 * Some Adopt's versions have been hardcoded (they only belong to MacOS 10.x and only to Adopt, no surprise is going to happen)
 * Adopt's versions `8` and `11` are using Adoptium's downloading links already (they got redirected once used), as per discussion it was considered ok as there are no literal changes besides naming and our main priority is saving all the existing paths.

#### Related issue: https://github.com/actions/virtual-environments/issues/3859

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
