### PR TITLE
[Windows] Fix Get-LatestChocoPackageVersion

### DIFF
--- a/images/win/scripts/ImageHelpers/ChocoHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/ChocoHelpers.ps1
@@ -57,6 +57,7 @@ function Get-LatestChocoPackageVersion {
     $incrementedVersion = $versionNumbers -join "."
     $filterQuery = "`$filter=(Id eq '$PackageName') and (IsPrerelease eq false) and (Version ge '$TargetVersion') and (Version lt '$incrementedVersion')"
     $latestVersion = (Send-RequestToChocolateyPackages -FilterQuery $filterQuery).properties.Version |
+        Where-Object {$_ -Like "$TargetVersion.*" -or $_ -eq $TargetVersion} |
         Sort-Object {[version]$_} |
         Select-Object -Last 1
 


### PR DESCRIPTION
# Description
Bug: Get-LatestChocoPackageVersion -TargetVersion '14.1' -PackageName "nodejs"  - returning "14.18.1" instead of 14.1.0

Filtering out query result to version like or equal target one.

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/2996

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
