### PR TITLE
[MacOS] fix OpenSSL version software report

### DIFF
--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -308,7 +308,8 @@ function Get-PackerVersion {
 }
 
 function Get-OpenSSLVersion {
-    $opensslVersion = Get-Item /usr/local/opt/openssl | ForEach-Object {"{0} ``({1} -> {2})``" -f (Run-Command "openssl version"), $_.FullName, $_.Target}
+    $opensslPath = (Get-Command openssl).Source
+    $opensslVersion = Get-Item $opensslPath | ForEach-Object {"{0} ``({1} -> {2})``" -f (Run-Command "openssl version"), $_.FullName, $_.Target}
     return $opensslVersion
 }
 


### PR DESCRIPTION
# Description
In our `openssl.sh` we [install](https://github.com/actions/virtual-environments/blob/b7f276c003aea42575b52247bdb2183e355fca2f/images/macos/provision/core/openssl.sh#L4) both the latest openssl version and 1.1.x. Starting from the last week latest openssl is 3.0, so in fact we are now installing two separate openssl versions which is ok per se. In our software report we are checking the openssl path based on the existence of the `/usr/local/opt/openssl` directory, but as soon as we have v3 installed there are the following directories

* /usr/local/opt/openssl@1.1
* /usr/local/opt/openssl@3
* /usr/local/opt/openssl

as a result the `/usr/local/opt/openssl` directory contains exactly the same files as `/usr/local/opt/openssl@3` does (I believe it has previously had files identical to the `/usr/local/opt/openssl@1.1` and that is why no mistakes were seen), literally:

* `diff /usr/local/opt/openssl /usr/local/opt/openssl@3` returns nothing
* `diff /usr/local/opt/openssl /usr/local/opt/openssl@1.1` (long diff) returns


```
...
<       "stable": "3.0.0",
---
>       "stable": "1.1.1l",
...
```
To prevent software reports generation mistakes I think we must check the actual symlink we install, as this symlink is what being followed as the `openssl` command call gets invoked, so we can be sure we have the right version pointed and can reveal further changes easily.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
