### PR TITLE
[Ubuntu] Downgrade mysql to 8.0.26

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Databases.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Databases.psm1
@@ -16,7 +16,7 @@ function Get-SqliteVersion {
 }
 
 function Get-MySQLVersion {
-    $mySQLVersion = mysqld --version | Take-OutputPart -Part 2 | Take-OutputPart -Part 0 -Delimiter "-"
+    $mySQLVersion = mysqld --version | Take-OutputPart -Part 2
     return "MySQL $mySQLVersion"
 }
 

--- a/images/linux/scripts/installers/mysql.sh
+++ b/images/linux/scripts/installers/mysql.sh
@@ -4,22 +4,41 @@
 ##  Desc:  Installs MySQL Client
 ################################################################################
 
-export ACCEPT_EULA=Y
+source /etc/os-release
 
 # Mysql setting up root password
 MYSQL_ROOT_PASSWORD=root
 echo "mysql-server mysql-server/root_password password $MYSQL_ROOT_PASSWORD" | debconf-set-selections
 echo "mysql-server mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD" | debconf-set-selections
 
-# Install MySQL Client
-apt-get install mysql-client -y
+mkdir -p /tmp/mysql
+pushd /tmp
 
-# Install MySQL Server
-apt-get install -y mysql-server
+# Mandatory dependency
+apt-get install -y libmecab2 libaio1
 
-#Install MySQL Dev tools
-apt install libmysqlclient-dev -y
+wget -q https://downloads.mysql.com/archives/get/p/23/file/mysql-server_8.0.26-1ubuntu${VERSION_ID}_amd64.deb-bundle.tar
+tar -xf mysql-server_8.0.26-1ubuntu${VERSION_ID}_amd64.deb-bundle.tar -C /tmp/mysql
 
+pushd mysql
+
+# Remove debs with debug info
+rm mysql-community-*debug*.deb
+
+mysql_debs=(
+    mysql-common*
+    mysql-community-client-plugins*
+    mysql-community-client*
+    mysql-client*
+    mysql-community-server*
+    mysql-server*
+    libmysqlclient21*
+    libmysqlclient-dev*
+)
+
+for package in ${mysql_debs[@]}; do
+dpkg -i $package
+done
 # Disable mysql.service
 systemctl is-active --quiet mysql.service && systemctl stop mysql.service
 systemctl disable mysql.service

--- a/images/linux/scripts/tests/Databases.Tests.ps1
+++ b/images/linux/scripts/tests/Databases.Tests.ps1
@@ -31,7 +31,7 @@ Describe "MySQL" {
 
     It "MySQL Service" {
         "sudo systemctl start mysql" | Should -ReturnZeroExitCode
-        mysql -s -N -h localhost -uroot -proot -e "select count(*) from mysql.user where user='root' and authentication_string is null;" | Should -BeExactly 0
+        sudo mysql -s -N -h localhost -uroot -proot -e "select count(*) from mysql.user where user='root' and authentication_string is null;" | Should -BeExactly 0
         "sudo mysql -vvv -e 'CREATE DATABASE smoke_test' -uroot -proot" | Should -ReturnZeroExitCode
         "sudo mysql -vvv -e 'DROP DATABASE smoke_test' -uroot -proot" | Should -ReturnZeroExitCode
         "sudo systemctl stop mysql" | Should -ReturnZeroExitCode 


### PR DESCRIPTION
# Description

As has been discussed with @MaksimZhukov and @miketimofeev lets downgrade mysql on ubuntu to 8.0.26 as 8.0.27 is buggy. As there is no an older version in Oracle's PPA repo there was a need to install all the dependencies step by step utilizing the `dpkg -i` command (the order in the `mysql_debs` array matters). No toolset and other flexible solutions were considered yet as the future of this solution is uncertain and will likely be changed.

#### Related issues: https://github.com/actions/virtual-environments-internal/issues/3036 https://github.com/actions/virtual-environments-internal/issues/2999 

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
