### PR TITLE
[Ubuntu] put snapd auto refresh on hold

### DIFF
--- a/images/linux/scripts/base/snap.sh
+++ b/images/linux/scripts/base/snap.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+# Put snapd auto refresh on hold
+# as it may generate too much traffic on Canonical's snap server
+# when they are rolling a new major update out.
+# Hold is calculated as today's date + 60 days
+
+snap set system refresh.hold="$(date --date='today+60 days' +%Y-%m-%dT%H:%M:%S%:z)"

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -318,7 +318,7 @@
         },
         {
             "type": "shell",
-            "script": "{{template_dir}}/scripts/base/snap.sh"
+            "script": "{{template_dir}}/scripts/base/snap.sh",
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -318,7 +318,7 @@
         },
         {
             "type": "shell",
-            "script": "{{template_dir}}/scripts/base/snap.sh
+            "script": "{{template_dir}}/scripts/base/snap.sh"
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -318,6 +318,11 @@
         },
         {
             "type": "shell",
+            "script": "{{template_dir}}/scripts/base/snap.sh
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
             "inline": [
                 "pwsh -File {{user `image_folder`}}/SoftwareReport/SoftwareReport.Generator.ps1 -OutputDirectory {{user `image_folder`}}",
                 "pwsh -File {{user `image_folder`}}/tests/RunAll-Tests.ps1 -OutputDirectory {{user `image_folder`}}"

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -319,6 +319,11 @@
         },
         {
             "type": "shell",
+            "script": "{{template_dir}}/scripts/base/snap.sh
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
             "inline": [
                 "pwsh -File {{user `image_folder`}}/SoftwareReport/SoftwareReport.Generator.ps1 -OutputDirectory {{user `image_folder`}}",
                 "pwsh -File {{user `image_folder`}}/tests/RunAll-Tests.ps1 -OutputDirectory {{user `image_folder`}}"

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -319,7 +319,7 @@
         },
         {
             "type": "shell",
-            "script": "{{template_dir}}/scripts/base/snap.sh
+            "script": "{{template_dir}}/scripts/base/snap.sh",
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {


### PR DESCRIPTION
# Description

Canonical has informed us that GitHub actions generates too much traffic on their snapd servers, investigation has reveled that we inherit snap from the Azure Ubuntu images where snapd auto refresh is enabled (default settings) which causes lots of traffic on the reimage by automatically pulling all possible updates (if any). There is no way to disable auto refresh effectively but unregister snapd or mask the snapd systemd service. The most elegant solution is to put auto refresh on 60 days hold (maximum is 90 now) and calculate the deadline date as the date of an image generation + 60 days. 

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/3056

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
