### PR TITLE
[Windows] win2019: enable use of test-signed code

### DIFF
--- a/images/win/scripts/Tests/WindowsFeatures.Tests.ps1
+++ b/images/win/scripts/Tests/WindowsFeatures.Tests.ps1
@@ -51,7 +51,7 @@ Describe "GDIProcessHandleQuota" {
     }
 }
 
-Describe "Test Signed Drivers" -Skip:(-not (Test-IsWin22)) {
+Describe "Test Signed Drivers" -Skip:(Test-IsWin16) {
     It "bcdedit testsigning should be Yes"{
         "$(bcdedit)" | Should -Match "testsigning\s+Yes"
     }

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -112,6 +112,14 @@
         },
         {
             "type": "powershell",
+            "inline": [
+                "bcdedit.exe /set TESTSIGNING ON"
+            ],
+            "elevated_user": "{{user `install_user`}}",
+            "elevated_password": "{{user `install_password`}}"
+        },
+        {
+            "type": "powershell",
             "environment_vars": [
                 "IMAGE_VERSION={{user `image_version`}}",
                 "IMAGE_OS={{user `image_os`}}",


### PR DESCRIPTION
# Description
In scope of this https://github.com/actions/virtual-environments/pull/4098 PR we have enabled test signing for Windows Server 2022. We have not tracked any complains related to this mode and we are planning to enable it for Windows Server 2019.

![image](https://user-images.githubusercontent.com/47745270/137730645-3ce066de-576a-4ea8-947e-7241a11524b2.png)

#### Related issue:
https://github.com/actions/virtual-environments/issues/1637

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
