### PR TITLE
[macOS] Add symlink for Xcode 12.5

### DIFF
--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -5,7 +5,7 @@
             { "link": "13.1", "version": "13.1.0" },
             { "link": "13.0", "version": "13.0.0" },
             { "link": "13.0_beta", "version": "13 beta 5", "skip-symlink": "true" },
-            { "link": "12.5.1", "version": "12.5.1" },
+            { "link": "12.5.1", "version": "12.5.1", "symlinks": ["12.5"] },
             { "link": "12.4", "version": "12.4.0" },
             { "link": "11.7", "version": "11.7.0", "symlinks": ["11.7_beta"] }
         ]


### PR DESCRIPTION
# Description
We forgot to add a symlink 12.5 -> 12.5.1 in this PR https://github.com/actions/virtual-environments/pull/4258

#### Related issue:
n\a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
