### PR TITLE
[Ubuntu] set default nodeJS version to 16

### DIFF
--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -280,7 +280,7 @@
     },
     "rubygems": [],
     "node": {
-        "default": "14"
+        "default": "16"
     },
     "node_modules": [
         {

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -281,7 +281,7 @@
         "binary_name": "selenium-server"
     },
     "node": {
-        "default": "14"
+        "default": "16"
     },
     "node_modules": [
         {


### PR DESCRIPTION
# Description

Node.js 16 has moved to Active LTS status and is ready for general use. We would like to provide images with the latest stable updates as default ones.

#### Related issue: https://github.com/actions/virtual-environments/issues/4446

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
