### PR TITLE
[Windows] Move Selenium version output to the browsers sector

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Browsers.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Browsers.psm1
@@ -54,6 +54,12 @@ function Get-SeleniumWebDriverVersion {
     return "$driverName $webDriverVersion"
 }
 
+function Get-SeleniumVersion {
+    $seleniumBinaryName = (Get-ToolsetContent).selenium.binary_name
+    $fullSeleniumVersion = (Get-ChildItem "C:\selenium\${seleniumBinaryName}-*").Name -replace "${seleniumBinaryName}-"
+    return "Selenium server $fullSeleniumVersion"
+}
+
 function Build-BrowserWebdriversEnvironmentTable {
     return @(
         @{
@@ -67,6 +73,10 @@ function Build-BrowserWebdriversEnvironmentTable {
         @{
             "Name" = "GECKOWEBDRIVER"
             "Value" = $env:GECKOWEBDRIVER
+        },
+        @{
+            "Name" = "SELENIUM_JAR_PATH"
+            "Value" = $env:SELENIUM_JAR_PATH
         }
     ) | ForEach-Object {
         [PSCustomObject] @{

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -119,7 +119,6 @@ $toolsList = @(
     (Get-StackVersion),
     (Get-SVNVersion),
     (Get-VSWhereVersion),
-    (Get-SeleniumVersion),
     (Get-SwigVersion),
     (Get-WinAppDriver),
     (Get-ZstdVersion),
@@ -178,7 +177,8 @@ $markdown += New-MDList -Style Unordered -Lines @(
     (Get-SeleniumWebDriverVersion -Driver "edge"),
     (Get-BrowserVersion -Browser "firefox"),
     (Get-SeleniumWebDriverVersion -Driver "firefox"),
-    (Get-SeleniumWebDriverVersion -Driver "iexplorer")
+    (Get-SeleniumWebDriverVersion -Driver "iexplorer"),
+    (Get-SeleniumVersion)
 )
 
 $markdown += New-MDHeader "Environment variables" -Level 4

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -275,9 +275,3 @@ function Get-SwigVersion {
     $swigVersion = $Matches.Version
     return "Swig $swigVersion"
 }
-
-function Get-SeleniumVersion {
-    $seleniumBinaryName = (Get-ToolsetContent).selenium.binary_name
-    $fullSeleniumVersion = (Get-ChildItem "C:\selenium\${seleniumBinaryName}-*").Name -replace "${seleniumBinaryName}-"
-    return "Selenium server $fullSeleniumVersion"
-}


### PR DESCRIPTION
# Description
In scope of this PR we are moving Selenium version output to the browsers section and adding info about `SELENIUM_JAR_PATH` env variable. 

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
