### PR TITLE
[MacOS] Do not install latest OpenSSL

### DIFF
--- a/images/macos/provision/core/openssl.sh
+++ b/images/macos/provision/core/openssl.sh
@@ -1,9 +1,6 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
 
-echo "Install latest openssl"
-brew_smart_install "openssl"
-
 echo "Install openssl@1.1"
 brew_smart_install "openssl@1.1"
 

--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -308,7 +308,7 @@ function Get-PackerVersion {
 }
 
 function Get-OpenSSLVersion {
-    $opensslVersion = Get-Item /usr/local/opt/openssl | ForEach-Object {"{0} ``({1} -> {2})``" -f (Run-Command "openssl version"), $_.FullName, $_.Target}
+    $opensslVersion = Get-Item /usr/local/opt/openssl@1.1 | ForEach-Object {"{0} ``({1} -> {2})``" -f (Run-Command "openssl version"), $_.FullName, $_.Target}
     return $opensslVersion
 }
 


### PR DESCRIPTION
# Description
In our `openssl.sh` we [install](https://github.com/actions/virtual-environments/blob/b7f276c003aea42575b52247bdb2183e355fca2f/images/macos/provision/core/openssl.sh#L4) both the latest openssl version and 1.1.x. Starting from the last week latest openssl is 3.0, so in fact we are now installing two separate openssl versions which is ok per se. In our software report we are checking the openssl path based on the existence of the `/usr/local/opt/openssl` directory, but as soon as we have v3 installed there are the following directories

* /usr/local/opt/openssl@1.1
* /usr/local/opt/openssl@3
* /usr/local/opt/openssl

as a result the `/usr/local/opt/openssl` directory contains exactly the same files as `/usr/local/opt/openssl@3` does (I believe it has previously had files identical to the `/usr/local/opt/openssl@1.1` and that is why no mistakes were seen), literally:

* `diff /usr/local/opt/openssl /usr/local/opt/openssl@3` returns nothing
* `diff /usr/local/opt/openssl /usr/local/opt/openssl@1.1` (long diff) returns


```
...
<       "stable": "3.0.0",
---
>       "stable": "1.1.1l",
...
```
The best course of action is not to install the latest openssl version at all, this is pretty dangerous and can be fatal in the next year or so, apart from that our tests are only checking 1.1.1.x existence. At last, whoever wish v3.0 installed might do it in runtime. 

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
