### PR TITLE
[Ubuntu] Pin mongodb version to 5.0

### DIFF
--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -328,6 +328,6 @@
         }
     ],
     "mongodb": {
-        "version": "5"
+        "version": "5.0"
     }
 }

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -333,6 +333,6 @@
         }
     ],
     "mongodb": {
-        "version": "5"
+        "version": "5.0"
     }
 }


### PR DESCRIPTION
# Description
Starting with MongoDB 5.0, MongoDB is released as two different release series:
- Major Releases
- Rapid Releases

**Major Releases are made available approximately once a year, and generally mark the introduction of new features and improvements. Major Releases are appropriate for all MongoDB deployments.
Rapid Releases are designed for use with MongoDB Atlas, and are not generally supported for use in an on-premise capacity.**

We have to pin the version to the latest Major 5.0 release.

#### Related issue:
https://github.com/actions/virtual-environments/discussions/4481

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
