### PR TITLE
Anka disable beta seed

### DIFF
--- a/images.CI/macos/anka/CreateCleanAnkaTemplate.ps1
+++ b/images.CI/macos/anka/CreateCleanAnkaTemplate.ps1
@@ -64,6 +64,10 @@ function Invoke-SoftwareUpdate {
 
     $ipAddress = Get-AnkaVMIPAddress -VMName $TemplateName
 
+    # Unenroll Seed
+    Write-Host "`t[*] Reseting the seed before requesting stable versions"
+    Remove-CurrentBetaSeed -HostName $ipAddress
+
     # Install Software Updates
     # Security updates may not be able to install(hang, freeze) when AutoLogon is turned off
     Write-Host "`t[*] Finding available software"

--- a/images.CI/macos/anka/CreateCleanAnkaTemplate.ps1
+++ b/images.CI/macos/anka/CreateCleanAnkaTemplate.ps1
@@ -66,7 +66,7 @@ function Invoke-SoftwareUpdate {
 
     # Unenroll Seed
     Write-Host "`t[*] Reseting the seed before requesting stable versions"
-    Remove-CurrentBetaSeed -HostName $ipAddress
+    Remove-CurrentBetaSeed -HostName $ipAddress | Show-StringWithFormat
 
     # Install Software Updates
     # Security updates may not be able to install(hang, freeze) when AutoLogon is turned off

--- a/images.CI/macos/anka/Service.Helpers.psm1
+++ b/images.CI/macos/anka/Service.Helpers.psm1
@@ -232,6 +232,17 @@ function Show-StringWithFormat {
     }
 }
 
+function Remove-CurrentBetaSeed {
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string] $HostName
+    )
+
+    $command = "sudo /System/Library/PrivateFrameworks/Seeding.framework/Versions/Current/Resources/seedutil unenroll"
+    Invoke-SSHPassCommand -HostName $HostName -Command $command
+}
+
 function Test-AutoLogon {
     param(
         [Parameter(Mandatory)]

--- a/images.CI/macos/anka/Service.Helpers.psm1
+++ b/images.CI/macos/anka/Service.Helpers.psm1
@@ -240,7 +240,7 @@ function Remove-CurrentBetaSeed {
     )
 
     $command = "sudo /System/Library/PrivateFrameworks/Seeding.framework/Versions/Current/Resources/seedutil unenroll"
-    Invoke-SSHPassCommand -HostName $HostName -Command $command
+    Invoke-SSHPassCommand -HostName $HostName -Command $command | Out-String
 }
 
 function Test-AutoLogon {


### PR DESCRIPTION
# Description
By default beta seed is enabled after a new clean vm has been created. We should install software updates only from stable channel.

Before:
```
[*] Fetching Software Updates ready to install on 'clean_macos_11_300gb' VM:
* Label: Device Support Update- 
    Title: Device Support Update, Version:  , Size: 191029K, Recommended: YES, 
* Label: Safari15.1BigSurAuto-15.1
    Title: Safari, Version: 15.1, Size: 118254K, Recommended: YES, 
* Label: macOS Big Sur 11.6.2-20G306
    Title: macOS Big Sur 11.6.2, Version: 11.6.2, Size: 2548664K, Recommended: YES, Action: restart
```

After:
```
* Label: Device Support Update- 
    Title: Device Support Update, Version:  , Size: 191029K, Recommended: YES, 
* Label: Safari15.1BigSurAuto-15.1
    Title: Safari, Version: 15.1, Size: 118254K, Recommended: YES,

```
#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/2995

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
