### PR TITLE
[Ubuntu] Add verbosity during software report generation

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -4,7 +4,7 @@ function Get-BashVersion {
 }
 
 function Get-CPPVersions {
-    $result = Get-CommandResult "apt list --installed" -Multiline
+    $result = Get-CommandResult "apt list --installed" -Multiline -ValidateExitCode
     $cppVersions = $result.Output | Where-Object { $_ -match "g\+\+-\d+"} | ForEach-Object {
         & $_.Split("/")[0] --version | Select-Object -First 1 | Take-OutputPart -Part 3
     } | Sort-Object {[Version]$_}
@@ -12,7 +12,7 @@ function Get-CPPVersions {
 }
 
 function Get-FortranVersions {
-    $result = Get-CommandResult "apt list --installed" -Multiline
+    $result = Get-CommandResult "apt list --installed" -Multiline -ValidateExitCode
     $fortranVersions = $result.Output | Where-Object { $_ -match "^gfortran-\d+"} | ForEach-Object {
         $_ -match "now (?<version>\d+\.\d+\.\d+)-" | Out-Null
         $Matches.version
@@ -27,7 +27,7 @@ function Get-ClangToolVersions {
         [string] $VersionPattern = "\d+\.\d+\.\d+)-"
     )
 
-    $result = Get-CommandResult "apt list --installed" -Multiline
+    $result = Get-CommandResult "apt list --installed" -Multiline -ValidateExitCode
     $toolVersions = $result.Output | Where-Object { $_ -match "^${ToolName}-\d+"} | ForEach-Object {
         $clangCommand = ($_ -Split "/")[0]
         Invoke-Expression "$clangCommand --version" | Where-Object { $_ -match "${ToolName} version" } | ForEach-Object {
@@ -57,7 +57,7 @@ function Get-ErlangVersion {
 }
 
 function Get-ErlangRebar3Version {
-    $result = Get-CommandResult "rebar3 --version"
+    $result = Get-CommandResult "rebar3 --version" -ValidateExitCode
     $result.Output -match "rebar (?<version>(\d+.){2}\d+)" | Out-Null
     $rebarVersion = $Matches.version
     return "Erlang rebar3 $rebarVersion"
@@ -92,13 +92,13 @@ function Get-PerlVersion {
 }
 
 function Get-PythonVersion {
-    $result = Get-CommandResult "python --version"
+    $result = Get-CommandResult "python --version" -ValidateExitCode
     $version = $result.Output | Take-OutputPart -Part 1
     return "Python $version"
 }
 
 function Get-Python3Version {
-    $result = Get-CommandResult "python3 --version"
+    $result = Get-CommandResult "python3 --version" -ValidateExitCode
     $version = $result.Output | Take-OutputPart -Part 1
     return "Python3 $version"
 }
@@ -133,21 +133,21 @@ function Get-LernaVersion {
 }
 
 function Get-HomebrewVersion {
-    $result = Get-CommandResult "brew -v"
+    $result = Get-CommandResult "brew -v" -ValidateExitCode
     $result.Output -match "Homebrew (?<version>\d+\.\d+\.\d+)" | Out-Null
     $version = $Matches.version
     return "Homebrew $version"
 }
 
 function Get-CpanVersion {
-    $result = Get-CommandResult "cpan --version"
+    $result = Get-CommandResult "cpan --version" -ValidateExitCode
     $result.Output -match "version (?<version>\d+\.\d+) " | Out-Null
     $cpanVersion = $Matches.version
     return "cpan $cpanVersion"
 }
 
 function Get-GemVersion {
-    $result = Get-CommandResult "gem --version"
+    $result = Get-CommandResult "gem --version" -ValidateExitCode
     $result.Output -match "(?<version>\d+\.\d+\.\d+)" | Out-Null
     $gemVersion = $Matches.version
     return "RubyGems $gemVersion"
@@ -180,21 +180,21 @@ function Get-ParcelVersion {
 }
 
 function Get-PipVersion {
-    $result = Get-CommandResult "pip --version"
+    $result = Get-CommandResult "pip --version" -ValidateExitCode
     $result.Output -match "pip (?<version>\d+\.\d+\.\d+)" | Out-Null
     $pipVersion = $Matches.version
     return "Pip $pipVersion"
 }
 
 function Get-Pip3Version {
-    $result = Get-CommandResult "pip3 --version"
+    $result = Get-CommandResult "pip3 --version" -ValidateExitCode
     $result.Output -match "pip (?<version>\d+\.\d+\.\d+)" | Out-Null
     $pipVersion = $Matches.version
     return "Pip3 $pipVersion"
 }
 
 function Get-VcpkgVersion {
-    $result = Get-CommandResult "vcpkg version"
+    $result = Get-CommandResult "vcpkg version" -ValidateExitCode
     $result.Output -match "version (?<version>\d+\.\d+\.\d+)" | Out-Null
     $vcpkgVersion = $Matches.version
     $commitId = git -C "/usr/local/share/vcpkg" rev-parse --short HEAD
@@ -221,14 +221,14 @@ function Get-MavenVersion {
 }
 
 function Get-SbtVersion {
-    $result = Get-CommandResult "sbt -version"
+    $result = Get-CommandResult "sbt -version" -ValidateExitCode
     $result.Output -match "sbt script version: (?<version>\d+\.\d+\.\d+)" | Out-Null
     $sbtVersion = $Matches.version
     return "Sbt $sbtVersion"
 }
 
 function Get-PHPVersions {
-    $result = Get-CommandResult "apt list --installed" -Multiline
+    $result = Get-CommandResult "apt list --installed" -Multiline -ValidateExitCode
     return $result.Output | Where-Object { $_ -match "^php\d+\.\d+/"} | ForEach-Object {
         $_ -match "now (?<version>\d+\.\d+\.\d+)-" | Out-Null
         $Matches.version
@@ -369,7 +369,7 @@ function Get-AptPackages {
 }
 
 function Get-PipxVersion {
-    $result = (Get-CommandResult "pipx --version").Output
+    $result = (Get-CommandResult "pipx --version" -ValidateExitCode).Output
     $result -match "(?<version>\d+\.\d+\.\d+\.?\d*)" | Out-Null
     $pipxVersion = $Matches.Version
     return "Pipx $pipxVersion"

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -4,7 +4,7 @@ function Get-BashVersion {
 }
 
 function Get-CPPVersions {
-    $result = Get-CommandResult "apt list --installed" -Multiline -ValidateExitCode
+    $result = Get-CommandResult "apt list --installed" -Multiline
     $cppVersions = $result.Output | Where-Object { $_ -match "g\+\+-\d+"} | ForEach-Object {
         & $_.Split("/")[0] --version | Select-Object -First 1 | Take-OutputPart -Part 3
     } | Sort-Object {[Version]$_}
@@ -12,7 +12,7 @@ function Get-CPPVersions {
 }
 
 function Get-FortranVersions {
-    $result = Get-CommandResult "apt list --installed" -Multiline -ValidateExitCode
+    $result = Get-CommandResult "apt list --installed" -Multiline
     $fortranVersions = $result.Output | Where-Object { $_ -match "^gfortran-\d+"} | ForEach-Object {
         $_ -match "now (?<version>\d+\.\d+\.\d+)-" | Out-Null
         $Matches.version
@@ -27,7 +27,7 @@ function Get-ClangToolVersions {
         [string] $VersionPattern = "\d+\.\d+\.\d+)-"
     )
 
-    $result = Get-CommandResult "apt list --installed" -Multiline -ValidateExitCode
+    $result = Get-CommandResult "apt list --installed" -Multiline
     $toolVersions = $result.Output | Where-Object { $_ -match "^${ToolName}-\d+"} | ForEach-Object {
         $clangCommand = ($_ -Split "/")[0]
         Invoke-Expression "$clangCommand --version" | Where-Object { $_ -match "${ToolName} version" } | ForEach-Object {
@@ -57,7 +57,7 @@ function Get-ErlangVersion {
 }
 
 function Get-ErlangRebar3Version {
-    $result = Get-CommandResult "rebar3 --version" -ValidateExitCode
+    $result = Get-CommandResult "rebar3 --version"
     $result.Output -match "rebar (?<version>(\d+.){2}\d+)" | Out-Null
     $rebarVersion = $Matches.version
     return "Erlang rebar3 $rebarVersion"
@@ -92,13 +92,13 @@ function Get-PerlVersion {
 }
 
 function Get-PythonVersion {
-    $result = Get-CommandResult "python --version" -ValidateExitCode
+    $result = Get-CommandResult "python --version"
     $version = $result.Output | Take-OutputPart -Part 1
     return "Python $version"
 }
 
 function Get-Python3Version {
-    $result = Get-CommandResult "python3 --version" -ValidateExitCode
+    $result = Get-CommandResult "python3 --version"
     $version = $result.Output | Take-OutputPart -Part 1
     return "Python3 $version"
 }
@@ -133,21 +133,21 @@ function Get-LernaVersion {
 }
 
 function Get-HomebrewVersion {
-    $result = Get-CommandResult "brew -v" -ValidateExitCode
+    $result = Get-CommandResult "brew -v"
     $result.Output -match "Homebrew (?<version>\d+\.\d+\.\d+)" | Out-Null
     $version = $Matches.version
     return "Homebrew $version"
 }
 
 function Get-CpanVersion {
-    $result = Get-CommandResult "cpan --version" -ValidateExitCode -ExpectExitCode @(25, 255)
+    $result = Get-CommandResult "cpan --version" -ExpectExitCode @(25, 255)
     $result.Output -match "version (?<version>\d+\.\d+) " | Out-Null
     $cpanVersion = $Matches.version
     return "cpan $cpanVersion"
 }
 
 function Get-GemVersion {
-    $result = Get-CommandResult "gem --version" -ValidateExitCode
+    $result = Get-CommandResult "gem --version"
     $result.Output -match "(?<version>\d+\.\d+\.\d+)" | Out-Null
     $gemVersion = $Matches.version
     return "RubyGems $gemVersion"
@@ -180,21 +180,21 @@ function Get-ParcelVersion {
 }
 
 function Get-PipVersion {
-    $result = Get-CommandResult "pip --version" -ValidateExitCode
+    $result = Get-CommandResult "pip --version"
     $result.Output -match "pip (?<version>\d+\.\d+\.\d+)" | Out-Null
     $pipVersion = $Matches.version
     return "Pip $pipVersion"
 }
 
 function Get-Pip3Version {
-    $result = Get-CommandResult "pip3 --version" -ValidateExitCode
+    $result = Get-CommandResult "pip3 --version"
     $result.Output -match "pip (?<version>\d+\.\d+\.\d+)" | Out-Null
     $pipVersion = $Matches.version
     return "Pip3 $pipVersion"
 }
 
 function Get-VcpkgVersion {
-    $result = Get-CommandResult "vcpkg version" -ValidateExitCode
+    $result = Get-CommandResult "vcpkg version"
     $result.Output -match "version (?<version>\d+\.\d+\.\d+)" | Out-Null
     $vcpkgVersion = $Matches.version
     $commitId = git -C "/usr/local/share/vcpkg" rev-parse --short HEAD
@@ -221,14 +221,14 @@ function Get-MavenVersion {
 }
 
 function Get-SbtVersion {
-    $result = Get-CommandResult "sbt -version" -ValidateExitCode
+    $result = Get-CommandResult "sbt -version"
     $result.Output -match "sbt script version: (?<version>\d+\.\d+\.\d+)" | Out-Null
     $sbtVersion = $Matches.version
     return "Sbt $sbtVersion"
 }
 
 function Get-PHPVersions {
-    $result = Get-CommandResult "apt list --installed" -Multiline -ValidateExitCode
+    $result = Get-CommandResult "apt list --installed" -Multiline
     return $result.Output | Where-Object { $_ -match "^php\d+\.\d+/"} | ForEach-Object {
         $_ -match "now (?<version>\d+\.\d+\.\d+)-" | Out-Null
         $Matches.version
@@ -369,7 +369,7 @@ function Get-AptPackages {
 }
 
 function Get-PipxVersion {
-    $result = (Get-CommandResult "pipx --version" -ValidateExitCode).Output
+    $result = (Get-CommandResult "pipx --version").Output
     $result -match "(?<version>\d+\.\d+\.\d+\.?\d*)" | Out-Null
     $pipxVersion = $Matches.Version
     return "Pipx $pipxVersion"

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -140,7 +140,7 @@ function Get-HomebrewVersion {
 }
 
 function Get-CpanVersion {
-    $result = Get-CommandResult "cpan --version" -ValidateExitCode
+    $result = Get-CommandResult "cpan --version" -ValidateExitCode -ExpectExitCode @(25, 255)
     $result.Output -match "version (?<version>\d+\.\d+) " | Out-Null
     $cpanVersion = $Matches.version
     return "cpan $cpanVersion"

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -3,7 +3,9 @@ param (
     $OutputDirectory
 )
 
-$ErrorActionPreference = "Stop"
+$global:ErrorActionPreference = "Stop"
+$global:ErrorView = "NormalView"
+Set-StrictMode -Version Latest
 
 Import-Module MarkdownPS
 Import-Module (Join-Path $PSScriptRoot "SoftwareReport.Android.psm1") -DisableNameChecking
@@ -36,41 +38,41 @@ $markdown += New-MDHeader "Installed Software" -Level 2
 $markdown += New-MDHeader "Language and Runtime" -Level 3
 
 $runtimesList = @(
-        (Get-BashVersion),
-        (Get-CPPVersions),
-        (Get-FortranVersions),
-        (Get-ErlangVersion),
-        (Get-ErlangRebar3Version),
-        (Get-MonoVersion),
-        (Get-MsbuildVersion),
-        (Get-NodeVersion),
-        (Get-PerlVersion),
-        (Get-PythonVersion),
-        (Get-Python3Version),
-        (Get-RubyVersion),
-        (Get-SwiftVersion),
-        (Get-JuliaVersion),
-        (Get-KotlinVersion),
-        (Get-ClangVersions),
-        (Get-ClangFormatVersions)
-        )
+    (Get-BashVersion),
+    (Get-CPPVersions),
+    (Get-FortranVersions),
+    (Get-ErlangVersion),
+    (Get-ErlangRebar3Version),
+    (Get-MonoVersion),
+    (Get-MsbuildVersion),
+    (Get-NodeVersion),
+    (Get-PerlVersion),
+    (Get-PythonVersion),
+    (Get-Python3Version),
+    (Get-RubyVersion),
+    (Get-SwiftVersion),
+    (Get-JuliaVersion),
+    (Get-KotlinVersion),
+    (Get-ClangVersions),
+    (Get-ClangFormatVersions)
+)
 
 $markdown += New-MDList -Style Unordered -Lines ($runtimesList | Sort-Object)
 
 $markdown += New-MDHeader "Package Management" -Level 3
 
 $packageManagementList = @(
-        (Get-HomebrewVersion),
-        (Get-CpanVersion),
-        (Get-GemVersion),
-        (Get-MinicondaVersion),
-        (Get-HelmVersion),
-        (Get-NpmVersion),
-        (Get-YarnVersion),
-        (Get-PipxVersion),
-        (Get-PipVersion),
-        (Get-Pip3Version),
-        (Get-VcpkgVersion)
+    (Get-HomebrewVersion),
+    (Get-CpanVersion),
+    (Get-GemVersion),
+    (Get-MinicondaVersion),
+    (Get-HelmVersion),
+    (Get-NpmVersion),
+    (Get-YarnVersion),
+    (Get-PipxVersion),
+    (Get-PipVersion),
+    (Get-Pip3Version),
+    (Get-VcpkgVersion)
 )
 
 $markdown += New-MDList -Style Unordered -Lines ($packageManagementList | Sort-Object)
@@ -273,4 +275,5 @@ $markdown += New-MDNewLine
 $markdown += New-MDHeader "Installed apt packages" -Level 3
 $markdown += Get-AptPackages | New-MDTable
 
+Test-BlankElement
 $markdown | Out-File -FilePath "${OutputDirectory}/Ubuntu-Readme.md"

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -21,7 +21,7 @@ function Get-BazelVersion {
 }
 
 function Get-BazeliskVersion {
-    $result = Get-CommandResult "bazelisk version" -Multiline
+    $result = Get-CommandResult "bazelisk version" -Multiline -ValidateExitCode
     $bazeliskVersion = $result.Output | Select-String "Bazelisk version:" | Take-OutputPart -Part 2 | Take-OutputPart -Part 0 -Delimiter "v"
     return "Bazelisk $bazeliskVersion"
 }
@@ -89,14 +89,14 @@ function Get-DockerBuildxVersion {
 }
 
 function Get-GitVersion {
-    $result = Get-CommandResult "git --version"
+    $result = Get-CommandResult "git --version" -ValidateExitCode
     $gitVersion = $result.Output | Take-OutputPart -Part 2
     $aptSourceRepo = Get-AptSourceRepository -PackageName "git-core"
     return "Git $gitVersion (apt source repository: $aptSourceRepo)"
 }
 
 function Get-GitLFSVersion {
-    $result = Get-CommandResult "git-lfs --version"
+    $result = Get-CommandResult "git-lfs --version" -ValidateExitCode
     $gitlfsversion = $result.Output | Take-OutputPart -Part 0 | Take-OutputPart -Part 1 -Delimiter "/"
     $aptSourceRepo = Get-AptSourceRepository -PackageName "git-lfs"
     return "Git LFS $gitlfsversion (apt source repository: $aptSourceRepo)"
@@ -182,7 +182,7 @@ function Get-NvmVersion {
 
 function Get-PackerVersion {
     # Packer 1.7.1 has a bug and outputs version to stderr instead of stdout https://github.com/hashicorp/packer/issues/10855
-    $result = (Get-CommandResult -Command "packer --version").Output
+    $result = (Get-CommandResult -Command "packer --version" -ValidateExitCode).Output
     $packerVersion = [regex]::matches($result, "(\d+.){2}\d+").Value
     return "Packer $packerVersion"
 }
@@ -222,7 +222,7 @@ function Get-AWSCliVersion {
 }
 
 function Get-AWSCliSessionManagerPluginVersion {
-    $result = (Get-CommandResult "session-manager-plugin --version").Output
+    $result = (Get-CommandResult "session-manager-plugin --version" -ValidateExitCode).Output
     return "AWS CLI Session manager plugin $result"
 }
 
@@ -271,7 +271,7 @@ function Get-PulumiVersion {
 }
 
 function Get-RVersion {
-    $rVersion = (Get-CommandResult "R --version | grep 'R version'").Output |  Take-OutputPart -Part 2
+    $rVersion = (Get-CommandResult "R --version | grep 'R version'" -ValidateExitCode).Output |  Take-OutputPart -Part 2
     return "R $rVersion"
 }
 

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -21,7 +21,7 @@ function Get-BazelVersion {
 }
 
 function Get-BazeliskVersion {
-    $result = Get-CommandResult "bazelisk version" -Multiline -ValidateExitCode
+    $result = Get-CommandResult "bazelisk version" -Multiline
     $bazeliskVersion = $result.Output | Select-String "Bazelisk version:" | Take-OutputPart -Part 2 | Take-OutputPart -Part 0 -Delimiter "v"
     return "Bazelisk $bazeliskVersion"
 }
@@ -89,14 +89,14 @@ function Get-DockerBuildxVersion {
 }
 
 function Get-GitVersion {
-    $result = Get-CommandResult "git --version" -ValidateExitCode
+    $result = Get-CommandResult "git --version"
     $gitVersion = $result.Output | Take-OutputPart -Part 2
     $aptSourceRepo = Get-AptSourceRepository -PackageName "git-core"
     return "Git $gitVersion (apt source repository: $aptSourceRepo)"
 }
 
 function Get-GitLFSVersion {
-    $result = Get-CommandResult "git-lfs --version" -ValidateExitCode
+    $result = Get-CommandResult "git-lfs --version"
     $gitlfsversion = $result.Output | Take-OutputPart -Part 0 | Take-OutputPart -Part 1 -Delimiter "/"
     $aptSourceRepo = Get-AptSourceRepository -PackageName "git-lfs"
     return "Git LFS $gitlfsversion (apt source repository: $aptSourceRepo)"
@@ -182,7 +182,7 @@ function Get-NvmVersion {
 
 function Get-PackerVersion {
     # Packer 1.7.1 has a bug and outputs version to stderr instead of stdout https://github.com/hashicorp/packer/issues/10855
-    $result = (Get-CommandResult -Command "packer --version" -ValidateExitCode).Output
+    $result = (Get-CommandResult "packer --version").Output
     $packerVersion = [regex]::matches($result, "(\d+.){2}\d+").Value
     return "Packer $packerVersion"
 }
@@ -222,7 +222,7 @@ function Get-AWSCliVersion {
 }
 
 function Get-AWSCliSessionManagerPluginVersion {
-    $result = (Get-CommandResult "session-manager-plugin --version" -ValidateExitCode).Output
+    $result = (Get-CommandResult "session-manager-plugin --version").Output
     return "AWS CLI Session manager plugin $result"
 }
 
@@ -271,7 +271,7 @@ function Get-PulumiVersion {
 }
 
 function Get-RVersion {
-    $rVersion = (Get-CommandResult "R --version | grep 'R version'" -ValidateExitCode).Output |  Take-OutputPart -Part 2
+    $rVersion = (Get-CommandResult "R --version | grep 'R version'").Output |  Take-OutputPart -Part 2
     return "R $rVersion"
 }
 

--- a/images/linux/scripts/helpers/Common.Helpers.psm1
+++ b/images/linux/scripts/helpers/Common.Helpers.psm1
@@ -4,8 +4,9 @@ function Get-CommandResult {
         [string] $Command,
         [int[]] $ExpectExitCode = 0,
         [switch] $Multiline,
-        [switch] $ValidateExitCode
+        [bool] $ValidateExitCode = $true
     )
+
     # Bash trick to suppress and show error output because some commands write to stderr (for example, "python --version")
     $stdout = & bash -c "$Command 2>&1"
     $exitCode = $LASTEXITCODE

--- a/images/linux/scripts/helpers/Common.Helpers.psm1
+++ b/images/linux/scripts/helpers/Common.Helpers.psm1
@@ -2,7 +2,7 @@ function Get-CommandResult {
     param (
         [Parameter(Mandatory=$true)]
         [string] $Command,
-        [int] $ExpectExitCode = 0,
+        [int[]] $ExpectExitCode = 0,
         [switch] $Multiline,
         [switch] $ValidateExitCode
     )
@@ -11,7 +11,7 @@ function Get-CommandResult {
     $exitCode = $LASTEXITCODE
 
     if ($ValidateExitCode) {
-        if ($exitCode -ne $ExpectExitCode) {
+        if ($ExpectExitCode -notcontains $exitCode) {
             try {
                 throw "StdOut: '$stdout' ExitCode: '$exitCode'"
             } catch {

--- a/images/linux/scripts/helpers/Tests.Helpers.psm1
+++ b/images/linux/scripts/helpers/Tests.Helpers.psm1
@@ -44,7 +44,7 @@ function Invoke-PesterTests {
 
 function ShouldReturnZeroExitCode {
     Param(
-        [String] $ActualValue,
+        [string] $ActualValue,
         [switch] $Negate,
         [string] $Because # This parameter is unused but we need it to match Pester asserts signature
     )
@@ -69,8 +69,8 @@ function ShouldReturnZeroExitCode {
 
 function ShouldMatchCommandOutput {
     Param(
-        [String] $ActualValue,
-        [String] $RegularExpression,
+        [string] $ActualValue,
+        [string] $RegularExpression,
         [switch] $Negate
     )
 

--- a/images/linux/scripts/helpers/Tests.Helpers.psm1
+++ b/images/linux/scripts/helpers/Tests.Helpers.psm1
@@ -49,7 +49,7 @@ function ShouldReturnZeroExitCode {
         [string] $Because # This parameter is unused but we need it to match Pester asserts signature
     )
 
-    $result = Get-CommandResult $ActualValue
+    $result = Get-CommandResult $ActualValue -ValidateExitCode $false
 
     [bool]$succeeded = $result.ExitCode -eq 0
     if ($Negate) { $succeeded = -not $succeeded }
@@ -74,7 +74,7 @@ function ShouldMatchCommandOutput {
         [switch] $Negate
     )
 
-    $output = (Get-CommandResult $ActualValue).Output | Out-String
+    $output = (Get-CommandResult $ActualValue -ValidateExitCode $false).Output | Out-String
     [bool] $succeeded = $output -cmatch $RegularExpression
 
     if ($Negate) {

--- a/images/linux/scripts/tests/Databases.Tests.ps1
+++ b/images/linux/scripts/tests/Databases.Tests.ps1
@@ -11,7 +11,7 @@ Describe "MongoDB" {
 Describe "PostgreSQL" {
     It "PostgreSQL Service" {
         "sudo systemctl start postgresql" | Should -ReturnZeroExitCode
-        (Get-CommandResult "pg_isready").Output | Should -Be "/var/run/postgresql:5432 - accepting connections"
+        "pg_isready" | Should -MatchCommandOutput "/var/run/postgresql:5432 - accepting connections"
         "sudo systemctl stop postgresql" | Should -ReturnZeroExitCode
     }
 

--- a/images/linux/scripts/tests/Java.Tests.ps1
+++ b/images/linux/scripts/tests/Java.Tests.ps1
@@ -42,6 +42,6 @@ Describe "Java" {
         if ($Version -eq 8) {
             $Version = "1.${Version}"
         }
-        $result.Output | Should -Match ([regex]::Escape("openjdk version `"${Version}."))
+        "`"$javaPath`" -version" | Should -MatchCommandOutput ([regex]::Escape("openjdk version `"${Version}."))
     }
 }

--- a/images/linux/scripts/tests/Java.Tests.ps1
+++ b/images/linux/scripts/tests/Java.Tests.ps1
@@ -29,8 +29,7 @@ Describe "Java" {
         $gradleVariableValue | Should -BeLike "/usr/share/gradle-*"
 
         $gradlePath = Join-Path $env:GRADLE_HOME "bin/gradle"
-        $result = Get-CommandResult "`"$GradlePath`" -version"
-        $result.ExitCode | Should -Be 0
+        "`"$GradlePath`" -version" | Should -ReturnZeroExitCode
     }
 
     It "Java <Version>" -TestCases $jdkVersions {
@@ -38,8 +37,7 @@ Describe "Java" {
         $javaVariableValue | Should -Not -BeNullOrEmpty
         $javaPath = Join-Path $javaVariableValue "bin/java"
 
-        $result = Get-CommandResult "`"$javaPath`" -version"
-        $result.ExitCode | Should -Be 0
+        "`"$javaPath`" -version" | Should -ReturnZeroExitCode
 
         if ($Version -eq 8) {
             $Version = "1.${Version}"


### PR DESCRIPTION
# Description
Provide more verbosity during software report generation:
- Add ValidateExitCode parameter(expect exit code is 0)
- NormalView: Consists of a description of the error and the name of the object involved in the error.
- Enable strict mode, PowerShell generates a terminating error when the content of an expression, script, or script block violates basic best-practice coding rules.
- Validate software with blank versions
- Validate blank rows in table

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3132

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
