### PR TITLE
[Ubuntu] remove `--unsafe-perm` code for netlify-cli

### DIFF
--- a/images/linux/scripts/installers/nodejs.sh
+++ b/images/linux/scripts/installers/nodejs.sh
@@ -14,20 +14,7 @@ bash ~/n $defaultVersion
 
 # Install node modules
 node_modules=$(get_toolset_value '.node_modules[].name')
-
-# remove commenting out of this line as nmp migrated to v7
-# npm install -g $node_modules
-
-# TODO: workaround for Netlify CLI with npm6. Remove 19-28 and uncomment 17 if migration to npm7 compelted
-for module in $node_modules; do
-    echo "Installing node module $module"
-    if [ $module = "netlify-cli" ];then
-      # Install the Netlify CLI using --unsafe-perm=true options to avoid permission issues
-      npm install -g --unsafe-perm=true $module
-    else    
-      npm install -g $module
-    fi
-done
+npm install -g $node_modules
 
 echo "Creating the symlink for [now] command to vercel CLI"
 ln -s /usr/local/bin/vercel /usr/local/bin/now


### PR DESCRIPTION
Since the migration to npm 8 is finished now, there's no need for this piece of code any more. So let's get rid of it! 🎉