### PR TITLE
Rebuilding Launch Services database

### DIFF
--- a/images/macos/helpers/Xcode.Installer.psm1
+++ b/images/macos/helpers/Xcode.Installer.psm1
@@ -182,7 +182,8 @@ function Rebuild-Xcode-LaunchServicesDb {
     )
 
     $xcodePath = Get-XcodeRootPath -Version $Version
-    Get-ChildItem -Recurse -Filter "*.app" $xcodePath | Select-Object FullName | Foreach-Object {Invoke-Expression '/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f $_'}
+    $lsregister = '/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister'
+    Get-ChildItem -Recurse -Filter "*.app" $xcodePath | Foreach-Object { & $lsregister -f $_.FullName}
 }
 
 function Build-ProvisionatorSymlink {

--- a/images/macos/helpers/Xcode.Installer.psm1
+++ b/images/macos/helpers/Xcode.Installer.psm1
@@ -175,10 +175,10 @@ function Build-XcodeSymlinks {
     }
 }
 
-function Rebuild-Xcode-LaunchServicesDb {
+function Rebuild-XcodeLaunchServicesDb {
     param(
         [Parameter(Mandatory)]
-        [string]$Version,
+        [string]$Version
     )
 
     $xcodePath = Get-XcodeRootPath -Version $Version

--- a/images/macos/helpers/Xcode.Installer.psm1
+++ b/images/macos/helpers/Xcode.Installer.psm1
@@ -175,6 +175,16 @@ function Build-XcodeSymlinks {
     }
 }
 
+function Rebuild-Xcode-LaunchServicesDb {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Version,
+    )
+
+    $xcodePath = Get-XcodeRootPath -Version $Version
+    Get-ChildItem -Recurse -Filter "*.app" $xcodePath | Select-Object FullName | Foreach-Object {Invoke-Expression '/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f $_'}
+}
+
 function Build-ProvisionatorSymlink {
     param(
         [Parameter(Mandatory)]

--- a/images/macos/provision/core/xcode.ps1
+++ b/images/macos/provision/core/xcode.ps1
@@ -53,7 +53,7 @@ $xcodeVersions | ForEach-Object {
 
 Write-Host "Rebuilding Launch Services database ..."
 $xcodeVersions | ForEach-Object {
-    Rebuild-Xcode-LaunchServicesDb -Version $_
+    Rebuild-XcodeLaunchServicesDb -Version $_.link
 }
 
 Write-Host "Setting default Xcode to $defaultXcode"

--- a/images/macos/provision/core/xcode.ps1
+++ b/images/macos/provision/core/xcode.ps1
@@ -51,6 +51,11 @@ $xcodeVersions | ForEach-Object {
     }
 }
 
+Write-Host "Rebuilding Launch Services database ..."
+$xcodeVersions | ForEach-Object {
+    Rebuild-Xcode-LaunchServicesDb -Version $_
+}
+
 Write-Host "Setting default Xcode to $defaultXcode"
 Switch-Xcode -Version $defaultXcode
 New-Item -Path "/Applications/Xcode.app" -ItemType SymbolicLink -Value (Get-XcodeRootPath -Version $defaultXcode) | Out-Null


### PR DESCRIPTION
# Description
 Improvement

Renaming Xcode directory to include version name destroys Launch Services database and prevents command `open` to work with .app bundles.

#### Related issue: https://github.com/actions/virtual-environments/issues/4545

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
