### PR TITLE
[macOS] Add GOROOT env variables

### DIFF
--- a/images/macos/helpers/SoftwareReport.Helpers.psm1
+++ b/images/macos/helpers/SoftwareReport.Helpers.psm1
@@ -60,3 +60,65 @@ function Get-BrewPackageVersion {
 
     return $packageVersion
 }
+
+function Get-CachedToolInstances
+{
+    <#
+    .SYNOPSIS
+    Returns hastable of installed cached tools.
+
+    .DESCRIPTION
+    Return hastable that contains versions and architectures for selected cached tool.
+
+    .PARAMETER Name
+    Name of cached tool.
+
+    .PARAMETER VersionCommand
+    Optional parameter. Command to return version of system default tool.
+
+    .EXAMPLE
+    Get-CachedToolInstances -Name "Python" -VersionCommand "--version"
+
+    #>
+
+    param
+    (
+        [String] $Name,
+        [String] $VersionCommand
+    )
+
+    $toolInstances = @()
+    $toolPath = Join-Path -Path $env:AGENT_TOOLSDIRECTORY -ChildPath $Name
+
+    # Get all installed versions from TOOLSDIRECTORY folder
+    $versions = Get-ChildItem $toolPath | Sort-Object { [System.Version]$_.Name }
+    foreach ($version in $versions)
+    {
+        $instanceInfo = @{}
+
+        # Create instance hashtable
+        [string]$instanceInfo.Path = Join-Path -Path $toolPath -ChildPath $version.Name
+        [string]$instanceInfo.Version = $version.Name
+
+        # Get all architectures for current version
+        [array]$instanceInfo.Architecture_Array = Get-ChildItem $version.FullName -Name -Directory | Where-Object { $_ -match "^x[0-9]{2}$" }
+        [string]$instanceInfo.Architecture = $instanceInfo.Architecture_Array -Join ", "
+
+        # Add (default) postfix to version name, in case if current version is in environment path
+        if (-not ([string]::IsNullOrEmpty($VersionCommand)))
+        {
+            $defaultVersion = $(& ($Name.ToLower()) $VersionCommand 2>&1)
+            $defaultToolVersion = $defaultVersion   | Select-String -Pattern "\d+\.\d+\.\d+" -AllMatches `
+                                                    | ForEach-Object { $_.Matches.Value }
+
+            if ([version]$version.Name -eq [version]$defaultToolVersion)
+            {
+                $instanceInfo.Version += " (Default)"
+            }
+        }
+
+        $toolInstances += $instanceInfo
+    }
+
+    return $toolInstances
+}

--- a/images/macos/provision/core/Configure-Toolset.ps1
+++ b/images/macos/provision/core/Configure-Toolset.ps1
@@ -1,0 +1,66 @@
+################################################################################
+##  File:  Configure-Toolset.ps1
+##  Team:  CI-Build
+##  Desc:  Configure toolset
+################################################################################
+
+Import-Module "~/image-generation/helpers/Common.Helpers.psm1"
+
+function Get-ToolsetToolFullPath
+{
+    param
+    (
+        [Parameter(Mandatory)] [string] $ToolName,
+        [Parameter(Mandatory)] [string] $ToolVersion,
+        [Parameter(Mandatory)] [string] $ToolArchitecture
+    )
+
+    $toolPath = Join-Path -Path $env:AGENT_TOOLSDIRECTORY -ChildPath $toolName
+    $toolPathVersion = Join-Path -Path $toolPath -ChildPath $toolVersion
+    $foundVersion = Get-Item $toolPathVersion | Sort-Object -Property {[version]$_.name} -Descending | Select-Object -First 1
+    $installationDir = Join-Path -Path $foundVersion -ChildPath $toolArchitecture
+    return $installationDir
+}
+
+function Add-EnvironmentVariable
+{
+    param
+    (
+        [Parameter(Mandatory)] [string] $Name,
+        [Parameter(Mandatory)] [string] $Value,
+        [string] $FilePath = "${env:HOME}/.bashrc"
+    )
+
+    $envVar = "{0}={1}" -f $name, $value
+    Tee-Object -InputObject $envVar -FilePath $filePath -Append
+}
+
+$toolsEnvironment = @{
+    go = @{
+        variableTemplate = "GOROOT_{0}_{1}_X64"
+    }
+}
+
+$toolset = Get-Content -Path "$env:HOME/image-generation/toolset.json" -Raw | ConvertFrom-Json
+
+foreach ($tool in $toolset.toolcache)
+{
+    $toolName = $tool.name
+    $toolArch = $tool.arch
+    $toolEnvironment = $toolsEnvironment[$toolName]
+
+    if (-not $toolEnvironment)
+    {
+        continue
+    }
+
+    foreach ($toolVersion in $tool.versions)
+    {
+        Write-Host "Set $toolName $toolVersion environment variable..."
+        $toolPath = Get-ToolsetToolFullPath -ToolName $toolName -ToolVersion $toolVersion -ToolArchitecture $toolArch
+        $envName = $toolEnvironment.variableTemplate -f $toolVersion.split(".")
+
+        # Add environment variable name=value
+        Add-EnvironmentVariable -Name $envName -Value $toolPath
+    }
+}

--- a/images/macos/software-report/SoftwareReport.Toolcache.psm1
+++ b/images/macos/software-report/SoftwareReport.Toolcache.psm1
@@ -28,9 +28,22 @@ function Get-ToolcacheNodeVersions {
     return Get-ChildItem $toolcachePath -Name | Sort-Object { [Version]$_ }
 }
 
-function Get-ToolcacheGoVersions {
-    $toolcachePath = Join-Path $env:HOME "hostedtoolcache" "Go"
-    return Get-ChildItem $toolcachePath -Name | Sort-Object { [Version]$_ }
+function Get-ToolcacheGoTable
+{
+    $ToolInstances = Get-CachedToolInstances -Name "Go" -VersionCommand "version"
+    foreach ($Instance in $ToolInstances)
+    {
+        $Version = [System.Version]($Instance.Version -Split(" "))[0]
+        $Instance."Environment Variable" = "GOROOT_$($Version.major)_$($Version.minor)_X64"
+    }
+
+    $Content = $ToolInstances | New-MDTable -Columns ([ordered]@{
+        Version = "left";
+        Architecture = "left";
+        "Environment Variable" = "left"
+    })
+
+    return $Content
 }
 
 function Build-ToolcacheSection { 
@@ -47,7 +60,7 @@ function Build-ToolcacheSection {
         $output += New-MDHeader "Node.js" -Level 4
         $output += New-MDList -Lines (Get-ToolcacheNodeVersions) -Style Unordered
         $output += New-MDHeader "Go" -Level 4
-        $output += New-MDList -Lines (Get-ToolcacheGoVersions) -Style Unordered
+        $output += (Get-ToolcacheGoTable)
     }
 
     return $output

--- a/images/macos/templates/macOS-10.15.json
+++ b/images/macos/templates/macOS-10.15.json
@@ -195,7 +195,10 @@
         {
             "type": "shell",
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}",
-            "scripts": "./provision/core/toolset.ps1"
+            "scripts": [ 
+                "./provision/core/toolset.ps1",
+                "./provision/core/Configure-Toolset.ps1"
+            ]
         },
         {
             "type": "shell",

--- a/images/macos/templates/macOS-11.json
+++ b/images/macos/templates/macOS-11.json
@@ -198,7 +198,10 @@
         {
             "type": "shell",
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}",
-            "scripts": "./provision/core/toolset.ps1"
+            "scripts": [ 
+                "./provision/core/toolset.ps1",
+                "./provision/core/Configure-Toolset.ps1"
+            ]
         },
         {
             "type": "shell",

--- a/images/macos/templates/macOS-12.json
+++ b/images/macos/templates/macOS-12.json
@@ -193,7 +193,10 @@
         {
             "type": "shell",
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}",
-            "scripts": "./provision/core/toolset.ps1"
+            "scripts": [ 
+                "./provision/core/toolset.ps1",
+                "./provision/core/Configure-Toolset.ps1"
+            ]
         },
         {
             "type": "shell",


### PR DESCRIPTION
# Description
Added environment variabels like `GOROOT_1_17_X64` for all Go versions on macOS images. Also updated documentation to represent Go versions and related environment variabels.

#### Related issue: https://github.com/actions/virtual-environments/issues/4156

## Check list
- [x] Related issue / work item is attached
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
