### PR TITLE
[Windows] zstd: Invoke Move-Item with retry

### DIFF
--- a/images/win/scripts/Installers/Install-Zstd.ps1
+++ b/images/win/scripts/Installers/Install-Zstd.ps1
@@ -15,7 +15,9 @@ $filesInArchive = 7z l $zstdArchivePath | Out-String
 
 if ($filesInArchive.Contains($zstdParentName)) {
     Extract-7Zip -Path $zstdArchivePath -DestinationPath $toolPath
-    Move-Item -Path "${zstdPath}*" -Destination $zstdPath
+    Invoke-SBWithRetry -Command {
+        Move-Item -Path "${zstdPath}*" -Destination $zstdPath -ErrorAction Stop
+    }
 } else {
     Extract-7Zip -Path $zstdArchivePath -DestinationPath $zstdPath
 }


### PR DESCRIPTION
# Description
Sometimes customers have an issue with Access is denied during image generation after invoking Extract-7Zip, as a workaround is using a function with retries.

#### Related issue:
https://github.com/actions/virtual-environments/issues/4277#issuecomment-981732230

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
