### PR TITLE
[macOS] Rework PowerShell installation

### DIFF
--- a/images/macos/provision/core/powershell.sh
+++ b/images/macos/provision/core/powershell.sh
@@ -2,7 +2,16 @@
 source ~/utils/utils.sh
 
 echo Installing PowerShell...
-brew install --cask powershell
+psRelease=$(curl -s "https://api.github.com/repos/PowerShell/PowerShell/releases/latest")
+psDownloadUrl=$(echo $psRelease | jq -r '.assets[].browser_download_url | select(contains("osx-x64.pkg"))' | head -n 1)
+download_with_retries $psDownloadUrl "/tmp" "powershell.pkg"
+
+# Work around the issue on macOS Big Sur 11.5 or higher for possible error message ("can't be opened because Apple cannot check it for malicious software") when installing the package
+if is_BigSur; then
+    xattr -rd com.apple.quarantine /tmp/powershell.pkg
+fi
+
+installer -pkg /tmp/powershell.pkg -target /
 
 # Install PowerShell modules
 psModules=$(get_toolset_value '.powershellModules[].name')

--- a/images/macos/provision/core/powershell.sh
+++ b/images/macos/provision/core/powershell.sh
@@ -7,7 +7,7 @@ psDownloadUrl=$(echo $psRelease | jq -r '.assets[].browser_download_url | select
 download_with_retries $psDownloadUrl "/tmp" "powershell.pkg"
 
 # Work around the issue on macOS Big Sur 11.5 or higher for possible error message ("can't be opened because Apple cannot check it for malicious software") when installing the package
-if is_BigSur; then
+if ! is_Less_BigSur; then
     sudo xattr -rd com.apple.quarantine /tmp/powershell.pkg
 fi
 

--- a/images/macos/provision/core/powershell.sh
+++ b/images/macos/provision/core/powershell.sh
@@ -8,10 +8,10 @@ download_with_retries $psDownloadUrl "/tmp" "powershell.pkg"
 
 # Work around the issue on macOS Big Sur 11.5 or higher for possible error message ("can't be opened because Apple cannot check it for malicious software") when installing the package
 if is_BigSur; then
-    xattr -rd com.apple.quarantine /tmp/powershell.pkg
+    sudo xattr -rd com.apple.quarantine /tmp/powershell.pkg
 fi
 
-installer -pkg /tmp/powershell.pkg -target /
+sudo installer -pkg /tmp/powershell.pkg -target /
 
 # Install PowerShell modules
 psModules=$(get_toolset_value '.powershellModules[].name')


### PR DESCRIPTION
# Description
Currently, we install `powershell` using brew, which [brings OpenSSL 3.0*](https://github.visualstudio.com/virtual-environments/_build/results?buildId=120506&view=logs&j=80d86624-2c9a-5cad-9434-144b838e69fb&t=7f6ff0d4-adc5-5557-eba3-0604338bbbf7#:~:text=Pouring%20openssl%403%2D%2D3.0.1.big_sur.bottle.tar.gz) in the process. To avoid such situation, we need to rework current approach of `powershell` installation.

#### Related issue: #4719 

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
