### PR TITLE
[macOS] Simpify ghcup code to use "ghcup whereis basedir"

### DIFF
--- a/images/macos/provision/core/haskell.sh
+++ b/images/macos/provision/core/haskell.sh
@@ -16,9 +16,7 @@ for majorMinorVersion in $minorMajorVersions; do
     ghcup set $fullVersion
 
     # remove docs and profiling libs
-    ghc_bin_dir="$(ghcup whereis --directory ghc $fullVersion)"
-    [ -e "${ghc_bin_dir}" ] || exit 1
-    ghc_dir="$( cd "$( dirname "${ghc_bin_dir}" )" > /dev/null 2>&1 && pwd )"
+    ghc_dir="$(ghcup whereis basedir)/ghc/$fullVersion"
     [ -e "${ghc_dir}" ] || exit 1
     find "${ghc_dir}" \( -name "*_p.a" -o -name "*.p_hi" \) -type f -delete
     rm -r "${ghc_dir}"/share/*


### PR DESCRIPTION
# Description
Starting with ghcup 0.1.17 we can query the basedir easier.

#### Related issue:
n\a

## Check list
- [n\a] Related issue / work item is attached
- [n\a] Tests are written (if applicable)
- [n\a ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
