### PR TITLE
[Windows] Stop SoftwareReport script if error

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -122,7 +122,7 @@ function Get-AndroidPlatformVersions {
 
 function Get-AndroidCommandLineToolsVersion {
     $commandLineTools = Get-AndroidSDKManagerPath
-    (& $commandLineTools --version | Out-String).Trim() -match "(?<version>^(\d+\.){1,}\d+$)" | Out-Null
+    (cmd /c "$commandLineTools --version 2>NUL" | Out-String).Trim() -match "(?<version>^(\d+\.){1,}\d+$)" | Out-Null
     $commandLineToolsVersion = $Matches.Version
     return $commandLineToolsVersion
 }

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -26,28 +26,29 @@ function Get-RustVersion {
 }
 
 function Get-RustupVersion {
-     $version = [regex]::matches($(rustup --version), "\d+\.\d+\.\d+").Value
-     return $version
+    $rustupInfo = cmd /c "rustup --version 2>NUL"
+    $version = [regex]::matches($rustupInfo, "\d+\.\d+\.\d+").Value
+    return $version
 }
 
 function Get-RustCargoVersion {
-     $version = [regex]::matches($(cargo --version), "\d+\.\d+\.\d+").Value
-     return $version
+    $version = [regex]::matches($(cargo --version), "\d+\.\d+\.\d+").Value
+    return $version
 }
 
 function Get-RustdocVersion {
-     $version = [regex]::matches($(rustdoc --version), "\d+\.\d+\.\d+").Value
-     return $version
+    $version = [regex]::matches($(rustdoc --version), "\d+\.\d+\.\d+").Value
+    return $version
 }
 
 function Get-RustfmtVersion {
-     $version = [regex]::matches($(rustfmt --version), "\d+\.\d+\.\d+").Value
-     return $version
+    $version = [regex]::matches($(rustfmt --version), "\d+\.\d+\.\d+").Value
+    return $version
 }
 
 function Get-RustClippyVersion {
-     $version = [regex]::matches($(cargo clippy  --version), "\d+\.\d+\.\d+").Value
-     return $version
+    $version = [regex]::matches($(cargo clippy  --version), "\d+\.\d+\.\d+").Value
+    return $version
 }
 
 function Get-BindgenVersion {
@@ -122,10 +123,8 @@ function Get-ChocoVersion {
 }
 
 function Get-VcpkgVersion {
-    ($(vcpkg version) | Out-String) -match "version (?<version>\d+\.\d+\.\d+)" | Out-Null
-    $vcpkgVersion = $Matches.Version
     $commitId = git -C "C:\vcpkg" rev-parse --short HEAD
-    return "Vcpkg $vcpkgVersion (build from master \<$commitId>)"
+    return "Vcpkg (build from master \<$commitId>)"
 }
 
 function Get-NPMVersion {

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -1,4 +1,6 @@
-$ErrorActionPreference = "Stop"
+$global:ErrorActionPreference = "Stop"
+$global:ProgressPreference = "SilentlyContinue"
+$ErrorView = "NormalView"
 Set-StrictMode -Version Latest
 
 Import-Module MarkdownPS
@@ -297,4 +299,5 @@ if ($cachedImages) {
     $markdown += $cachedImages | New-MDTable
 }
 
+Test-BlankElement -Markdown $markdown
 $markdown | Out-File -FilePath "C:\InstalledSoftware.md"

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -1,3 +1,6 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
 Import-Module MarkdownPS
 Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Android.psm1") -DisableNameChecking
 Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Browsers.psm1") -DisableNameChecking

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Helpers.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Helpers.psm1
@@ -122,7 +122,7 @@ function Test-BlankElement {
 
     $splitByLines = $Markdown.Split("`n")
     # Validate entry without version
-    $blankVersions = $splitByLines -match "^-" -notmatch "WSL|Vcpkg|\d\." | Out-String
+    $blankVersions = $splitByLines -match "^-" -notmatch "(OS|Image) Version|WSL|Vcpkg|\d\." | Out-String
 
     # Validate tables with blank rows
     $blankRows = ""
@@ -131,10 +131,10 @@ function Test-BlankElement {
         $table = @()
         if ($splitByLines[$i].StartsWith("#") -and $splitByLines[$i+1].StartsWith("|")) {
             $table += $splitByLines[$i,($i+1),($i+2)]
-            $i += 2
+            $i += 3
             $current = $splitByLines[$i]
             while ($current.StartsWith("|")) {
-                $isBlankRow = $current.Trim("|").Split("|").Trim() -contains ""
+                $isBlankRow = $current.Substring(1, $current.LastIndexOf("|") - 2).Split("|").Trim() -contains ""
                 if ($isBlankRow) {
                     $table += $current
                     $addRows = $true
@@ -158,6 +158,6 @@ function Test-BlankElement {
         $isReport = $true
     }
     if ($isReport) {
-        Write-Host exit 1
+        exit 1
     }
 }

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Helpers.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Helpers.psm1
@@ -114,3 +114,50 @@ function Get-PathWithLink {
     $link = Get-LinkTarget($inputPath)
     return "${inputPath}${link}"
 }
+
+function Test-BlankElement {
+    param(
+        [string] $Markdown
+    )
+
+    $splitByLines = $Markdown.Split("`n")
+    # Validate entry without version
+    $blankVersions = $splitByLines -match "^-" -notmatch "WSL|Vcpkg|\d\." | Out-String
+
+    # Validate tables with blank rows
+    $blankRows = ""
+    for($i = 0; $i -lt $splitByLines.Length; $i++) {
+        $addRows= $false
+        $table = @()
+        if ($splitByLines[$i].StartsWith("#") -and $splitByLines[$i+1].StartsWith("|")) {
+            $table += $splitByLines[$i,($i+1),($i+2)]
+            $i += 2
+            $current = $splitByLines[$i]
+            while ($current.StartsWith("|")) {
+                $isBlankRow = $current.Trim("|").Split("|").Trim() -contains ""
+                if ($isBlankRow) {
+                    $table += $current
+                    $addRows = $true
+                }
+                $current = $splitByLines[++$i]
+            }
+            if ($addRows) {
+                $blankRows += $table | Out-String
+            }
+        }
+    }
+
+    # Display report
+    $isReport = $false
+    if ($blankVersions) {
+        Write-Host "Software list with blank version:`n${blankVersions}"
+        $isReport = $true
+    }
+    if ($blankRows) {
+        Write-Host "Tables with blank rows:`n${blankRows}"
+        $isReport = $true
+    }
+    if ($isReport) {
+        Write-Host exit 1
+    }
+}


### PR DESCRIPTION
# Description
If any function doesn't exist or provide incorrect results the script won't stop and create a readme.
- Displays the error message and stops executing(ErrorActionPreference)
- Don't display the progress bar(ProgressPreference)
- NormalView: Consists of a description of the error and the name of the object involved in the error.
- Enable strict mode, PowerShell generates a terminating error when the content of an expression, script, or script block violates basic best-practice coding rules.
- Validate software with blank versions
- Validate blank rows in table

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3128

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
