### PR TITLE
[Windows] Set Microsoft Defender Antivirus to passive mode

### DIFF
--- a/images/win/scripts/Installers/Configure-Antivirus.ps1
+++ b/images/win/scripts/Installers/Configure-Antivirus.ps1
@@ -3,3 +3,11 @@ Set-MpPreference -ScanAvgCPULoadFactor 5 -ExclusionPath "D:\", "C:\"
 
 Write-Host "Disable Antivirus"
 Set-MpPreference -DisableRealtimeMonitoring $true
+
+# https://github.com/actions/virtual-environments/issues/4277
+# https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/microsoft-defender-antivirus-compatibility?view=o365-worldwide
+$atpRegPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows Advanced Threat Protection'
+if (Test-Path $atpRegPath) {
+    Write-Host "Set Microsoft Defender Antivirus to passive mode"
+    Set-ItemProperty -Path $atpRegPath -Name 'ForceDefenderPassiveMode' -Value '1' -Type 'DWORD'
+}


### PR DESCRIPTION
# Description

SenseCE.exe and MsSense.exe which are part of Windows Defender Advanced Threat Protection can scan system during image generation process and causes files lock( `==> vhd: Move-Item : Access to the path 'C:\Users\packer\AppData\Local\Temp\rubyinstaller-2.4.10-1-x64' is denied.`).
```
Name        : SenseCE.exe
    vhd: CommandLine : "C:\Program Files\Windows Defender Advanced Threat Protection\Classification\SenseCE.exe" "1624"
    vhd:               "2ec11e40-f8f5-4d82-8e24-9621b82273bd" "1800" "60" 
    
vhd: MsSense.exe pid: 5024 \<unable to open process>
    vhd:    48: File  (RW-)   C:\Windows\System32
    vhd:    7C: Section       \BaseNamedObjects\__ComCatalogCache__
    vhd:    8C: Section       \BaseNamedObjects\__ComCatalogCache__
    vhd:   134: File  (R-D)   C:\Program Files\Windows Defender Advanced Threat Protection\en-US\MsSense.exe.mui
```

#### Related issue:
https://github.com/actions/virtual-environments/issues/4277

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
