### PR TITLE
Expose ghcup binary to PATH on windows

### DIFF
--- a/images/win/scripts/Installers/Install-Haskell.ps1
+++ b/images/win/scripts/Installers/Install-Haskell.ps1
@@ -32,8 +32,6 @@ Add-MachinePathItem -PathItem $DefaultGhcPath
 Write-Host 'Installing cabal...'
 Choco-Install -PackageName cabal
 
-Invoke-PesterTests -TestFile 'Haskell'
-
 # install minimal ghcup, utilizing pre-installed msys2 at C:\msys64
 $msysPath = "C:\msys64"
 $ghcupPrefix = "C:\"
@@ -45,3 +43,5 @@ Set-SystemVariable "GHCUP_MSYS2" $msysPath
 Set-SystemVariable "CABAL_DIR" $cabalDir
 Add-MachinePathItem "$ghcupPrefix\ghcup\bin"
 Add-MachinePathItem "$cabalDir\bin"
+
+Invoke-PesterTests -TestFile 'Haskell'

--- a/images/win/scripts/Installers/Install-Haskell.ps1
+++ b/images/win/scripts/Installers/Install-Haskell.ps1
@@ -38,6 +38,7 @@ Invoke-PesterTests -TestFile 'Haskell'
 $msysPath = "C:\msys64"
 $ghcupPrefix = "C:\"
 $cabalDir = "C:\cabal"
+$bootstrapHaskell = Invoke-WebRequest https://www.haskell.org/ghcup/sh/bootstrap-haskell.ps1 -UseBasicParsing
 Invoke-Command -ScriptBlock ([ScriptBlock]::Create($bootstrapHaskell)) -ArgumentList $false, $true, $true, $false, $false, $false, $false, $ghcupPrefix, "", $msysPath, $cabalDir
 Set-SystemVariable "GHCUP_INSTALL_BASE_PREFIX" $ghcupPrefix
 Set-SystemVariable "GHCUP_MSYS2" $msysPath

--- a/images/win/scripts/Installers/Install-Haskell.ps1
+++ b/images/win/scripts/Installers/Install-Haskell.ps1
@@ -33,6 +33,7 @@ Write-Host 'Installing cabal...'
 Choco-Install -PackageName cabal
 
 # install minimal ghcup, utilizing pre-installed msys2 at C:\msys64
+Write-Host 'Installing ghcup...'
 $msysPath = "C:\msys64"
 $ghcupPrefix = "C:\"
 $cabalDir = "C:\cabal"

--- a/images/win/scripts/Installers/Install-Haskell.ps1
+++ b/images/win/scripts/Installers/Install-Haskell.ps1
@@ -38,7 +38,7 @@ $msysPath = "C:\msys64"
 $ghcupPrefix = "C:\"
 $cabalDir = "C:\cabal"
 $bootstrapHaskell = Invoke-WebRequest https://www.haskell.org/ghcup/sh/bootstrap-haskell.ps1 -UseBasicParsing
-Invoke-Command -ScriptBlock ([ScriptBlock]::Create($bootstrapHaskell)) -ArgumentList $false, $true, $true, $false, $false, $false, $false, $ghcupPrefix, "", $msysPath, $cabalDir
+Invoke-Command -ScriptBlock ([ScriptBlock]::Create($bootstrapHaskell)) -ArgumentList $false, $true, $true, $false, $true, $false, $false, $ghcupPrefix, "", $msysPath, $cabalDir
 Set-SystemVariable "GHCUP_INSTALL_BASE_PREFIX" $ghcupPrefix
 Set-SystemVariable "GHCUP_MSYS2" $msysPath
 Set-SystemVariable "CABAL_DIR" $cabalDir

--- a/images/win/scripts/Installers/Install-Haskell.ps1
+++ b/images/win/scripts/Installers/Install-Haskell.ps1
@@ -44,3 +44,4 @@ Invoke-Command -ScriptBlock ([ScriptBlock]::Create($bootstrapHaskell)) -Argument
 [Environment]::SetEnvironmentVariable("GHCUP_MSYS2", $msysPath, [System.EnvironmentVariableTarget]::Machine)
 [Environment]::SetEnvironmentVariable("CABAL_DIR", $cabalDir, [System.EnvironmentVariableTarget]::Machine)
 Add-MachinePathItem "$ghcupPrefix\ghcup\bin"
+Add-MachinePathItem "$cabalDir\bin"

