### PR TITLE
[Ubuntu] Verify checksum of `rustup-init.sh`

### DIFF
--- a/images/linux/scripts/installers/rust.sh
+++ b/images/linux/scripts/installers/rust.sh
@@ -10,7 +10,12 @@ source $HELPER_SCRIPTS/etc-environment.sh
 export RUSTUP_HOME=/usr/share/rust/.rustup
 export CARGO_HOME=/usr/share/rust/.cargo
 
-curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=stable --profile=minimal
+RUSTUP_LATEST_VERSION=1.24.3
+RUSTUP_INIT_SHA="a3cb081f88a6789d104518b30d4aa410009cd08c3822a1226991d6cf0442a0f8"
+curl --proto '=https' --tlsv1.2 -sSf \
+  https://raw.githubusercontent.com/rust-lang/rustup/${RUSTUP_LATEST_VERSION}/rustup-init.sh -O
+echo "${RUSTUP_INIT_SHA} rustup-init.sh" | sha256sum --check --
+sh rustup-init.sh -y --default-toolchain=stable --profile=minimal
 
 # Initialize environment variables
 source $CARGO_HOME/env


### PR DESCRIPTION
Given the risk of "piping to bash", this adds a checksum verification to the rustup bash script before running. This does require some maintenance, but rustup is updated relatively infrequently. The security gains seem worth the cost.

I haven't been able to test this yet with a VM yet, but the change should be straightforward.