### PR TITLE
Revert "Ubuntu 18.04 (20211208 update)"

### DIFF
--- a/images/linux/Ubuntu1804-README.md
+++ b/images/linux/Ubuntu1804-README.md
@@ -1,21 +1,25 @@
+| Announcements |
+|-|
+| [[all OSs] Default Nodejs version will be set to 16 on November, 29](https://github.com/actions/virtual-environments/issues/4446) |
+***
 # Ubuntu 18.04.6 LTS
-- Linux kernel version: 5.4.0-1064-azure
-- Image Version: 20211208.3
+- Linux kernel version: 5.4.0-1063-azure
+- Image Version: 20211129.1
 
 ## Installed Software
 ### Language and Runtime
 - Bash 4.4.20(1)-release
 - Clang 9.0.0
 - Clang-format 9.0.0
-- Erlang 24.1.7 (Eshell 12.1.5)
+- Erlang 24.1.6 (Eshell 12.1.5)
 - Erlang rebar3 3.17.0
 - GNU C++ 7.5.0, 9.4.0, 10.3.0
 - GNU Fortran 7.5.0, 9.4.0, 10.3.0
-- Julia 1.7.0
+- Julia 1.6.4
 - Kotlin 1.6.0-release-798
 - Mono 6.12.0.122 (apt source repository: https://download.mono-project.com/repo/ubuntu stable-bionic main)
 - MSBuild 16.6.0.15201 (from /usr/lib/mono/msbuild/15.0/bin/MSBuild.dll)
-- Node 16.13.1
+- Node 16.13.0
 - Perl 5.26.1
 - Python 2.7.17
 - Python3 3.6.9
@@ -25,14 +29,14 @@
 ### Package Management
 - cpan 1.64
 - Helm 3.7.1
-- Homebrew 3.3.7
+- Homebrew 3.3.5
 - Miniconda 4.10.3
-- Npm 8.1.2
+- Npm 8.1.0
 - Pip 9.0.1
 - Pip3 9.0.1
 - Pipx 0.16.4
 - RubyGems 2.7.6
-- Vcpkg  (build from master \<7bb175eaf>)
+- Vcpkg  (build from master \<3a68454af>)
 - Yarn 1.22.17
 
 #### Environment variables
@@ -43,68 +47,68 @@
 
 ### Project Management
 - Ant 1.10.5
-- Gradle 7.3.1
+- Gradle 7.3
 - Maven 3.8.4
 - Sbt 1.5.5
 
 ### Tools
-- Ansible 2.11.7
+- Ansible 2.11.6
 - apt-fast 1.9.11
 - AzCopy 10.13.0 (available by `azcopy` and `azcopy10` aliases)
-- Bazel 4.2.2
+- Bazel 4.2.1
 - Bazelisk 1.10.1
 - Bicep 0.4.1008
 - Buildah 1.19.6 (apt source repository: https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable)
-- CMake 3.22.1
-- CodeQL Action Bundle 2.7.3
+- CMake 3.22.0
+- CodeQL Action Bundle 2.7.2
 - Docker Compose v1 1.29.2
-- Docker Compose v2 2.1.1+azure-2
-- Docker-Buildx 0.7.1
-- Docker-Moby Client 20.10.11+azure-2
-- Docker-Moby Server 20.10.11+azure-2
+- Docker Compose v2 2.1.1+azure-1
+- Docker-Buildx 0.7.0
+- Docker-Moby Client 20.10.11+azure-1
+- Docker-Moby Server 20.10.11+azure-1
 - Git 2.34.1 (apt source repository: ppa:git-core/ppa)
 - Git LFS 3.0.2 (apt source repository: https://packagecloud.io/install/repositories/github/git-lfs)
 - Git-ftp 1.3.1
 - Haveged 1.9.1
 - Heroku 7.59.2
-- HHVM (HipHop VM) 4.138.0
+- HHVM (HipHop VM) 4.137.0
 - jq 1.5
 - Kind 0.11.1
-- Kubectl 1.23.0
+- Kubectl 1.22.4
 - Kustomize 4.4.1
 - Leiningen 2.9.8
 - MediaInfo 17.12
 - Mercurial 4.5.3
 - Minikube 1.24.0
-- n 8.0.1
+- n 8.0.0
 - Newman 5.3.0
 - nvm 0.39.0
 - OpenSSL 1.1.1  11 Sep 2018
 - Packer 1.7.8
 - PhantomJS 2.1.1
 - Podman 3.0.1 (apt source repository: https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable)
-- Pulumi 3.19.0
+- Pulumi 3.18.1
 - R 4.1.2
 - Skopeo 1.2.2 (apt source repository: https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable)
 - Sphinx Open Source Search Server 2.2.11
 - SVN 1.9.7
 - Terraform 1.0.11
 - yamllint 1.26.3
-- yq 4.16.1
+- yq 4.15.1
 - zstd 1.5.0 (homebrew)
 
 ### CLI Tools
-- Alibaba Cloud CLI 3.0.100
-- AWS CLI 1.22.21
+- Alibaba Cloud CLI 3.0.99
+- AWS CLI 1.22.14
 - AWS CLI Session manager plugin 1.2.279.0
 - AWS SAM CLI 1.36.0
-- Azure CLI (azure-cli) 2.31.0 (installation method: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt)
+- Azure CLI (azure-cli) 2.30.0 (installation method: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt)
 - Azure CLI (azure-devops) 0.22.0
-- GitHub CLI 2.3.0
-- Google Cloud SDK 366.0.0 (apt source repository: https://packages.cloud.google.com/apt)
+- GitHub CLI 2.2.0
+- Google Cloud SDK 365.0.1 (apt source repository: https://packages.cloud.google.com/apt)
 - Hub CLI 2.14.2
-- Netlify CLI 8.0.16
-- OpenShift CLI 4.9.10
+- Netlify CLI 8.0.3
+- OpenShift CLI 4.9.8
 - ORAS CLI 0.12.0
 - Vercel CLI 23.1.2
 
@@ -116,11 +120,11 @@
 | 12.0.2+10           | Adopt OpenJDK | JAVA_HOME_12_X64     |
 
 ### PHP
-| Tool     | Version                                  |
-| -------- | ---------------------------------------- |
-| PHP      | 7.1.33 7.2.34 7.3.33 7.4.26 8.0.13 8.1.0 |
-| Composer | 2.1.14                                   |
-| PHPUnit  | 8.5.21                                   |
+| Tool     | Version                            |
+| -------- | ---------------------------------- |
+| PHP      | 7.1.33 7.2.34 7.3.33 7.4.26 8.0.13 |
+| Composer | 2.1.12                             |
+| PHPUnit  | 8.5.21                             |
 ```
     Both Xdebug and PCOV extensions are installed, but only Xdebug is enabled.
 ```
@@ -131,21 +135,21 @@
 - Stack 2.7.3
 
 ### Rust Tools
-- Cargo 1.57.0
-- Rust 1.57.0
-- Rustdoc 1.57.0
+- Cargo 1.56.0
+- Rust 1.56.1
+- Rustdoc 1.56.1
 - Rustup 1.24.3
 
 #### Packages
 - Bindgen 0.59.2
 - Cargo audit 0.16.0
-- Cargo clippy 0.1.57
+- Cargo clippy 0.1.56
 - Cargo outdated 0.10.2
 - Cbindgen 0.20.0
 - Rustfmt 1.4.37
 
 ### Browsers and Drivers
-- Google Chrome 96.0.4664.93
+- Google Chrome 96.0.4664.45
 - ChromeDriver 96.0.4664.45
 - Mozilla Firefox 94.0
 - Geckodriver 0.30.0
@@ -163,12 +167,12 @@
 - 2.1.302 2.1.403 2.1.526 2.1.617 2.1.701 2.1.818 3.1.120 3.1.202 3.1.302 3.1.415 5.0.104 5.0.209 5.0.303 5.0.403
 
 ### Databases
-- MongoDB 5.0.5 (apt source repository: https://repo.mongodb.org/apt/ubuntu)
+- MongoDB 5.0.4 (apt source repository: https://repo.mongodb.org/apt/ubuntu)
 - PostgreSQL 14.1 (apt source repository: https://apt.postgresql.org/pub/repos/apt/)
 - sqlite3 3.22.0
 
 #### MySQL
-- MySQL 5.7.36-0ubuntu0.18.04.1
+- MySQL 5.7.36
 - MySQL Server (user:root password:root)
 
 ```
@@ -181,13 +185,13 @@
 ### Cached Tools
 #### Go
 - 1.15.15
-- 1.16.11
-- 1.17.4
+- 1.16.10
+- 1.17.3
 
 #### Node.js
 - 12.22.7
-- 14.18.2
-- 16.13.1
+- 14.18.1
+- 16.13.0
 
 #### PyPy
 - 2.7.18 [PyPy 7.3.6]
@@ -213,8 +217,8 @@
 | Name            | Value                               | Architecture |
 | --------------- | ----------------------------------- | ------------ |
 | GOROOT_1_15_X64 | /opt/hostedtoolcache/go/1.15.15/x64 | x64          |
-| GOROOT_1_16_X64 | /opt/hostedtoolcache/go/1.16.11/x64 | x64          |
-| GOROOT_1_17_X64 | /opt/hostedtoolcache/go/1.17.4/x64  | x64          |
+| GOROOT_1_16_X64 | /opt/hostedtoolcache/go/1.16.10/x64 | x64          |
+| GOROOT_1_17_X64 | /opt/hostedtoolcache/go/1.17.3/x64  | x64          |
 
 ### PowerShell Tools
 - PowerShell 7.2.0
@@ -235,21 +239,21 @@
 | nginx   | 1.14.0  | /etc/nginx/nginx.conf     | inactive      | 80         |
 
 ### Android
-| Package Name               | Version                                                                                                                                                                                                                                                           |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Android Command Line Tools | 4.0                                                                                                                                                                                                                                                               |
-| Android Emulator           | 31.1.4                                                                                                                                                                                                                                                            |
-| Android SDK Build-tools    | 32.0.0<br>31.0.0<br>30.0.0 30.0.1 30.0.2 30.0.3<br>29.0.0 29.0.1 29.0.2 29.0.3<br>28.0.0 28.0.1 28.0.2 28.0.3<br>27.0.0 27.0.1 27.0.2 27.0.3<br>26.0.0 26.0.1 26.0.2 26.0.3<br>25.0.0 25.0.1 25.0.2 25.0.3<br>24.0.0 24.0.1 24.0.2 24.0.3<br>23.0.1 23.0.2 23.0.3 |
-| Android SDK Platform-Tools | 31.0.3                                                                                                                                                                                                                                                            |
-| Android SDK Platforms      | android-32 (rev 1)<br>android-31 (rev 1)<br>android-30 (rev 3)<br>android-29 (rev 5)<br>android-28 (rev 6)<br>android-27 (rev 3)<br>android-26 (rev 2)<br>android-25 (rev 3)<br>android-24 (rev 2)<br>android-23 (rev 3)                                          |
-| Android SDK Tools          | 26.1.1                                                                                                                                                                                                                                                            |
-| Android Support Repository | 47.0.0                                                                                                                                                                                                                                                            |
-| CMake                      | 3.10.2<br>3.18.1                                                                                                                                                                                                                                                  |
-| Google APIs                | addon-google_apis-google-21<br>addon-google_apis-google-22<br>addon-google_apis-google-23<br>addon-google_apis-google-24                                                                                                                                          |
-| Google Play services       | 49                                                                                                                                                                                                                                                                |
-| Google Repository          | 58                                                                                                                                                                                                                                                                |
-| NDK                        | 21.4.7075529 (default)<br>23.1.7779620                                                                                                                                                                                                                            |
-| SDK Patch Applier v4       | 1                                                                                                                                                                                                                                                                 |
+| Package Name               | Version                                                                                                                                                                                                                                                 |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Android Command Line Tools | 4.0                                                                                                                                                                                                                                                     |
+| Android Emulator           | 30.9.5                                                                                                                                                                                                                                                  |
+| Android SDK Build-tools    | 31.0.0<br>30.0.0 30.0.1 30.0.2 30.0.3<br>29.0.0 29.0.1 29.0.2 29.0.3<br>28.0.0 28.0.1 28.0.2 28.0.3<br>27.0.0 27.0.1 27.0.2 27.0.3<br>26.0.0 26.0.1 26.0.2 26.0.3<br>25.0.0 25.0.1 25.0.2 25.0.3<br>24.0.0 24.0.1 24.0.2 24.0.3<br>23.0.1 23.0.2 23.0.3 |
+| Android SDK Platform-Tools | 31.0.3                                                                                                                                                                                                                                                  |
+| Android SDK Platforms      | android-31 (rev 1)<br>android-30 (rev 3)<br>android-29 (rev 5)<br>android-28 (rev 6)<br>android-27 (rev 3)<br>android-26 (rev 2)<br>android-25 (rev 3)<br>android-24 (rev 2)<br>android-23 (rev 3)                                                      |
+| Android SDK Tools          | 26.1.1                                                                                                                                                                                                                                                  |
+| Android Support Repository | 47.0.0                                                                                                                                                                                                                                                  |
+| CMake                      | 3.10.2<br>3.18.1                                                                                                                                                                                                                                        |
+| Google APIs                | addon-google_apis-google-21<br>addon-google_apis-google-22<br>addon-google_apis-google-23<br>addon-google_apis-google-24                                                                                                                                |
+| Google Play services       | 49                                                                                                                                                                                                                                                      |
+| Google Repository          | 58                                                                                                                                                                                                                                                      |
+| NDK                        | 21.4.7075529 (default)<br>23.1.7779620                                                                                                                                                                                                                  |
+| SDK Patch Applier v4       | 1                                                                                                                                                                                                                                                       |
 
 #### Environment variables
 | Name                    | Value                                                                                |
@@ -266,19 +270,19 @@
 | alpine:3.12             | sha256:d9459083f962de6bd980ae6a05be2a4cf670df6a1d898157bceb420342bec280  | 2021-11-12 |
 | alpine:3.13             | sha256:026f721af4cf2843e07bba648e158fb35ecc876d822130633cc49f707f0fc88c  | 2021-11-12 |
 | alpine:3.14             | sha256:635f0aa53d99017b38d1a0aa5b2082f7812b03e3cdb299103fe77b5c8a07f1d2  | 2021-11-12 |
-| buildpack-deps:bullseye | sha256:5445b145c8a1a2f7e5a4b233f571c629aed12fce435496f942ad267f21a05ff2  | 2021-12-02 |
-| buildpack-deps:buster   | sha256:c11cd0a4c97acd1aa8d2289aee5c126ac78adc48108744c104f6741cbd9a1f6c  | 2021-12-02 |
-| buildpack-deps:stretch  | sha256:bb93e2c2858cb20f7f16e433773adb2c583fce38dc9c71976c62bf098f956093  | 2021-12-02 |
-| debian:10               | sha256:5b57f8c365c40fde437d53b953c436995525be7c481eb0128b1cbf3b49b0df18  | 2021-12-02 |
-| debian:11               | sha256:45ee40a844048c2f6d0105899c1a17733530b56d481612608aab5e2e4048570b  | 2021-12-02 |
-| debian:9                | sha256:aa78ddaa7f8a14bad8f940ebff5542377f91843f6dcc168e41a8628c6007e815  | 2021-12-02 |
+| buildpack-deps:bullseye | sha256:b83c9c8628517694fc9adea2dc25f70113f511606482c79e1a7689ba4893f7c4  | 2021-11-17 |
+| buildpack-deps:buster   | sha256:184194bf02563c474132a6982ed5878ef32b19b9f2a10029422ab304ca88ade1  | 2021-11-17 |
+| buildpack-deps:stretch  | sha256:36fba449401e28a20c9fc9ebae94b4071c0a69bab5aade3340539ac9c857375a  | 2021-11-17 |
+| debian:10               | sha256:e5333f8697a86fa1be53b2a7e994247083f61885166df0cdda9f812acb514d7c  | 2021-11-17 |
+| debian:11               | sha256:e8c184b56a94db0947a9d51ec68f42ef5584442f20547fa3bd8cbd00203b2e7a  | 2021-11-17 |
+| debian:9                | sha256:d8ee86bf0afeb901de293c692a540307a670306cbdb7a06e2c840f17b0c35374  | 2021-11-17 |
 | moby/buildkit:latest    | sha256:d6c89b7085b106301645ddcc77cf64eb7b705ab507b72d52d130ac33f1300417  | 2021-11-18 |
-| node:12                 | sha256:eb92ed2473762b6d11736a4b4345aa3ef68f773999fe633bc4d9c91fa5d8f9d6  | 2021-12-02 |
+| node:12                 | sha256:cb615135757e6e2eed4fad6d80f07b13d9f35072700c01da6de26fde5c9e8632  | 2021-11-17 |
 | node:12-alpine          | sha256:0eca266c5fe38ba93aebac00e45c9ac1bb7328b0702a6dc10e1a6ea543d49301  | 2021-11-13 |
-| node:14                 | sha256:52c884d7cf8509c27def168415a1ff23a0bd95d358dd5787ca77b60474dcb3db  | 2021-12-02 |
-| node:14-alpine          | sha256:7bcf853eeb97a25465cb385b015606c22e926f548cbd117f85b7196df8aa0d29  | 2021-12-02 |
-| node:16                 | sha256:89b59ce49929d8a8e230946bdb1b58c14cdbbb86c9a7397610afcecfce1be035  | 2021-12-02 |
-| node:16-alpine          | sha256:a9b9cb880fa429b0bea899cd3b1bc081ab7277cc97e6d2dcd84bd9753b2027e1  | 2021-12-02 |
+| node:14                 | sha256:fbd6954d3941ebd1e12cd995dc10a4994535aa44d47271a91a829a2d1f88fc4c  | 2021-11-17 |
+| node:14-alpine          | sha256:240e1e6ef6dfba3bb70d6e88cca6cbb0b5a6f3a2b4496ed7edc5474e8ed594bd  | 2021-11-13 |
+| node:16                 | sha256:580a0850049c59a48f06090edd48c9f966c5e6572bbbabc369ba3ecbc4855dba  | 2021-11-17 |
+| node:16-alpine          | sha256:60ef0bed1dc2ec835cfe3c4226d074fdfaba571fd619c280474cc04e93f0ec5b  | 2021-11-13 |
 | ubuntu:16.04            | sha256:0f71fa8d4d2d4292c3c617fda2b36f6dabe5c8b6e34c3dc5b0d17d4e704bd39c  | 2021-08-31 |
 | ubuntu:18.04            | sha256:0fedbd5bd9fb72089c7bbca476949e10593cebed9b1fb9edf5b79dbbacddd7d6  | 2021-10-01 |
 | ubuntu:20.04            | sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3322  | 2021-10-16 |
@@ -303,7 +307,7 @@
 | ftp               | 0.17-34                           |
 | gnupg2            | 2.2.4-1ubuntu1.4                  |
 | haveged           | 1.9.1-6                           |
-| imagemagick       | 8:6.9.7.4+dfsg-16ubuntu6.12       |
+| imagemagick       | 8:6.9.7.4+dfsg-16ubuntu6.11       |
 | iproute2          | 4.15.0-2ubuntu1.3                 |
 | iputils-ping      | 3:20161105-1ubuntu3               |
 | jq                | 1.5+dfsg-2                        |
@@ -316,8 +320,8 @@
 | libgsl-dev        | 2.4+dfsg-6                        |
 | libgtk-3-0        | 3.22.30-1ubuntu4                  |
 | libmagic-dev      | 1:5.32-2ubuntu0.4                 |
-| libmagickcore-dev | 8:6.9.7.4+dfsg-16ubuntu6.12       |
-| libmagickwand-dev | 8:6.9.7.4+dfsg-16ubuntu6.12       |
+| libmagickcore-dev | 8:6.9.7.4+dfsg-16ubuntu6.11       |
+| libmagickwand-dev | 8:6.9.7.4+dfsg-16ubuntu6.11       |
 | libsecret-1-dev   | 0.18.6-1                          |
 | libsqlite3-dev    | 3.22.0-1ubuntu0.4                 |
 | libunwind8        | 1.2.1-8                           |
@@ -361,4 +365,5 @@
 | xz-utils          | 5.2.2-1.3                         |
 | zip               | 3.0-11build1                      |
 | zsync             | 0.6.2-3ubuntu1                    |
+
 


### PR DESCRIPTION
Ubuntu image is rolled back due to issues with Code QL