### PR TITLE
[Ubuntu] Install latest available cabal version

### DIFF
--- a/images/linux/scripts/installers/haskell.sh
+++ b/images/linux/scripts/installers/haskell.sh
@@ -38,7 +38,7 @@ for majorMinorVersion in $minorMajorVersions; do
 done
 
 echo "install cabal..."
-ghcup install cabal
+ghcup install cabal latest
 
 chmod -R 777 $GHCUP_INSTALL_BASE_PREFIX/.ghcup
 ln -s $GHCUP_INSTALL_BASE_PREFIX/.ghcup /etc/skel/.ghcup


### PR DESCRIPTION
# Description
For some reason, current installation approach installs `3.4.1.0` version of `cabal`, which is not the latest available. Adding `latest` flag to fix it.

#### Related issue: https://github.com/actions/virtual-environments/pull/4251#discussion_r725900570

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
