### PR TITLE
Initialize Visual Studio Experimental Instance on the correct user

### DIFF
--- a/images/win/post-generation/VSConfiguration.ps1
+++ b/images/win/post-generation/VSConfiguration.ps1
@@ -1,4 +1,8 @@
 $vsInstallRoot = (Get-VisualStudioInstance).InstallationPath
 $devEnvPath = "$vsInstallRoot\Common7\IDE\devenv.exe"
 
+# Initialize Visual Studio Experimental Instance
+# The Out-Null cmdlet is required to ensure PowerShell waits until the '/ResetSettings' command fully completes.
+& "$devEnvPath" /RootSuffix Exp /ResetSettings General.vssettings /Command File.Exit | Out-Null
+
 cmd.exe /c "`"$devEnvPath`" /updateconfiguration"

--- a/images/win/scripts/Installers/Install-VS.ps1
+++ b/images/win/scripts/Installers/Install-VS.ps1
@@ -31,12 +31,6 @@ if ($instanceFolders -is [array])
     exit 1
 }
 
-$vsInstallRoot = (Get-VisualStudioInstance).InstallationPath
-
-# Initialize Visual Studio Experimental Instance
-# The Out-Null cmdlet is required to ensure PowerShell waits until the '/ResetSettings' command fully completes.
-& "$vsInstallRoot\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings /Command File.Exit | Out-Null
-
 # Updating content of MachineState.json file to disable autoupdate of VSIX extensions
 $newContent = '{"Extensions":[{"Key":"1e906ff5-9da8-4091-a299-5c253c55fdc9","Value":{"ShouldAutoUpdate":false}},{"Key":"Microsoft.VisualStudio.Web.AzureFunctions","Value":{"ShouldAutoUpdate":false}}],"ShouldAutoUpdate":false,"ShouldCheckForUpdates":false}'
 Set-Content -Path "$vsInstallRoot\Common7\IDE\Extensions\MachineState.json" -Value $newContent


### PR DESCRIPTION
The Visual Studio Experimental Instance initialization needs to happen in the user where the GA workflow will run (`runneradmin`), not on the `installer` user which is currently the case due to https://github.com/actions/virtual-environments/blob/c161416ac88327a4362f4fb8b3413fea4fe9289b/images/win/windows2022.json#L165.

See my previous pull request https://github.com/actions/virtual-environments/pull/4143 why this is needed.

