### PR TITLE
[macos] pester: Replace service status stopped to none

### DIFF
--- a/images/macos/tests/WebServers.Tests.ps1
+++ b/images/macos/tests/WebServers.Tests.ps1
@@ -6,7 +6,7 @@ Describe "Apache" -Skip:($os.IsLessThanCatalina) {
     }
 
     It "Apache Service" {
-        brew services list | Out-String | Should -Match "httpd\s+stopped"
+        brew services list | Out-String | Should -Match "httpd\s+none"
     }
 }
 
@@ -16,6 +16,6 @@ Describe "Nginx" -Skip:($os.IsLessThanCatalina) {
     }
 
     It "Nginx Service" {
-        brew services list | Out-String | Should -Match "nginx\s+stopped"
+        brew services list | Out-String | Should -Match "nginx\s+none"
     }
 }

--- a/images/macos/tests/WebServers.Tests.ps1
+++ b/images/macos/tests/WebServers.Tests.ps1
@@ -6,7 +6,7 @@ Describe "Apache" -Skip:($os.IsLessThanCatalina) {
     }
 
     It "Apache Service" {
-        brew services list | Out-String | Should -Match "httpd\s+none"
+        brew services list | Out-String | Should -Match "httpd\s+(stopped|none)"
     }
 }
 
@@ -16,6 +16,6 @@ Describe "Nginx" -Skip:($os.IsLessThanCatalina) {
     }
 
     It "Nginx Service" {
-        brew services list | Out-String | Should -Match "nginx\s+none"
+        brew services list | Out-String | Should -Match "nginx\s+(stopped|none)"
     }
 }


### PR DESCRIPTION
# Description
Previously the command `brew services list` returned stopped status for a service even if the service was never stopped. Current behavior returns `none` status for a service.

```
~ runner$ brew services start httpd
==> Successfully started `httpd` (label: homebrew.mxcl.httpd)
~ runner$ brew services list
Name    Status  User   File
httpd   started runner ~/Library/LaunchAgents/homebrew.mxcl.httpd.plist
php     none
unbound none
~ runner$ brew services stop httpd
Stopping `httpd`... (might take a while)
==> Successfully stopped `httpd` (label: homebrew.mxcl.httpd)
~ runner$ brew services list
Name    Status  User File
httpd   none
php     none
unbound none
```