### PR TITLE
[Ubuntu] Cleanup /root/.cache directory

### DIFF
--- a/images/linux/scripts/installers/cleanup.sh
+++ b/images/linux/scripts/installers/cleanup.sh
@@ -7,6 +7,7 @@ before=$(df / -Pm | awk 'NR==2{print $4}')
 # It removes everything but the lock file from /var/cache/apt/archives/ and /var/cache/apt/archives/partial
 apt-get clean
 rm -rf /tmp/*
+rm -rf /root/.cache
 
 # journalctl
 if command -v journalctl; then


### PR DESCRIPTION
# Description
Some files are left after the image generation in the `/root/.cache` and can be safely deleted.

#### Related issue:
n\a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
