### PR TITLE
[macOS] install X libraries

### DIFF
--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -522,6 +522,16 @@ function Get-ZlibVersion {
 	return "Zlib $zlibVersion"
 }
 
+function Get-LibXftVersion {
+    $libXftVersion = (brew info libxft)[0] | Take-Part -Part 2
+    return "libXft $libXftVersion"
+}
+
+function Get-LibXextVersion {
+    $libXextVersion = (brew info libxext)[0] | Take-Part -Part 2
+    return "libXext $libXextVersion"
+}
+
 function Build-PackageManagementEnvironmentTable {
     return @(
         @{

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -292,7 +292,12 @@ $markdown += Build-AndroidEnvironmentTable | New-MDTable
 $markdown += New-MDNewLine
 
 $markdown += New-MDHeader "Miscellaneous" -Level 3
-$markdown += New-MDList -Lines @(Get-ZlibVersion) -Style Unordered
+$markdown += New-MDList -Style Unordered -Lines (@(
+    (Get-ZlibVersion),
+    (Get-LibXextVersion),
+    (Get-LibXftVersion)
+    ) | Sort-Object
+)
 
 #
 # Generate systeminfo.txt with information about image (for debug purpose)

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -225,7 +225,9 @@
             "swig",
             "xctool",
             "zstd",
-            "zlib"
+            "zlib",
+            "libxext",
+            "libxft"
         ],
         "cask_packages": [
             "julia",

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -185,7 +185,9 @@
             "swiftformat",
             "swig",
             "zstd",
-            "zlib"
+            "zlib",
+            "libxext",
+            "libxft"
         ],
         "cask_packages": [
             "julia"

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -100,7 +100,9 @@
             "swig",
             "zstd",
             "gmp",
-            "zlib"
+            "zlib",
+            "libxext",
+            "libxft"
         ],
         "cask_packages": [
             "julia"


### PR DESCRIPTION
# Description

This pull request unblocks python3.10 generation by adding missing X libraries into the image. libxext and libxft are needed as dependencies of libtk (which in turn is being used on the python building and testing stages for the `tkinter` and `turtle` python modules).
For the software report I preserved the original libraries naming with the capital 'X'.


#### Related issue: https://github.com/actions/virtual-environments-internal/issues/3057

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
