### PR TITLE
[Windows] make choco dummy call for currently installed version

### DIFF
--- a/images/win/post-generation/Choco.ps1
+++ b/images/win/post-generation/Choco.ps1
@@ -1,2 +1,5 @@
-# Step to avoid initial delay for choco scripts
-choco upgrade chocolatey
+# Step to avoid initial delay for choco scripts.
+# On calling the first choco command
+# Chocolatey spends 2 minutes cleaning up and removing unneeded packages in the environment.
+$ChocoVersion = choco --version
+choco upgrade chocolatey --version=$ChocoVersion


### PR DESCRIPTION
# Description

Currently a choco dummy call performed as a post-generation step might elicit unwanted upgrade (if available).
This, in turn leads to unwanted consequences like bringing the `cpack` command alias back into our images.
To prevent this a dummy call must be done for the currently installed version only.


#### Related issue: https://github.com/actions/virtual-environments/issues/4360

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
