### PR TITLE
Add Jazzy tool to MacOS 10.14-12.0

### DIFF
--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -512,6 +512,11 @@ function Get-SbtVersion {
     return "Sbt $sbtVersion"
 }
 
+function Get-JazzyVersion {
+    $jazzyVersion = Run-Command "jazzy --version" | Take-Part -Part 2
+    return "Jazzy $jazzyVersion"
+}
+
 function Build-PackageManagementEnvironmentTable {
     return @(
         @{

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -176,6 +176,7 @@ $markdown += New-MDNewLine
 # Tools
 $markdown += New-MDHeader "Tools" -Level 3
 $toolsList = @(
+    (Get-JazzyVersion),
     (Get-FastlaneVersion),
     (Get-CmakeVersion),
     (Get-AppCenterCLIVersion),

--- a/images/macos/tests/RubyGem.Tests.ps1
+++ b/images/macos/tests/RubyGem.Tests.ps1
@@ -36,3 +36,9 @@ Describe "xcpretty" {
         "xcpretty --version" | Should -ReturnZeroExitCode
     }
 }
+
+Describe "jazzy" {
+    It "jazzy" {
+        "jazzy --version" | Should -ReturnZeroExitCode
+    }
+}

--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -371,7 +371,8 @@
             "nomad-cli",
             "xcpretty",
             "bundler",
-            "fastlane"
+            "fastlane",
+            "jazzy"
         ]
     },
     "go": {

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -325,7 +325,8 @@
             "nomad-cli",
             "xcpretty",
             "bundler",
-            "fastlane"
+            "fastlane",
+            "jazzy"
         ]
     },
     "go": {

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -268,7 +268,8 @@
             "nomad-cli",
             "xcpretty",
             "bundler",
-            "fastlane"
+            "fastlane",
+            "jazzy"
         ]
     },
     "go": {

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -168,7 +168,8 @@
             "cocoapods",
             "xcpretty",
             "bundler",
-            "fastlane"
+            "fastlane",
+            "jazzy"
         ]
     },
     "go": {


### PR DESCRIPTION
## Description
This PR adds Jazzy tool to MacOS 10.14-12.0 images.

## Related issue: 
https://github.com/actions/virtual-environments/issues/4320

## Test builds:
[MacOS 10.14](https://github.visualstudio.com/virtual-environments/_build/results?buildId=118269&view=results)
[MacOS 11.0](https://github.visualstudio.com/virtual-environments/_build/results?buildId=118270&view=results)

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
