### PR TITLE
[Windows] Add test to validate windows updates installation

### DIFF
--- a/images/win/scripts/ImageHelpers/ImageHelpers.psm1
+++ b/images/win/scripts/ImageHelpers/ImageHelpers.psm1
@@ -41,4 +41,5 @@ Export-ModuleMember -Function @(
     'Get-AndroidPackagesByVersion'
     'Get-VisualStudioInstance'
     'Get-VisualStudioComponents'
+    'Get-WindowsUpdatesHistory'
 )

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -503,17 +503,17 @@ function Get-WindowsUpdatesHistory {
     $events = Get-WinEvent -FilterHashtable $filter -ErrorAction SilentlyContinue | Sort-Object Id
 
     foreach ( $event in $events ) {
-        switch ( $evnt.Id ) {
+        switch ( $event.Id ) {
             19 {
                 $status = "Successful"
                 $title = $event.Properties[0].Value
-                $allEvents.Add($title, "")
+                $allEvents[$title] = ""
                 break
             }
             20 {
                 $status = "Failure"
                 $title = $event.Properties[1].Value
-                $allEvents.Add($title, "")
+                $allEvents[$title] = ""
                 break
             }
             43 {

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -489,3 +489,47 @@ function Get-AndroidPackagesByVersion {
     $packagesByVersion = $packagesByName | Where-Object { ($_.Split($Delimiter)[$Index] -as $Type) -ge $MinimumVersion }
     return $packagesByVersion | Sort-Object { $_.Split($Delimiter)[$Index] -as $Type} -Unique
 }
+
+function Get-WindowsUpdatesHistory {
+    $allEvents = @{}
+    # 19 - Installation Successful: Windows successfully installed the following update
+    # 20 - Installation Failure: Windows failed to install the following update with error
+    # 43 - Installation Started: Windows has started installing the following update
+    $filter = @{
+        LogName = "System"
+        Id = 19, 20, 43
+        ProviderName = "Microsoft-Windows-WindowsUpdateClient"
+    }
+    $events = Get-WinEvent -FilterHashtable $filter -ErrorAction SilentlyContinue | Sort-Object Id
+
+    foreach ( $event in $events ) {
+        switch ( $evnt.Id ) {
+            19 {
+                $status = "Successful"
+                $title = $event.Properties[0].Value
+                $allEvents.Add($title, "")
+                break
+            }
+            20 {
+                $status = "Failure"
+                $title = $event.Properties[1].Value
+                $allEvents.Add($title, "")
+                break
+            }
+            43 {
+                $status = "InProgress"
+                $title = $event.Properties[0].Value
+                break 
+            }
+        }
+
+        if ( $status -eq "InProgress" -and $allEvents.ContainsKey($title) ) {
+            continue
+        }
+
+        [PSCustomObject]@{
+            Status = $status
+            Title = $title
+        }
+    }
+}

--- a/images/win/scripts/Installers/Install-WindowsUpdates.ps1
+++ b/images/win/scripts/Installers/Install-WindowsUpdates.ps1
@@ -17,7 +17,7 @@ function Install-WindowsUpdates {
     }
 
     Write-Host "Installing windows updates"
-    Get-WindowsUpdate -MicrosoftUpdate -AcceptAll -Install -IgnoreUserInput -IgnoreReboot -OutVariable current | Out-Host
+    Get-WindowsUpdate -MicrosoftUpdate -AcceptAll -Install -IgnoreUserInput -IgnoreReboot | Out-Host
 
     Write-Host "Validating windows updates installation and skip Microsoft Defender Antivirus"
     # Azure service can automatic updates AV engine(Microsoft.Azure.Security.AntimalwareSignature.AntimalwareConfiguration)

--- a/images/win/scripts/Installers/Install-WindowsUpdates.ps1
+++ b/images/win/scripts/Installers/Install-WindowsUpdates.ps1
@@ -4,5 +4,34 @@
 ##         Should be run at end, just before SoftwareReport and Finalize-VM.ps1.
 ################################################################################
 
-Write-Host "Run windows updates"
-Get-WUInstall -MicrosoftUpdate -AcceptAll -Install -IgnoreUserInput -IgnoreReboot
+function Install-WindowsUpdates {
+    Write-Host "Starting wuauserv"
+    Start-Service -Name wuauserv -PassThru | Out-Host
+
+    Write-Host "Getting list of available windows updates"
+    Get-WindowsUpdate -MicrosoftUpdate -OutVariable updates | Out-Host
+
+    if ( -not $updates ) {
+        Write-Host "There are no windows updates to install"
+        return
+    }
+
+    Write-Host "Installing windows updates"
+    Get-WindowsUpdate -MicrosoftUpdate -AcceptAll -Install -IgnoreUserInput -IgnoreReboot | Out-Host
+
+    Write-Host "Validating windows updates installation and skip Microsoft Defender Antivirus"
+    # Azure service can automatic updates AV engine(Microsoft.Azure.Security.AntimalwareSignature.AntimalwareConfiguration)
+    # Operationname = Installation and Restul=Succeeded/InProgress
+    $wuHistory = Get-WUHistory | Where-Object { $_.OperationName -eq "Installation" -and $_.Result -in ("Succeeded", "InProgress") }
+    $wuFail = $updates[0] | Where-Object Title -notmatch "Microsoft Defender Antivirus" | Where-Object KB -notin $wuHistory.KB
+
+    if ( $wuFail ) {
+        Write-Host "Windows updates failed to install: $($wuFail.KB)"
+        exit 1
+    }
+}
+
+Install-WindowsUpdates
+
+# Create complete windows update file
+New-Item -Path $env:windir -Name WindowsUpdateDone.txt -ItemType File | Out-Null

--- a/images/win/scripts/Tests/WindowsFeatures.Tests.ps1
+++ b/images/win/scripts/Tests/WindowsFeatures.Tests.ps1
@@ -62,16 +62,19 @@ Describe "Windows Updates" {
         "$env:windir\WindowsUpdateDone.txt" | Should -Exist
     }
 
-    $testCases = Get-WUHistory | Where-Object Title -notmatch "Microsoft Defender Antivirus" | ForEach-Object {
+    $testCases = Get-WindowsUpdatesHistory | Sort-Object Title | ForEach-Object {
         @{
             Title = $_.Title
-            Result = $_.Result
-            OperationName = $_.OperationName
+            Status = $_.Status
         }
     }
 
     It "<Title>" -TestCases $testCases {
-        $Result | Should -Be "Succeeded"
-        $OperationName | Should -Be "Installation"
+        $expect = "Successful"
+        if ( $Title -match "Microsoft Defender Antivirus" ) {
+            $expect = "Successful", "Failure"
+        }
+
+        $Status | Should -BeIn $expect
     }
 }

--- a/images/win/scripts/Tests/WindowsFeatures.Tests.ps1
+++ b/images/win/scripts/Tests/WindowsFeatures.Tests.ps1
@@ -56,3 +56,22 @@ Describe "Test Signed Drivers" -Skip:(Test-IsWin16) {
         "$(bcdedit)" | Should -Match "testsigning\s+Yes"
     }
 }
+
+Describe "Windows Updates" {
+    It "WindowsUpdateDone.txt should exist" {
+        "$env:windir\WindowsUpdateDone.txt" | Should -Exist
+    }
+
+    $testCases = Get-WUHistory | Where-Object Title -notmatch "Microsoft Defender Antivirus" | ForEach-Object {
+        @{
+            Title = $_.Title
+            Result = $_.Result
+            OperationName = $_.OperationName
+        }
+    }
+
+    It "<Title>" -TestCases $testCases {
+        $Result | Should -Be "Succeeded"
+        $OperationName | Should -Be "Installation"
+    }
+}

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -144,21 +144,6 @@
         {
             "type": "powershell",
             "scripts": [
-                "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1"
-            ],
-            "elevated_user": "{{user `install_user`}}",
-            "elevated_password": "{{user `install_password`}}"
-        },
-        {
-            "type": "windows-restart",
-            "check_registry": true,
-            "restart_check_command": "powershell -command \"& {if ((-not (Get-Process TiWorker.exe -ErrorAction SilentlyContinue)) -and (-not [System.Environment]::HasShutdownStarted) ) { Write-Output 'Restart complete' }}\"",
-            "restart_timeout": "30m"
-        },
-        {
-            "type": "powershell",
-            "pause_before": "2m",
-            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-VCRedist.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Docker.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-PowershellCore.ps1",
@@ -271,11 +256,22 @@
             ]
         },
         {
+            "type": "powershell",
+            "scripts": [
+                "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1"
+            ],
+            "elevated_user": "{{user `install_user`}}",
+            "elevated_password": "{{user `install_password`}}"
+        },
+        {
             "type": "windows-restart",
-            "restart_timeout": "10m"
+            "check_registry": true,
+            "restart_check_command": "powershell -command \"& {if ((-not (Get-Process TiWorker.exe -ErrorAction SilentlyContinue)) -and (-not [System.Environment]::HasShutdownStarted) ) { Write-Output 'Restart complete' }}\"",
+            "restart_timeout": "30m"
         },
         {
             "type": "powershell",
+            "pause_before": "2m",
             "scripts": [
                 "{{ template_dir }}/scripts/Tests/RunAll-Tests.ps1"
             ]


### PR DESCRIPTION
# Description
It turned out Windows updates are not installed during the image generation, only accepted:
![image](https://user-images.githubusercontent.com/47745270/141439461-28813d04-659b-4c68-9a03-f82c7ed591fc.png)

- Add test to validate failed updates except Windows Defender
- Move installation script at the end as for other distros

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2943

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
