### PR TITLE
[Windows] Docker service does not start on Windows Server 2016-2022

### DIFF
--- a/images/win/scripts/Installers/Install-Docker.ps1
+++ b/images/win/scripts/Installers/Install-Docker.ps1
@@ -23,4 +23,10 @@ foreach ($dockerImage in $dockerImages) {
     }
 }
 
+# fatal: open C:\ProgramData\docker\panic.log: Access is denied.
+$panicLog = "C:\ProgramData\docker\panic.log"
+if (Test-Path -Path $panicLog) {
+    Set-ItemProperty -Path "C:\ProgramData\docker\panic.log" -Name IsReadOnly -Value $false
+}
+
 Invoke-PesterTests -TestFile "Docker"


### PR DESCRIPTION
# Description
Docker service doesn't start properly after reboot with error:
`fatal: open C:\ProgramData\docker\panic.log: Access is denied.
`
#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2920

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
