### PR TITLE
[Windows] Add wasm.tools component to VS2022

### DIFF
--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -236,7 +236,8 @@
             "Microsoft.VisualStudio.Workload.Python",
             "Microsoft.VisualStudio.Workload.Universal",
             "Microsoft.VisualStudio.Workload.VisualStudioExtension",
-            "Component.MDD.Linux"
+            "Component.MDD.Linux",
+            "wasm.tools"
         ],
         "vsix": []
     },


### PR DESCRIPTION
# Description
`wasm.tools` is an optional component from `.NET WebAssembly build tools` workload, which is required for some customers' builds. Installation time in runtime is about 5 minutes so it's worth baking the component into the image.

#### Related issue:
https://github.com/actions/virtual-environments/issues/4479

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
