### PR TITLE
[Windows] Initialize rust environment to get software report

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -1,3 +1,9 @@
+function Initialize-RustEnvironment {
+    $env:RUSTUP_HOME = "C:\Users\Default\.rustup"
+    $env:CARGO_HOME = "C:\Users\Default\.cargo"
+    $env:Path += ";$env:CARGO_HOME\bin"
+}
+
 function Get-OSName {
     return (Get-CimInstance -ClassName Win32_OperatingSystem).Caption
 }
@@ -14,6 +20,7 @@ function Get-BashVersion {
 }
 
 function Get-RustVersion {
+    Initialize-RustEnvironment
     $rustVersion = [regex]::matches($(rustc --version), "\d+\.\d+\.\d+").Value
     return $rustVersion
 }
@@ -349,4 +356,3 @@ function Build-PackageManagementEnvironmentTable {
         }
     }
 }
-


### PR DESCRIPTION
# Description
The rust environment is not properly initialized that's why the software section is blank:
```
### Rust Tools
- Cargo 
- Rust 
- Rustdoc 
- Rustup 1.24.3
```

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3138

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
