### PR TITLE
[Windows] Add installer projects to VS on Windows-2022

### DIFF
--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -252,7 +252,6 @@ function Install-VsixExtension
         [string] $Url,
         [Parameter(Mandatory = $true)]
         [string] $Name,
-        [string] $InstallPath = ${env:ProgramFiles(x86)},
         [string] $FilePath,
         [Parameter(Mandatory = $true)]
         [string] $VSversion,
@@ -271,15 +270,17 @@ function Install-VsixExtension
     $vsEdition = (Get-ToolsetContent).visualStudio.edition
     try
     {
+        $installPath = ${env:ProgramFiles(x86)}
+        
         if (Test-IsWin22)
         {
-            $InstallPath = ${env:ProgramFiles}
+            $installPath = ${env:ProgramFiles}
         }
         
         #There are 2 types of packages at the moment - exe and vsix
         if ($Name -match "vsix")
         {
-            $process = Start-Process -FilePath "${InstallPath}\Microsoft Visual Studio\${VSversion}\${vsEdition}\Common7\IDE\VSIXInstaller.exe" -ArgumentList $argumentList -Wait -PassThru
+            $process = Start-Process -FilePath "${installPath}\Microsoft Visual Studio\${VSversion}\${vsEdition}\Common7\IDE\VSIXInstaller.exe" -ArgumentList $argumentList -Wait -PassThru
         }
         else
         {

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -252,6 +252,7 @@ function Install-VsixExtension
         [string] $Url,
         [Parameter(Mandatory = $true)]
         [string] $Name,
+        [string] $InstallPath = ${env:ProgramFiles(x86)},
         [string] $FilePath,
         [Parameter(Mandatory = $true)]
         [string] $VSversion,
@@ -270,10 +271,15 @@ function Install-VsixExtension
     $vsEdition = (Get-ToolsetContent).visualStudio.edition
     try
     {
+        if (Test-IsWin22)
+        {
+            $InstallPath = ${env:ProgramFiles}
+        }
+        
         #There are 2 types of packages at the moment - exe and vsix
         if ($Name -match "vsix")
         {
-            $process = Start-Process -FilePath "C:\Program Files (x86)\Microsoft Visual Studio\$VSversion\${vsEdition}\Common7\IDE\VSIXInstaller.exe" -ArgumentList $argumentList -Wait -PassThru
+            $process = Start-Process -FilePath "${InstallPath}\Microsoft Visual Studio\${VSversion}\${vsEdition}\Common7\IDE\VSIXInstaller.exe" -ArgumentList $argumentList -Wait -PassThru
         }
         else
         {

--- a/images/win/scripts/Installers/Install-Vsix.ps1
+++ b/images/win/scripts/Installers/Install-Vsix.ps1
@@ -12,7 +12,7 @@ if (-not $vsixPackagesList) {
 
 $vsVersion = $toolset.visualStudio.Version
 $vsixPackagesList | ForEach-Object {
-    # Retrieve cdn endpoint to avoid HTTP error 429 https://github.com/actions/virtual-environments/issues/3074 
+    # Retrieve cdn endpoint to avoid HTTP error 429 https://github.com/actions/virtual-environments/issues/3074
     $vsixPackage = Get-VsixExtenstionFromMarketplace -ExtensionMarketPlaceName $_
     Install-VsixExtension -Url $vsixPackage.DownloadUri -Name $vsixPackage.FileName -VSversion $vsVersion
 }

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -240,7 +240,9 @@
             "Component.MDD.Linux",
             "wasm.tools"
         ],
-        "vsix": []
+        "vsix": [
+            "VisualStudioClient.MicrosoftVisualStudio2022InstallerProjects"
+        ]
     },
     "docker": {
         "images": [


### PR DESCRIPTION
# Description
This PR adds  extension "Installer projects" to Visual Studio 2022 on Windows-2022

#### Related issue: https://github.com/actions/virtual-environments/issues/4580

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
