### PR TITLE
fix(chromium): Fix for chromium using very low base position

### DIFF
--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -17,8 +17,9 @@ function GetChromiumRevision {
     # Take the first part of the revision variable to search not only for a specific version,
     # but also for similar ones, so that we can get a previous one if the required revision is not found
     FIRST_PART_OF_REVISION=${REVISION:0:${#REVISION}/2}
-    URL="https://www.googleapis.com/storage/v1/b/chromium-browser-snapshots/o?delimiter=/&prefix=Linux_x64/${FIRST_PART_OF_REVISION}"
-    VERSIONS=$(curl -s $URL | jq -r '.prefixes[]' | cut -d "/" -f 2 | sort --version-sort)
+    FIRST_PART_OF_PREVIOUS_REVISION=$(expr $FIRST_PART_OF_REVISION - 1)
+    URL="https://www.googleapis.com/storage/v1/b/chromium-browser-snapshots/o?delimiter=/&prefix=Linux_x64"
+    VERSIONS=$((curl -s $URL/${FIRST_PART_OF_REVISION} | jq -r '.prefixes[]' && curl -s $URL/${FIRST_PART_OF_PREVIOUS_REVISION} | jq -r '.prefixes[]') | cut -d "/" -f 2 | sort --version-sort)
 
     # If required Chromium revision is not found in the list
     # we should have to decrement the revision number until we find one.


### PR DESCRIPTION
# Description
This is a bug fix for #4314.  This change adds an additional version lookup to the `n - 1` base position for the installed version of google-chrome.  This resolves the issue where the `GetChromiumRevision` function returns an incorrect and out-of-date version when the base position of the installed google-chrome version ends in digits close to `000`

This has built successfully on our internal fork of the linux virtualenvironment


#### Related issue: #4314

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
