### PR TITLE
[Linux] Rework NodeJS install

### DIFF
--- a/images/linux/scripts/installers/nodejs.sh
+++ b/images/linux/scripts/installers/nodejs.sh
@@ -7,9 +7,12 @@
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
 
-# Install LTS Node.js and related build tools
+# Install default Node.js
+defaultVersion=$(get_toolset_value '.node.default')
+# TODO: Usage of "githubusercontent.com/mklement0" doesn't look like a correct approach. Need to correct it according to the official Node.js docs.
 curl -sL https://raw.githubusercontent.com/mklement0/n-install/stable/bin/n-install | bash -s -- -ny -
-~/n/bin/n lts
+~/n/bin/n $defaultVersion
+
 # Install node modules
 node_modules=$(get_toolset_value '.node_modules[].name')
 

--- a/images/linux/scripts/tests/Node.Tests.ps1
+++ b/images/linux/scripts/tests/Node.Tests.ps1
@@ -10,5 +10,9 @@ Describe "Node.js" {
 
         "$NodeCommand --version" | Should -ReturnZeroExitCode
     }
+
+    It "Node.js version should correspond to the version in the toolset" {
+        node --version | Should -BeLike "v$((Get-ToolsetContent).node.default).*"
+    }
 }
 

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -283,6 +283,9 @@
         "binary_name": "selenium-server-standalone"
     },
     "rubygems": [],
+    "node": {
+        "default": "14"
+    },
     "node_modules": [
         {
             "name": "grunt",

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -283,6 +283,9 @@
         "version": "3",
         "binary_name": "selenium-server-standalone"
     },
+    "node": {
+        "default": "14"
+    },
     "node_modules": [
         {
             "name": "grunt",


### PR DESCRIPTION
## Description
This PR changes way of Node.js install to use default version from toolset instead of LTS. 

## Related issue: 
https://github.com/actions/virtual-environments-internal/issues/2890

## Test builds:
- [Ubuntu2004](https://github.visualstudio.com/virtual-environments/_build/results?buildId=118471&view=results)

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
