### PR TITLE
[Windows] win: add vcredist 2010 test

### DIFF
--- a/images/win/scripts/Installers/Install-VCRedist.ps1
+++ b/images/win/scripts/Installers/Install-VCRedist.ps1
@@ -13,3 +13,5 @@ if (Test-IsWin19) {
     Install-Binary -Url $Vc2010x86URI -Name $Vc2010x86Name -ArgumentList $ArgumentList
     Install-Binary -Url $Vc2010x64URI -Name $Vc2010x64Name -ArgumentList $ArgumentList
 }
+
+Invoke-PesterTests -TestFile "Tools" -TestName "VCRedist"

--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -179,7 +179,7 @@ Describe "VCRedist" -Skip:(!(Test-IsWin19)) {
 
     It "vcredist_2010_x64" {
         "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{1D8E6291-B0D5-35EC-8441-6616F567A0F7}" | Should -Exist
-        "C:\Windows\System32\msvcr110.dll" | Should -Exist
+        "C:\Windows\System32\msvcr100.dll" | Should -Exist
     }
 }
 

--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -171,13 +171,17 @@ Describe "Vcpkg" {
     }
 }
 
-Describe "VCRedist" -Skip:(!(Test-IsWin19)) {
-    It "vcredist_2010_x86" {
-        "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\{F0C3E5D1-1ADE-321E-8167-68EF0DE699A5}" | Should -Exist
-        "C:\Windows\SysWOW64\mfcm100u.dll" | Should -Exist
+Describe "VCRedist" -Skip:(Test-IsWin22) {
+    It "vcredist_140" -Skip:(Test-IsWin19) {
+        "C:\Windows\System32\vcruntime140.dll" | Should -Exist
     }
 
-    It "vcredist_2010_x64" {
+    It "vcredist_2010_x64" -Skip:(Test-IsWin16) {
+        "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{1D8E6291-B0D5-35EC-8441-6616F567A0F7}" | Should -Exist
+        "C:\Windows\System32\msvcr100.dll" | Should -Exist
+    }
+
+    It "vcredist_2010_x64" -Skip:(Test-IsWin16) {
         "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{1D8E6291-B0D5-35EC-8441-6616F567A0F7}" | Should -Exist
         "C:\Windows\System32\msvcr100.dll" | Should -Exist
     }

--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -171,6 +171,18 @@ Describe "Vcpkg" {
     }
 }
 
+Describe "VCRedist" -Skip:(!(Test-IsWin19)) {
+    It "vcredist_2010_x86" {
+        "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\{F0C3E5D1-1ADE-321E-8167-68EF0DE699A5}" | Should -Exist
+        "C:\Windows\SysWOW64\mfcm100u.dll" | Should -Exist
+    }
+
+    It "vcredist_2010_x64" {
+        "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{1D8E6291-B0D5-35EC-8441-6616F567A0F7}" | Should -Exist
+        "C:\Windows\System32\msvcr110.dll" | Should -Exist
+    }
+}
+
 Describe "WebPlatformInstaller" -Skip:(Test-IsWin22) {
     It "WebPlatformInstaller" {
         "WebPICMD" | Should -ReturnZeroExitCode

--- a/images/win/windows2016.json
+++ b/images/win/windows2016.json
@@ -137,9 +137,9 @@
         {
             "type": "powershell",
             "scripts": [
-                "{{ template_dir }}/scripts/Installers/Install-VCRedist.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Docker.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-PowershellCore.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-VCRedist.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-WebPlatformInstaller.ps1"
             ]
         },

--- a/images/win/windows2016.json
+++ b/images/win/windows2016.json
@@ -137,9 +137,9 @@
         {
             "type": "powershell",
             "scripts": [
+                "{{ template_dir }}/scripts/Installers/Install-VCRedist.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Docker.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-PowershellCore.ps1",
-                "{{ template_dir }}/scripts/Installers/Install-VCRedist.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-WebPlatformInstaller.ps1"
             ]
         },

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -136,6 +136,20 @@
         {
             "type": "powershell",
             "scripts": [
+                "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1"
+            ],
+            "elevated_user": "{{user `install_user`}}",
+            "elevated_password": "{{user `install_password`}}"
+        },
+        {
+            "type": "windows-restart",
+            "check_registry": true,
+            "restart_check_command": "powershell -command \"& {if (-not (Get-Process TiWorker.exe -ErrorAction SilentlyContinue)) { Write-Output 'Restart complete' }}\"",
+            "restart_timeout": "30m"
+        },
+        {
+            "type": "powershell",
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-VCRedist.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Docker.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-PowershellCore.ps1",
@@ -251,19 +265,6 @@
         {
             "type": "windows-restart",
             "restart_timeout": "10m"
-        },
-        {
-            "type": "powershell",
-            "scripts": [
-                "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1"
-            ],
-            "elevated_user": "{{user `install_user`}}",
-            "elevated_password": "{{user `install_password`}}"
-        },
-        {
-            "type": "windows-restart",
-            "check_registry": true,
-            "restart_timeout": "30m"
         },
         {
             "type": "powershell",

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -136,21 +136,9 @@
         {
             "type": "powershell",
             "scripts": [
-                "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1"
-            ],
-            "elevated_user": "{{user `install_user`}}",
-            "elevated_password": "{{user `install_password`}}"
-        },
-        {
-            "type": "windows-restart",
-            "restart_timeout": "30m"
-        },
-        {
-            "type": "powershell",
-            "scripts": [
+                "{{ template_dir }}/scripts/Installers/Install-VCRedist.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Docker.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-PowershellCore.ps1",
-                "{{ template_dir }}/scripts/Installers/Install-VCRedist.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-WebPlatformInstaller.ps1"
             ]
         },
@@ -263,6 +251,19 @@
         {
             "type": "windows-restart",
             "restart_timeout": "10m"
+        },
+        {
+            "type": "powershell",
+            "scripts": [
+                "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1"
+            ],
+            "elevated_user": "{{user `install_user`}}",
+            "elevated_password": "{{user `install_password`}}"
+        },
+        {
+            "type": "windows-restart",
+            "check_registry": true,
+            "restart_timeout": "30m"
         },
         {
             "type": "powershell",

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -148,9 +148,9 @@
         {
             "type": "powershell",
             "scripts": [
-                "{{ template_dir }}/scripts/Installers/Install-VCRedist.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Docker.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-PowershellCore.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-VCRedist.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-WebPlatformInstaller.ps1"
             ]
         },

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -144,7 +144,6 @@
         {
             "type": "powershell",
             "scripts": [
-                "{{ template_dir }}/scripts/Installers/Install-VCRedist.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Docker.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-PowershellCore.ps1"
             ]


### PR DESCRIPTION
# Description
Sometime logs for Windows Server 2019 do not contain all info:
```
==> vhd: Provisioning with Powershell...
==> vhd: Provisioning with powershell script: C:\agent\_work\4\s\images\win/scripts/Installers/Install-VCRedist.ps1
    vhd: Downloading vcredist_x86.exe...
    vhd: Downloading package from: https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x86.exe to path C:\Users\packer\AppData\Local\Temp\vcredist_x86.exe .
==> vhd: Provisioning with powershell script: C:\agent\_work\4\s\images\win/scripts/Installers/Install-Docker.ps1
```
- Add check_registry param
- Add vcredist test for Windows Server 2016/2019
- Remove Install-VCRedist.ps1 for Windows Server 2022

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