--- a/images/win/scripts/Installers/Install-Haskell.ps1
+++ b/images/win/scripts/Installers/Install-Haskell.ps1
@@ -37,8 +37,7 @@ Invoke-PesterTests -TestFile 'Haskell'
 # install minimal ghcup, utilizing pre-installed msys2 at C:\msys64
 $msysPath = "C:\msys64"
 $ghcupPrefix = "C:\"
-$appdata = [Environment]::GetEnvironmentVariable('APPDATA', [System.EnvironmentVariableTarget]::Machine) 
-$cabalDir = "$appdata\cabal"
+$cabalDir = "C:\cabal"
 Invoke-Command -ScriptBlock ([ScriptBlock]::Create($bootstrapHaskell)) -ArgumentList $false, $true, $true, $false, $false, $false, $false, $ghcupPrefix, "", $msysPath, $cabalDir
 Set-SystemVariable "GHCUP_INSTALL_BASE_PREFIX" $ghcupPrefix
 Set-SystemVariable "GHCUP_MSYS2" $msysPath

--- a/images/win/scripts/Installers/Install-Haskell.ps1
+++ b/images/win/scripts/Installers/Install-Haskell.ps1
@@ -37,7 +37,10 @@ Invoke-PesterTests -TestFile 'Haskell'
 # install minimal ghcup, utilizing pre-installed msys2 at C:\msys64
 $msysPath = "C:\msys64"
 $ghcupPrefix = "C:\"
-Invoke-Command -ScriptBlock ([ScriptBlock]::Create($bootstrapHaskell)) -ArgumentList $false, $true, $true, $false, $false, $false, $false, $ghcupPrefix, "", $msysPath, C:\cabal
+$appdata = [Environment]::GetEnvironmentVariable('APPDATA', [System.EnvironmentVariableTarget]::Machine) 
+$cabalDir = "$appdata\cabal"
+Invoke-Command -ScriptBlock ([ScriptBlock]::Create($bootstrapHaskell)) -ArgumentList $false, $true, $true, $false, $false, $false, $false, $ghcupPrefix, "", $msysPath, $cabalDir
 [Environment]::SetEnvironmentVariable("GHCUP_INSTALL_BASE_PREFIX", $ghcupPrefix, [System.EnvironmentVariableTarget]::Machine)
 [Environment]::SetEnvironmentVariable("GHCUP_MSYS2", $msysPath, [System.EnvironmentVariableTarget]::Machine)
+[Environment]::SetEnvironmentVariable("CABAL_DIR", $cabalDir, [System.EnvironmentVariableTarget]::Machine)
 Add-MachinePathItem "$ghcupPrefix\ghcup\bin"

--- a/images/win/scripts/Installers/Install-Haskell.ps1
+++ b/images/win/scripts/Installers/Install-Haskell.ps1
@@ -40,8 +40,8 @@ $ghcupPrefix = "C:\"
 $appdata = [Environment]::GetEnvironmentVariable('APPDATA', [System.EnvironmentVariableTarget]::Machine) 
 $cabalDir = "$appdata\cabal"
 Invoke-Command -ScriptBlock ([ScriptBlock]::Create($bootstrapHaskell)) -ArgumentList $false, $true, $true, $false, $false, $false, $false, $ghcupPrefix, "", $msysPath, $cabalDir
-[Environment]::SetEnvironmentVariable("GHCUP_INSTALL_BASE_PREFIX", $ghcupPrefix, [System.EnvironmentVariableTarget]::Machine)
-[Environment]::SetEnvironmentVariable("GHCUP_MSYS2", $msysPath, [System.EnvironmentVariableTarget]::Machine)
-[Environment]::SetEnvironmentVariable("CABAL_DIR", $cabalDir, [System.EnvironmentVariableTarget]::Machine)
+Set-SystemVariable "GHCUP_INSTALL_BASE_PREFIX" $ghcupPrefix
+Set-SystemVariable "GHCUP_MSYS2" $msysPath
+Set-SystemVariable "CABAL_DIR" $cabalDir
 Add-MachinePathItem "$ghcupPrefix\ghcup\bin"
 Add-MachinePathItem "$cabalDir\bin"

--- a/images/win/scripts/Installers/Install-Haskell.ps1
+++ b/images/win/scripts/Installers/Install-Haskell.ps1
@@ -35,5 +35,9 @@ Choco-Install -PackageName cabal
 Invoke-PesterTests -TestFile 'Haskell'
 
 # install minimal ghcup, utilizing pre-installed msys2 at C:\msys64
