### PR TITLE
[Windows] Add gulp-cli global npm package

### DIFF
--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -264,7 +264,8 @@
         "global_packages": [
             { "name": "yarn", "test": "yarn --version" },
             { "name": "newman", "test": "newman --version" },
-            { "name": "lerna", "test": "lerna --version" }
+            { "name": "lerna", "test": "lerna --version" },
+            { "name": "gulp-cli", "test": "gulp --version" }
         ]
     },
     "dotnet": {


### PR DESCRIPTION
## Description
This PR adds Gulp CLI global npm package to Windows 2022

## Related issue: 
https://github.com/actions/virtual-environments/issues/4577

## Test builds:
- [Windows2022](https://github.visualstudio.com/virtual-environments/_build/results?buildId=119716&view=results)

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
