### PR TITLE
[Ubuntu] fix software report for azure-cli

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -196,15 +196,13 @@ function Get-JqVersion {
 }
 
 function Get-AzureCliVersion {
-    $result = az version | ConvertFrom-Json
-    $azcliVersion = $result.'azure-cli'
+    $azcliVersion = (az version | ConvertFrom-Json).'azure-cli'
     $aptSourceRepo = Get-AptSourceRepository -PackageName "azure-cli"
     return "Azure CLI (azure-cli) $azcliVersion (installation method: $aptSourceRepo)"
 }
 
 function Get-AzureDevopsVersion {
-    $result = az version | ConvertFrom-Json
-    $azdevopsVersion = $result.extensions.'azure-devops'
+    $azdevopsVersion = (az version | ConvertFrom-Json).extensions.'azure-devops'
     return "Azure CLI (azure-devops) $azdevopsVersion"
 }
 


### PR DESCRIPTION
# Description
This pull request fixes the `Get-AzureCliVersion` and `Get-AzureDevopsVersion` functions as it returns incorrect `azure-cli` and `azure-devops` version by now.
Whenever the `az -v` command reports a message about the update possibility, the output is going to be incorrect as the `Take-OutputPart` function returns the rightmost part of the string (which is the asterisk character when update is possible).
The `Make-Output Port` function call was replaced with  processing output the command `az -v` using PowerShell tools to reflect a correct version.

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
