### PR TITLE
[Ubuntu] docker: add buildkit image

### DIFF
--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -213,6 +213,7 @@
             "debian:9",
             "debian:10",
             "debian:11",
+            "moby/buildkit:latest",
             "node:10",
             "node:12",
             "node:14",

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -211,6 +211,7 @@
             "debian:9",
             "debian:10",
             "debian:11",
+            "moby/buildkit:latest",
             "node:10",
             "node:12",
             "node:14",


### PR DESCRIPTION
# Description

[BuildKit](https://github.com/moby/buildkit) is probably the most used build engine for Docker images via our [docker/build-push-action](https://github.com/docker/build-push-action/) GitHub Action.

Whenever a build is triggered, the latest [BuildKit image](https://hub.docker.com/r/moby/buildkit) is pulled from Docker Hub and we think it would be more efficient for GitHub to have it preloaded.

cc @chrispat @justincormack @chris-crone @tonistiigi

#### Related issue: -
