### PR TITLE
[Ubuntu] fix apt proxy settings

### DIFF
--- a/images/linux/scripts/base/apt.sh
+++ b/images/linux/scripts/base/apt.sh
@@ -14,6 +14,13 @@ echo "APT::Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries
 # Configure apt to always assume Y
 echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
 
+# Fix bad proxy and http headers settings
+cat <<EOF >> /etc/apt/apt.conf.d/99bad_proxy
+Acquire::http::Pipeline-Depth 0;
+Acquire::http::No-Cache true;
+Acquire::BrokenProxy    true;
+EOF
+
 # Uninstall unattended-upgrades
 apt-get purge unattended-upgrades
 


### PR DESCRIPTION
# Description

This commit adds http-related apt settings which allows to fix problems like hash sum mismatching error in the `Packages.gz` files by modifying  apt's http request headers. 
More information about settings can be found at [1] and [2].

[1] - https://manpages.debian.org/unstable/apt/apt-transport-http.1.en.html
[2] - https://manpages.debian.org/unstable/apt/apt.conf.5.en.html

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/2895

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
