### PR TITLE
[Windows] Pin mongodb to 5.0

### DIFF
--- a/images/win/scripts/Installers/Install-MongoDB.ps1
+++ b/images/win/scripts/Installers/Install-MongoDB.ps1
@@ -5,7 +5,7 @@
 
 $toolsetVersion = (Get-ToolsetContent).mongodb.version
 $latestChocoPackage = Get-LatestChocoPackageVersion -TargetVersion $toolsetVersion -PackageName "mongodb"
-Choco-Install -PackageName mongodb -ArgumentList "--version $latestChocoPackage"
+Choco-Install -PackageName mongodb -ArgumentList "--version=$latestChocoPackage"
 $mongoPath = (Get-CimInstance Win32_Service -Filter "Name LIKE 'mongodb'").PathName
 $mongoBin = Split-Path -Path $mongoPath.split('"')[1]
 Add-MachinePathItem "$mongoBin"

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -423,6 +423,6 @@
         "default": "14"
     },
     "mongodb": {
-        "version": "5"
+        "version": "5.0"
     }
 }

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -455,6 +455,6 @@
         "default": "14"
     },
     "mongodb": {
-        "version": "5"
+        "version": "5.0"
     }
 }

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -305,6 +305,6 @@
         "default": "14"
     },
     "mongodb": {
-        "version": "5"
+        "version": "5.0"
     }
 }


### PR DESCRIPTION
# Description
Starting with MongoDB 5.0, MongoDB is released as two different release series:
- Major Releases
- Rapid Releases

**Major Releases are made available approximately once a year, and generally mark the introduction of new features and improvements. Major Releases are appropriate for all MongoDB deployments.
Rapid Releases are designed for use with MongoDB Atlas, and are not generally supported for use in an on-premise capacity.**

We have to pin the version to the latest Major 5.0 release.

#### Related issue:
https://github.com/actions/virtual-environments/discussions/4481

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
