### PR TITLE
Revert "[Ubuntu] java: do not use the github tag release"

### DIFF
--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -63,10 +63,12 @@ apt-fast install -y --no-install-recommends ant ant-optional
 echo "ANT_HOME=/usr/share/ant" | tee -a /etc/environment
 
 # Install Maven
-mavenDownloadUrl=$(curl -sL https://maven.apache.org/download.cgi | grep -oP 'https://[^/"].+/binaries/apache-maven-.+-bin.zip(?=")')
+json=$(curl -s "https://api.github.com/repos/apache/maven/tags")
+latestMavenVersion=$(echo $json | jq -r '.[] | select(.name | match("^(maven-[0-9.]*)$")) | .name' | head -1 | cut -d- -f2)
+mavenDownloadUrl="https://www-eu.apache.org/dist/maven/maven-3/${latestMavenVersion}/binaries/apache-maven-${latestMavenVersion}-bin.zip"
 download_with_retries $mavenDownloadUrl "/tmp" "maven.zip"
 unzip -qq -d /usr/share /tmp/maven.zip
-ln -s /usr/share/apache-maven-*/bin/mvn /usr/bin/mvn
+ln -s /usr/share/apache-maven-${latestMavenVersion}/bin/mvn /usr/bin/mvn
 
 # Install Gradle
 # This script founds the latest gradle release from https://services.gradle.org/versions/all


### PR DESCRIPTION
Reverts actions/virtual-environments#4182

Binaries 3.8.2 have been removed without updating links to download the latest version - https://maven.apache.org/download.cgi