### PR TITLE
[Windows] Add Service Fabric SDK to windows 2022

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -110,6 +110,7 @@ $toolsList = @(
     (Get-PackerVersion),
     (Get-PulumiVersion),
     (Get-RVersion),
+    (Get-ServiceFabricSDKVersion),
     (Get-StackVersion),
     (Get-SVNVersion),
     (Get-VSWhereVersion),
@@ -122,8 +123,7 @@ $toolsList = @(
 if ((Test-IsWin16) -or (Test-IsWin19)) {
     $toolsList += @(
         (Get-GoogleCloudSDKVersion),
-        (Get-ParcelVersion),
-        (Get-ServiceFabricSDKVersion)
+        (Get-ParcelVersion)
     )
 }
 $markdown += New-MDList -Style Unordered -Lines ($toolsList | Sort-Object)

--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -130,7 +130,7 @@ Describe "Sbt" {
     }
 }
 
-Describe "ServiceFabricSDK" -Skip:(Test-IsWin22) {
+Describe "ServiceFabricSDK" {
     It "PowerShell Module" {
         Get-Module -Name ServiceFabric -ListAvailable | Should -Not -BeNullOrEmpty
     }
@@ -176,7 +176,7 @@ Describe "VCRedist" -Skip:(Test-IsWin22) {
     }
 }
 
-Describe "WebPlatformInstaller" -Skip:(Test-IsWin22) {
+Describe "WebPlatformInstaller" {
     It "WebPlatformInstaller" {
         "WebPICMD" | Should -ReturnZeroExitCode
     }

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -147,7 +147,8 @@
             "type": "powershell",
             "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-Docker.ps1",
-                "{{ template_dir }}/scripts/Installers/Install-PowershellCore.ps1"
+                "{{ template_dir }}/scripts/Installers/Install-PowershellCore.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-WebPlatformInstaller.ps1"
             ]
         },
         {
@@ -179,6 +180,13 @@
                 "{{ template_dir }}/scripts/Installers/Install-JavaTools.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Kotlin.ps1"
             ]
+        },
+        {
+            "type": "powershell",
+            "scripts": [
+                "{{ template_dir }}/scripts/Installers/Install-ServiceFabricSDK.ps1"
+            ],
+            "execution_policy": "remotesigned"
         },
         {
             "type": "windows-restart",


### PR DESCRIPTION
# Description
It turned out that Service Fabric SDK is available for windows-2022, just not mentioned in the official docs yet. This PR adds SF SDK installation and also Web Platform Installer installation as WPI is a recommended way to install SF SDK.

#### Related issue:
https://github.com/actions/virtual-environments/issues/4546

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
