### PR TITLE
[MacOS] Pin PostgreSQL version installed in the toolset

### DIFF
--- a/images/macos/provision/core/postgresql.sh
+++ b/images/macos/provision/core/postgresql.sh
@@ -1,13 +1,19 @@
-#!/bin/bash -e -o pipefail
+# !/bin/bash -e -o pipefail
 source ~/utils/utils.sh
 
-#Install latest version of postgresql
-brew_smart_install "postgres"
+# Fetch postgresql version to install from the toolset
+toolsetVersion=$(get_toolset_value '.postgresql.version')
 
-#Service postgresql should be started before use.
+# Search for the latest version of the postgresql corresponding to version from the toolset
+versionToInstall=$(brew search /postgresql@$toolsetVersion/ | awk -F' ' '{print $1}' | tail -1)
+
+# Install latest version of postgresql
+brew_smart_install $versionToInstall
+
+# Service postgresql should be started before use
 brew services start postgresql
 
-#Verify PostgreSQL is ready for accept incoming connections
+# Verify PostgreSQL is ready for accept incoming connections
 echo "Check PostgreSQL service is running"
 i=10
 COMMAND='pg_isready'
@@ -23,7 +29,7 @@ while [ $i -gt 0 ]; do
     sleep 10
 done
 
-#Stop postgresql
+# Stop postgresql
 brew services stop postgresql
 
 invoke_tests "Databases" "PostgreSQL"

--- a/images/macos/provision/core/postgresql.sh
+++ b/images/macos/provision/core/postgresql.sh
@@ -1,4 +1,4 @@
-# !/bin/bash -e -o pipefail
+#!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
 
 # Fetch postgresql version to install from the toolset

--- a/images/macos/provision/core/postgresql.sh
+++ b/images/macos/provision/core/postgresql.sh
@@ -1,16 +1,13 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
 
-# Fetch postgresql version to install from the toolset
+# Fetch PostgreSQL version to install from the toolset
 toolsetVersion=$(get_toolset_value '.postgresql.version')
 
-# Search for the latest version of the postgresql corresponding to version from the toolset
-versionToInstall=$(brew search /postgresql@$toolsetVersion/ | awk -F' ' '{print $1}' | tail -1)
+# Install latest version of PostgreSQL
+brew_smart_install postgresql@$toolsetVersion
 
-# Install latest version of postgresql
-brew_smart_install $versionToInstall
-
-# Service postgresql should be started before use
+# Service PostgreSQL should be started before use
 brew services start postgresql
 
 # Verify PostgreSQL is ready for accept incoming connections
@@ -29,7 +26,7 @@ while [ $i -gt 0 ]; do
     sleep 10
 done
 
-# Stop postgresql
+# Stop PostgreSQL
 brew services stop postgresql
 
 invoke_tests "Databases" "PostgreSQL"

--- a/images/macos/tests/Databases.Tests.ps1
+++ b/images/macos/tests/Databases.Tests.ps1
@@ -12,8 +12,8 @@ Describe "PostgreSQL" {
     It "PostgreSQL version should correspond to the version in the toolset" {
         $toolsetVersion = Get-ToolsetValue 'postgresql.version'
         # Client version
-        (&psql --version).split(" ")[-1] | Should -BeLike "$toolsetVersion*"
+        (psql --version).split()[-1] | Should -BeLike "$toolsetVersion*"
         # Server version
-        (&pg_config --version).split(" ")[-1] | Should -BeLike "$toolsetVersion*"
+        (pg_config --version).split()[-1] | Should -BeLike "$toolsetVersion*"
     }
 }

--- a/images/macos/tests/Databases.Tests.ps1
+++ b/images/macos/tests/Databases.Tests.ps1
@@ -9,11 +9,11 @@ Describe "MongoDB" {
 }
 
 Describe "PostgreSQL" {
-    It "PostgreSQL-Client" {
-        "psql --version" | Should -ReturnZeroExitCode
-    }
-
-    It "PostgreSQL-Server" {
-        "pg_config --version" | Should -ReturnZeroExitCode
+    It "PostgreSQL version should correspond to the version in the toolset" {
+        $toolsetVersion = Get-ToolsetValue 'postgresql.version'
+        # Client version
+        (&psql --version).split(" ")[-1] | Should -BeLike "$toolsetVersion*"
+        # Server version
+        (&pg_config --version).split(" ")[-1] | Should -BeLike "$toolsetVersion*"
     }
 }

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -344,5 +344,8 @@
     },
     "mongodb": {
         "version": "5.0"
+    },
+    "postgresql": {
+        "version": "14"
     }
 }

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -296,5 +296,8 @@
     },
     "mongodb": {
         "version": "5.0"
+    },
+    "postgresql": {
+        "version": "14"
     }
 }

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -194,5 +194,8 @@
     },
     "mongodb": {
         "version": "5.0"
+    },
+    "postgresql": {
+        "version": "14"
     }
 }


### PR DESCRIPTION
# Description
We need to move PostgreSQL along with some other tools to the toolset on all OSes to make versions control more granular.
#### Related issue: https://github.com/actions/virtual-environments-internal/issues/2910

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated