### PR TITLE
[macOS] install zlib

### DIFF
--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -517,6 +517,11 @@ function Get-JazzyVersion {
     return "Jazzy $jazzyVersion"
 }
 
+function Get-ZlibVersion {
+	$zlibVersion = (brew info zlib)[0] | Take-Part -Part 2
+	return "Zlib $zlibVersion"
+}
+
 function Build-PackageManagementEnvironmentTable {
     return @(
         @{

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -291,6 +291,9 @@ $markdown += New-MDHeader "Environment variables" -Level 4
 $markdown += Build-AndroidEnvironmentTable | New-MDTable
 $markdown += New-MDNewLine
 
+$markdown += New-MDHeader "Miscellaneous" -Level 3
+$markdown += New-MDList -Lines @(Get-ZlibVersion) -Style Unordered
+
 #
 # Generate systeminfo.txt with information about image (for debug purpose)
 #

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -224,7 +224,8 @@
             "swiftformat",
             "swig",
             "xctool",
-            "zstd"
+            "zstd",
+            "zlib"
         ],
         "cask_packages": [
             "julia",

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -183,7 +183,8 @@
             "subversion",
             "swiftformat",
             "swig",
-            "zstd"
+            "zstd",
+            "zlib"
         ],
         "cask_packages": [
             "julia"

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -98,7 +98,8 @@
             "subversion",
             "swig",
             "zstd",
-            "gmp"
+            "gmp",
+            "zlib"
         ],
         "cask_packages": [
             "julia"


### PR DESCRIPTION
# Description

The original discussion started [here](https://github.com/actions/python-versions/pull/128). zlib is quite popular and widely used compression/decompression library and lots of tools/utilities/language bindings rely on it, it is worth having zlib explicitly installed in our images to ease further development.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
