### PR TITLE
[Windows] Pin Docker EE to 20.10.7 version

### DIFF
--- a/images/win/scripts/Installers/Install-Docker.ps1
+++ b/images/win/scripts/Installers/Install-Docker.ps1
@@ -5,8 +5,10 @@
 ##         can continue.
 ################################################################################
 
+# Docker EE 20.10.8 has the regression
+# fatal: open C:\ProgramData\docker\panic.log: Access is denied.
 Write-Host "Install-Package Docker"
-Install-Package -Name docker -ProviderName DockerMsftProvider -Force
+Install-Package -Name docker -ProviderName DockerMsftProvider -RequiredVersion 20.10.7 -Force
 Start-Service docker
 
 Write-Host "Install-Package Docker-Compose"


### PR DESCRIPTION
# Description
Pin Docker EE to 20.10.7 version due to panic.log ReadOnly attribute file regression in Docker EE 20.10.8.

#### Related issue:
[actions/virtual-environments-internal#2920](https://github.com/actions/virtual-environments-internal/issues/2920)

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
