### PR TITLE
[Windows] move llvm to toolset

### DIFF
--- a/images/win/scripts/Installers/Install-LLVM.ps1
+++ b/images/win/scripts/Installers/Install-LLVM.ps1
@@ -4,7 +4,7 @@
 ################################################################################
 
 $llvmVersion = (Get-ToolsetContent).llvm.version
-$latestChocoVersion = Get-LatestChocoPackageVersion -TargetVersion ${llvmVersion} -PackageName "llvm"
-Choco-Install -PackageName llvm -ArgumentList "--version ${latestChocoVersion}"
+$latestChocoVersion = Get-LatestChocoPackageVersion -TargetVersion $llvmVersion -PackageName "llvm"
+Choco-Install -PackageName llvm -ArgumentList "--version $latestChocoVersion"
 
 Invoke-PesterTests -TestFile "LLVM"

--- a/images/win/scripts/Installers/Install-LLVM.ps1
+++ b/images/win/scripts/Installers/Install-LLVM.ps1
@@ -1,0 +1,10 @@
+################################################################################
+##  File:  Install-LLVM.ps1
+##  Desc:  Install the latest stable version of llvm and clang compilers
+################################################################################
+
+$llvmVersion = (Get-ToolsetContent).llvm.version
+$latestChocoVersion = Get-LatestChocoPackageVersion -TargetVersion ${llvmVersion} -PackageName "llvm"
+Choco-Install -PackageName llvm -ArgumentList "--version ${latestChocoVersion}"
+
+Invoke-PesterTests -TestFile "LLVM"

--- a/images/win/scripts/Tests/LLVM.Tests.ps1
+++ b/images/win/scripts/Tests/LLVM.Tests.ps1
@@ -1,0 +1,7 @@
+Describe "Clang/LLVM" {
+    It "Clang/LLVM installed and version is correct" {
+        $toolsetVersion = (Get-ToolsetContent).llvm.version
+        $clangVersion = clang --version
+        $clangVersion[0] | Should -BeLike "*${toolsetVersion}*"
+    }
+}

--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -81,15 +81,6 @@ Describe "KubernetesTools" {
     }
 }
 
-Describe "LLVM" {
-    It "<ToolName>" -TestCases @(
-        @{ ToolName = "clang" }
-        @{ ToolName = "clang++" }
-    ) {
-        "$ToolName --version" | Should -ReturnZeroExitCode
-    }
-}
-
 Describe "Mingw64" {
     It "<ToolName>" -TestCases @(
         @{ ToolName = "gcc" }

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -397,7 +397,6 @@
             { "name": "gitversion.portable" },
             { "name": "innosetup" },
             { "name": "jq" },
-            { "name": "llvm" },
             { "name": "NuGet.CommandLine" },
             {
                 "name": "openssl.light",
@@ -427,5 +426,8 @@
     },
     "mongodb": {
         "version": "5"
+    },
+    "llvm": {
+        "version": "13"
     }
 }

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -429,7 +429,6 @@
             { "name": "gitversion.portable" },
             { "name": "innosetup" },
             { "name": "jq" },
-            { "name": "llvm" },
             { "name": "NuGet.CommandLine" },
             {
                 "name": "openssl.light",
@@ -459,5 +458,8 @@
     },
     "mongodb": {
         "version": "5"
+    },
+    "llvm": {
+        "version": "13"
     }
 }

--- a/images/win/windows2016.json
+++ b/images/win/windows2016.json
@@ -206,7 +206,8 @@
                 "{{ template_dir }}/scripts/Installers/Install-Selenium.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-IEWebDriver.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Apache.ps1",
-                "{{ template_dir }}/scripts/Installers/Install-Nginx.ps1"
+                "{{ template_dir }}/scripts/Installers/Install-Nginx.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-LLVM.ps1"
             ]
         },
         {

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -267,7 +267,8 @@
                 "{{ template_dir }}/scripts/Installers/Configure-DynamicPort.ps1",
                 "{{ template_dir }}/scripts/Installers/Configure-GDIProcessHandleQuota.ps1",
                 "{{ template_dir }}/scripts/Installers/Configure-Shell.ps1",
-                "{{ template_dir }}/scripts/Installers/Enable-DeveloperMode.ps1"
+                "{{ template_dir }}/scripts/Installers/Enable-DeveloperMode.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-LLVM.ps1"
             ]
         },
         {


### PR DESCRIPTION
# Description

Pinned latest llvm version using the recently added `Get-LatestChocoPackageVersion` function.
I also propose we dropping the `clang++ --version` check in tests as `clang++` calls are literally equal to the `clang -x` and `clang -lstdc++` ones (i.e. binary is in fact the same but installed a little bit differently).

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/2918

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
