### PR TITLE
[macOS] Add Xcode 13.1 to macOS 11 & 12

### DIFF
--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -2,6 +2,7 @@
     "xcode": {
         "default": "13.0",
         "versions": [
+            { "link": "13.1", "version": "13.1.0" },
             { "link": "13.0", "version": "13.0.0" },
             { "link": "13.0_beta", "version": "13 beta 5", "skip-symlink": "true" },
             { "link": "12.5.1", "version": "12.5.1" },

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -2,6 +2,7 @@
     "xcode": {
         "default": "13.0",
         "versions": [
+            { "link": "13.1", "version": "13.1.0" },
             { "link": "13.0", "version": "13.0.0"}
         ]
     },


### PR DESCRIPTION
# Description
[Xcode 13.1RC has been released](https://developer.apple.com/documentation/xcode-release-notes/xcode-13_1-release-notes), and while it claims to only support macOS-12, it looks like macOS-11 is also compatible.
![image](https://user-images.githubusercontent.com/48208649/137804160-8e1f8cdb-6d38-4b57-9d90-9284d78bc983.png)

#### Related issue:
https://github.com/actions/virtual-environments/issues/4300

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
