### PR TITLE
[Windows] Pin Selenium to 3.141.59 version

### DIFF
--- a/images/win/scripts/Installers/Install-Selenium.ps1
+++ b/images/win/scripts/Installers/Install-Selenium.ps1
@@ -9,11 +9,12 @@ $seleniumFileName = "selenium-server-standalone.jar"
 
 New-Item -ItemType directory -Path $seleniumDirectory
 
-# Download Selenium
-$url = "https://api.github.com/repos/SeleniumHQ/selenium/releases/latest"
-[System.String] $seleniumReleaseUrl = (Invoke-RestMethod -Uri $url).assets.browser_download_url -match "selenium-server-standalone-.+.jar"
+# Download Selenium 3.141.59, since 4.* contains some breaking changes
+#$url = "https://api.github.com/repos/SeleniumHQ/selenium/releases/latest"
+#[System.String] $seleniumReleaseUrl = (Invoke-RestMethod -Uri $url).assets.browser_download_url -match "selenium-server-standalone-.+.jar"
+$seleniumDownloadUrl = "https://selenium-release.storage.googleapis.com/3.141/selenium-server-standalone-3.141.59.jar"
 
-Start-DownloadWithRetry -Url $seleniumReleaseUrl -Name $seleniumFileName -DownloadPath $seleniumDirectory
+Start-DownloadWithRetry -Url $seleniumDownloadUrl -Name $seleniumFileName -DownloadPath $seleniumDirectory
 
 # Add SELENIUM_JAR_PATH environment variable
 $seleniumBinPath = Join-Path $seleniumDirectory $seleniumFileName

--- a/images/win/scripts/Installers/Install-Selenium.ps1
+++ b/images/win/scripts/Installers/Install-Selenium.ps1
@@ -9,11 +9,11 @@ $seleniumFileName = "selenium-server-standalone.jar"
 
 New-Item -ItemType directory -Path $seleniumDirectory
 
-# Download Selenium 3.141.59, since 4.* contains some breaking changes
-#$url = "https://api.github.com/repos/SeleniumHQ/selenium/releases/latest"
+# Temporarily download Selenium 3.141.59, since 4.* can contain some breaking changes
+#$url = "https://api.github.com/repos/SeleniumHQ/selenium/releases"
 #[System.String] $seleniumReleaseUrl = (Invoke-RestMethod -Uri $url).assets.browser_download_url -match "selenium-server-standalone-.+.jar"
-$seleniumDownloadUrl = "https://selenium-release.storage.googleapis.com/3.141/selenium-server-standalone-3.141.59.jar"
 
+$seleniumDownloadUrl = "https://github.com/SeleniumHQ/selenium/releases/download/selenium-3.141.59/selenium-server-standalone-3.141.59.jar"
 Start-DownloadWithRetry -Url $seleniumDownloadUrl -Name $seleniumFileName -DownloadPath $seleniumDirectory
 
 # Add SELENIUM_JAR_PATH environment variable


### PR DESCRIPTION
# Description
`Selenium` was recently updated to 4.* version that can contain some breaking changes. We decided to pin its version to `3.141.59` for some time.

#### Related issue: [#4271](https://github.com/actions/virtual-environments/issues/4271)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
