### PR TITLE
[macOS] move llvm to toolset

### DIFF
--- a/images/macos/provision/core/commonutils.sh
+++ b/images/macos/provision/core/commonutils.sh
@@ -2,8 +2,8 @@
 source ~/utils/utils.sh
 
 # Monterey needs future review:
-# Llvm, aliyun-cli, gnupg, helm have issues with building from the source code.
-# Added gmp for now, because toolcache ruby needs its libs. Remove it when php starts to build from source code. 
+# aliyun-cli, gnupg, helm have issues with building from the source code.
+# Added gmp for now, because toolcache ruby needs its libs. Remove it when php starts to build from source code.
 common_packages=$(get_toolset_value '.brew.common_packages[]')
 for package in $common_packages; do
     echo "Installing $package..."

--- a/images/macos/provision/core/llvm.sh
+++ b/images/macos/provision/core/llvm.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e -o pipefail
+source ~/utils/utils.sh
+
+llvmVersion=$(get_toolset_value '.llvm.version')
+
+brew_smart_install "llvm@${llvmVersion}"
+
+invoke_tests "LLVM"

--- a/images/macos/templates/macOS-10.15.json
+++ b/images/macos/templates/macOS-10.15.json
@@ -160,6 +160,7 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "scripts": [
                 "./provision/core/commonutils.sh",
+                "./provision/core/llvm.sh",
                 "./provision/core/golang.sh",
                 "./provision/core/swiftlint.sh",
                 "./provision/core/openjdk.sh",

--- a/images/macos/templates/macOS-11.json
+++ b/images/macos/templates/macOS-11.json
@@ -165,6 +165,7 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "scripts": [
                 "./provision/core/commonutils.sh",
+                "./provision/core/llvm.sh",
                 "./provision/core/golang.sh",
                 "./provision/core/swiftlint.sh",
                 "./provision/core/openjdk.sh",
@@ -198,7 +199,7 @@
         {
             "type": "shell",
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}",
-            "scripts": [ 
+            "scripts": [
                 "./provision/core/toolset.ps1",
                 "./provision/core/configure-toolset.ps1"
             ]

--- a/images/macos/templates/macOS-11.pkr.hcl
+++ b/images/macos/templates/macOS-11.pkr.hcl
@@ -163,6 +163,7 @@ build {
   provisioner "shell" {
     scripts = [
                 "./provision/core/commonutils.sh",
+                "./provision/core/llvm.sh",
                 "./provision/core/golang.sh",
                 "./provision/core/swiftlint.sh",
                 "./provision/core/openjdk.sh",

--- a/images/macos/tests/BasicTools.Tests.ps1
+++ b/images/macos/tests/BasicTools.Tests.ps1
@@ -30,16 +30,9 @@ Describe "SwiftFormat" -Skip:($os.IsMonterey) {
     }
 }
 
-
 Describe "GnuPG" -Skip:($os.IsMonterey) {
     It "GnuPG" {
         "gpg --version" | Should -ReturnZeroExitCode
-    }
-}
-
-Describe "Clang/LLVM" -Skip:($os.IsMonterey) {
-    It "Clang/LLVM is installed" {
-        "$(brew --prefix llvm)/bin/clang --version" | Should -ReturnZeroExitCode
     }
 }
 

--- a/images/macos/tests/LLVM.Tests.ps1
+++ b/images/macos/tests/LLVM.Tests.ps1
@@ -1,0 +1,9 @@
+$os = Get-OSVersion
+
+Describe "Clang/LLVM" -Skip:($os.IsMonterey) {
+    It "Clang/LLVM is installed and version is correct" {
+        $toolsetVersion = Get-ToolsetValue 'llvm.version'
+        $clangVersion = & "$(brew --prefix llvm)/bin/clang" --version
+        $clangVersion[0] | Should -BeLike "*${toolsetVersion}*"
+    }
+}

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -215,7 +215,6 @@
             "helm",
             "kotlin",
             "libpq",
-            "llvm",
             "p7zip",
             "packer",
             "parallel",
@@ -339,5 +338,8 @@
             "12",
             "14"
         ]
+    },
+    "llvm": {
+        "version": "13"
     }
 }

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -177,7 +177,6 @@
             "helm",
             "kotlin",
             "libpq",
-            "llvm",
             "p7zip",
             "packer",
             "perl",
@@ -292,5 +291,8 @@
             "12",
             "14"
         ]
+    },
+    "llvm": {
+        "version": "13"
     }
 }


### PR DESCRIPTION
# Description

Pinned the latest llvm version. The real problem I have faced is our current `clang --version` call in the test suite.
Currently `"$(brew --prefix llvm)/bin/clang --version" | Should -ReturnZeroExitCode` will be expanded to the
`/usr/local/opt/llvm/bin/clang --version` string, i.e. only brew prefix is going to be expanded but no real clang invocation happen. Suggestions on how to improve the test are welcome.
Also moved llvm to its own installer for consistency as this does not belong to `commonutils.sh` now (nor to its toolset section).

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/2918

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [X] Changes are tested and related VM images are successfully generated
