### PR TITLE
[Windows] Wait Containers installation feature

### DIFF
--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -139,12 +139,12 @@
         },
         {
             "type": "windows-restart",
+            "restart_check_command": "powershell -command \"& {while ( (Get-WindowsOptionalFeature -Online -FeatureName Containers -ErrorAction SilentlyContinue).State -eq 'Enabled' ) { Start-Sleep 30; Write-Output 'InProgress' }}\"",
             "check_registry": true,
             "restart_timeout": "10m"
         },
         {
             "type": "powershell",
-            "pause_before": "2m",
             "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-Docker.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-PowershellCore.ps1"

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -140,6 +140,7 @@
         {
             "type": "windows-restart",
             "check_registry": true,
+            "restart_check_command": "powershell -command \"& {while ( (Get-WindowsOptionalFeature -Online -FeatureName Containers -ErrorAction SilentlyContinue).State -ne 'Enabled' ) { Start-Sleep 30; Write-Output 'InProgress' }}\"",
             "restart_timeout": "10m"
         },
         {

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -139,7 +139,6 @@
         },
         {
             "type": "windows-restart",
-            "restart_check_command": "powershell -command \"& {while ( (Get-WindowsOptionalFeature -Online -FeatureName Containers -ErrorAction SilentlyContinue).State -ne 'Enabled' ) { Start-Sleep 30; Write-Output 'InProgress' }}\"",
             "check_registry": true,
             "restart_timeout": "10m"
         },

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -139,7 +139,7 @@
         },
         {
             "type": "windows-restart",
-            "restart_check_command": "powershell -command \"& {while ( (Get-WindowsOptionalFeature -Online -FeatureName Containers -ErrorAction SilentlyContinue).State -eq 'Enabled' ) { Start-Sleep 30; Write-Output 'InProgress' }}\"",
+            "restart_check_command": "powershell -command \"& {while ( (Get-WindowsOptionalFeature -Online -FeatureName Containers -ErrorAction SilentlyContinue).State -ne 'Enabled' ) { Start-Sleep 30; Write-Output 'InProgress' }}\"",
             "check_registry": true,
             "restart_timeout": "10m"
         },


### PR DESCRIPTION
# Description

Sometimes container feature is not enabled. The provisioner should wait it before invoking Install-Docker.ps1 script.
```
    vhd: WARNING: A restart is required to enable the containers feature. Please restart your machine.
    vhd:
    vhd: Name                           Version          Source           Summary
    vhd: ----                           -------          ------           -------
    vhd: Docker                         20.10.7          DockerDefault    Contains Docker EE for use with Windows Server.
==> vhd: Start-Service : Failed to start service 'Docker Engine (docker)'
```.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3096

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
