### PR TITLE
[macOS] upgrade php version to 8.1

### DIFF
--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -342,7 +342,7 @@
         "version": "13"
     },
     "php": {
-        "version": "8.0"
+        "version": "8.1"
     },
     "mongodb": {
         "version": "5.0"

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -294,7 +294,7 @@
         "version": "13"
     },
     "php": {
-        "version": "8.0"
+        "version": "8.1"
     },
     "mongodb": {
         "version": "5.0"

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -192,7 +192,7 @@
         ]
     },
     "php": {
-        "version": "8.0"
+        "version": "8.1"
     },
     "mongodb": {
         "version": "5.0"


### PR DESCRIPTION
# Description

php-8.1 is considered  [stable](https://www.php.net/ChangeLog-8.php#8.1.0) we must upgrade too, as composer now requires 8.1 strictly

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/3030

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
