### PR TITLE
[MacOS] Go versions less than 1.15 should be removed until November, 8

### DIFF
--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -333,8 +333,6 @@
             "platform" : "darwin",
             "variable_template" : "GOROOT_{0}_{1}_X64",
             "versions": [
-                "1.13.*",
-                "1.14.*",
                 "1.15.*",
                 "1.16.*",
                 "1.17.*"

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -287,8 +287,6 @@
             "platform" : "darwin",
             "variable_template" : "GOROOT_{0}_{1}_X64",
             "versions": [
-                "1.13.*",
-                "1.14.*",
                 "1.15.*",
                 "1.16.*",
                 "1.17.*"


### PR DESCRIPTION
# Description
All pre-cached Go versions less than 1.15 will be removed from all operating systems.
#### Related issue: https://github.com/actions/virtual-environments/issues/4311

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
