### PR TITLE
[windows] Add miniconda to windows 2022 image

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -51,6 +51,7 @@ $markdown += New-MDList -Style Unordered -Lines ($languageTools | Sort-Object)
 
 $packageManagementList = @(
     (Get-ChocoVersion),
+    (Get-CondaVersion),
     (Get-ComposerVersion),
     (Get-HelmVersion),
     (Get-NPMVersion),
@@ -61,12 +62,6 @@ $packageManagementList = @(
     (Get-VcpkgVersion),
     (Get-YarnVersion)
 )
-
-if ((Test-IsWin16) -or (Test-IsWin19)) {
-    $packageManagementList += @(
-        (Get-CondaVersion)
-    )
-}
 
 $markdown += New-MDHeader "Package Management" -Level 3
 $markdown += New-MDList -Style Unordered -Lines ($packageManagementList | Sort-Object)

--- a/images/win/scripts/Tests/Miniconda.Tests.ps1
+++ b/images/win/scripts/Tests/Miniconda.Tests.ps1
@@ -1,8 +1,8 @@
-Describe "Miniconda" -Skip:(Test-IsWin22) {
+Describe "Miniconda" {
     It "Miniconda Environment variables is set. " {
         ${env:CONDA} | Should -Not -BeNullOrEmpty
     }
-    
+
     It "Miniconda $env:CONDA\<PathTest> " -TestCases @(
         @{ PathTest = "python.exe" }
         @{ PathTest = "Scripts\conda.exe" }

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -221,6 +221,7 @@
                 "{{ template_dir }}/scripts/Installers/Install-Mingw64.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Haskell.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Stack.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-Miniconda.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-AzureCosmosDbEmulator.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Mercurial.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Zstd.ps1",


### PR DESCRIPTION
# Description
Miniconda is not installed on the image but is required for some ADO users.

#### Related issue:
https://github.com/actions/virtual-environments/issues/4450

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
