### PR TITLE
[Ubuntu] restart snapd during images generation

### DIFF
--- a/images/linux/scripts/base/snap.sh
+++ b/images/linux/scripts/base/snap.sh
@@ -5,4 +5,10 @@
 # when they are rolling a new major update out.
 # Hold is calculated as today's date + 60 days
 
+# snapd is started automatically, but during image generation
+# a unix socket may die, restart snapd.service (and therefore snapd.socket)
+# to make sure the socket is alive.
+
+systemctl restart snapd.socket
+systemctl restart snapd
 snap set system refresh.hold="$(date --date='today+60 days' +%Y-%m-%dT%H:%M:%S%:z)"


### PR DESCRIPTION
# Description

We change snapd settings during the images generation process but there is no guarantee that snapd daemon (and its unix socket) is alive by the time the `snapd.sh` script is being run as we do not manage the snapd systemd unit explicitly (it is provided by the azure images themselves). Prior snapd restart must do the trick and bring the daemon/unix socket back before changes are made.

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/3161

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
