### PR TITLE
[Windows] Install the latest available azure-cli msi package

### DIFF
--- a/images/win/scripts/Installers/Install-AzureCli.ps1
+++ b/images/win/scripts/Installers/Install-AzureCli.ps1
@@ -4,8 +4,8 @@
 ################################################################################
 
 Write-Host "Install the latest Azure CLI release"
-$assets = Invoke-RestMethod -Uri 'https://api.github.com/repos/Azure/azure-cli/releases/latest'
-$azCliUrl = $assets.assets.browser_download_url
+$assets = Invoke-RestMethod -Uri 'https://api.github.com/repos/Azure/azure-cli/releases'
+$azCliUrl = $assets.assets.browser_download_url[0]
 $azCliName = [IO.Path]::GetFileName($azCliUrl)
 Install-Binary -Url $azCliUrl -Name $azCliName -ArgumentList ("/qn", "/norestart")
 

--- a/images/win/scripts/Installers/Install-AzureCli.ps1
+++ b/images/win/scripts/Installers/Install-AzureCli.ps1
@@ -4,10 +4,8 @@
 ################################################################################
 
 Write-Host "Install the latest Azure CLI release"
-$assets = Invoke-RestMethod -Uri 'https://api.github.com/repos/Azure/azure-cli/releases'
-$azCliUrl = $assets.assets.browser_download_url[0]
-$azCliName = [IO.Path]::GetFileName($azCliUrl)
-Install-Binary -Url $azCliUrl -Name $azCliName -ArgumentList ("/qn", "/norestart")
+$azCliUrl = "https://aka.ms/installazurecliwindows"
+Install-Binary -Url $azCliUrl -Name "azure-cli.msi" -ArgumentList ("/qn", "/norestart")
 
 $azureCliExtensionPath = Join-Path $Env:CommonProgramFiles 'AzureCliExtensionDirectory'
 $null = New-Item -ItemType "Directory" -Path $azureCliExtensionPath


### PR DESCRIPTION
# Description
The latest azure-cli is not available via msi package, it can be installed using python only https://github.com/Azure/azure-cli/issues/19811
This PR changes the way we get the version as the latest release does not always include msi package.

#### Related issue:
n\a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
