### PR TITLE
[Windows] Add sbt to Windows 2022 image

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -74,13 +74,10 @@ $markdown += New-MDHeader "Project Management" -Level 3
 $projectManagementTools = @(
     (Get-AntVersion),
     (Get-GradleVersion),
-    (Get-MavenVersion)
+    (Get-MavenVersion),
+    (Get-SbtVersion)
 )
-if ((Test-IsWin16) -or (Test-IsWin19)) {
-    $projectManagementTools += @(
-        (Get-SbtVersion)
-    )
-}
+
 $markdown += New-MDList -Style Unordered -Lines ($projectManagementTools | Sort-Object)
 
 $markdown += New-MDHeader "Tools" -Level 3

--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -124,7 +124,7 @@ Describe "PowerShell Core" {
     }
 }
 
-Describe "Sbt" -Skip:(Test-IsWin22) {
+Describe "Sbt" {
     It "sbt" {
         "sbt --version" | Should -ReturnZeroExitCode
     }
@@ -199,7 +199,7 @@ Describe "Pipx" {
 Describe "Kotlin" {
     $kotlinPackages =  @("kapt", "kotlin", "kotlinc", "kotlin-dce-js", "kotlinc-js", "kotlinc-jvm")
 
-    It "<toolName> is available" -TestCases ($kotlinPackages | ForEach-Object { @{ toolName = $_ } })  { 
+    It "<toolName> is available" -TestCases ($kotlinPackages | ForEach-Object { @{ toolName = $_ } })  {
         "$toolName -version" | Should -ReturnZeroExitCode
     }
 }

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -203,6 +203,7 @@
                 "{{ template_dir }}/scripts/Installers/Install-GitHub-CLI.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-PHP.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Rust.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-Sbt.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Chrome.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Edge.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Firefox.ps1",


### PR DESCRIPTION
# Description
Adds [sbt](https://github.com/sbt/sbt) to the Windows 2022 image. It's already installed for the Windows Server 2016 and 2019 images, and this PR adds it also to the 2022 image.

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
