### PR TITLE
[Ubuntu]  fix software report for mysql

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Databases.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Databases.psm1
@@ -17,6 +17,9 @@ function Get-SqliteVersion {
 
 function Get-MySQLVersion {
     $mySQLVersion = mysqld --version | Take-OutputPart -Part 2
+    if (-not (Test-IsUbuntu20)) {
+        $mySQLVersion = $mySQLVersion | Take-OutputPart -Part 0 -Delimiter "-"
+    }
     return "MySQL $mySQLVersion"
 }
 


### PR DESCRIPTION
# Description

mysql-5.7.x was added back to ubuntu 18.04 but `mysqld --version` output differs from a repository and non-repository version of mysql, so for clear software report we must do a version-dependent report generation. (5.7.x reports `5.7.36-0ubuntu0.18.04.1` and we do not need ubuntu postfix as a tail).

#### Related issue: n/a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
