### PR TITLE
Windows 2022 MSYS2 - add base-devel & compression groups

### DIFF
--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -139,7 +139,10 @@
         }
     },
     "MsysPackages": {
-        "msys2": [],
+        "msys2": [
+            "base-devel",
+            "compression"
+        ],
         "mingw": []
     },
     "windowsFeatures": [


### PR DESCRIPTION
# Description

Windows 2022 image removed MSYS2 mingw build tools, and also removed 'shared' MSYS2 tools.  Adds base-devel & compression groups to the MSYS2 Install.  Previously, no testing was done on these packages, which do add several exe files.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
