### PR TITLE
[Ubuntu] Chmod known directories

### DIFF
--- a/images/linux/scripts/installers/post-deployment.sh
+++ b/images/linux/scripts/installers/post-deployment.sh
@@ -6,7 +6,6 @@
 
 mv -f /imagegeneration/post-generation /opt
 
-
 echo "chmod -R 777 /opt"
 chmod -R 777 /opt
 echo "chmod -R 777 /usr/share"

--- a/images/linux/scripts/installers/post-deployment.sh
+++ b/images/linux/scripts/installers/post-deployment.sh
@@ -6,11 +6,13 @@
 
 mv -f /imagegeneration/post-generation /opt
 
-# set chmod -R 777 /opt
-if [[ -d "/opt" ]]; then
-    echo "chmod -R 777 /opt"
-    chmod -R 777 /opt
-fi
+
+echo "chmod -R 777 /opt"
+chmod -R 777 /opt
+echo "chmod -R 777 /usr/share"
+chmod -R 777 /usr/share
+echo "chmod -R 777 /home"
+chmod -R 777 /home
 
 # remove installer and helper folders
 rm -rf $HELPER_SCRIPT_FOLDER


### PR DESCRIPTION
# Description
In scope of this PR, we set chmod 777 on the following known directories:
- `/opt`
- `/usr/share`
- `/home`

The purpose of this PR is bringing some Provisioner legacy scripts to public repo. We already invoke these commands during deployment so we just move it to image-generation stage since they don't depend on user.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
