### PR TITLE
[Windows] pin mysql release version in toolset

### DIFF
--- a/images/win/scripts/Installers/Install-MysqlCli.ps1
+++ b/images/win/scripts/Installers/Install-MysqlCli.ps1
@@ -11,9 +11,9 @@ $ArgumentList = ("/install", "/quiet", "/norestart")
 Install-Binary -Url $InstallerURI -Name $InstallerName -ArgumentList $ArgumentList
 
 ## Downloading mysql
-$MysqlMajorMinor = (Get-ToolsetContent).Mysql.version
-$MysqlFullVersion = ((Invoke-WebRequest -Uri https://dev.mysql.com/downloads/mysql/${MysqlMajorMinor}.html).Content | Select-String -Pattern "${MysqlMajorMinor}\.\d+").Matches.Value
-$MysqlVersionUrl = "https://dev.mysql.com/get/Downloads/MySQL-${MysqlMajorMinor}/mysql-${MysqlFullVersion}-winx64.zip"
+$MysqlMajorVersion = (Get-ToolsetContent).mysql.major_version
+$MysqlFullVersion = (Get-ToolsetContent).mysql.full_version
+$MysqlVersionUrl = "https://dev.mysql.com/get/Downloads/MySQL-${MysqlMajorVersion}/mysql-${MysqlFullVersion}-winx64.zip"
 
 $MysqlArchPath = Start-DownloadWithRetry -Url $MysqlVersionUrl -Name "mysql.zip"
 

--- a/images/win/scripts/Tests/Databases.Tests.ps1
+++ b/images/win/scripts/Tests/Databases.Tests.ps1
@@ -65,7 +65,7 @@ Describe "PostgreSQL" {
 
 Describe "MySQL" {
     It "MySQL CLI" {
-        $MysqlMajorMinor = (Get-ToolsetContent).Mysql.version
-        mysql -V | Should -BeLike "*${MysqlMajorMinor}*"
+        $MysqlMajorVersion = (Get-ToolsetContent).mysql.major_version
+        mysql -V | Should -BeLike "*${MysqlMajorVersion}*"
     }
 }

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -421,8 +421,9 @@
     "node": {
         "default": "16"
     },
-    "Mysql": {
-        "version": "5.7"
+    "mysql": {
+        "major_version": "5.7",
+        "full_version": "5.7.35"
     },
     "mongodb": {
         "version": "5.0"

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -453,8 +453,9 @@
     "node": {
         "default": "16"
     },
-    "Mysql": {
-        "version": "5.7"
+    "mysql": {
+        "major_version": "5.7",
+        "full_version": "5.7.35"
     },
     "mongodb": {
         "version": "5.0"

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -305,8 +305,9 @@
     "node": {
         "default": "16"
     },
-    "Mysql": {
-        "version": "8.0"
+    "mysql": {
+        "major_version": "8.0",
+        "full_version": "8.0.26"
     },
     "mongodb": {
         "version": "5.0"


### PR DESCRIPTION
# Description

v8.0.27 is buggy as described in the related issue, we must downgrade it, and I think stay with the release version pinned in the toolset as God knows what bugs Oracle will ship with another new version of mysql.

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/2999

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
