### PR TITLE
[macOS] Downgrade RubyGems version to 3.2.33

### DIFF
--- a/images/macos/provision/core/rubygem.sh
+++ b/images/macos/provision/core/rubygem.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
 
+# Temporarily downgrade RubyGems version to 3.2.33 due to issue with RubyGems 3.3.3 (https://github.com/actions/virtual-environments-internal/issues/3162)
 echo Updating RubyGems...
-gem update --system
+gem update --system 3.2.33
 
 gemsToInstall=$(get_toolset_value '.ruby.rubygems | .[]')
 if [ -n "$gemsToInstall" ]; then


### PR DESCRIPTION
# Description
The root cause of issues with `cocoapods` in software report is the updated version (`3.3.3`) of `RubyGems`. We need to downgrade it to `3.2.33` version until the issue is resolved.

#### Related issue: [#3162](https://github.com/actions/virtual-environments-internal/issues/3162)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
