### PR TITLE
[Windows] Do not escape special char in Java tests

### DIFF
--- a/images/win/scripts/Tests/Java.Tests.ps1
+++ b/images/win/scripts/Tests/Java.Tests.ps1
@@ -36,18 +36,20 @@ Describe "Java" {
         if ($Version -eq 8) {
             $Version = "1.${Version}"
         }
-        $result.Output[0] | Should -Match ([regex]::Escape("openjdk version `"${Version}."))
+        $outputPattern = "openjdk version `"${Version}"
+        $result.Output[0] | Should -Match $outputPattern
     }
 
     It "Java Adopt Jdk <Version>" -TestCases $adoptJdkVersions {
         $adoptPath = Join-Path (Get-ChildItem ${env:AGENT_TOOLSDIRECTORY}\Java_Adopt_jdk\${Version}*) "x64\bin\java"
-    
+
         $result = Get-CommandResult "`"$adoptPath`" -version"
         $result.ExitCode | Should -Be 0
-    
+
         if ($Version -eq 8) {
             $Version = "1.${Version}"
         }
-        $result.Output[0] | Should -Match ([regex]::Escape("openjdk version `"${Version}."))
+        $outputPattern = "openjdk version `"${Version}"
+        $result.Output[0] | Should -Match $outputPattern
     }
 }


### PR DESCRIPTION
# Description

Temurin-Hotspot 17 LTS breaks the `Get-CommandResult` output's parsing by having the incorrect regular expression pattern. The pattern currently escapes dots, but jdk 17 does not have any delimiters and semiversions. Just to illustrate what I mean:

Temurin-Hotspot 17

<img width="1376" alt="Screenshot 2021-09-22 at 23 38 01" src="https://user-images.githubusercontent.com/88318005/134421426-670f7622-31cb-4e37-a201-b3d991db39e3.png">

Adopt 13

<img width="1412" alt="Screenshot 2021-09-22 at 23 39 22" src="https://user-images.githubusercontent.com/88318005/134421652-010b3fa2-20ff-4ca4-9952-2e6af479c750.png">

I assume that parsing the major component of a version number would be enough for testing.
We are currently blocked on https://github.com/actions/virtual-environments/pull/4129 otherwise.
 


#### Related issue: n/a

## Check list
- [ n/a ] Related issue / work item is attached
- [ n/a ] Tests are written (if applicable)
- [ n/a ] Documentation is updated (if applicable)
- [ n/a ] Changes are tested and related VM images are successfully generated
