### PR TITLE
[macOS] Fix markdown in the software report

### DIFF
--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -171,7 +171,6 @@ if ($os.IsLessThanMonterey) {
 }
 
 $markdown += New-MDList -Style Unordered -Lines ($utilitiesList | Sort-Object)
-$markdown += New-MDNewLine
 
 # Tools
 $markdown += New-MDHeader "Tools" -Level 3
@@ -231,6 +230,7 @@ $markdown += New-MDNewLine
 
 # Toolcache
 $markdown += Build-ToolcacheSection
+$markdown += New-MDNewLine
 
 $markdown += New-MDHeader "Rust Tools" -Level 3
 $markdown += New-MDList -Style Unordered -Lines (@(


### PR DESCRIPTION
# Description
This pull request is fixing markdown in the software report. Removed double empty line after utilities list.  Added 
an empty string before the blok "Rust Tools".

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/2961

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
