### PR TITLE
[macOS] Fix software report: gcc and fortran versions

### DIFF
--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -31,22 +31,22 @@ $markdown += New-MDList -Style Unordered -Lines ("Image Version: {0}" -f $ImageN
 $markdown += New-MDHeader "Installed Software" -Level 2
 $markdown += New-MDHeader "Language and Runtime" -Level 3
 $languageAndRuntimeList = @(
-    (Get-BashVersion),
-    (Get-MSBuildVersion),
-    (Get-NodeVersion),
-    (Get-NVMVersion),
-    (Get-NVMNodeVersionList),
-    (Get-PerlVersion),
-    (Get-PythonVersion),
-    (Get-Python3Version),
-    (Get-RubyVersion),
-    (Get-DotnetVersionList),
-    (Get-GoVersion),
-    (Get-JuliaVersion),
-    (Get-KotlinVersion),
-    (Get-PHPVersion),
-    (Get-ClangLLVMVersion),
-    (Get-GccVersion),
+    (Get-BashVersion)
+    (Get-MSBuildVersion)
+    (Get-NodeVersion)
+    (Get-NVMVersion)
+    (Get-NVMNodeVersionList)
+    (Get-PerlVersion)
+    (Get-PythonVersion)
+    (Get-Python3Version)
+    (Get-RubyVersion)
+    (Get-DotnetVersionList)
+    (Get-GoVersion)
+    (Get-JuliaVersion)
+    (Get-KotlinVersion)
+    (Get-PHPVersion)
+    (Get-ClangLLVMVersion)
+    (Get-GccVersion)
     (Get-FortranVersion)
 )
 


### PR DESCRIPTION
# Description
Bug fixing: software report.
The nested arrays with the `gcc` and` fortran` versions in the language and runtime list have been expanded by removing the commas in the array literal because otherwise they are treated as a single element.

Test reports: https://github.com/vsafonkin/test-repo/runs/4482460272?check_suite_focus=true

Probably, we have to do it for all array literals in software report generation.
#### Related issue: [internal issue](https://github.com/actions/virtual-environments-internal/issues/3081)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
