### PR TITLE
[macOS] Set Xcode 13.0 as default and remove Xcode 12.5 on BigSur

### DIFF
--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -1,12 +1,11 @@
 {
     "xcode": {
-        "default": "12.5.1",
+        "default": "13.0",
         "versions": [
-            { "link": "13.0", "version": "13.0.0"},
-            { "link": "13.0_beta", "version": "13 beta 5", "skip-symlink": "true"},
-            { "link": "12.5.1", "version": "12.5.1"},
-            { "link": "12.5", "version": "12.5.0"},
-            { "link": "12.4", "version": "12.4.0"},
+            { "link": "13.0", "version": "13.0.0" },
+            { "link": "13.0_beta", "version": "13 beta 5", "skip-symlink": "true" },
+            { "link": "12.5.1", "version": "12.5.1" },
+            { "link": "12.4", "version": "12.4.0" },
             { "link": "11.7", "version": "11.7.0", "symlinks": ["11.7_beta"] }
         ]
     },


### PR DESCRIPTION
# Description
In scope of this PR we are changing default Xcode version on BigSur to 13.0 and removing Xcode 12.5 

#### Related issue: [#4180](https://github.com/actions/virtual-environments/issues/4180), [#4183](https://github.com/actions/virtual-environments/issues/4183)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
