### PR TITLE
[macOS] utils:  silently ignore records that would violate

### DIFF
--- a/images/macos/provision/utils/utils.sh
+++ b/images/macos/provision/utils/utils.sh
@@ -196,7 +196,7 @@ configure_system_tccdb () {
     local values=$1
 
     local dbPath="/Library/Application Support/com.apple.TCC/TCC.db"
-    local sqlQuery="INSERT INTO access VALUES($values);"
+    local sqlQuery="INSERT OR IGNORE INTO access VALUES($values);"
     sudo sqlite3 "$dbPath" "$sqlQuery"
 }
 
@@ -204,6 +204,6 @@ configure_user_tccdb () {
     local values=$1
 
     local dbPath="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
-    local sqlQuery="INSERT INTO access VALUES($values);"
+    local sqlQuery="INSERT OR IGNORE INTO access VALUES($values);"
     sqlite3 "$dbPath" "$sqlQuery"
 }


### PR DESCRIPTION
# Issue
Some records already exist in the TCC.db and we get an error like:
`UNIQUE constraint failed: access.service, access.client, access.client_type, access.indirect_object_identifier`

We should ignore records which are present in the TCC.db.

E.g:
```
$ sudo sqlite3 $HOME/Library/Application\ Support/com.apple.TCC/TCC.db "SELECT * FROM access;"
kTCCServiceUbiquity|/System/Library/PrivateFrameworks/ContactsDonation.framework/Versions/A/Support/contactsdonationagent|1|2|5|1||||UNUSED||0|1633987653
kTCCServiceUbiquity|/System/Library/PrivateFrameworks/Tourist.framework/Versions/A/Resources/touristd|1|2|5|1||||UNUSED||0|1633987899
kTCCServiceUbiquity|com.apple.mail|0|2|5|1||||UNUSED||0|1633989914

$ sudo sqlite3 "$HOME/Library/Application Support/com.apple.TCC/TCC.db" "INSERT INTO access VALUES('kTCCServiceUbiquity','com.apple.mail',0,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1551941469);"
Error: UNIQUE constraint failed: access.service, access.client, access.client_type, access.indirect_object_identifier

$ sudo sqlite3 "$HOME/Library/Application Support/com.apple.TCC/TCC.db" "INSERT OR IGNORE INTO access VALUES('kTCCServiceUbiquity','com.apple.mail',0,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1551941469);"
$ echo $?
0
```

