### PR TITLE
[MacOS] Fix software report for azure-cli

### DIFF
--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -418,7 +418,7 @@ function Get-AppCenterCLIVersion {
 }
 
 function Get-AzureCLIVersion {
-    $azureCLIVersion = Run-Command "az -v" | Select-String "^azure-cli" | Take-Part -Part 1
+    $azureCLIVersion = (az version | ConvertFrom-Json).'azure-cli'
     return "Azure CLI $azureCLIVersion"
 }
 


### PR DESCRIPTION
# Description 
This pull request fixes the `Get-AzureCLIVersion` function as it returns incorrect `azure-cli` version by now.
Whenever the `az -v` command reports a message about the update possibility, the output is going to be incorrect as the `Take-OutputPart` function returns the rightmost part of the string (which is the asterisk character when update is possible).
The `Make-Output Port` function call was replaced with processing output the command `az version` using PowerShell tools to reflect a correct version.

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/2889

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
