### PR TITLE
[Windows] Fix Ruby permissions

### DIFF
--- a/images/win/scripts/Installers/Install-Ruby.ps1
+++ b/images/win/scripts/Installers/Install-Ruby.ps1
@@ -43,10 +43,18 @@ function Install-Ruby
         [String]$Architecture = "x64"
     )
 
+    # Create Ruby toolcache folder
+    $rubyToolcachePath = Join-Path -Path $env:AGENT_TOOLSDIRECTORY -ChildPath "Ruby"
+    if (-not (Test-Path $rubyToolcachePath))
+    {
+        Write-Host "Creating Ruby toolcache folder"
+        New-Item -ItemType Directory -Path $rubyToolcachePath | Out-Null
+    }
+
     # Expand archive with binaries
     $packageName = [IO.Path]::GetFileNameWithoutExtension((Split-Path -Path $PackagePath -Leaf))
-    $tempFolder = Join-Path -Path $env:TEMP -ChildPath $packageName
-    Extract-7Zip -Path $PackagePath -DestinationPath $env:TEMP
+    $tempFolder = Join-Path -Path $rubyToolcachePath -ChildPath $packageName
+    Extract-7Zip -Path $PackagePath -DestinationPath $rubyToolcachePath
 
     # Get Ruby version from binaries
     $rubyVersion = & "$tempFolder\bin\ruby.exe" -e "print RUBY_VERSION"
@@ -54,15 +62,8 @@ function Install-Ruby
     if ($rubyVersion)
     {
         Write-Host "Installing Ruby $rubyVersion"
-        $rubyToolcachePath = Join-Path -Path $env:AGENT_TOOLSDIRECTORY -ChildPath "Ruby"
         $rubyVersionPath = Join-Path -Path $rubyToolcachePath -ChildPath $rubyVersion
         $rubyArchPath = Join-Path -Path $rubyVersionPath -ChildPath $Architecture
-
-        if (-not (Test-Path $rubyToolcachePath))
-        {
-            Write-Host "Creating Ruby toolcache folder"
-            New-Item -ItemType Directory -Path $rubyToolcachePath | Out-Null
-        }
 
         Write-Host "Creating Ruby '${rubyVersion}' folder in '${rubyVersionPath}'"
         New-Item -ItemType Directory -Path $rubyVersionPath -Force | Out-Null


### PR DESCRIPTION
# Description
When you copy a protected file to a folder on the same, or a different volume, it inherits the permissions of the target directory. However, when you move a protected file to a different location on the same volume, the file retains its access permission setting as though it is an explicit permission(in our case it's TEMP dir).

Fix: 
- Expand an archive to the hostedtoolcache folder and preserve inheritance permissions for Authenticated Users group

#### Related issue:
https://github.com/actions/virtual-environments/issues/4277

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
