### PR TITLE
Add Microsoft Graph PowerShell SDK, update readme

### DIFF
--- a/images/win/Windows2016-Readme.md
+++ b/images/win/Windows2016-Readme.md
@@ -544,6 +544,7 @@ All other versions are saved but not installed.
 | PSWindowsUpdate    | 2.2.0.2          |
 | SqlServer          | 21.1.18256       |
 | VSSetup            | 2.2.16           |
+| Microsoft.Graph    | 1.7.0            |
 
 ### Android
 | Package Name               | Version                                                                                                                                                                                                                                                                                         |

--- a/images/win/Windows2019-Readme.md
+++ b/images/win/Windows2019-Readme.md
@@ -538,6 +538,7 @@ All other versions are saved but not installed.
 | PSWindowsUpdate    | 2.2.0.2          |
 | SqlServer          | 21.1.18256       |
 | VSSetup            | 2.2.16           |
+| Microsoft.Graph    | 1.7.0            |
 
 ### Android
 | Package Name               | Version                                                                                                                                                                                                                                                                                         |

--- a/images/win/Windows2022-Readme.md
+++ b/images/win/Windows2022-Readme.md
@@ -440,6 +440,7 @@ All other versions are saved but not installed.
 | PSWindowsUpdate    | 2.2.0.2          |
 | SqlServer          | 21.1.18256       |
 | VSSetup            | 2.2.16           |
+| Microsoft.Graph    | 1.7.0            |
 
 ### Android
 | Package Name               | Version                                                                                                                            |

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -87,7 +87,8 @@
         {"name": "PSScriptAnalyzer"},
         {"name": "PSWindowsUpdate"},
         {"name": "SqlServer"},
-        {"name": "VSSetup"}
+        {"name": "VSSetup"},
+        {"name": "Microsoft.Graph"}
     ],
     "azureModules": [
         {

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -87,7 +87,8 @@
         {"name": "PSScriptAnalyzer"},
         {"name": "PSWindowsUpdate"},
         {"name": "SqlServer"},
-        {"name": "VSSetup"}
+        {"name": "VSSetup"},
+        {"name": "Microsoft.Graph"}
     ],
     "azureModules": [
         {

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -64,7 +64,8 @@
         { "name": "PSScriptAnalyzer" },
         { "name": "PSWindowsUpdate" },
         { "name": "SqlServer" },
-        { "name": "VSSetup" }
+        { "name": "VSSetup" },
+        { "name": "Microsoft.Graph" }
     ],
     "azureModules": [
         {


### PR DESCRIPTION
# Description
New tool  
The Microsoft Graph PowerShell SDK is a collection of PowerShell modules that contain commands for calling Microsoft Graph service. It's the replacement of the AzureAD PowerShell module and the way forward in PowerShell to call the Microsoft Graph.
See #4268 for more information.

Size: 76,4 mb
Installation time: 41 seconds

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
