### PR TITLE
[Ubuntu] java: do not use the github tag release

### DIFF
--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -66,7 +66,7 @@ echo "ANT_HOME=/usr/share/ant" | tee -a /etc/environment
 mavenDownloadUrl=$(curl -sL https://maven.apache.org/download.cgi | grep -oP 'https://[^/"].+/binaries/apache-maven-.+-bin.zip(?=")')
 download_with_retries $mavenDownloadUrl "/tmp" "maven.zip"
 unzip -qq -d /usr/share /tmp/maven.zip
-ln -s /usr/share/apache-maven-${latestMavenVersion}/bin/mvn /usr/bin/mvn
+ln -s /usr/share/apache-maven-*/bin/mvn /usr/bin/mvn
 
 # Install Gradle
 # This script founds the latest gradle release from https://services.gradle.org/versions/all


### PR DESCRIPTION
# Description
Currently the latest tag is 3.8.3, but there is no available binaries for this release. We should get the latest available maven version from the maven.apache.org site.

#### Related issue:
https://github.com/actions/virtual-environments/issues/4172

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
