### PR TITLE
[MacOS] Add GCC and remove Nomad from MacOS 12 image

### DIFF
--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -45,15 +45,10 @@ $languageAndRuntimeList = @(
     (Get-JuliaVersion),
     (Get-KotlinVersion),
     (Get-PHPVersion),
-    (Get-ClangLLVMVersion)
+    (Get-ClangLLVMVersion),
+    (Get-GccVersion),
+    (Get-FortranVersion)
 )
-
-if ($os.IsLessThanMonterey) {
-    $languageAndRuntimeList += @(
-        (Get-GccVersion),
-        (Get-FortranVersion)
-   )
-}
 
 if ($os.IsLessThanBigSur) {
     $languageAndRuntimeList += @(

--- a/images/macos/templates/macOS-12.json
+++ b/images/macos/templates/macOS-12.json
@@ -172,6 +172,7 @@
                 "./provision/core/php.sh",
                 "./provision/core/aws.sh",
                 "./provision/core/rust.sh",
+                "./provision/core/gcc.sh",
                 "./provision/core/haskell.sh",
                 "./provision/core/stack.sh",
                 "./provision/core/cocoapods.sh",

--- a/images/macos/tests/Common.Tests.ps1
+++ b/images/macos/tests/Common.Tests.ps1
@@ -9,7 +9,7 @@ Describe ".NET" {
     }
 }
 
-Describe "GCC" -Skip:($os.IsMonterey) {
+Describe "GCC" {
     $testCases = Get-ToolsetValue -KeyPath gcc.versions | ForEach-Object { @{Version = $_} }
 
     It "GCC <Version>" -TestCases $testCases {

--- a/images/macos/tests/RubyGem.Tests.ps1
+++ b/images/macos/tests/RubyGem.Tests.ps1
@@ -19,7 +19,7 @@ Describe "Bundler" {
     }
 }
 
-Describe "Nomad shenzhen CLI" {
+Describe "Nomad shenzhen CLI" -Skip:($os.IsMonterey) {
     It "Nomad shenzhen CLI" {
         "ipa --version" | Should -ReturnZeroExitCode
     }

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -104,6 +104,11 @@
             "julia"
         ]
     },
+    "gcc": {
+        "versions": [
+            "11"
+        ]
+    },
     "toolcache": [
         {
             "name": "Python",

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -181,7 +181,6 @@
         "rubygems": [
             "xcode-install",
             "cocoapods",
-            "nomad-cli",
             "xcpretty",
             "bundler",
             "fastlane",


### PR DESCRIPTION
# Description
Adding GCC version 11 to MacOS 12. And removing Nomad shenzhen CLI since it's in the list of software to deprecate: https://github.com/actions/virtual-environments-internal/issues/2647

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/3002

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
