### PR TITLE
[macOS] Pin mongodb version to 5.0

### DIFF
--- a/images/macos/toolsets/toolset-10.14.json
+++ b/images/macos/toolsets/toolset-10.14.json
@@ -385,6 +385,6 @@
         ]
     },
     "mongodb": {
-        "version": "5"
+        "version": "5.0"
     }
 }

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -343,6 +343,6 @@
         "version": "13"
     },
     "mongodb": {
-        "version": "5"
+        "version": "5.0"
     }
 }

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -295,6 +295,6 @@
         "version": "13"
     },
     "mongodb": {
-        "version": "5"
+        "version": "5.0"
     }
 }

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -193,6 +193,6 @@
         ]
     },
     "mongodb": {
-        "version": "5"
+        "version": "5.0"
     }
 }


### PR DESCRIPTION
# Description
Starting with MongoDB 5.0, MongoDB is released as two different release series:
- Major Releases
- Rapid Releases

**Major Releases are made available approximately once a year, and generally mark the introduction of new features and improvements. Major Releases are appropriate for all MongoDB deployments.
Rapid Releases are designed for use with MongoDB Atlas, and are not generally supported for use in an on-premise capacity.**

We have to pin the version to the latest Major 5.0 release.

#### Related issue:
https://github.com/actions/virtual-environments/discussions/4481

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
