### PR TITLE
[Ubuntu] Fix Aliyun-cli installation

### DIFF
--- a/images/linux/scripts/installers/aliyun-cli.sh
+++ b/images/linux/scripts/installers/aliyun-cli.sh
@@ -8,7 +8,7 @@
 source $HELPER_SCRIPTS/install.sh
 
 # Install Alibaba Cloud CLI
-URL=$(curl -s https://api.github.com/repos/aliyun/aliyun-cli/releases/latest | jq -r '.assets[].browser_download_url | select(contains("aliyun-cli-linux"))')
+URL=$(curl -s https://api.github.com/repos/aliyun/aliyun-cli/releases/latest | jq -r '.assets[].browser_download_url | select(contains("aliyun-cli-linux") and endswith("amd64.tgz"))')
 download_with_retries $URL "/tmp"
 tar xzf /tmp/aliyun-cli-linux-*-amd64.tgz
 mv aliyun /usr/local/bin


### PR DESCRIPTION
# Description
Current approach returns 2 entries:
```
https://github.com/aliyun/aliyun-cli/releases/download/v3.0.93/aliyun-cli-linux-3.0.93-amd64.tgz
https://github.com/aliyun/aliyun-cli/releases/download/v3.0.93/aliyun-cli-linux-3.0.93-arm64.tgz
```
We should use only `amd64` version.

#### Related issue: [#4146](https://github.com/actions/virtual-environments/issues/4146)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
