### PR TITLE
[macOS] Update Openssl up to 3* version

### DIFF
--- a/images/macos/provision/core/openssl.sh
+++ b/images/macos/provision/core/openssl.sh
@@ -1,13 +1,13 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
 
-echo "Install openssl@1.1"
-brew_smart_install "openssl@1.1"
+echo "Install openssl@3"
+brew_smart_install "openssl@3"
 
-# Symlink brew openssl@1.1 to `/usr/local/bin` as Homebrew refuses
-ln -sf $(brew --prefix openssl@1.1)/bin/openssl /usr/local/bin/openssl
+# Symlink brew openssl@3 to `/usr/local/bin` as Homebrew refuses
+ln -sf $(brew --prefix openssl@3)/bin/openssl /usr/local/bin/openssl
 
 # Most of buildsystems and scripts look up ssl here
-ln -sf $(brew --cellar openssl@1.1)/1.1* /usr/local/opt/openssl
+ln -sf $(brew --cellar openssl@3)/3* /usr/local/opt/openssl
 
 invoke_tests "OpenSSL"

--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -303,7 +303,7 @@ function Get-PackerVersion {
 }
 
 function Get-OpenSSLVersion {
-    $opensslVersion = Get-Item /usr/local/opt/openssl@1.1 | ForEach-Object {"{0} ``({1} -> {2})``" -f (Run-Command "openssl version"), $_.FullName, $_.Target}
+    $opensslVersion = Get-Item /usr/local/opt/openssl@3 | ForEach-Object {"{0} ``({1} -> {2})``" -f (Run-Command "openssl version"), $_.FullName, $_.Target}
     return $opensslVersion
 }
 

--- a/images/macos/tests/OpenSSL.Tests.ps1
+++ b/images/macos/tests/OpenSSL.Tests.ps1
@@ -5,17 +5,17 @@ Describe "OpenSSL" {
         }
     }
 
-    Context "OpenSSL 1.1 Path Check" {
-        It "OpenSSL 1.1 path exists" {
-            $openSSLpath = "/usr/local/opt/openssl@1.1"
+    Context "OpenSSL 3 Path Check" {
+        It "OpenSSL 3 path exists" {
+            $openSSLpath = "/usr/local/opt/openssl@3"
             $openSSLpath | Should -Exist
         }
     }
     
-    Context "OpenSSL 1.1 is default" {
-        It "Default OpenSSL version is 1.1" {
+    Context "OpenSSL 3 is default" {
+        It "Default OpenSSL version is 3" {
             $commandResult = Get-CommandResult "openssl version"
-            $commandResult.Output | Should -Match "OpenSSL 1.1"
+            $commandResult.Output | Should -Match "OpenSSL 3"
         }
     }
 }


### PR DESCRIPTION
# Description
Currently we install `OpenSSL 1.1`, but in scope of `powershell.sh` script `OpenSSL`  is getting updated automatically up to 3* version. Let's update OpenSSL version up to 3* on our macOS images to avoid confusion.

#### Related issue: #4719 

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
