### PR TITLE
[Windows] Add grunt-cli to global npm packages on Windows 2022

### DIFF
--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -266,7 +266,8 @@
             { "name": "yarn", "test": "yarn --version" },
             { "name": "newman", "test": "newman --version" },
             { "name": "lerna", "test": "lerna --version" },
-            { "name": "gulp-cli", "test": "gulp --version" }
+            { "name": "gulp-cli", "test": "gulp --version" },
+            { "name": "grunt-cli", "test": "grunt --version" }
         ]
     },
     "dotnet": {


### PR DESCRIPTION
# Description
New tool: `grunt-cli` global npm package

#### Related issue: #4661 

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
