### PR TITLE
[Ubuntu] Update maven to 3.8.4

### DIFF
--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -74,7 +74,7 @@
         "versions": [
             "8", "11", "12"
         ],
-        "maven": "3.8.3"
+        "maven": "3.8.4"
     },
     "android": {
         "platform_min_version": "23",

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -75,7 +75,7 @@
         "versions": [
             "8", "11"
         ],
-        "maven": "3.8.3"
+        "maven": "3.8.4"
     },
     "android": {
         "platform_min_version": "27",


### PR DESCRIPTION
# Description

The version got updated without preserving 3.8.3 (who knows why), blocks our ubuntu images generation.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
