### PR TITLE
[Windows] packer: add pause after windows update

### DIFF
--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -144,11 +144,12 @@
         {
             "type": "windows-restart",
             "check_registry": true,
-            "restart_check_command": "powershell -command \"& {if (-not (Get-Process TiWorker.exe -ErrorAction SilentlyContinue)) { Write-Output 'Restart complete' }}\"",
+            "restart_check_command": "powershell -command \"& {if ((-not (Get-Process TiWorker.exe -ErrorAction SilentlyContinue)) -and (-not [System.Environment]::HasShutdownStarted) ) { Write-Output 'Restart complete' }}\"",
             "restart_timeout": "30m"
         },
         {
             "type": "powershell",
+            "pause_before": "2m",
             "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-VCRedist.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Docker.ps1",


### PR DESCRIPTION
# Description
Occurrence, only for Windows Server 2019, after installing windows updates the process is still in progress and packer can't detect properly this status, that's why we have a chance to get:

1. Error:
`==> vhd: A system shutdown is in progress. Error: 0x8007045b
`

2. Skip software installation
```
==> vhd: Provisioning with powershell script: C:\agent\_work\3\s\images\win/scripts/Installers/Install-VCRedist.ps1
    vhd: Downloading vcredist_x86.exe...
    vhd: Downloading package from: https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x86.exe to path C:\Users\packer\AppData\Local\Temp\vcredist_x86.exe .
    vhd: Package downloaded successfully in 0.45 seconds
    vhd: Starting Install vcredist_x86.exe...
==> vhd: Provisioning with powershell script: C:\agent\_work\3\s\images\win/scripts/Installers/Install-Docker.ps1
```

Default behavior should be:
```
==> vhd: Provisioning with powershell script: C:\agent\_work\1\s\images\win/scripts/Installers/Install-VCRedist.ps1
    vhd: Downloading vcredist_x86.exe...
    vhd: Downloading package from: https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x86.exe to path C:\Users\packer\AppData\Local\Temp\vcredist_x86.exe .
    vhd: Package downloaded successfully in 0.44 seconds
    vhd: Starting Install vcredist_x86.exe...
    vhd: Installation successful in 6.35 seconds
    vhd: Downloading vcredist_x64.exe...
    vhd: Downloading package from: https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x64.exe to path C:\Users\packer\AppData\Local\Temp\vcredist_x64.exe .
    vhd: Package downloaded successfully in 0.13 seconds
    vhd: Starting Install vcredist_x64.exe...
    vhd: Installation successful in 5.09 seconds
    vhd: Pester v5.3.1
    vhd:
    vhd: Starting discovery in 1 files.
    vhd: Discovery found 44 tests in 1.14s.
    vhd: Filter 'FullName' set to ('VCRedist').
    vhd: Filters selected 3 tests to run.
    vhd: Running tests.
    vhd:
    vhd: Running tests from 'C:\image\Tests\Tools.Tests.ps1'
    vhd: Describing VCRedist
    vhd:   [!] vcredist_140 203ms (0ms|203ms)
    vhd:   [+] vcredist_2010_x64 531ms (516ms|16ms)
    vhd:   [+] vcredist_2010_x64 6ms (5ms|1ms)
    vhd: Tests completed in 4.48s
    vhd: Tests Passed: 2, Failed: 0, Skipped: 1 NotRun: 41
==> vhd: Provisioning with powershell script: C:\agent\_work\1\s\images\win/scripts/Installers/Install-Docker.ps1
```

- Add `pause_before=2m` to sleep for duration before execution