### PR TITLE
[Ubuntu] add maven back to toolset

### DIFF
--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -34,7 +34,7 @@ for JAVA_VERSION in ${JAVA_VERSIONS_LIST[@]}; do
     if [[ -z $fullJavaVersion ]]; then
         fullJavaVersion=$(java -fullversion 2>&1 | tr -d "\"" | tr "+" "-" | awk '{print $4}')
     fi
-    
+
     javaToolcacheVersionPath="$JAVA_TOOLCACHE_PATH/$fullJavaVersion"
     mkdir -p "$javaToolcacheVersionPath"
 
@@ -57,12 +57,11 @@ apt-fast install -y --no-install-recommends ant ant-optional
 echo "ANT_HOME=/usr/share/ant" | tee -a /etc/environment
 
 # Install Maven
-json=$(curl -s "https://api.github.com/repos/apache/maven/tags")
-latestMavenVersion=$(echo $json | jq -r '.[] | select(.name | match("^(maven-[0-9.]*)$")) | .name' | head -1 | cut -d- -f2)
-mavenDownloadUrl="https://www-eu.apache.org/dist/maven/maven-3/${latestMavenVersion}/binaries/apache-maven-${latestMavenVersion}-bin.zip"
-download_with_retries $mavenDownloadUrl "/tmp" "maven.zip"
+mavenVersion=$(get_toolset_value '.java.maven')
+mavenDownloadUrl="https://www-eu.apache.org/dist/maven/maven-3/${mavenVersion}/binaries/apache-maven-${mavenVersion}-bin.zip"
+download_with_retries ${mavenDownloadUrl} "/tmp" "maven.zip"
 unzip -qq -d /usr/share /tmp/maven.zip
-ln -s /usr/share/apache-maven-${latestMavenVersion}/bin/mvn /usr/bin/mvn
+ln -s /usr/share/apache-maven-${mavenVersion}/bin/mvn /usr/bin/mvn
 
 # Install Gradle
 # This script founds the latest gradle release from https://services.gradle.org/versions/all

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -73,7 +73,8 @@
         "default": "8",
         "versions": [
             "8", "11", "12"
-        ]
+        ],
+        "maven": "3.8.3"
     },
     "android": {
         "platform_min_version": "23",

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -74,7 +74,8 @@
         "default": "11",
         "versions": [
             "8", "11"
-        ]
+        ],
+        "maven": "3.8.3"
     },
     "android": {
         "platform_min_version": "27",


### PR DESCRIPTION
# Description

As was discussed at the standup.  
Lets add maven back to toolset as we have experienced multiple problems as github versions and apache foundation mirror versions are out of sync too frequently.

#### Related issue: https://github.com/actions/virtual-environments/issues/4503 https://github.com/actions/virtual-environments-internal/issues/2968

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
