### PR TITLE
[Windows] vs: revert $vsInstallRoot

### DIFF
--- a/images/win/scripts/Installers/Install-VS.ps1
+++ b/images/win/scripts/Installers/Install-VS.ps1
@@ -32,6 +32,7 @@ if ($instanceFolders -is [array])
 }
 
 # Updating content of MachineState.json file to disable autoupdate of VSIX extensions
+$vsInstallRoot = (Get-VisualStudioInstance).InstallationPath
 $newContent = '{"Extensions":[{"Key":"1e906ff5-9da8-4091-a299-5c253c55fdc9","Value":{"ShouldAutoUpdate":false}},{"Key":"Microsoft.VisualStudio.Web.AzureFunctions","Value":{"ShouldAutoUpdate":false}}],"ShouldAutoUpdate":false,"ShouldCheckForUpdates":false}'
 Set-Content -Path "$vsInstallRoot\Common7\IDE\Extensions\MachineState.json" -Value $newContent
 


### PR DESCRIPTION
# Description
Image generation process has been starting to fail at the `Install-VS.ps1` script with `Set-Content : Could not find a part of the path 'C:\Common7\IDE\Extensions\MachineState.json'` error,  after regression was included in  https://github.com/actions/virtual-environments/pull/4223 PR. We should revert $vsInstallRoot statement to fix the issue.