### PR TITLE
Update java-tools.sh to utilize github provided zipball_url preventing 404s

### DIFF
--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -59,7 +59,7 @@ echo "ANT_HOME=/usr/share/ant" | tee -a /etc/environment
 # Install Maven
 json=$(curl -s "https://api.github.com/repos/apache/maven/tags")
 latestMavenVersion=$(echo $json | jq -r '.[] | select(.name | match("^(maven-[0-9.]*)$")) | .name' | head -1 | cut -d- -f2)
-mavenDownloadUrl="https://www-eu.apache.org/dist/maven/maven-3/${latestMavenVersion}/binaries/apache-maven-${latestMavenVersion}-bin.zip"
+mavenDownloadUrl=$(echo $json | jq -r ".[] | select(.name==\"maven-$latestMavenVersion\") | .zipball_url")
 download_with_retries $mavenDownloadUrl "/tmp" "maven.zip"
 unzip -qq -d /usr/share /tmp/maven.zip
 ln -s /usr/share/apache-maven-${latestMavenVersion}/bin/mvn /usr/bin/mvn


### PR DESCRIPTION
- Remove hardcoded mavenDownloadUrl var that is causing 404 errors
- Use zipball_url key provided via initial curl to https://api.github.com/repos/apache/maven/tags 

```shell
    azure-arm: Unpacking ant-optional (1.10.7-1) ...
    azure-arm: Setting up ant (1.10.7-1) ...
    azure-arm: Setting up ant-optional (1.10.7-1) ...
    azure-arm: Processing triggers for man-db (2.9.1-1) ...
    azure-arm: ANT_HOME=/usr/share/ant
    azure-arm: Downloading 'https://www-eu.apache.org/dist/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.zip' to '/tmp/maven.zip'...
    azure-arm: Error — Either HTTP response code for 'https://www-eu.apache.org/dist/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.zip' is wrong - '404' or exit code is not 0 - '0'. Waiting 30 seconds before the next attempt, 19 attempts left
```

# Description
Bug fix to prevent 404 errors from bad mirrors for maven.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [X] Changes are tested and related VM images are successfully generated
