### PR TITLE
[Ubuntu] Update docker-compose assets filter

### DIFF
--- a/images/linux/scripts/installers/docker-compose.sh
+++ b/images/linux/scripts/installers/docker-compose.sh
@@ -5,7 +5,7 @@
 ################################################################################
 
 # Install latest docker-compose from releases
-URL=$(curl -s https://api.github.com/repos/docker/compose/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("docker-compose-Linux-x86_64"))')
+URL=$(curl -s https://api.github.com/repos/docker/compose/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("docker-compose-linux-amd64"))')
 curl -L $URL -o /usr/local/bin/docker-compose
 chmod +x /usr/local/bin/docker-compose
 


### PR DESCRIPTION
# Description
Update jq filter patter to allow download v2 version due to  `docker-compose-Linux-x86_64`  is changed to `docker-compose-linux-amd64`

#### Related issue:
https://github.com/actions/virtual-environments/issues/4163

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
