### PR TITLE
[Windows] Add Llvm.Clang component to VS 2022

### DIFF
--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -190,6 +190,7 @@
             "Microsoft.VisualStudio.Component.VC.CLI.Support",
             "Microsoft.VisualStudio.Component.VC.CMake.Project",
             "Microsoft.VisualStudio.Component.VC.DiagnosticTools",
+            "Microsoft.VisualStudio.Component.VC.Llvm.Clang",
             "Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset",
             "Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre",
             "Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre",


### PR DESCRIPTION
# Description

This adds the `Microsoft.VisualStudio.Component.VC.Llvm.Clang` component to Visual Studio 2022.

Currently the Clang compiler is not functional in Visual Studio 2022, because the following directory is missing:

```
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm\lib\clang\12.0.0
```

The directory comes from this component, so adding it should fix the problem.

Hopefully the existing tests for the VS 2022 image are sufficient.

#### Related issue: n/a

## Check list

- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
