### PR TITLE
[Windows] Add pause after installation windows features

### DIFF
--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -139,10 +139,12 @@
         },
         {
             "type": "windows-restart",
+            "check_registry": true,
             "restart_timeout": "10m"
         },
         {
             "type": "powershell",
+            "pause_before": "2m",
             "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-Docker.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-PowershellCore.ps1"


### PR DESCRIPTION
# Description
We should add a pause after installation windows features due to prevent skip running scripts after reboot.

Unexpected[run during reboot]:
```
==> vhd: Provisioning with powershell script: C:\agent\_work\12\s\images\win/scripts/Installers/Install-Docker.ps1
    vhd: Install-Package Docker
==> vhd: Provisioning with powershell script: C:\agent\_work\12\s\images\win/scripts/Installers/Install-PowershellCore.ps1
    vhd: VERBOSE: About to download package from
```

Expected:
```
==> vhd: A system shutdown is in progress.(1115)
    vhd: pkrvm9lsr8en0xg restarted.
    vhd: False
    vhd: True
    vhd: False
    vhd: pkrvm9lsr8en0xg restarted.
    vhd: False
    vhd: True
    vhd: False
    vhd: pkrvm9lsr8en0xg restarted.
    vhd: False
    vhd: True
    vhd: False
    vhd: pkrvm9lsr8en0xg restarted.
    vhd: False
    vhd: False
    vhd: False
==> vhd: Machine successfully restarted, moving on
==> vhd: Pausing 2m0s before the next provisioner...
==> vhd: Provisioning with Powershell...
==> vhd: Provisioning with powershell script: C:\agent\_work\13\s\images\win/scripts/Installers/Install-Docker.ps1
    vhd: Install-Package Docker
    vhd:
    vhd: Name                           Version          Source           Summary
    vhd: ----                           -------          ------           -------
    vhd: Docker                         20.10.7          DockerDefault    Contains Docker EE for use with Windows Server.
    vhd: Install-Package Docker-Compose
```
