### PR TITLE
CI: Run linter only on changes of JSON and MD files

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter@v4
+        uses: github/super-linter/slim@v4
         env:
           VALIDATE_ALL_CODEBASE: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -26,7 +26,7 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_JSON: true
-          VALIDATE_MD: true
+          VALIDATE_MARKDOWN: true
           DEFAULT_BRANCH: ${{ github.base_ref }}
 
       - name: Checking shebang lines in MacOS and Ubuntu releases.

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -5,6 +5,9 @@ name: Linter
 on:
   pull_request:
     branches: [ main ]
+    paths:
+      - '**.json'
+      - '**.md'
 
 jobs:
   build:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - '**.json'
       - '**.md'
+      - '**.sh'
 
 jobs:
   build:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter@v3
+        uses: github/super-linter@v4
         env:
           VALIDATE_ALL_CODEBASE: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the CI linter workflow to only run if a JSON of MD file is changed. This saves CI time on PRs that only have changes to other file types.

Also updates [github/super-linter](https://github.com/github/super-linter) to version 4.