### PR TITLE
[Ubuntu] Change source of n tool to official

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -126,6 +126,7 @@ $toolsList = @(
     (Get-HGVersion),
     (Get-MinikubeVersion),
     (Get-NewmanVersion),
+    (Get-NVersion),
     (Get-NvmVersion),
     (Get-OpensslVersion),
     (Get-PackerVersion),

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -170,6 +170,11 @@ function Get-NewmanVersion {
     return "Newman $(newman --version)"
 }
 
+Get-NVersion {
+    $nVersion = (n --version).Replace('v', '')
+    return "n $nVersion"
+}
+
 function Get-NvmVersion {
     $nvmVersion = bash -c "source /etc/skel/.nvm/nvm.sh && nvm --version"
     return "nvm $nvmVersion"

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -170,7 +170,7 @@ function Get-NewmanVersion {
     return "Newman $(newman --version)"
 }
 
-Get-NVersion {
+function Get-NVersion {
     $nVersion = (n --version).Replace('v', '')
     return "n $nVersion"
 }

--- a/images/linux/scripts/installers/nodejs.sh
+++ b/images/linux/scripts/installers/nodejs.sh
@@ -9,9 +9,8 @@ source $HELPER_SCRIPTS/install.sh
 
 # Install default Node.js
 defaultVersion=$(get_toolset_value '.node.default')
-# TODO: Usage of "githubusercontent.com/mklement0" doesn't look like a correct approach. Need to correct it according to the official Node.js docs.
-curl -sL https://raw.githubusercontent.com/mklement0/n-install/stable/bin/n-install | bash -s -- -ny -
-~/n/bin/n $defaultVersion
+curl -L https://raw.githubusercontent.com/tj/n/master/bin/n -o ~/n
+bash ~/n $defaultVersion
 
 # Install node modules
 node_modules=$(get_toolset_value '.node_modules[].name')


### PR DESCRIPTION
## Description
This PR corrects source of n tool according to [official documentation](https://github.com/tj/n) and adds gathering of n version to Software Report.

## Related issue: 
https://github.com/actions/virtual-environments-internal/issues/2890

## Test builds:
- [Ubuntu 1804](https://github.visualstudio.com/virtual-environments/_build/results?buildId=118902&view=results)
- [Ubuntu 2004](https://github.visualstudio.com/virtual-environments/_build/results?buildId=118901&view=results)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
