### PR TITLE
[Ubuntu] Fixing kotlin latest release retrieval

### DIFF
--- a/images/linux/scripts/installers/kotlin.sh
+++ b/images/linux/scripts/installers/kotlin.sh
@@ -8,7 +8,9 @@ source $HELPER_SCRIPTS/install.sh
 
 KOTLIN_ROOT="/usr/share"
 
-URL=$(curl -s https://api.github.com/repos/JetBrains/kotlin/releases/latest | jq -r '.assets[].browser_download_url | select(contains("kotlin-compiler"))')
+kotlinReleasesUrl="https://api.github.com/repos/JetBrains/kotlin/releases"
+latestRelease=$(curl -s $kotlinReleasesUrl | jq -r 'map(select(.prerelease == false)) | sort_by(.target_commitish)[-1]')
+URL=$(echo $latestRelease | jq -r '.assets[].browser_download_url | select(contains("kotlin-compiler"))')
 download_with_retries $URL "/tmp"
 
 unzip -qq /tmp/kotlin-compiler*.zip -d $KOTLIN_ROOT


### PR DESCRIPTION
# Description
Fetching all kotlin releases and sorting out just latest version instead of direct fetching latest which is not.

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/3083

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
