### PR TITLE
[Windows] set default nodeJS version to 16

### DIFF
--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -419,7 +419,7 @@
         ]
     },
     "node": {
-        "default": "14"
+        "default": "16"
     },
     "Mysql": {
         "version": "5.7"

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -451,7 +451,7 @@
         ]
     },
     "node": {
-        "default": "14"
+        "default": "16"
     },
     "Mysql": {
         "version": "5.7"

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -303,7 +303,7 @@
         ]
     },
     "node": {
-        "default": "14"
+        "default": "16"
     },
     "Mysql": {
         "version": "8.0"


### PR DESCRIPTION
# Description

Node.js 16 has moved to Active LTS status and is ready for general use. We would like to provide images with the latest stable updates as default ones.

#### Related issue: https://github.com/actions/virtual-environments/issues/4446

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
