### PR TITLE
[Windows] Fix markdown in the software report

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -310,7 +310,7 @@ function Get-PacmanVersion {
     $rawVersion = & $pacmanPath --version
     $rawVersion.Split([System.Environment]::NewLine)[1] -match "\d+\.\d+(\.\d+)?" | Out-Null
     $pacmanVersion = $matches[0]
-    return "- Pacman $pacmanVersion"
+    return "Pacman $pacmanVersion"
 }
 
 function Get-YAMLLintVersion {
@@ -319,7 +319,7 @@ function Get-YAMLLintVersion {
 
 function Get-BizTalkVersion {
     $bizTalkReg = Get-ItemProperty "HKLM:\SOFTWARE\WOW6432Node\Microsoft\BizTalk Server\3.0"
-    return "- $($bizTalkReg.ProductName) $($bizTalkReg.ProductVersion) "
+    return "$($bizTalkReg.ProductName) $($bizTalkReg.ProductVersion)"
 }
 
 function Get-PipxVersion {

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -189,32 +189,28 @@ $markdown += Get-ShellTarget
 $markdown += New-MDNewLine
 
 $markdown += New-MDHeader "MSYS2" -Level 3
-$markdown += Get-PacmanVersion
-$markdown += New-MDNewLine
+$markdown += "$(Get-PacmanVersion)" | New-MDList -Style Unordered
 $markdown += New-MDHeader "Notes:" -Level 5
-$markdown += @'
+$reportMsys64 = @'
 ```
 Location: C:\msys64
 
 Note: MSYS2 is pre-installed on image but not added to PATH.
 ```
 '@
-$markdown += New-MDNewLine
+$markdown += New-MDParagraph -Lines $reportMsys64
 
 if (Test-IsWin19)
 {
     $markdown += New-MDHeader "BizTalk Server" -Level 3
-    $markdown += Get-BizTalkVersion
-    $markdown += New-MDNewLine
+    $markdown += "$(Get-BizTalkVersion)" | New-MDList -Style Unordered
 }
 
 $markdown += New-MDHeader "Cached Tools" -Level 3
 $markdown += (Build-CachedToolsMarkdown)
-$markdown += New-MDNewLine
 
 $markdown += New-MDHeader "Databases" -Level 3
 $markdown += Build-DatabasesMarkdown
-$markdown += New-MDNewLine
 
 $markdown += New-MDHeader "Database tools" -Level 3
 $markdown += New-MDList -Style Unordered -Lines (@(
@@ -224,7 +220,6 @@ $markdown += New-MDList -Style Unordered -Lines (@(
     (Get-SQLPSVersion)
     ) | Sort-Object
 )
-$markdown += New-MDNewLine
 
 $markdown += Build-WebServersSection
 
@@ -234,12 +229,10 @@ $markdown += $vs | New-MDTable
 $markdown += New-MDNewLine
 
 $markdown += New-MDHeader "Workloads, components and extensions:" -Level 4
-$markdown += New-MDNewLine
 $markdown += ((Get-VisualStudioComponents) + (Get-VisualStudioExtensions)) | New-MDTable
 $markdown += New-MDNewLine
 
 $markdown += New-MDHeader "Microsoft Visual C++:" -Level 4
-$markdown += New-MDNewLine
 $markdown += Get-VisualCPPComponents | New-MDTable
 $markdown += New-MDNewLine
 
@@ -272,14 +265,14 @@ $markdown += New-MDList -Lines (Get-PowershellCoreVersion) -Style Unordered
 
 $markdown += New-MDHeader "Azure Powershell Modules" -Level 4
 $markdown += Get-PowerShellAzureModules | New-MDTable
-$markdown += @'
+$reportAzPwsh = @'
 ```
 Azure PowerShell module 2.1.0 and AzureRM PowerShell module 2.1.0 are installed
 and are available via 'Get-Module -ListAvailable'.
 All other versions are saved but not installed.
 ```
 '@
-$markdown += New-MDNewLine
+$markdown += New-MDParagraph -Lines $reportAzPwsh
 
 $markdown += New-MDHeader "Powershell Modules" -Level 4
 $markdown += Get-PowerShellModules | New-MDTable
@@ -298,7 +291,6 @@ $cachedImages = Get-CachedDockerImagesTableData
 if ($cachedImages) {
     $markdown += New-MDHeader "Cached Docker images" -Level 3
     $markdown += $cachedImages | New-MDTable
-    $markdown += New-MDNewLine
 }
 
 $markdown | Out-File -FilePath "C:\InstalledSoftware.md"

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Helpers.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Helpers.psm1
@@ -21,7 +21,7 @@ function Build-MarkdownElement
     )
 
     $markdown = New-MDHeader $Head -Level 4
-    $markdown += New-MDParagraph -Lines $Content
+    $markdown += New-MDParagraph -Lines $Content -NoNewLine
 
     return $markdown
 }


### PR DESCRIPTION
# Description
This pull request is fixing markdown in the software report. Removed double empty line after utilities list. Added separating empty lines in places where it is necessary.

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/2961

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
