### PR TITLE
[Windows] Add Service Fabric SDK to Software Report

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -123,7 +123,8 @@ $toolsList = @(
 )
 if ((Test-IsWin16) -or (Test-IsWin19)) {
     $toolsList += @(
-        (Get-GoogleCloudSDKVersion)
+        (Get-GoogleCloudSDKVersion),
+        (Get-ServiceFabricSDKVersion)
     )
 }
 $markdown += New-MDList -Style Unordered -Lines ($toolsList | Sort-Object)

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -249,6 +249,11 @@ function Get-GoogleCloudSDKVersion {
     (gcloud --version) -match "Google Cloud SDK"
 }
 
+function Get-ServiceFabricSDKVersion {
+    $serviceFabricSDKVersion = Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Service Fabric\' -Name FabricVersion
+    return "Service Fabric SDK $serviceFabricSDKVersion"
+}
+
 function Get-NewmanVersion {
     return "Newman $(newman --version)"
 }

--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -101,12 +101,6 @@ Describe "GoogleCloudSDK" -Skip:(Test-IsWin22) {
     }
 }
 
-Describe "ServiceFabricSDK" -Skip:(Test-IsWin22) {
-    It "ServiceFabricSDK" {
-        Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Service Fabric\' -Name FabricVersion | Should -ReturnZeroExitCode
-    }
-}
-
 Describe "NET48" {
     It "NET48" {
         $netPath = (Get-DotnetFrameworkTools).Path.Split("<")[0]
@@ -139,6 +133,10 @@ Describe "Sbt" -Skip:(Test-IsWin22) {
 Describe "ServiceFabricSDK" -Skip:(Test-IsWin22) {
     It "PowerShell Module" {
         Get-Module -Name ServiceFabric -ListAvailable | Should -Not -BeNullOrEmpty
+    }
+
+    It "ServiceFabricSDK version" {
+        Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Service Fabric\' -Name FabricVersion | Should -ReturnZeroExitCode
     }
 }
 

--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -136,7 +136,7 @@ Describe "ServiceFabricSDK" -Skip:(Test-IsWin22) {
     }
 
     It "ServiceFabricSDK version" {
-        Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Service Fabric\' -Name FabricVersion | Should -ReturnZeroExitCode
+        Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Service Fabric\' -Name FabricVersion | Should -Not -BeNullOrEmpty
     }
 }
 

--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -101,6 +101,12 @@ Describe "GoogleCloudSDK" -Skip:(Test-IsWin22) {
     }
 }
 
+Describe "ServiceFabricSDK" -Skip:(Test-IsWin22) {
+    It "ServiceFabricSDK" {
+        Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Service Fabric\' -Name FabricVersion | Should -ReturnZeroExitCode
+    }
+}
+
 Describe "NET48" {
     It "NET48" {
         $netPath = (Get-DotnetFrameworkTools).Path.Split("<")[0]


### PR DESCRIPTION
## Description
This PR adds information about installed Service Fabric SDK version to Software Report. 

## Related issue: 
https://github.com/actions/virtual-environments/issues/4546

## Test builds:
- [Windows 2019](https://github.visualstudio.com/virtual-environments/_build/results?buildId=119560&view=results)
- [Windows 2022](https://github.visualstudio.com/virtual-environments/_build/results?buildId=119561&view=results)

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
