### PR TITLE
CodeQL: Pull the bundle from codeql-action@v1 rather than main.

### DIFF
--- a/images/linux/scripts/installers/codeql-bundle.sh
+++ b/images/linux/scripts/installers/codeql-bundle.sh
@@ -7,7 +7,7 @@
 source $HELPER_SCRIPTS/install.sh
 
 # Retrieve the name of the CodeQL bundle preferred by the Action (in the format codeql-bundle-YYYYMMDD).
-codeql_bundle_name="$(curl -sSL https://raw.githubusercontent.com/github/codeql-action/main/src/defaults.json | jq -r .bundleVersion)"
+codeql_bundle_name="$(curl -sSL https://raw.githubusercontent.com/github/codeql-action/v1/src/defaults.json | jq -r .bundleVersion)"
 # Convert the bundle name to a version number (0.0.0-YYYYMMDD).
 codeql_bundle_version="0.0.0-${codeql_bundle_name##*-}"
 

--- a/images/win/scripts/Installers/Install-CodeQLBundle.ps1
+++ b/images/win/scripts/Installers/Install-CodeQLBundle.ps1
@@ -4,7 +4,7 @@
 ################################################################################
 
 # Retrieve the name of the CodeQL bundle preferred by the Action (in the format codeql-bundle-YYYYMMDD).
-$CodeQLBundleName = (Invoke-RestMethod "https://raw.githubusercontent.com/github/codeql-action/main/src/defaults.json").bundleVersion
+$CodeQLBundleName = (Invoke-RestMethod "https://raw.githubusercontent.com/github/codeql-action/v1/src/defaults.json").bundleVersion
 # Convert the bundle name to a version number (0.0.0-YYYYMMDD).
 $CodeQLBundleVersion = "0.0.0-" + $CodeQLBundleName.split("-")[-1]
 


### PR DESCRIPTION
# Description
As github/codeql-action by default uses the bundle from the toolcache,
make sure that that is considered stable.

On Dec 7, we published a broken pre-release into `main` of `github/codeql-action`, which then unfortunately was picked up by the image build and deployed on Dec 9, breaking certain code-scanning workflows.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
