### PR TITLE
[Ubuntu] Add node 16 to the toolcache + docker images

### DIFF
--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -33,7 +33,8 @@
             "versions": [
                 "10.*",
                 "12.*",
-                "14.*"
+                "14.*",
+                "16.*"
             ]
         },
         {
@@ -219,9 +220,11 @@
             "node:10",
             "node:12",
             "node:14",
+            "node:16",
             "node:10-alpine",
             "node:12-alpine",
             "node:14-alpine",
+            "node:16-alpine",
             "ubuntu:16.04",
             "ubuntu:18.04",
             "ubuntu:20.04"

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -34,7 +34,8 @@
             "versions": [
                 "10.*",
                 "12.*",
-                "14.*"
+                "14.*",
+                "16.*"
             ]
         },
         {
@@ -217,9 +218,11 @@
             "node:10",
             "node:12",
             "node:14",
+            "node:16",
             "node:10-alpine",
             "node:12-alpine",
             "node:14-alpine",
+            "node:16-alpine",
             "ubuntu:16.04",
             "ubuntu:18.04",
             "ubuntu:20.04"


### PR DESCRIPTION
# Description
Node 16 has started its LTS cycle on 10\26. According to our [Software and image guidelines policy](https://github.com/actions/virtual-environments/blob/main/docs/software-and-images-guidelines.md) we have to pre-cache 3 latest LTS versions of Nodejs. This PR adds Node 16 to the toolcache, and also adds corresponding docker images. Node 10 and its docker images will be removed in the scope of another PR.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2891

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
