### PR TITLE
[Ubuntu] set docker-compose v1

### DIFF
--- a/images/linux/scripts/installers/docker-compose.sh
+++ b/images/linux/scripts/installers/docker-compose.sh
@@ -5,7 +5,7 @@
 ################################################################################
 
 # Install latest docker-compose from releases
-URL=$(curl -s https://api.github.com/repos/docker/compose/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("docker-compose-Linux-x86_64"))')
+URL="https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64"
 curl -L $URL -o /usr/local/bin/docker-compose
 chmod +x /usr/local/bin/docker-compose
 

--- a/images/linux/scripts/installers/docker-compose.sh
+++ b/images/linux/scripts/installers/docker-compose.sh
@@ -4,7 +4,7 @@
 ##  Desc:  Installs Docker Compose
 ################################################################################
 
-# Install latest docker-compose from releases
+# Install docker-compose v1 from releases
 URL="https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64"
 curl -L $URL -o /usr/local/bin/docker-compose
 chmod +x /usr/local/bin/docker-compose


### PR DESCRIPTION
# Description
Temporary stick docker-compose to 1.29.2 until `moby-compose` package is released with docker-compose v2.

#### Related issue:
https://github.com/actions/virtual-environments/issues/4163

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
