### PR TITLE
[Windows] Rework NodeJS install

### DIFF
--- a/images/win/scripts/Installers/Install-NodeLts.ps1
+++ b/images/win/scripts/Installers/Install-NodeLts.ps1
@@ -10,7 +10,8 @@ $CachePath = 'C:\npm\cache'
 New-Item -Path $PrefixPath -Force -ItemType Directory
 New-Item -Path $CachePath -Force -ItemType Directory
 
-Choco-Install -PackageName nodejs-lts -ArgumentList "--force"
+$defaultVersion = (Get-ToolsetContent).node.default
+Choco-Install -PackageName nodejs -ArgumentList "--version=$defaultVersion"
 
 Add-MachinePathItem $PrefixPath
 $env:Path = Get-MachinePath

--- a/images/win/scripts/Tests/Node.Tests.ps1
+++ b/images/win/scripts/Tests/Node.Tests.ps1
@@ -16,4 +16,10 @@ Describe "Node.JS" {
             $Test | Should -ReturnZeroExitCode
         }
     }
+
+    Context "Node.js version" {
+        It "Node.js version should correspond to the version in the toolset" {
+            node --version | Should -BeLike "v$((Get-ToolsetContent).node.default).*"
+        }
+    }
 }

--- a/images/win/scripts/Tests/Node.Tests.ps1
+++ b/images/win/scripts/Tests/Node.Tests.ps1
@@ -19,7 +19,7 @@ Describe "Node.JS" {
 
     Context "Node.js version" {
         It "Node.js version should correspond to the version in the toolset" {
-            node --version | Should -BeLike "v$((Get-ToolsetContent).node.default).*"
+            node --version | Should -BeLike "v$((Get-ToolsetContent).node.default)*"
         }
     }
 }

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -420,5 +420,8 @@
                 "args": [ "--installargs", "ADD_CMAKE_TO_PATH=\"System\"" ]
             }
         ]
+    },
+    "node": {
+        "default": "14.18.1"
     }
 }

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -451,5 +451,8 @@
                 "args": [ "--installargs", "ADD_CMAKE_TO_PATH=\"System\"" ]
             }
         ]
+    },
+    "node": {
+        "default": "14.18.1"
     }
 }

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -288,5 +288,8 @@
                 "args": [ "--installargs", "ADD_CMAKE_TO_PATH=\"System\"" ]
             }
         ]
+    },
+    "node": {
+        "default": "14.18.1"
     }
 }


### PR DESCRIPTION
## Description
This PR changes way of Node.js install to use default version from toolset instead of LTS. 

## Related issue: 
https://github.com/actions/virtual-environments-internal/issues/2890

## Test builds:
- [Windows2022](https://github.visualstudio.com/virtual-environments/_build/results?buildId=118470&view=results)

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
