### PR TITLE
[macOS] overwrite php symlink

### DIFF
--- a/images/macos/provision/core/php.sh
+++ b/images/macos/provision/core/php.sh
@@ -8,4 +8,6 @@ brew_smart_install "php@${phpVersionToolset}"
 echo Installing composer
 brew_smart_install "composer"
 
+brew link --overwrite php@${phpVersionToolset}
+
 invoke_tests "PHP"


### PR DESCRIPTION
# Description

Composer is depending on the latest version of php, which is now 8.1. In the toolset we keep the latest brew slot which is 8.0, as a result once composer is installed the `/usr/local/bin/php` symlink points to the latest installed php (even if php-8.0 is installed after 8.1). We need to override the symlink to make 8.0 available  by default (there is no the `php@8.1` slot so we can't simply update our toolset and be fine).

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/3030

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
