### PR TITLE
PathHelpers: Dealing with hardcoded registry paths and optimizing code

### DIFF
--- a/images/win/scripts/ImageHelpers/PathHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/PathHelpers.ps1
@@ -2,6 +2,7 @@ function Get-SystemVariable {
     param(
         [string]$SystemVariable
     )
+    
     [System.Environment]::GetEnvironmentVariable($SystemVariable, "Machine")
 }
 
@@ -10,6 +11,7 @@ function Set-SystemVariable {
         [string]$SystemVariable,
         [string]$Value
     )
+    
     [System.Environment]::SetEnvironmentVariable($SystemVariable, $Value, "Machine")
     Get-SystemVariable $SystemVariable
 }
@@ -22,6 +24,7 @@ function Set-MachinePath {
     param(
         [string]$NewPath
     )
+    
     Set-SystemVariable PATH $NewPath
 }
 

--- a/images/win/scripts/ImageHelpers/PathHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/PathHelpers.ps1
@@ -17,11 +17,7 @@ function Set-SystemVariable {
 }
 
 function Get-MachinePath {
-    [CmdletBinding()]
-    param(
-
-    )
-    return Get-SystemVariable PATH
+    Get-SystemVariable PATH
 }
 
 function Set-MachinePath {
@@ -44,11 +40,12 @@ function Test-MachinePath {
 }
 
 function Add-MachinePathItem {
+    [CmdletBinding()]
     param(
         [string]$PathItem
     )
 
     $currentPath = Get-MachinePath
     $newPath = $PathItem + ';' + $currentPath
-    Set-MachinePath -NewPath $newPath
+    return Set-MachinePath -NewPath $newPath
 }

--- a/images/win/scripts/ImageHelpers/PathHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/PathHelpers.ps1
@@ -30,7 +30,6 @@ function Set-MachinePath {
         [string]$NewPath
     )
     Set-SystemVariable PATH $NewPath
-    return Get-SystemVariable PATH
 }
 
 function Test-MachinePath {
@@ -45,12 +44,11 @@ function Test-MachinePath {
 }
 
 function Add-MachinePathItem {
-    [CmdletBinding()]
     param(
         [string]$PathItem
     )
 
     $currentPath = Get-MachinePath
     $newPath = $PathItem + ';' + $currentPath
-    return Set-MachinePath -NewPath $newPath
+    Set-MachinePath -NewPath $newPath
 }

--- a/images/win/scripts/ImageHelpers/PathHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/PathHelpers.ps1
@@ -1,19 +1,17 @@
 function Get-SystemVariable {
-    [CmdletBinding()]
     param(
         [string]$SystemVariable
     )
-    return [System.Environment]::GetEnvironmentVariable($SystemVariable, "Machine")
+    [System.Environment]::GetEnvironmentVariable($SystemVariable, "Machine")
 }
 
 function Set-SystemVariable {
-    [CmdletBinding()]
     param(
         [string]$SystemVariable,
         [string]$Value
     )
     [System.Environment]::SetEnvironmentVariable($SystemVariable, $Value, "Machine")
-    return Get-SystemVariable $SystemVariable
+    Get-SystemVariable $SystemVariable
 }
 
 function Get-MachinePath {
@@ -21,7 +19,6 @@ function Get-MachinePath {
 }
 
 function Set-MachinePath {
-    [CmdletBinding()]
     param(
         [string]$NewPath
     )
@@ -29,23 +26,20 @@ function Set-MachinePath {
 }
 
 function Test-MachinePath {
-    [CmdletBinding()]
     param(
         [string]$PathItem
     )
 
     $pathItems = (Get-MachinePath).Split(';')
-
-    return $pathItems.Contains($PathItem)
+    $pathItems.Contains($PathItem)
 }
 
 function Add-MachinePathItem {
-    [CmdletBinding()]
     param(
         [string]$PathItem
     )
 
     $currentPath = Get-MachinePath
     $newPath = $PathItem + ';' + $currentPath
-    return Set-MachinePath -NewPath $newPath
+    Set-MachinePath -NewPath $newPath
 }

--- a/images/win/scripts/ImageHelpers/PathHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/PathHelpers.ps1
@@ -1,4 +1,4 @@
-function Get-SystemVariable{
+function Get-SystemVariable {
     [CmdletBinding()]
     param(
         [string]$SystemVariable
@@ -6,7 +6,7 @@ function Get-SystemVariable{
     return [System.Environment]::GetEnvironmentVariable($SystemVariable, "Machine")
 }
 
-function Set-SystemVariable{
+function Set-SystemVariable {
     [CmdletBinding()]
     param(
         [string]$SystemVariable,
@@ -16,7 +16,7 @@ function Set-SystemVariable{
     return Get-SystemVariable $SystemVariable
 }
 
-function Get-MachinePath{
+function Get-MachinePath {
     [CmdletBinding()]
     param(
 
@@ -24,7 +24,7 @@ function Get-MachinePath{
     return Get-SystemVariable PATH
 }
 
-function Set-MachinePath{
+function Set-MachinePath {
     [CmdletBinding()]
     param(
         [string]$NewPath
@@ -32,7 +32,8 @@ function Set-MachinePath{
     Set-SystemVariable PATH $NewPath
     return Get-SystemVariable PATH
 }
-function Test-MachinePath{
+
+function Test-MachinePath {
     [CmdletBinding()]
     param(
         [string]$PathItem
@@ -43,8 +44,7 @@ function Test-MachinePath{
     return $pathItems.Contains($PathItem)
 }
 
-function Add-MachinePathItem
-{
+function Add-MachinePathItem {
     [CmdletBinding()]
     param(
         [string]$PathItem

--- a/images/win/scripts/ImageHelpers/PathHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/PathHelpers.ps1
@@ -1,21 +1,27 @@
-function Test-MachinePath{
+function Get-SystemVariable{
     [CmdletBinding()]
     param(
-        [string]$PathItem
+        [string]$SystemVariable
     )
+    return [System.Environment]::GetEnvironmentVariable($SystemVariable, "Machine")
+}
 
-    $currentPath = Get-MachinePath
+function Set-SystemVariable{
+    [CmdletBinding()]
+    param(
+        [string]$SystemVariable,
+        [string]$Value
+    )
+    [System.Environment]::SetEnvironmentVariable($SystemVariable, $Value, "Machine")
+    return Get-SystemVariable $SystemVariable
+}
 
-    $pathItems = $currentPath.Split(';')
+function Get-MachinePath{
+    [CmdletBinding()]
+    param(
 
-    if($pathItems.Contains($PathItem))
-    {
-        return $true
-    }
-    else
-    {
-        return $false
-    }
+    )
+    return Get-SystemVariable PATH
 }
 
 function Set-MachinePath{
@@ -23,8 +29,18 @@ function Set-MachinePath{
     param(
         [string]$NewPath
     )
-    Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name Path -Value $NewPath
-    return $NewPath
+    Set-SystemVariable PATH $NewPath
+    return Get-SystemVariable PATH
+}
+function Test-MachinePath{
+    [CmdletBinding()]
+    param(
+        [string]$PathItem
+    )
+
+    $pathItems = (Get-MachinePath).Split(';')
+
+    return $pathItems.Contains($PathItem)
 }
 
 function Add-MachinePathItem
@@ -37,32 +53,4 @@ function Add-MachinePathItem
     $currentPath = Get-MachinePath
     $newPath = $PathItem + ';' + $currentPath
     return Set-MachinePath -NewPath $newPath
-}
-
-function Get-MachinePath{
-    [CmdletBinding()]
-    param(
-
-    )
-    $currentPath = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
-    return $currentPath
-}
-
-function Get-SystemVariable{
-    [CmdletBinding()]
-    param(
-        [string]$SystemVariable
-    )
-    $currentPath = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name $SystemVariable).$SystemVariable
-    return $currentPath
-}
-
-function Set-SystemVariable{
-    [CmdletBinding()]
-    param(
-        [string]$SystemVariable,
-        [string]$Value
-    )
-    Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name $SystemVariable -Value $Value
-    return $Value
 }


### PR DESCRIPTION
# Description
PathHelpers: removing interaction with system registry and hardcoded registry paths. Working with system environment variables instead.
Also changing functions order for better readability to following:
- Get-SystemVariable
- Set-SystemVariable
- Get-MachinePath
- Set-MachinePath
- Test-MachinePath
- Add-MachinePathItem

### Test run:
https://github.visualstudio.com/virtual-environments/_build/results?buildId=116836

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
