### PR TITLE
Remove Ubuntu 16.04 from templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/announcement.yml
+++ b/.github/ISSUE_TEMPLATE/announcement.yml
@@ -30,7 +30,6 @@ body:
     attributes:
       label: Virtual environments affected
       options:
-        - label: Ubuntu 16.04
         - label: Ubuntu 18.04
         - label: Ubuntu 20.04
         - label: macOS 10.15

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -12,7 +12,6 @@ body:
     attributes:
       label: Virtual environments affected
       options:
-        - label: Ubuntu 16.04
         - label: Ubuntu 18.04
         - label: Ubuntu 20.04
         - label: macOS 10.15

--- a/.github/ISSUE_TEMPLATE/tool-request.yml
+++ b/.github/ISSUE_TEMPLATE/tool-request.yml
@@ -51,7 +51,6 @@ body:
     attributes:
       label: Virtual environments affected
       options:
-        - label: Ubuntu 16.04
         - label: Ubuntu 18.04
         - label: Ubuntu 20.04
         - label: macOS 10.15

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ You can also track upcoming changes using the [awaiting-deployment](https://gith
 
 [ubuntu-20.04]: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
 [ubuntu-18.04]: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md
-[ubuntu-16.04]: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1604-README.md
 [windows-2022]: https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md
 [windows-2019]: https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md
 [windows-2016]: https://github.com/actions/virtual-environments/blob/main/images/win/Windows2016-Readme.md


### PR DESCRIPTION
# Description
Ubuntu 16.04 has been removed.

#### Related issue:
https://github.com/actions/virtual-environments/issues/3287

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
