### PR TITLE
[Ubuntu] enable -e bash mode in mysql helper

### DIFF
--- a/images/linux/scripts/helpers/mysql-service-helper.sh
+++ b/images/linux/scripts/helpers/mysql-service-helper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Temporary fix for the https://github.com/actions/virtual-environments/issues/4732 issue
 # Taken from the official ubuntu:20.04 docker container


### PR DESCRIPTION
# Description

There were no plans to change shebang initially, as we wanted to keep a vanilla mysql init script taken from ubuntu (this script is only used for the mysqld service and not being called directly during images generation that is why we left it as it was).
As we now have a test which checks that the `/etc/init.d/mysql` start/stop procedure was successful let's fix the shebang to silence the linter and see what happens.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
