### PR TITLE
[Windows] Update Kotlin install

### DIFF
--- a/images/win/scripts/ImageHelpers/ImageHelpers.psm1
+++ b/images/win/scripts/ImageHelpers/ImageHelpers.psm1
@@ -38,6 +38,7 @@ Export-ModuleMember -Function @(
     'Choco-Install'
     'Send-RequestToCocolateyPackages'
     'Get-LatestChocoPackageVersion'
+    'Get-GitHubPackageDownloadUrl'
     'Extract-7Zip'
     'Get-CommandResult'
     'Get-WhichTool'

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -569,12 +569,12 @@ function Get-GitHubPackageDownloadUrl {
     )
 
     if ($Version -eq "latest") { 
-        $Version = "" 
+        $Version = "*" 
     }
     $json = Invoke-RestMethod -Uri "https://api.github.com/repos/${RepoOwner}/${RepoName}/releases?per_page=100"
     $latestVersion = ($json.Where{ -not $_.prerelease }.tag_name |
         Select-String -Pattern "\d+.\d+.\d+").Matches.Value |
-            Where-Object {$Version -eq "" -or $_ -Like "${Version}.*" -or $_ -eq ${Version}} |
+            Where-Object {$_ -Like "${Version}.*" -or $_ -eq ${Version}} |
             Sort-Object {[version]$_} |
             Select-Object -Last 1
     $downloadUrl = $json.assets.browser_download_url -like "*${BinaryName}-${latestVersion}.*"

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -559,3 +559,25 @@ function Invoke-SBWithRetry {
         }
     }
 }
+
+function Get-GitHubPackageDownloadUrl {
+    param (
+        [string]$RepoOwner,
+        [string]$RepoName,
+        [string]$BinaryName,
+        [string]$Version
+    )
+
+    if ($Version -eq "latest") { 
+        $Version = "" 
+    }
+    $json = Invoke-RestMethod -Uri "https://api.github.com/repos/${RepoOwner}/${RepoName}/releases?per_page=100"
+    $latestVersion = ($json.Where{ -not $_.prerelease }.tag_name |
+        Select-String -Pattern "\d+.\d+.\d+").Matches.Value |
+            Where-Object {$Version -eq "" -or $_ -Like "${Version}.*" -or $_ -eq ${Version}} |
+            Sort-Object {[version]$_} |
+            Select-Object -Last 1
+    $downloadUrl = $json.assets.browser_download_url -like "*${BinaryName}-${latestVersion}.*"
+
+    return $downloadUrl
+}

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -566,14 +566,16 @@ function Get-GitHubPackageDownloadUrl {
         [string]$RepoName,
         [string]$BinaryName,
         [string]$Version,
-        [string]$UrlFilter
+        [string]$UrlFilter,
+        [boolean]$IsPrerelease = $false,
+        [int]$SearchInCount = 100
     )
 
     if ($Version -eq "latest") { 
         $Version = "*" 
     }
