### PR TITLE
[macOS] fix AdoptOpenJDK api url

### DIFF
--- a/images/macos/provision/core/openjdk.sh
+++ b/images/macos/provision/core/openjdk.sh
@@ -22,9 +22,7 @@ installOpenJDK() {
     local VENDOR_NAME=$2
 
     # Get link for Java binaries and Java version
-    if [[ ${VENDOR_NAME} == "Temurin-Hotspot" ]]; then
-        assetUrl=$(curl -s "https://api.adoptium.net/v3/assets/latest/${JAVA_VERSION}/hotspot")
-    elif [[ ${VENDOR_NAME} == "Adopt" ]]; then
+    if [[ ${VENDOR_NAME} == "Temurin-Hotspot" ]] || [[ ${VENDOR_NAME} == "Adopt" ]] ; then
         assetUrl=$(curl -s "https://api.adoptium.net/v3/assets/latest/${JAVA_VERSION}/hotspot")
     else
         echo "${VENDOR_NAME} is invalid, valid names are: Temurin-Hotspot and Adopt"
@@ -42,7 +40,7 @@ installOpenJDK() {
 
     # Download and extract Java binaries
     download_with_retries ${archivePath} /tmp OpenJDK-${VENDOR_NAME}-${fullVersion}.tar.gz
-    
+
     echo "Creating ${javaToolcacheVersionArchPath} directory"
     mkdir -p ${javaToolcacheVersionArchPath}
 


### PR DESCRIPTION
# Description

AdoptOpenJDK gets abandoned more and more and now our installer can't fetch jdk11 anymore.
[api.adoptopenjdk.net](api.adoptopenjdk.net) redirects to the Adoptium Github org. since at least September, literally:

for AdoptOpenJDK:

```csl
asset=$(curl -s "https://api.adoptopenjdk.net/v3/assets/latest/11/hotspot" | jq -r '.[] | select(.binary.os=="mac" and .binary.architecture=="x64" and .binary.image_type=="jdk")')

echo ${asset} | jq -r '.binary.package.link'
```
query returns

`
https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%27%2B8/OpenJDK11U-jdk_x64_mac_hotspot_11.0.13_8.tar.gz
`

For Adoptium the same query with address changed to `api.adoptium.net` returns

`https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_x64_mac_hotspot_11.0.13_8.tar.gz`

The difference is in the url encoding characters. I have contacted Adoptium upstream developers and they recommended switching to their api server as redirection takes place in anyway.


#### Related issue: https://github.com/actions/virtual-environments-internal/issues/2888

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