-$bootstrapHaskell = Invoke-WebRequest https://www.haskell.org/ghcup/sh/bootstrap-haskell.ps1 -UseBasicParsing
-Invoke-Command -ScriptBlock ([ScriptBlock]::Create($bootstrapHaskell)) -ArgumentList $false, $true, $true, $false, $false, $false, $false, C:\, "", C:\msys64, C:\cabal
+$msysPath = "C:\msys64"
+$ghcupPrefix = "C:\"
+Invoke-Command -ScriptBlock ([ScriptBlock]::Create($bootstrapHaskell)) -ArgumentList $false, $true, $true, $false, $false, $false, $false, $ghcupPrefix, "", $msysPath, C:\cabal
+[Environment]::SetEnvironmentVariable("GHCUP_INSTALL_BASE_PREFIX", $ghcupPrefix, [System.EnvironmentVariableTarget]::Machine)
+[Environment]::SetEnvironmentVariable("GHCUP_MSYS2", $msysPath, [System.EnvironmentVariableTarget]::Machine)
+Add-MachinePathItem "$ghcupPrefix\ghcup\bin"

--- a/images/win/scripts/Tests/Haskell.Tests.ps1
+++ b/images/win/scripts/Tests/Haskell.Tests.ps1
@@ -30,7 +30,7 @@ Describe "Haskell" {
     )
 
     It "<envVar> environment variable exists" -TestCases $ghcupEnvExists {
-        [Environment]::GetEnvironmentVariables("Machine").ContainsKey($envVar) | Should -BeTrue
+        Test-Path env:\$envVar
     }
 
     It "Accurate 3 versions of GHC are installed" -TestCases @{ghcCount = $ghcCount} {
@@ -50,8 +50,8 @@ Describe "Haskell" {
     }
 
     It "cabal config was modified and exists" {
-        [Environment]::GetEnvironmentVariable('CABAL_DIR', [System.EnvironmentVariableTarget]::Machine) | Should -Exist
-        "cabal user-config diff" | Should -Not -BeNullOrEmpty
+        $env:CABAL_DIR | Should -Exist
+        "cabal user-config diff" | Should -ReturnZeroExitCode
     }
 
     It "ghcup is installed" {

--- a/images/win/scripts/Tests/Haskell.Tests.ps1
+++ b/images/win/scripts/Tests/Haskell.Tests.ps1
@@ -49,6 +49,11 @@ Describe "Haskell" {
         "cabal --version" | Should -ReturnZeroExitCode
     }
 
+    It "cabal config was modified and exists" {
+        [Environment]::GetEnvironmentVariable('CABAL_DIR', [System.EnvironmentVariableTarget]::Machine) | Should -Exist
+        "cabal user-config diff" | Should -Not -BeNullOrEmpty
+    }
+
     It "ghcup is installed" {
         "ghcup --version" | Should -ReturnZeroExitCode
     }

--- a/images/win/scripts/Tests/Haskell.Tests.ps1
+++ b/images/win/scripts/Tests/Haskell.Tests.ps1
@@ -24,6 +24,15 @@ Describe "Haskell" {
         }
     }
 
+    $ghcupEnvExists = @(
+        @{envVar = "GHCUP_INSTALL_BASE_PREFIX"}
+        @{envVar = "GHCUP_MSYS2"}
+    )
+
+    It "<envVar> environment variable exists" -TestCases $ghcupEnvExists {
+        [Environment]::GetEnvironmentVariables("Machine").ContainsKey($envVar) | Should -BeTrue
+    }
+
     It "Accurate 3 versions of GHC are installed" -TestCases @{ghcCount = $ghcCount} {
         $ghcCount | Should -BeExactly 3
     }
@@ -38,5 +47,9 @@ Describe "Haskell" {
 
     It "Cabal is installed" {
         "cabal --version" | Should -ReturnZeroExitCode
+    }
+
+    It "ghcup is installed" {
+        "ghcup --version" | Should -ReturnZeroExitCode
     }
 }


### PR DESCRIPTION
The [bootstrap-haskell.ps1](https://gitlab.haskell.org/haskell/ghcup-hs/-/blob/master/scripts/bootstrap/bootstrap-haskell.ps1) script uses
`[System.EnvironmentVariableTarget]::User` instead of
`[System.EnvironmentVariableTarget]::Machine`, so it appears
ghcup env vars and PATH update never make it. Do these manually
for now.

@newhoggy

https://github.com/haskell/actions/issues/70#issuecomment-927078557

----

Can't really say if this works as expected, hence the newly added tests. I tried to be as conservative as possible, so not changing default cabal config directory.