### PR TITLE
[Ubuntu] Pin MongoDB to the specific version defined in the toolset

### DIFF
--- a/images/linux/scripts/installers/mongodb.sh
+++ b/images/linux/scripts/installers/mongodb.sh
@@ -6,17 +6,21 @@
 
 # Source the helpers
 source $HELPER_SCRIPTS/os.sh
+source $HELPER_SCRIPTS/install.sh
 
 REPO_URL="https://repo.mongodb.org/apt/ubuntu"
+osLabel=$(getOSVersionLabel)
+toolsetVersion=$(get_toolset_value '.mongodb.default')
+latestVersion=$(curl $REPO_URL/dists/$osLabel/mongodb-org/ | grep $toolsetVersion\.. | awk -F'>|<' '{print $3}' | tail -1)
 
 #  Install Mongo DB
-wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | sudo apt-key add -
-version=$(getOSVersionLabel)
-echo "deb [ arch=amd64,arm64 ] $REPO_URL $version/mongodb-org/5.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-5.0.list
+wget -qO - https://www.mongodb.org/static/pgp/server-$latestVersion.asc | sudo apt-key add -
+
+echo "deb [ arch=amd64,arm64 ] $REPO_URL $osLabel/mongodb-org/$latestVersion multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-$latestVersion.list
 sudo apt-get update
 sudo apt-get install -y mongodb-org
 
-rm /etc/apt/sources.list.d/mongodb-org-5.0.list
+rm /etc/apt/sources.list.d/mongodb-org-$latestVersion.list
 
 echo "mongodb $REPO_URL" >> $HELPER_SCRIPTS/apt-sources.txt
 

--- a/images/linux/scripts/tests/Databases.Tests.ps1
+++ b/images/linux/scripts/tests/Databases.Tests.ps1
@@ -3,7 +3,8 @@ Describe "MongoDB" {
         @{ ToolName = "mongo" }
         @{ ToolName = "mongod" }
     ) {
-        "$ToolName --version" | Should -ReturnZeroExitCode
+        toolsetVersion=$(get_toolset_value '.mongodb.default')
+        (&$ToolName --version)[2].Split('"')[-2] | Should -BeLike "$toolsetVersion*"
     }
 }
 

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -329,5 +329,8 @@
             "name": "yarn",
             "command": "yarn"
         }
-    ]
+    ],
+    "mongodb": {
+        "default": "5"
+    }
 }

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -334,5 +334,8 @@
             "name": "yarn",
             "command": "yarn"
         }
-    ]
+    ],
+    "mongodb": {
+        "default": "5"
+    }
 }


### PR DESCRIPTION
# Description
We need to move mongo along with some other tools to the toolset on all OSes to make versions control more granular.

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/2916

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated