### PR TITLE
[macOS] Enable voiceover if SIP is disabled

### DIFF
--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -19,7 +19,7 @@ fi
 
 # Update VoiceOver Utility to allow VoiceOver to be controlled with AppleScript by creating a special file (SIP must be disabled)
 if csrutil status | grep -Eq  "System Integrity Protection status: (disabled|unknown)"; then
-    sudo echo -n "a" > /private/var/db/Accessibility/.VoiceOverAppleScriptEnabled
+    sudo bash -c 'echo -n "a" > /private/var/db/Accessibility/.VoiceOverAppleScriptEnabled'
 fi
 
 # https://developer.apple.com/support/expiration/

--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -19,7 +19,7 @@ fi
 
 # Update VoiceOver Utility to allow VoiceOver to be controlled with AppleScript by creating a special file (SIP must be disabled)
 if csrutil status | grep -Eq  "System Integrity Protection status: (disabled|unknown)"; then
-    sudo touch /private/var/db/Accessibility/.VoiceOverAppleScriptEnabled
+    sudo echo -n "a" > /private/var/db/Accessibility/.VoiceOverAppleScriptEnabled
 fi
 
 # https://developer.apple.com/support/expiration/

--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -17,6 +17,11 @@ if [ -d "/Library/Application Support/VMware Tools" ]; then
     sudo "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1176 885
 fi
 
+# Update VoiceOver Utility to allow VoiceOver to be controlled with AppleScript by creating a special file (SIP must be disabled)
+if csrutil status | grep -Eq  "System Integrity Protection status: (disabled|unknown)"; then
+    sudo touch /private/var/db/Accessibility/.VoiceOverAppleScriptEnabled
+fi
+
 # https://developer.apple.com/support/expiration/
 # Enterprise iOS Distribution Certificates generated between February 7 and September 1st, 2020 will expire on February 7, 2023.
 # Rotate the certificate before expiration to ensure your apps are installed and signed with an active certificate.


### PR DESCRIPTION
# Description
VoiceOver is a screen reader system application that provides auditory descriptions of elements help you easily navigate your screen with keyboard or gestures.
This PR enables voiceover during the image generation by creating a special file (only works if SIP is disabled).

#### Related issue:
https://github.com/actions/virtual-environments/issues/4770

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
