### PR TITLE
[Windows] Add UWP VC++ ARM64 component

### DIFF
--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -187,6 +187,7 @@
             "Microsoft.VisualStudio.Component.TeamOffice",
             "Microsoft.VisualStudio.Component.TestTools.CodedUITest",
             "Microsoft.VisualStudio.Component.TestTools.WebLoadTest",
+            "Microsoft.VisualStudio.Component.UWP.VC.ARM64",
             "Microsoft.VisualStudio.Component.VC.CLI.Support",
             "Microsoft.VisualStudio.Component.VC.CMake.Project",
             "Microsoft.VisualStudio.Component.VC.DiagnosticTools",


### PR DESCRIPTION
# Description
Add the UWP C++ tools for ARM64 to the Visual Studio installation. These tools are present on windows-2019; this PR adds them to windows-2022.

#### Related issue: #4745

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
