### PR TITLE
[Windows] Add Perl to windows-2022

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -42,16 +42,12 @@ $languageTools = @(
     (Get-JuliaVersion),
     (Get-LLVMVersion),
     (Get-NodeVersion),
+    (Get-PerlVersion)
     (Get-PHPVersion),
     (Get-PythonVersion),
     (Get-RubyVersion),
     (Get-KotlinVersion)
 )
-if ((Test-IsWin16) -or (Test-IsWin19)) {
-    $languageTools += @(
-        (Get-PerlVersion)
-    )
-}
 $markdown += New-MDList -Style Unordered -Lines ($languageTools | Sort-Object)
 
 $packageManagementList = @(

--- a/images/win/scripts/Tests/ChocoPackages.Tests.ps1
+++ b/images/win/scripts/Tests/ChocoPackages.Tests.ps1
@@ -58,7 +58,7 @@ Describe "Packer" {
     }
 }
 
-Describe "Perl" -Skip:(Test-IsWin22) {
+Describe "Perl" {
     It "Perl" {
        "perl --version" | Should -ReturnZeroExitCode
     }

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -295,6 +295,7 @@
                 "args": [ "--version=1.1.1.20181020" ]
             },
             { "name": "packer" },
+            { "name": "strawberryperl" },
             { "name": "pulumi" },
             { "name": "tortoisesvn" },
             { "name": "swig" },


### PR DESCRIPTION
# Description
We haven't included Perl at the beginning but it seems we need to reconsider the decision given the fact that we are going to migrate windows-latest to win2022 soon.

#### Related issue:
https://github.com/actions/virtual-environments/issues/4804

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
