### PR TITLE
[Ubuntu] Do not use apt-fast

### DIFF
--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -53,7 +53,7 @@ echo "JAVA_HOME=/usr/lib/jvm/adoptopenjdk-${DEFAULT_JDK_VERSION}-hotspot-amd64" 
 # add extra permissions to be able execute command without sudo
 chmod -R 777 /usr/lib/jvm
 # Install Ant
-apt-fast install -y --no-install-recommends ant ant-optional
+apt-get install -y --no-install-recommends ant ant-optional
 echo "ANT_HOME=/usr/share/ant" | tee -a /etc/environment
 
 # Install Maven

--- a/images/linux/scripts/installers/php.sh
+++ b/images/linux/scripts/installers/php.sh
@@ -18,7 +18,7 @@ php_versions=$(get_toolset_value '.php.versions[]')
 
 for version in $php_versions; do
     echo "Installing PHP $version"
-    apt-fast install -y --no-install-recommends \
+    apt-get install -y --no-install-recommends \
         php$version \
         php$version-amqp \
         php$version-apcu \
@@ -65,19 +65,19 @@ for version in $php_versions; do
         php$version-zmq
 
     if [[ $version == "5.6" || $version == "7.0" || $version == "7.1" ]]; then
-        apt-fast install -y --no-install-recommends php$version-mcrypt php$version-recode
+        apt-get install -y --no-install-recommends php$version-mcrypt php$version-recode
     fi
 
     if [[ $version == "7.2" || $version == "7.3" ]]; then
-        apt-fast install -y --no-install-recommends php$version-recode
+        apt-get install -y --no-install-recommends php$version-recode
     fi
 
     if [[ $version != "8.0" && $version != "8.1" ]]; then
-        apt-fast install -y --no-install-recommends php$version-xmlrpc php$version-json
+        apt-get install -y --no-install-recommends php$version-xmlrpc php$version-json
     fi
 
     if [[ $version != "5.6" && $version != "7.0" ]]; then
-        apt-fast install -y --no-install-recommends php$version-pcov
+        apt-get install -y --no-install-recommends php$version-pcov
 
         # Disable PCOV, as Xdebug is enabled by default
         # https://github.com/krakjoe/pcov#interoperability
@@ -85,13 +85,13 @@ for version in $php_versions; do
     fi
 
     if [[ $version = "7.0" || $version = "7.1" ]]; then
-        apt-fast install -y --no-install-recommends php$version-sodium
+        apt-get install -y --no-install-recommends php$version-sodium
     fi
 done
 
-apt-fast install -y --no-install-recommends php-pear
+apt-get install -y --no-install-recommends php-pear
 
-apt-fast install -y --no-install-recommends snmp
+apt-get install -y --no-install-recommends snmp
 
 # Install composer
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"


### PR DESCRIPTION
# Description

apt-fast is kind of hack on top of the normal apt to speed up downloading by using either axel or aria2 downloading manager.
It is currently used by only `php.sh` and `java-tools.sh` installers and rationale behind its usage these days is unclear (we are using fast enough mirrors not to use an additional layer for packages management).
I have discussed it with @miketimofeev and we have come to conclusion it might be removed. 

EDIT: lets just stop using it but keep installed

#### Related issue: https://github.com/actions/virtual-environments/issues/4780

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
