### PR TITLE
[Windows] Improve MySQL install

### DIFF
--- a/images/win/scripts/Installers/Install-MysqlCli.ps1
+++ b/images/win/scripts/Installers/Install-MysqlCli.ps1
@@ -11,17 +11,17 @@ $ArgumentList = ("/install", "/quiet", "/norestart")
 Install-Binary -Url $InstallerURI -Name $InstallerName -ArgumentList $ArgumentList
 
 ## Downloading mysql
-$MysqlVersion = [version](Get-ToolsetContent).mysql.version
+[version]$MysqlVersion = (Get-ToolsetContent).mysql.version
+$MysqlVersionMajorMinor = $MysqlVersion.ToString(2)
+
 if ($MysqlVersion.Build -lt 0) {
-    $MysqlVersion = New-Object System.Version (
-        $MysqlVersion.Major,
-        $MysqlVersion.Minor,
-        ([version]((Invoke-WebRequest -Uri https://dev.mysql.com/downloads/mysql/$($MysqlVersion.Major).$($MysqlVersion.Minor).html -UseBasicParsing).Content |
-            Select-String -Pattern "$($MysqlVersion.Major).$($MysqlVersion.Minor)\.\d+").Matches.Value).Build
-    )
+    $MysqlVersion = ((Invoke-WebRequest -Uri https://dev.mysql.com/downloads/mysql/${MysqlVersionMajorMinor}.html -UseBasicParsing).Content |
+        Select-String -Pattern "${MysqlVersionMajorMinor}\.\d+").Matches.Value
+
 }
 
-$MysqlVersionUrl = "https://dev.mysql.com/get/Downloads/MySQL-$($MysqlVersion.Major).$($MysqlVersion.Minor)/mysql-$($MysqlVersion.ToString())-winx64.zip"
+$MysqlVersionFull = $MysqlVersion.ToString()
+$MysqlVersionUrl = "https://dev.mysql.com/get/Downloads/MySQL-${MysqlVersionMajorMinor}/mysql-${MysqlVersionFull}-winx64.zip"
 
 $MysqlArchPath = Start-DownloadWithRetry -Url $MysqlVersionUrl -Name "mysql.zip"
 
@@ -31,7 +31,7 @@ Extract-7Zip -Path $MysqlArchPath -DestinationPath "C:\"
 # Rename mysql-version to mysql folder
 $MysqlPath = "C:\mysql"
 Invoke-SBWithRetry -Command {
-    Rename-Item -Path "C:\mysql-$($MysqlVersion.ToString())-winx64" -NewName $MysqlPath -ErrorAction Stop
+    Rename-Item -Path "C:\mysql-${MysqlVersionFull}-winx64" -NewName $MysqlPath -ErrorAction Stop
 }
 
 # Adding mysql in system environment path

--- a/images/win/scripts/Installers/Install-MysqlCli.ps1
+++ b/images/win/scripts/Installers/Install-MysqlCli.ps1
@@ -15,7 +15,7 @@ Install-Binary -Url $InstallerURI -Name $InstallerName -ArgumentList $ArgumentLi
 $MysqlVersionMajorMinor = $MysqlVersion.ToString(2)
 
 if ($MysqlVersion.Build -lt 0) {
-    $MysqlVersion = ((Invoke-WebRequest -Uri https://dev.mysql.com/downloads/mysql/${MysqlVersionMajorMinor}.html -UseBasicParsing).Content |
+    $MysqlVersion = (Invoke-RestMethod -Uri "https://dev.mysql.com/downloads/mysql/${MysqlVersionMajorMinor}.html" |
         Select-String -Pattern "${MysqlVersionMajorMinor}\.\d+").Matches.Value
 }
 

--- a/images/win/scripts/Installers/Install-MysqlCli.ps1
+++ b/images/win/scripts/Installers/Install-MysqlCli.ps1
@@ -17,7 +17,6 @@ $MysqlVersionMajorMinor = $MysqlVersion.ToString(2)
 if ($MysqlVersion.Build -lt 0) {
     $MysqlVersion = ((Invoke-WebRequest -Uri https://dev.mysql.com/downloads/mysql/${MysqlVersionMajorMinor}.html -UseBasicParsing).Content |
         Select-String -Pattern "${MysqlVersionMajorMinor}\.\d+").Matches.Value
-
 }
 
 $MysqlVersionFull = $MysqlVersion.ToString()

--- a/images/win/scripts/Tests/Databases.Tests.ps1
+++ b/images/win/scripts/Tests/Databases.Tests.ps1
@@ -65,7 +65,7 @@ Describe "PostgreSQL" {
 
 Describe "MySQL" {
     It "MySQL CLI" {
-        $MysqlMajorVersion = (Get-ToolsetContent).mysql.major_version
-        mysql -V | Should -BeLike "*${MysqlMajorVersion}*"
+        $MysqlVersion = (Get-ToolsetContent).mysql.version
+        mysql -V | Should -BeLike "*${MysqlVersion}*"
     }
 }

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -422,8 +422,7 @@
         "default": "16"
     },
     "mysql": {
-        "major_version": "5.7",
-        "full_version": "5.7.36"
+        "version": "5.7"
     },
     "mongodb": {
         "version": "5.0"

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -454,8 +454,7 @@
         "default": "16"
     },
     "mysql": {
-        "major_version": "5.7",
-        "full_version": "5.7.36"
+        "version": "5.7"
     },
     "mongodb": {
         "version": "5.0"

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -307,8 +307,7 @@
         "default": "16"
     },
     "mysql": {
-        "major_version": "8.0",
-        "full_version": "8.0.26"
+        "version": "8.0.26"
     },
     "mongodb": {
         "version": "5.0"


### PR DESCRIPTION
## Description
This PR corrects MySQL installation script to add ability use Major.Minor version (and automatically determine the latest Build) or stick to specified Major.Minor.Build in case of some issues with the latest version. 

## Related issue: 
https://github.com/actions/virtual-environments-internal/issues/3031

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
