### PR TITLE
[macOS] Perform a full clone of vcpkg instead of depth=1

### DIFF
--- a/images/macos/provision/core/vcpkg.sh
+++ b/images/macos/provision/core/vcpkg.sh
@@ -6,7 +6,7 @@ VCPKG_INSTALLATION_ROOT=/usr/local/share/vcpkg
 echo "export VCPKG_INSTALLATION_ROOT=${VCPKG_INSTALLATION_ROOT}" | tee -a ~/.bashrc
 
 # Install vcpkg
-git clone --depth=1 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT
+git clone https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT
 $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh
 $VCPKG_INSTALLATION_ROOT/vcpkg integrate install
 chmod -R 0777 $VCPKG_INSTALLATION_ROOT


### PR DESCRIPTION
# Description
The vcpkg versioning features rely on retrieving information from its git repository history. This means users need a deep clone to access earlier versions and baselines.

See https://github.com/microsoft/vcpkg/blob/master/docs/users/versioning.md#builtin-baseline for one of the user-facing points that requires specifying a git commit id from the history

#### Related issue:
https://github.com/actions/virtual-environments/pull/4272

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
