### PR TITLE
[macOS] Remove code duplication for Get-PHPVersion function.

### DIFF
--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -151,11 +151,6 @@ function Build-OSInfoSection {
     return $output
 }
 
-function Get-PHPVersion {
-    $PHPVersion = Run-Command "php --version" | Select-Object -First 1 | Take-Part -Part 0,1
-    return $PHPVersion
-}
-
 function Get-MSBuildVersion {
     $msbuildVersion = msbuild -version | Select-Object -Last 1
     $result = Select-String -Path (Get-Command msbuild).Source -Pattern "msbuild"


### PR DESCRIPTION
# Description
In scope of this pull request we remove code duplication for Get-PHPVersion function.
1. [Get-PHPVersion](https://github.com/actions/virtual-environments/blob/main/images/macos/software-report/SoftwareReport.Common.psm1#L192-L195)
2. [Get-PHPVersion](https://github.com/actions/virtual-environments/blob/main/images/macos/software-report/SoftwareReport.Common.psm1#L154-L157)

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
