### PR TITLE
[Windows] Add WiX tool for Windows 2022

### DIFF
--- a/images/win/scripts/Installers/Install-Wix.ps1
+++ b/images/win/scripts/Installers/Install-Wix.ps1
@@ -15,14 +15,13 @@ elseif (Test-IsWin16)
     $extensionUrl = "https://robmensching.gallerycdn.vsassets.io/extensions/robmensching/wixtoolsetvisualstudio2017extension/0.9.21.62588/1494013210879/250616/4/Votive2017.vsix"
     $VSver = "2017"
 }
-else
+
+if (-not (Test-IsWin22))
 {
-    throw "Invalid version of Visual Studio is found. Either 2017 or 2019 are required"
+    $extensionName = "Votive$VSver.vsix"
+
+    #Installing VS extension 'Wix Toolset Visual Studio Extension'
+    Install-VsixExtension -Url $extensionUrl -Name $extensionName -VSversion $VSver
 }
-
-$extensionName = "Votive$VSver.vsix"
-
-#Installing VS extension 'Wix Toolset Visual Studio Extension'
-Install-VsixExtension -Url $extensionUrl -Name $extensionName -VSversion $VSver
 
 Invoke-PesterTests -TestFile "Wix"

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -114,6 +114,7 @@ $toolsList = @(
     (Get-VSWhereVersion),
     (Get-SwigVersion),
     (Get-WinAppDriver),
+    (Get-WixVersion),
     (Get-ZstdVersion),
     (Get-YAMLLintVersion)
 )

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -161,6 +161,12 @@ function Get-WinAppDriver {
     return "WinAppDriver $winAppDriverVersion"
 }
 
+function Get-WixVersion {
+    $regKey = "HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
+    $installedApplications = Get-ItemProperty -Path $regKey
+    return ($installedApplications | Where-Object { $_.BundleCachePath -imatch ".*\\WiX\d*\.exe$" } | Select-Object -First 1).DisplayName
+}
+
 function Get-ZstdVersion {
     $(zstd --version) -match "v(?<version>\d+\.\d+\.\d+)" | Out-Null
     $zstdVersion = $Matches.Version

--- a/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
@@ -13,12 +13,6 @@ function Get-SDKVersion {
     ($installedApplications | Where-Object { $_.DisplayName -eq 'Windows SDK' } | Select-Object -First 1).DisplayVersion
 }
 
-function Get-WixVersion {
-    $regKey = "HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
-    $installedApplications = Get-ItemProperty -Path $regKey
-    ($installedApplications | Where-Object { $_.DisplayName -match "wix" } | Select-Object -First 1).DisplayVersion
-}
-
 function Get-WDKVersion {
     $regKey = "HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
     $installedApplications = Get-ItemProperty -Path $regKey
@@ -68,10 +62,8 @@ function Get-VisualStudioExtensions {
 
     if ((Test-IsWin16) -or (Test-IsWin19)) {
         # Wix
-        $wixPackageVersion = Get-WixVersion
         $wixExtensionVersion = ($vsPackages | Where-Object {$_.Id -match 'WixToolset.VisualStudioExtension.Dev' -and $_.type -eq 'vsix'}).Version
         $wixPackages = @(
-            @{Package = 'WIX Toolset'; Version = $wixPackageVersion}
             @{Package = "WIX Toolset Studio $vs Extension"; Version = $wixExtensionVersion}
         )
 

--- a/images/win/scripts/Tests/Wix.Tests.ps1
+++ b/images/win/scripts/Tests/Wix.Tests.ps1
@@ -1,15 +1,15 @@
-Describe "Wix" -Skip:(Test-IsWin22) {
+Describe "Wix" {
     BeforeAll {
       $regKey = "HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
       $installedApplications = Get-ItemProperty -Path $regKey
-      $version = ($installedApplications | Where-Object { $_.DisplayName -and $_.DisplayName.toLower().Contains("wix") } | Select-Object -First 1).DisplayVersion
+      $version = ($installedApplications | Where-Object { $_.BundleCachePath -imatch ".*\\WiX\d*\.exe$" } | Select-Object -First 1).DisplayName
     }
 
     It "Wix Toolset version from registry" {
       $version | Should -Not -BeNullOrEmpty
     }
 
-    It "Wix Toolset version from system" {
+    It "Wix Toolset version from system" -Skip:(Test-IsWin22) {
       if (Test-IsWin19)
       {
         $exVersion = Get-VSExtensionVersion -packageName "WixToolset.VisualStudioExtension.Dev16"

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -168,6 +168,7 @@
         {
             "type": "powershell",
             "scripts": [
+                "{{ template_dir }}/scripts/Installers/Install-Wix.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Vsix.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-AzureCli.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-AzureDevOpsCli.ps1",


### PR DESCRIPTION
## Description
This PR adds WiX Toolset to Windows 2022 image.

## Related issue: 
https://github.com/actions/virtual-environments/issues/4419

## Test builds:
- [Windows 2016](https://github.visualstudio.com/virtual-environments/_build/results?buildId=119788&view=results)
- [Windows 2019](https://github.visualstudio.com/virtual-environments/_build/results?buildId=119787&view=results)
- [Windows 2022](https://github.visualstudio.com/virtual-environments/_build/results?buildId=119786&view=results)

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