-    $json = Invoke-RestMethod -Uri "https://api.github.com/repos/${RepoOwner}/${RepoName}/releases?per_page=100"
-    $versionToDownload = ($json.Where{ -not $_.prerelease }.tag_name |
+    $json = Invoke-RestMethod -Uri "https://api.github.com/repos/${RepoOwner}/${RepoName}/releases?per_page=${SearchInCount}"
+    $versionToDownload = ($json.Where{ $_.prerelease -eq $IsPrerelease }.tag_name |
         Select-String -Pattern "\d+.\d+.\d+").Matches.Value |
             Where-Object {$_ -Like "${Version}.*" -or $_ -eq ${Version}} |
             Sort-Object {[version]$_} |

--- a/images/win/scripts/Installers/Install-Kotlin.ps1
+++ b/images/win/scripts/Installers/Install-Kotlin.ps1
@@ -4,9 +4,14 @@
 ################################################################################
 
 # Install Kotlin
-$url = "https://api.github.com/repos/JetBrains/kotlin/releases/latest"
-[System.String] $kotlinLatest = (Invoke-RestMethod -Uri $url).assets.browser_download_url -match "kotlin-compiler"
-$kotlinInstallerPath = Start-DownloadWithRetry -Url $kotlinLatest -Name "kotlin-compiler.zip"
+$kotlinVersion = (Get-ToolsetContent).kotlin.version
+$kotlinBinaryName = (Get-ToolsetContent).kotlin.binary_name
+$json = Invoke-RestMethod -Uri "https://api.github.com/repos/JetBrains/kotlin/releases?per_page=100"
+$kotlinDownloadUrl = $json.Where{ -not $_.prerelease }.assets.browser_download_url | 
+    Where-Object { $_ -like "*${kotlinBinaryName}-${kotlinVersion}*" } |
+    Select-Object -First 1
+
+$kotlinInstallerPath = Start-DownloadWithRetry -Url $kotlinDownloadUrl -Name "$kotlinBinaryName.zip"
 
 Write-Host "Expand Kotlin archive"
 $kotlinPath = "C:\tools"

--- a/images/win/scripts/Installers/Install-Kotlin.ps1
+++ b/images/win/scripts/Installers/Install-Kotlin.ps1
@@ -6,11 +6,8 @@
 # Install Kotlin
 $kotlinVersion = (Get-ToolsetContent).kotlin.version
 $kotlinBinaryName = (Get-ToolsetContent).kotlin.binary_name
-$json = Invoke-RestMethod -Uri "https://api.github.com/repos/JetBrains/kotlin/releases?per_page=100"
-$kotlinDownloadUrl = $json.Where{ -not $_.prerelease }.assets.browser_download_url | 
-    Where-Object { $_ -like "*${kotlinBinaryName}-${kotlinVersion}*" } |
-    Select-Object -First 1
 
+$kotlinDownloadUrl = Get-GitHubPackageDownloadUrl -RepoOwner "JetBrains" -RepoName "kotlin" -BinaryName $kotlinBinaryName -Version $kotlinVersion
 $kotlinInstallerPath = Start-DownloadWithRetry -Url $kotlinDownloadUrl -Name "$kotlinBinaryName.zip"
 
 Write-Host "Expand Kotlin archive"

--- a/images/win/scripts/Installers/Install-Kotlin.ps1
+++ b/images/win/scripts/Installers/Install-Kotlin.ps1
@@ -7,7 +7,7 @@
 $kotlinVersion = (Get-ToolsetContent).kotlin.version
 $kotlinBinaryName = (Get-ToolsetContent).kotlin.binary_name
 
-$kotlinDownloadUrl = Get-GitHubPackageDownloadUrl -RepoOwner "JetBrains" -RepoName "kotlin" -BinaryName $kotlinBinaryName -Version $kotlinVersion
+$kotlinDownloadUrl = Get-GitHubPackageDownloadUrl -RepoOwner "JetBrains" -RepoName "kotlin" -BinaryName $kotlinBinaryName -Version $kotlinVersion -UrlFilter "*{BinaryName}-{Version}.zip"
 $kotlinInstallerPath = Start-DownloadWithRetry -Url $kotlinDownloadUrl -Name "$kotlinBinaryName.zip"
 
 Write-Host "Expand Kotlin archive"

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -438,7 +438,7 @@
         "version": "14"
     },
     "kotlin": {
-        "version": "1.6",
+        "version": "latest",
         "binary_name": "kotlin-compiler"
     }
 }

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -436,5 +436,9 @@
     },
     "postgresql": {
         "version": "14"
+    },
+    "kotlin": {
+        "version": "1.6",
+        "binary_name": "kotlin-compiler"
     }
 }

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -470,7 +470,7 @@
         "version": "14"
     },
     "kotlin": {
-        "version": "1.6",
+        "version": "latest",
         "binary_name": "kotlin-compiler"
     }
 }

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -468,5 +468,9 @@
     },
     "postgresql": {
         "version": "14"
+    },
+    "kotlin": {
+        "version": "1.6",
+        "binary_name": "kotlin-compiler"
     }
 }

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -320,7 +320,7 @@
         "version": "14"
     },
     "kotlin": {
-        "version": "1.6",
+        "version": "latest",
         "binary_name": "kotlin-compiler"
     }
 }

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -318,5 +318,9 @@
     },
     "postgresql": {
         "version": "14"
+    },
+    "kotlin": {
+        "version": "1.6",
+        "binary_name": "kotlin-compiler"
     }
 }


### PR DESCRIPTION
## Description
This PR corrects Kotlin installation script to use Get-GitHubPackageDownloadUrl function which allow to use any version to get correct download url (Major, Major.Minor, Major.Minor.Build or "latest" to get correct highest release instead of latest GitHub release url that led us to downgrade).

## Related issue: 
https://github.com/actions/virtual-environments-internal/issues/3034

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
