### PR TITLE
[Anka] Clear LastRecommendedMajorOSBundleIdentifier property

### DIFF
--- a/images.CI/macos/anka/Service.Helpers.psm1
+++ b/images.CI/macos/anka/Service.Helpers.psm1
@@ -334,6 +334,6 @@ function Update-SoftwareBundle {
 
     if ( $productVersion.StartsWith('11.') ) {
         sudo rm -rf /Library/Preferences/com.apple.commerce.plist
-        sudo /usr/bin/defaults write /Library/Preferences/com.apple.SoftwareUpdate.plist LastRecommendedMajorOSBundleIdentifier ''
+        sudo /usr/bin/defaults delete /Library/Preferences/com.apple.SoftwareUpdate.plist LastRecommendedMajorOSBundleIdentifier | Out-Null
     }
 }

--- a/images.CI/macos/anka/Service.Helpers.psm1
+++ b/images.CI/macos/anka/Service.Helpers.psm1
@@ -93,6 +93,10 @@ function Get-MacOSInstaller {
         sudo rm -rf "$previousInstallerPath"
     }
 
+    # Clear LastRecommendedMajorOSBundleIdentifier to prevent error during fetching updates
+    # Install failed with error: Update not found
+    Update-SoftwareBundle
+
     # Download macOS installer
     Write-Host "`t[*] Requested macOS '$MacOSVersion' version installer found, fetching it from Apple Software Update"
     $result = Invoke-WithRetry { /usr/sbin/softwareupdate --fetch-full-installer --full-installer-version $MacOSVersion } {$LASTEXITCODE -eq 0} | Out-String
@@ -323,4 +327,13 @@ function Wait-LoginWindow {
         $proc.Contains($lw) -and $proc.Contains($ctk)
     }
     Invoke-WithRetry -RetryCount $RetryCount -Seconds $Seconds -BreakCondition $condition
+}
+
+function Update-SoftwareBundle {
+    $productVersion = sw_vers -productVersion
+
+    if ( $productVersion.StartsWith('11.') ) {
+        sudo rm -rf /Library/Preferences/com.apple.commerce.plist
+        sudo /usr/bin/defaults write /Library/Preferences/com.apple.SoftwareUpdate.plist LastRecommendedMajorOSBundleIdentifier ''
+    }
 }


### PR DESCRIPTION
# Description
Unable to fetch full installer:
```
 % /usr/sbin/softwareupdate --fetch-full-installer --full-installer-version 11.6.1
Scanning for 11.6.1 installer
Install failed with error: Update not found
```

Clear `LastRecommendedMajorOSBundleIdentifier` property:
```
[*] The 'DownloadLatestVersion' flag is set. Latest macOS version is '11.6.1' now
[*] Removing '/Applications/Install macOS Big Sur.app' installation app before downloading the new one
[*] Requested macOS '11.6.1' version installer found, fetching it from Apple Software Update
[*] Installer successfully downloaded to '/Applications/Install macOS Big Sur.app'
```