### PR TITLE
[macOS] Remove Xcode 13 beta & set Xcode 13.1 as default

### DIFF
--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -1,11 +1,10 @@
 {
     "xcode": {
-        "default": "13.0",
+        "default": "13.1",
         "versions": [
             { "link": "13.2", "version": "13.2.0" },
             { "link": "13.1", "version": "13.1.0" },
             { "link": "13.0", "version": "13.0.0" },
-            { "link": "13.0_beta", "version": "13 beta 5", "skip-symlink": "true" },
             { "link": "12.5.1", "version": "12.5.1", "symlinks": ["12.5"] },
             { "link": "12.4", "version": "12.4.0" },
             { "link": "11.7", "version": "11.7.0", "symlinks": ["11.7_beta"] }

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -3,8 +3,7 @@
         "default": "13.1",
         "versions": [
             { "link": "13.2", "version": "13.2.0" },
-            { "link": "13.1", "version": "13.1.0" },
-            { "link": "13.0", "version": "13.0.0"}
+            { "link": "13.1", "version": "13.1.0" }
         ]
     },
     "xamarin": {


### PR DESCRIPTION
# Description
Xcode beta 13 was preserved on the image due to a lack of macOS 12 SDK in the stable Xcode 13 version. Since Xcode 13.1 contains the necessary SDK we can get rid of Xcode 13 beta from the image.
The default Xcode will be also set to 13.1 because we would like to provide images with the latest stable updates as default ones.
This PR also removes Xcode 13 from macOS-12 as macOS-12 SDK is not supported in this version.

#### Related issue:
https://github.com/actions/virtual-environments/issues/4355

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
