### PR TITLE
[Windows] Do not use M2_HOME env var to get mvn path

### DIFF
--- a/images/win/scripts/Installers/Install-JavaTools.ps1
+++ b/images/win/scripts/Installers/Install-JavaTools.ps1
@@ -135,7 +135,7 @@ Choco-Install -PackageName maven -ArgumentList "-i"
 Choco-Install -PackageName gradle
 
 # Add maven env variables to Machine
-$m2 = Split-Path (Get-Command mvn).Path
+[string]$m2 = (Get-MachinePath).Split(";") -match "maven"
 $maven_opts = '-Xms256m'
 
 $m2_repo = 'C:\ProgramData\m2'


### PR DESCRIPTION
# Description
In scope of this https://github.com/TheCakeIsNaOH/chocolatey-packages/issues/17 PR the M2_HOME variable was removed. We should get the path from mvn path.

