### PR TITLE
[Windows] Change channel from pre to release for VS22

### DIFF
--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -170,7 +170,7 @@
         "version" : "2022",
         "subversion" : "17",
         "edition" : "Enterprise",
-        "channel": "pre",
+        "channel": "release",
         "workloads": [
             "Component.Linux.CMake",
             "Component.UnityEngine.x64",


### PR DESCRIPTION
# Description
Visual Studio 2022 has been released and we need to change the channel from `pre` to `release`.

#### Related issue:
n\a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
