### PR TITLE
[Ubuntu] do not install mysql 8.x on 18.04

### DIFF
--- a/images/linux/scripts/installers/mysql.sh
+++ b/images/linux/scripts/installers/mysql.sh
@@ -5,40 +5,63 @@
 ################################################################################
 
 source /etc/os-release
+source $HELPER_SCRIPTS/os.sh
 
 # Mysql setting up root password
 MYSQL_ROOT_PASSWORD=root
 echo "mysql-server mysql-server/root_password password $MYSQL_ROOT_PASSWORD" | debconf-set-selections
 echo "mysql-server mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD" | debconf-set-selections
 
-mkdir -p /tmp/mysql
-pushd /tmp
+# Ubuntu's repo now contains 8.0.28 which is buggy,
+# see https://bugs.mysql.com/bug.php?id=105288
 
-# Mandatory dependency
-apt-get install -y libmecab2 libaio1
+if isUbuntu20 ; then
+    mkdir -p /tmp/mysql
+    pushd /tmp
 
-wget -q https://downloads.mysql.com/archives/get/p/23/file/mysql-server_8.0.26-1ubuntu${VERSION_ID}_amd64.deb-bundle.tar
-tar -xf mysql-server_8.0.26-1ubuntu${VERSION_ID}_amd64.deb-bundle.tar -C /tmp/mysql
+    # Mandatory dependency
+    apt-get install -y libmecab2 libaio1
 
-pushd mysql
+    wget -q https://downloads.mysql.com/archives/get/p/23/file/mysql-server_8.0.26-1ubuntu${VERSION_ID}_amd64.deb-bundle.tar
+    tar -xf mysql-server_8.0.26-1ubuntu${VERSION_ID}_amd64.deb-bundle.tar -C /tmp/mysql
 
-# Remove debs with debug info
-rm mysql-community-*debug*.deb
+    pushd mysql
 
-mysql_debs=(
-    mysql-common*
-    mysql-community-client-plugins*
-    mysql-community-client*
-    mysql-client*
-    mysql-community-server*
-    mysql-server*
-    libmysqlclient21*
-    libmysqlclient-dev*
-)
+    # Remove debs with debug info
+    rm mysql-community-*debug*.deb
 
-for package in ${mysql_debs[@]}; do
-dpkg -i $package
-done
+    mysql_debs=(
+        mysql-common*
+        mysql-community-client-plugins*
+        mysql-community-client*
+        mysql-client*
+        mysql-community-server*
+        mysql-server*
+        libmysqlclient21*
+        libmysqlclient-dev*
+    )
+
+    for package in ${mysql_debs[@]}; do
+        dpkg -i $package
+    done
+
+    # Start mysql to change its settings
+    systemctl start mysql.service
+    # Enable mysql log-in without sudo by activation of the mysql_native_password plugin
+    mysql -s -N -h localhost -uroot -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;"
+else
+    export ACCEPT_EULA=Y
+
+    # Install MySQL Client
+    apt-get install mysql-client -y
+
+    # Install MySQL Server
+    apt-get install -y mysql-server
+
+    #Install MySQL Dev tools
+    apt install libmysqlclient-dev -y
+fi
+
 # Disable mysql.service
 systemctl is-active --quiet mysql.service && systemctl stop mysql.service
 systemctl disable mysql.service

--- a/images/linux/scripts/tests/Databases.Tests.ps1
+++ b/images/linux/scripts/tests/Databases.Tests.ps1
@@ -31,9 +31,9 @@ Describe "MySQL" {
 
     It "MySQL Service" {
         "sudo systemctl start mysql" | Should -ReturnZeroExitCode
-        sudo mysql -s -N -h localhost -uroot -proot -e "select count(*) from mysql.user where user='root' and authentication_string is null;" | Should -BeExactly 0
+        mysql -s -N -h localhost -uroot -proot -e "select count(*) from mysql.user where user='root' and authentication_string is null;" | Should -BeExactly 0
         "sudo mysql -vvv -e 'CREATE DATABASE smoke_test' -uroot -proot" | Should -ReturnZeroExitCode
         "sudo mysql -vvv -e 'DROP DATABASE smoke_test' -uroot -proot" | Should -ReturnZeroExitCode
-        "sudo systemctl stop mysql" | Should -ReturnZeroExitCode 
+        "sudo systemctl stop mysql" | Should -ReturnZeroExitCode
     }
 }


### PR DESCRIPTION
# Description

Recent mysql downgrade changes brought mysql 8.x to ubuntu 18.04 too, while it works, this update is unwanted and we must keep repository-provided 5.7.x

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
