### PR TITLE
[Windows] Add pause after Windows Update

### DIFF
--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -519,7 +519,7 @@ function Get-WindowsUpdatesHistory {
             43 {
                 $status = "InProgress"
                 $title = $event.Properties[0].Value
-                break 
+                break
             }
         }
 

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -538,7 +538,7 @@ function Invoke-SBWithRetry {
     param (
         [scriptblock] $Command,
         [int] $RetryCount = 10,
-        [int] $TimeoutInSecs = 5
+        [int] $RetryIntervalSeconds = 5
     )
 
     while ($RetryCount -gt 0) {
@@ -554,8 +554,8 @@ function Invoke-SBWithRetry {
                 exit 1
             }
 
-            Write-Host "Waiting $TimeoutInSecs seconds before retrying. Retries left: $RetryCount"
-            Start-Sleep -Seconds $TimeoutInSecs
+            Write-Host "Waiting $RetryIntervalSeconds seconds before retrying. Retries left: $RetryCount"
+            Start-Sleep -Seconds $RetryIntervalSeconds
         }
     }
 }

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -547,7 +547,7 @@ function Invoke-SBWithRetry {
             return
         }
         catch {
-            Write-Host "There is an error encounterd:`n $_"
+            Write-Host "There is an error encountered:`n $_"
             $RetryCount--
 
             if ($RetryCount -eq 0) {

--- a/images/win/scripts/Installers/Wait-WindowsUpdatesForInstall.ps1
+++ b/images/win/scripts/Installers/Wait-WindowsUpdatesForInstall.ps1
@@ -3,7 +3,7 @@
 ##  Desc:  Wait for installation windows updates to complete
 ################################################################################
 
-Invoke-SBWithRetry -RetryCount 10 -TimeoutInSecs 60 -Command {
+Invoke-SBWithRetry -RetryCount 10 -TimeoutInSecs 120 -Command {
     $inProgress = Get-WindowsUpdatesHistory | Where-Object Status -eq "InProgress"
     if ( $inProgress ) {
         $title = $inProgress.Title -join "`n"

--- a/images/win/scripts/Installers/Wait-WindowsUpdatesForInstall.ps1
+++ b/images/win/scripts/Installers/Wait-WindowsUpdatesForInstall.ps1
@@ -3,7 +3,7 @@
 ##  Desc:  Wait for installation windows updates to complete
 ################################################################################
 
-Invoke-SBWithRetry -RetryCount 10 -TimeoutInSecs 120 -Command {
+Invoke-SBWithRetry -RetryCount 10 -RetryIntervalSeconds 120 -Command {
     $inProgress = Get-WindowsUpdatesHistory | Where-Object Status -eq "InProgress"
     if ( $inProgress ) {
         $title = $inProgress.Title -join "`n"

--- a/images/win/scripts/Installers/Wait-WindowsUpdatesForInstall.ps1
+++ b/images/win/scripts/Installers/Wait-WindowsUpdatesForInstall.ps1
@@ -1,0 +1,12 @@
+################################################################################
+##  File:  Wait-WindowsUpdatesForInstall.ps1
+##  Desc:  Wait for installation windows updates to complete
+################################################################################
+
+Invoke-SBWithRetry -RetryCount 10 -TimeoutInSecs 60 -Command {
+    $inProgress = Get-WindowsUpdatesHistory | Where-Object Status -eq "InProgress"
+    if ( $inProgress ) {
+        $title = $inProgress.Title -join "`n"
+        throw "InProgress: $title"
+    }
+}

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -274,6 +274,7 @@
             "type": "powershell",
             "pause_before": "2m",
             "scripts": [
+                "{{ template_dir }}/scripts/Installers/Wait-WindowsUpdatesForInstall.ps1",
                 "{{ template_dir }}/scripts/Tests/RunAll-Tests.ps1"
             ]
         },

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -251,10 +251,13 @@
         },
         {
             "type": "windows-restart",
+            "check_registry": true,
+            "restart_check_command": "powershell -command \"& {if ((-not (Get-Process TiWorker.exe -ErrorAction SilentlyContinue)) -and (-not [System.Environment]::HasShutdownStarted) ) { Write-Output 'Restart complete' }}\"",
             "restart_timeout": "30m"
         },
         {
             "type": "powershell",
+            "pause_before": "2m",
             "scripts": [
                 "{{ template_dir }}/scripts/Tests/RunAll-Tests.ps1"
             ]

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -259,7 +259,7 @@
             "type": "powershell",
             "pause_before": "2m",
             "scripts": [
-                "{{ template_dir }}/scripts/Tests/Wait-WindowsUpdatesForInstall.ps1",
+                "{{ template_dir }}/scripts/Wait-WindowsUpdatesForInstall.ps1",
                 "{{ template_dir }}/scripts/Tests/RunAll-Tests.ps1"
             ]
         },

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -259,6 +259,7 @@
             "type": "powershell",
             "pause_before": "2m",
             "scripts": [
+                "{{ template_dir }}/scripts/Tests/Wait-WindowsUpdatesForInstall.ps1",
                 "{{ template_dir }}/scripts/Tests/RunAll-Tests.ps1"
             ]
         },

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -259,7 +259,7 @@
             "type": "powershell",
             "pause_before": "2m",
             "scripts": [
-                "{{ template_dir }}/scripts/Wait-WindowsUpdatesForInstall.ps1",
+                "{{ template_dir }}/scripts/Installers/Wait-WindowsUpdatesForInstall.ps1",
                 "{{ template_dir }}/scripts/Tests/RunAll-Tests.ps1"
             ]
         },


### PR DESCRIPTION
# Description
Some updates (e.g. `2021-11 Cumulative Update Preview for .NET Framework 3.5 and 4.8 for Microsoft server operating system version 21H2 for x64 (KB5007293)` )  are still in progress state during tests validation. We should wait for installation to complete.

```
PS > Get-WindowsUpdatesHistory

Status     Title
------     -----
Successful Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.353.1825.0)
Successful Windows Malicious Software Removal Tool x64 - v5.95 (KB890830)
Successful 2021-11 Cumulative Update for Microsoft server operating system version 21H2 for x64-based Systems (KB500...
InProgress 2021-11 Cumulative Update Preview for .NET Framework 3.5 and 4.8 for Microsoft server operating system ve...
```

Waiting ~10 minutes to finish:

```
PS > Get-WindowsUpdatesHistory

Status     Title
------     -----
Successful Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.353.1825.0)
Successful Windows Malicious Software Removal Tool x64 - v5.95 (KB890830)
Successful 2021-11 Cumulative Update Preview for .NET Framework 3.5 and 4.8 for Microsoft server operating system version 21H2 for x64 (KB5007293)
Successful 2021-11 Cumulative Update for Microsoft server operating system version 21H2 for x64-based Systems (KB5007205)
```

#### Related issue:
https://github.com/actions/virtual-environments/issues/4636

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
