### PR TITLE
[Windows] Use Get-LatestChocoPackageVersion to get nodejs version to install

### DIFF
--- a/images/win/scripts/ImageHelpers/ChocoHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/ChocoHelpers.ps1
@@ -31,7 +31,7 @@ function Choco-Install {
     }
 }
 
-function Send-RequestToCocolateyPackages {
+function Send-RequestToChocolateyPackages {
     param(
         [Parameter(Mandatory)]
         [string] $FilterQuery,
@@ -56,9 +56,9 @@ function Get-LatestChocoPackageVersion {
     [int]$versionNumbers[-1] += 1
     $incrementedVersion = $versionNumbers -join "."
     $filterQuery = "`$filter=(Id eq '$PackageName') and (IsPrerelease eq false) and (Version ge '$TargetVersion') and (Version lt '$incrementedVersion')"
-    $latestVersion = (Send-RequestToCocolateyPackages -FilterQuery $filterQuery).properties.Version |
+    $latestVersion = (Send-RequestToChocolateyPackages -FilterQuery $filterQuery).properties.Version |
         Sort-Object {[version]$_} |
         Select-Object -Last 1
-    
+
     return $latestVersion
 }

--- a/images/win/scripts/Installers/Install-NodeLts.ps1
+++ b/images/win/scripts/Installers/Install-NodeLts.ps1
@@ -11,16 +11,7 @@ New-Item -Path $PrefixPath -Force -ItemType Directory
 New-Item -Path $CachePath -Force -ItemType Directory
 
 $defaultVersion = (Get-ToolsetContent).node.default
-$queryFilter = "`$filter=(Id eq 'nodejs') and (IsPrerelease eq false) and (Version ge '$defaultVersion')"
-$url = "https://community.chocolatey.org/api/v2/Packages()?$queryFilter"
-$chocoVersionsOutput = (Invoke-RestMethod -Uri $url).properties.Version
-# Take the latest version available for given default version from the toolset which is used as wildcard
-# Toolset file can contain a version in any form: Major, Major.Minor or even the exact version
-$versionToInstall = $chocoVersionsOutput |
-    # Take the exact default version and its subversions
-    Where-Object { $_ -Like "$defaultVersion.*" -or $_ -eq $defaultVersion } |
-    Sort-Object { [Version]$_ } |
-    Select-Object -Last 1
+$versionToInstall = Get-LatestChocoPackageVersion -TargetVersion $defaultVersion -PackageName "nodejs"
 
 Choco-Install -PackageName nodejs -ArgumentList "--version=$versionToInstall"
 


### PR DESCRIPTION
# Description
We have the [Get-LatestChocoPackageVersion](https://github.com/actions/virtual-environments/blob/main/images/win/scripts/ImageHelpers/ChocoHelpers.ps1#L47) function now so the installation script can be simplified.

#### Related issue:
n\a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
