### PR TITLE
[macOS] set default nodeJS version to 16

### DIFF
--- a/images/macos/tests/Node.Tests.ps1
+++ b/images/macos/tests/Node.Tests.ps1
@@ -4,7 +4,6 @@ Import-Module "$PSScriptRoot/../helpers/Tests.Helpers.psm1" -DisableNameChecking
 $os = Get-OSVersion
 
 Describe "Node.js" {
-
     It "Node.js is installed" {
         "node --version" | Should -ReturnZeroExitCode
     }

--- a/images/macos/tests/Node.Tests.ps1
+++ b/images/macos/tests/Node.Tests.ps1
@@ -4,10 +4,6 @@ Import-Module "$PSScriptRoot/../helpers/Tests.Helpers.psm1" -DisableNameChecking
 $os = Get-OSVersion
 
 Describe "Node.js" {
-    BeforeAll {
-        $os = Get-OSVersion
-        $expectedNodeVersion = if ($os.IsHigherThanMojave) { "v14.*" } else { "v8.*" }
-    }
 
     It "Node.js is installed" {
         "node --version" | Should -ReturnZeroExitCode
@@ -15,10 +11,6 @@ Describe "Node.js" {
 
     It "Node.js version should correspond to the version in the toolset" {
         node --version | Should -BeLike "v$(Get-ToolsetValue 'node.default')*"
-    }
-
-    It "Node.js $expectedNodeVersion is default" {
-        (Get-CommandResult "node --version").Output | Should -BeLike $expectedNodeVersion
     }
 
     It "NPM is installed" {

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -331,7 +331,7 @@
         "default": "1.15"
     },
     "node": {
-        "default": "14",
+        "default": "16",
         "nvm_versions": [
             "12",
             "14",

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -283,7 +283,7 @@
         "default": "1.15"
     },
     "node": {
-        "default": "14",
+        "default": "16",
         "nvm_versions": [
             "12",
             "14",

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -184,7 +184,7 @@
         "default": "1.17"
     },
     "node": {
-        "default": "14",
+        "default": "16",
         "nvm_versions": [
             "12",
             "14",


### PR DESCRIPTION
# Description

Node.js 16 has moved to Active LTS status and is ready for general use. We would like to provide images with the latest stable updates as default ones.

#### Related issue: https://github.com/actions/virtual-environments/issues/4446

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
