### PR TITLE
[Ubuntu] list mysql-core dependencies explicitly

### DIFF
--- a/images/linux/scripts/installers/mysql.sh
+++ b/images/linux/scripts/installers/mysql.sh
@@ -33,8 +33,10 @@ if isUbuntu20 ; then
     mysql_debs=(
         mysql-common*
         mysql-community-client-plugins*
+        mysql-community-client-core*
         mysql-community-client*
         mysql-client*
+        mysql-community-server-core*
         mysql-community-server*
         mysql-server*
         libmysqlclient21*


### PR DESCRIPTION
# Description

In the images generation process mysql-0.27 is being installed first (and the packages dependency tree is saved in apt package index), then it is being overwritten with the deb packages in the `mysql.sh` script, which makes apt guess the dependency tree even though some mysql dependencies are not listed (apt simply remembers the dependency order, no matter for which version and supplies needed missing packages automatically).
This may lead to a random failure if a customer builds their own image and exclude a script that does install mysql beforehand the actual `mysql.sh` script. To prevent this the core dependencies must be listed explicitly in the installer.


#### Related issue: https://github.com/actions/virtual-environments/issues/4764

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
