### PR TITLE
[Ubuntu] Pin Selenium to 3.141.59 version

### DIFF
--- a/images/linux/scripts/installers/selenium.sh
+++ b/images/linux/scripts/installers/selenium.sh
@@ -10,10 +10,10 @@ source $HELPER_SCRIPTS/install.sh
 # Temporarily download Selenium 3.141.59, since 4.* can contain some breaking changes
 SELENIUM_JAR_NAME="selenium-server-standalone.jar"
 SELENIUM_JAR_PATH="/usr/share/java"
-SELENIUM_LATEST_VERSION_URL="https://github.com/SeleniumHQ/selenium/releases/download/selenium-3.141.59/selenium-server-standalone-3.141.59.jar"
+SELENIUM_DOWNLOAD_URL="https://github.com/SeleniumHQ/selenium/releases/download/selenium-3.141.59/selenium-server-standalone-3.141.59.jar"
 #SELENIUM_LATEST_VERSION_URL="$(curl -s https://api.github.com/repos/SeleniumHQ/selenium/releases/latest |\
 #    jq -r '.assets[].browser_download_url | select(contains("selenium-server-standalone") and endswith(".jar"))')"
-download_with_retries $SELENIUM_LATEST_VERSION_URL $SELENIUM_JAR_PATH $SELENIUM_JAR_NAME
+download_with_retries $SELENIUM_DOWNLOAD_URL $SELENIUM_JAR_PATH $SELENIUM_JAR_NAME
 
 # Add SELENIUM_JAR_PATH environment variable
 echo "SELENIUM_JAR_PATH=$SELENIUM_JAR_PATH/$SELENIUM_JAR_NAME" | tee -a /etc/environment


### PR DESCRIPTION
# Description
`Selenium` was recently updated to 4.* version that can contain some breaking changes. We decided to pin its version to `3.141.59` for some time.

#### Related issue: [#4271](https://github.com/actions/virtual-environments/issues/4271)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
