### PR TITLE
[Windows] softwarereport: do not use regex to get version of choco

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -111,9 +111,7 @@ function Get-NodeVersion {
 }
 
 function Get-ChocoVersion {
-    ($(choco version) | Out-String) -match "v(?<version>\d+\.\d+\.\d+)" | Out-Null
-    $chocoVersion = $Matches.Version
-    return "Chocolatey $chocoVersion"
+    return "Chocolatey $(choco --version)"
 }
 
 function Get-VcpkgVersion {


### PR DESCRIPTION
# Description
- DEPRECATION NOTICE - choco version command is deprecated and will be removed in version 1.0.0.
- Do not use regex get version of choco