### PR TITLE
[macOS] install vcpkg from specific commit

### DIFF
--- a/images/macos/provision/core/vcpkg.sh
+++ b/images/macos/provision/core/vcpkg.sh
@@ -2,14 +2,24 @@
 source ~/utils/utils.sh
 
 # Set env variable for vcpkg
+
+# Checkout the specific commit as master builds are falling.
+# Upstream report: https://github.com/microsoft/vcpkg/issues/21107
+GIT_COMMIT_HASH=d78a0b47bdd4deb6bc5547e06e289672892ed226
 VCPKG_INSTALLATION_ROOT=/usr/local/share/vcpkg
 echo "export VCPKG_INSTALLATION_ROOT=${VCPKG_INSTALLATION_ROOT}" | tee -a ~/.bashrc
 
 # Install vcpkg
-git clone --depth=1 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT
+git clone https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT
+
+pushd $VCPKG_INSTALLATION_ROOT
+git checkout $GIT_COMMIT_HASH
+popd
+
 $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh
 $VCPKG_INSTALLATION_ROOT/vcpkg integrate install
 chmod -R 0777 $VCPKG_INSTALLATION_ROOT
-ln -sf $VCPKG_INSTALLATION_ROOT/vcpkg /usr/local/bin
+mkdir -p /usr/local/bin
+ln -sf $VCPKG_INSTALLATION_ROOT/vcpkg /usr/local/bin/vcpkg
 
 invoke_tests "Common" "vcpkg"


### PR DESCRIPTION
# Description

Latest commit in master does not build, pick the previous one which builds fine. Also fixed the symlink,

`/usr/local/bin -> /usr/local/bin/vcpkg` (`bin` must remain a directory). 



## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated

