### PR TITLE
Add install of dotnet tools

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -331,6 +331,22 @@ function Get-DotNetCoreSdkVersions {
     return $dotNetCoreSdkVersion
 }
 
+function Get-DotnetTools {
+
+    $dotnetToolset = (Get-ToolsetContent).dotnet
+    $dotnetTools = $dotnetToolset.tools
+
+    $toolsList = @()
+
+    ForEach ($dotnetTool in $dotnetTools)
+    {
+        (dotnet tool update -g $dotnetTool | Out-String) -match "was reinstalled with the latest stable version \(version \'(?<version>\d+\.\d+\.\d+)" | Out-Null
+        $toolsList += [PSCustomObject]@{
+            ToolInfo = "$dotnetTool v" + $Matches.Version
+        }
+    }
+}
+
 function Get-CachedDockerImages {
     $toolsetJson = Get-ToolsetContent
     $images = $toolsetJson.docker.images

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -333,7 +333,6 @@ function Get-DotNetCoreSdkVersions {
 
 function Get-DotnetTools {
     $dotnetTools = (Get-ToolsetContent).dotnet.tools
-    $dotnetTools = $dotnetToolset.tools
 
     $toolsList = @()
 

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -332,15 +332,13 @@ function Get-DotNetCoreSdkVersions {
 }
 
 function Get-DotnetTools {
-    $dotnetToolset = (Get-ToolsetContent).dotnet
+    $dotnetTools = (Get-ToolsetContent).dotnet.tools
     $dotnetTools = $dotnetToolset.tools
 
     $toolsList = @()
 
     ForEach ($dotnetTool in $dotnetTools) {
-        foreach  ($dotnetTool in $dotnetTools) {
-            $toolsList += $dotnetTool.name + " " + (Invoke-Expression $dotnetTool.getversion)
-        }
+        $toolsList += $dotnetTool.name + " " + (Invoke-Expression $dotnetTool.getversion)
     }
 
     return $toolsList

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -337,11 +337,10 @@ function Get-DotnetTools {
 
     $toolsList = @()
 
-    ForEach ($dotnetTool in $dotnetTools)
-    {
-        (dotnet tool update -g $dotnetTool | Out-String) -match "was reinstalled with the latest stable version \(version \'(?<version>\d+\.\d+\.\d+)" | Out-Null
+    ForEach ($dotnetTool in $dotnetTools) {
+        $version = $dotnetTool.getversion
         $toolsList += [PSCustomObject]@{
-            ToolInfo = "$dotnetTool v" + $Matches.Version
+            ToolInfo = "$dotnetTool.name v" + $version
         }
     }
 }

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -338,9 +338,8 @@ function Get-DotnetTools {
     $toolsList = @()
 
     ForEach ($dotnetTool in $dotnetTools) {
-        $version = ($dotnetTool.getversion)
-        $toolsList += [PSCustomObject]@{
-            ToolInfo = $dotnetTool.name + " v" + $version
+        foreach  ($dotnetTool in $dotnetTools) {
+            $toolsList += $dotnetTool.name + " " + (Invoke-Expression $dotnetTool.getversion)
         }
     }
 

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -332,7 +332,6 @@ function Get-DotNetCoreSdkVersions {
 }
 
 function Get-DotnetTools {
-
     $dotnetToolset = (Get-ToolsetContent).dotnet
     $dotnetTools = $dotnetToolset.tools
 

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -338,7 +338,7 @@ function Get-DotnetTools {
     $toolsList = @()
 
     ForEach ($dotnetTool in $dotnetTools) {
-        $version = $dotnetTool.getversion
+        $version = Invoke-Expression $dotnetTool.getversion
         $toolsList += [PSCustomObject]@{
             ToolInfo = $dotnetTool.name + " v" + $version
         }

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -332,6 +332,8 @@ function Get-DotNetCoreSdkVersions {
 }
 
 function Get-DotnetTools {
+    $env:PATH = "/etc/skel/.dotnet/tools:$($env:PATH)"
+
     $dotnetTools = (Get-ToolsetContent).dotnet.tools
 
     $toolsList = @()

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -340,9 +340,11 @@ function Get-DotnetTools {
     ForEach ($dotnetTool in $dotnetTools) {
         $version = $dotnetTool.getversion
         $toolsList += [PSCustomObject]@{
-            ToolInfo = "$dotnetTool.name v" + $version
+            ToolInfo = $dotnetTool.name + " v" + $version
         }
     }
+
+    return $toolsList
 }
 
 function Get-CachedDockerImages {

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -338,7 +338,7 @@ function Get-DotnetTools {
     $toolsList = @()
 
     ForEach ($dotnetTool in $dotnetTools) {
-        $version = Invoke-Expression $dotnetTool.getversion
+        $version = ($dotnetTool.getversion)
         $toolsList += [PSCustomObject]@{
             ToolInfo = $dotnetTool.name + " v" + $version
         }

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -232,7 +232,6 @@ $markdown += New-MDList -Style Unordered -Lines @(
 
 $markdown += New-MDHeader ".NET tools" -Level 3
 $tools = Get-DotnetTools
-$markdown += New-MDNewLine
 $markdown += New-MDList -Lines $tools -Style Unordered
 
 $markdown += New-MDHeader "Databases" -Level 3

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -233,7 +233,7 @@ $markdown += New-MDList -Style Unordered -Lines @(
 $markdown += New-MDHeader ".NET tools" -Level 3
 $tools = Get-DotnetTools
 $markdown += New-MDNewLine
-$markdown += New-MDList -Lines $tools.ToolInfo -Style Unordered
+$markdown += New-MDList -Lines $tools -Style Unordered
 
 $markdown += New-MDHeader "Databases" -Level 3
 $markdown += New-MDList -Style Unordered -Lines (@(

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -230,6 +230,11 @@ $markdown += New-MDList -Style Unordered -Lines @(
     (Get-DotNetCoreSdkVersions)
 )
 
+$markdown += New-MDHeader ".NET tools" -Level 3
+$tools = Get-DotnetTools
+$markdown += New-MDNewLine
+$markdown += New-MDList -Lines $tools.ToolInfo -Style Unordered
+
 $markdown += New-MDHeader "Databases" -Level 3
 $markdown += New-MDList -Style Unordered -Lines (@(
     (Get-PostgreSqlVersion),

--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -11,7 +11,7 @@ source $HELPER_SCRIPTS/os.sh
 # Ubuntu 20 doesn't support EOL versions
 LATEST_DOTNET_PACKAGES=$(get_toolset_value '.dotnet.aptPackages[]')
 DOTNET_VERSIONS=$(get_toolset_value '.dotnet.versions[]')
-DOTNET_TOOLS=$(get_toolset_value '.dotnet.tools[]')
+DOTNET_TOOLS=$(get_toolset_value '.dotnet.tools["name"]')
 
 # Disable telemetry
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
@@ -70,8 +70,8 @@ prependEtcEnvironmentPath '$HOME/.dotnet/tools'
 
 # install dotnet tools
 for dotnet_tool in ${DOTNET_TOOLS[@]}; do
-    echo "Installing dotnet tool ($dotnet_tool)"
-    dotnet tool install -g ${dotnet_tool}.name
+    echo "Installing dotnet tool $dotnet_tool"
+    dotnet tool install -g $dotnet_tool
 done
 
 invoke_tests "DotnetSDK"

--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -71,7 +71,7 @@ prependEtcEnvironmentPath '$HOME/.dotnet/tools'
 # install dotnet tools
 for dotnet_tool in ${DOTNET_TOOLS[@]}; do
     echo "Installing dotnet tool ($dotnet_tool)"
-    dotnet tool install -g ${dotnetTool}.name
+    dotnet tool install -g ${dotnet_tool}.name
 done
 
 invoke_tests "DotnetSDK"

--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -71,7 +71,7 @@ prependEtcEnvironmentPath '$HOME/.dotnet/tools'
 # install dotnet tools
 for dotnet_tool in ${DOTNET_TOOLS[@]}; do
     echo "Installing dotnet tool $dotnet_tool"
-    dotnet tool install -g $dotnet_tool
+    dotnet tool install $dotnet_tool --tool-path '/etc/skel/.donet/tools'
 done
 
 invoke_tests "DotnetSDK"

--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -71,7 +71,7 @@ prependEtcEnvironmentPath '$HOME/.dotnet/tools'
 # install dotnet tools
 for dotnet_tool in ${DOTNET_TOOLS[@]}; do
     echo "Installing dotnet tool $dotnet_tool"
-    dotnet tool install $dotnet_tool --tool-path '/etc/skel/.donet/tools'
+    dotnet tool install $dotnet_tool --tool-path '/etc/skel/.dotnet/tools'
 done
 
 invoke_tests "DotnetSDK"

--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -71,7 +71,7 @@ prependEtcEnvironmentPath '$HOME/.dotnet/tools'
 # install dotnet tools
 for dotnet_tool in ${DOTNET_TOOLS[@]}; do
     echo "Installing dotnet tool ($dotnet_tool)"
-    dotnet tool install -g $dotnetTool
+    dotnet tool install -g ${dotnetTool}.name
 done
 
 invoke_tests "DotnetSDK"

--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -11,6 +11,7 @@ source $HELPER_SCRIPTS/os.sh
 # Ubuntu 20 doesn't support EOL versions
 LATEST_DOTNET_PACKAGES=$(get_toolset_value '.dotnet.aptPackages[]')
 DOTNET_VERSIONS=$(get_toolset_value '.dotnet.versions[]')
+DOTNET_TOOLS=$(get_toolset_value '.dotnet.tools[]')
 
 # Disable telemetry
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
@@ -66,5 +67,11 @@ setEtcEnvironmentVariable DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1
 setEtcEnvironmentVariable DOTNET_NOLOGO 1
 setEtcEnvironmentVariable DOTNET_MULTILEVEL_LOOKUP 0
 prependEtcEnvironmentPath '$HOME/.dotnet/tools'
+
+# install dotnet tools
+for dotnet_tool in ${DOTNET_TOOLS[@]}; do
+    echo "Installing dotnet tool ($dotnet_tool)"
+    dotnet tool install -g $dotnetTool
+done
 
 invoke_tests "DotnetSDK"

--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -11,7 +11,7 @@ source $HELPER_SCRIPTS/os.sh
 # Ubuntu 20 doesn't support EOL versions
 LATEST_DOTNET_PACKAGES=$(get_toolset_value '.dotnet.aptPackages[]')
 DOTNET_VERSIONS=$(get_toolset_value '.dotnet.versions[]')
-DOTNET_TOOLS=$(get_toolset_value '.dotnet.tools["name"]')
+DOTNET_TOOLS=$(get_toolset_value '.dotnet.tools[].name')
 
 # Disable telemetry
 export DOTNET_CLI_TELEMETRY_OPTOUT=1

--- a/images/linux/scripts/tests/DotnetSDK.Tests.ps1
+++ b/images/linux/scripts/tests/DotnetSDK.Tests.ps1
@@ -31,10 +31,9 @@ Describe "Dotnet and tools" {
 
     $dotnetTools = (Get-ToolsetContent).dotnet.tools
     foreach ($dotnetTool in $dotnetTools) {
-        Context "Dotnet tool $dotnetTool" {
-            It "dotnet tool '$dotnetTool' is available" {
-                
-                $dotnetTool
+        Context "Dotnet tool $dotnetTool.name" {
+            It "dotnet tool '$dotnetTool.name' is available" {
+                $dotnetTool.test | Should -Not -BeNullOrEmpty
             }
         }
     }

--- a/images/linux/scripts/tests/DotnetSDK.Tests.ps1
+++ b/images/linux/scripts/tests/DotnetSDK.Tests.ps1
@@ -33,8 +33,7 @@ Describe "Dotnet and tools" {
     foreach ($dotnetTool in $dotnetTools) {
         Context "Dotnet tool $($dotnetTool.name)" {
             It "dotnet tool $($dotnetTool.name) is available" {
-                $testResult = ($dotnetTool.test)
-                $testResult | Should -Not -BeNullOrEmpty
+                $dotnetTool.test | Should -ReturnZeroExitCode
             }
         }
     }

--- a/images/linux/scripts/tests/DotnetSDK.Tests.ps1
+++ b/images/linux/scripts/tests/DotnetSDK.Tests.ps1
@@ -33,7 +33,7 @@ Describe "Dotnet and tools" {
     foreach ($dotnetTool in $dotnetTools) {
         Context "Dotnet tool $($dotnetTool.name)" {
             It "dotnet tool $($dotnetTool.name) is available" {
-                $dotnetTool.test | Should -Not -BeNullOrEmpty
+                Invoke-Expression $dotnetTool.test | Should -Not -BeNullOrEmpty
             }
         }
     }

--- a/images/linux/scripts/tests/DotnetSDK.Tests.ps1
+++ b/images/linux/scripts/tests/DotnetSDK.Tests.ps1
@@ -31,8 +31,8 @@ Describe "Dotnet and tools" {
 
     $dotnetTools = (Get-ToolsetContent).dotnet.tools
     foreach ($dotnetTool in $dotnetTools) {
-        Context "Dotnet tool " + $dotnetTool.name {
-            It "dotnet tool " + $dotnetTool.name + " is available" {
+        Context "Dotnet tool $($dotnetTool.name)" {
+            It "dotnet tool $($dotnetTool.name) is available" {
                 $dotnetTool.test | Should -Not -BeNullOrEmpty
             }
         }

--- a/images/linux/scripts/tests/DotnetSDK.Tests.ps1
+++ b/images/linux/scripts/tests/DotnetSDK.Tests.ps1
@@ -29,12 +29,13 @@ Describe "Dotnet and tools" {
         }
     }
 
-    $dotnetTools = (Get-ToolsetContent).dotnet.tools
-    foreach ($dotnetTool in $dotnetTools) {
-        Context "Dotnet tool $($dotnetTool.name)" {
-            It "dotnet tool $($dotnetTool.name) is available" {
-                $dotnetTool.test | Should -ReturnZeroExitCode
-            }
+    Context "Dotnet tools" {
+        $dotnetTools = (Get-ToolsetContent).dotnet.tools
+        $testCases = $dotnetTools | ForEach-Object { @{ ToolName = $_.name; TestInstance = $_.test }}
+
+        It "<ToolName> is available" -TestCases $testCases {
+            "$TestInstance" | Should -ReturnZeroExitCode
         }
     }
+
 }

--- a/images/linux/scripts/tests/DotnetSDK.Tests.ps1
+++ b/images/linux/scripts/tests/DotnetSDK.Tests.ps1
@@ -1,6 +1,6 @@
 Import-Module "$PSScriptRoot/../helpers/Common.Helpers.psm1"
 
-Describe "Dotnet" {
+Describe "Dotnet and tools" {
 
     BeforeAll {
         $dotnetSDKs = dotnet --list-sdks | ConvertTo-Json
@@ -25,6 +25,17 @@ Describe "Dotnet" {
 
             It "Runtime $version is available" -TestCases $dotnet {
                 $dotnetRuntimes | Should -Match "$dotnetVersion.[1-9]*"
+            }
+        }
+    }
+
+    $dotnetTools = (Get-ToolsetContent).dotnet.tools
+
+    foreach ($dotnetTool in $dotnetTools) {
+        Context "Dotnet tool $dotnetTool" {
+            It "dotnet tool '$dotnetTool' is available" {
+                
+                $dotnetTool
             }
         }
     }

--- a/images/linux/scripts/tests/DotnetSDK.Tests.ps1
+++ b/images/linux/scripts/tests/DotnetSDK.Tests.ps1
@@ -30,7 +30,6 @@ Describe "Dotnet and tools" {
     }
 
     $dotnetTools = (Get-ToolsetContent).dotnet.tools
-
     foreach ($dotnetTool in $dotnetTools) {
         Context "Dotnet tool $dotnetTool" {
             It "dotnet tool '$dotnetTool' is available" {

--- a/images/linux/scripts/tests/DotnetSDK.Tests.ps1
+++ b/images/linux/scripts/tests/DotnetSDK.Tests.ps1
@@ -33,7 +33,8 @@ Describe "Dotnet and tools" {
     foreach ($dotnetTool in $dotnetTools) {
         Context "Dotnet tool $($dotnetTool.name)" {
             It "dotnet tool $($dotnetTool.name) is available" {
-                Invoke-Expression $dotnetTool.test | Should -Not -BeNullOrEmpty
+                $testResult = ($dotnetTool.test)
+                $testResult | Should -Not -BeNullOrEmpty
             }
         }
     }

--- a/images/linux/scripts/tests/DotnetSDK.Tests.ps1
+++ b/images/linux/scripts/tests/DotnetSDK.Tests.ps1
@@ -31,8 +31,8 @@ Describe "Dotnet and tools" {
 
     $dotnetTools = (Get-ToolsetContent).dotnet.tools
     foreach ($dotnetTool in $dotnetTools) {
-        Context "Dotnet tool $dotnetTool.name" {
-            It "dotnet tool '$dotnetTool.name' is available" {
+        Context "Dotnet tool " + $dotnetTool.name {
+            It "dotnet tool " + $dotnetTool.name + " is available" {
                 $dotnetTool.test | Should -Not -BeNullOrEmpty
             }
         }

--- a/images/linux/scripts/tests/DotnetSDK.Tests.ps1
+++ b/images/linux/scripts/tests/DotnetSDK.Tests.ps1
@@ -3,6 +3,7 @@ Import-Module "$PSScriptRoot/../helpers/Common.Helpers.psm1"
 Describe "Dotnet and tools" {
 
     BeforeAll {
+        $env:PATH = "/etc/skel/.dotnet/tools:$($env:PATH)"
         $dotnetSDKs = dotnet --list-sdks | ConvertTo-Json
         $dotnetRuntimes = dotnet --list-runtimes | ConvertTo-Json
     }

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -254,6 +254,9 @@
             "2.1",
             "3.1",
             "5.0"
+        ],
+        "tools": [
+            { "name": "nbgv", "test": "nbgv --version", "getversion" : "nbgv --version" }
         ]
     },
     "clang": {

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -254,6 +254,9 @@
             "2.1",
             "3.1",
             "5.0"
+        ],
+        "tools": [
+            { "name": "nbgv", "test": "nbgv --version", "getversion" : "nbgv --version" }
         ]
     },
     "clang": {

--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -114,7 +114,9 @@ function InstallTools()
 
     ForEach ($dotnetTool in $dotnetTools)
     {
-        dotnet tool install -g $dotnetTool.name --add-source https://api.nuget.org/v3/index.json | Out-Null
+        Write-Host "Installing dotnet tool '$($dotnetTool.name)'"
+
+        dotnet tool install -g $($dotnetTool.name) --add-source https://api.nuget.org/v3/index.json
     }
 }
 

--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -115,7 +115,7 @@ function InstallTools()
 
     ForEach ($dotnetTool in $dotnetTools)
     {
-        dotnet tool install -g $dotnetTool | Out-Null
+        dotnet tool install -g $dotnetTool.name | Out-Null
     }
 }
 

--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -108,6 +108,17 @@ function InstallAllValidSdks()
     }
 }
 
+function InstallTools()
+{
+    $dotnetToolset = (Get-ToolsetContent).dotnet
+    $dotnetTools = $dotnetToolset.tools
+
+    ForEach ($dotnetTool in $dotnetTools)
+    {
+        dotnet tool install -g $dotnetTool | Out-Null
+    }
+}
+
 function RunPostInstallationSteps()
 {
     # Add dotnet to PATH
@@ -128,6 +139,7 @@ function RunPostInstallationSteps()
 }
 
 InstallAllValidSdks
+InstallTools
 RunPostInstallationSteps
 
 Invoke-PesterTests -TestFile "DotnetSDK"

--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -110,8 +110,7 @@ function InstallAllValidSdks()
 
 function InstallTools()
 {
-    $dotnetToolset = (Get-ToolsetContent).dotnet
-    $dotnetTools = $dotnetToolset.tools
+    $dotnetTools = (Get-ToolsetContent).dotnet.tools
 
     ForEach ($dotnetTool in $dotnetTools)
     {
@@ -139,7 +138,7 @@ function RunPostInstallationSteps()
 }
 
 InstallAllValidSdks
-InstallTools
 RunPostInstallationSteps
+InstallTools
 
 Invoke-PesterTests -TestFile "DotnetSDK"

--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -115,7 +115,7 @@ function InstallTools()
 
     ForEach ($dotnetTool in $dotnetTools)
     {
-        dotnet tool install -g $dotnetTool.name
+        dotnet tool install -g $dotnetTool.name --add-source https://api.nuget.org/v3/index.json | Out-Null
     }
 }
 

--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -115,7 +115,7 @@ function InstallTools()
 
     ForEach ($dotnetTool in $dotnetTools)
     {
-        dotnet tool install -g $dotnetTool.name | Out-Null
+        dotnet tool install -g $dotnetTool.name
     }
 }
 

--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -114,9 +114,7 @@ function InstallTools()
 
     ForEach ($dotnetTool in $dotnetTools)
     {
-        Write-Host "Installing dotnet tool '$($dotnetTool.name)'"
-
-        dotnet tool install $($dotnetTool.name) --tool-path "C:\Users\Default.dotnet\tools" --add-source https://api.nuget.org/v3/index.json
+        dotnet tool install $($dotnetTool.name) --tool-path "C:\Users\Default.dotnet\tools" --add-source https://api.nuget.org/v3/index.json | Out-Null
     }
 }
 

--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -116,7 +116,7 @@ function InstallTools()
     {
         Write-Host "Installing dotnet tool '$($dotnetTool.name)'"
 
-        dotnet tool install -g $($dotnetTool.name) --add-source https://api.nuget.org/v3/index.json
+        dotnet tool install $($dotnetTool.name) --tool-path "C:\Users\Default.dotnet\tools" --add-source https://api.nuget.org/v3/index.json
     }
 }
 

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -200,6 +200,22 @@ function Get-DotnetSdks {
     }
 }
 
+function Get-DotnetTools {
+
+    $dotnetToolset = (Get-ToolsetContent).dotnet
+    $dotnetTools = $dotnetToolset.tools
+
+    $toolsList = @()
+
+    ForEach ($dotnetTool in $dotnetTools)
+    {
+        (dotnet tool update -g $dotnetTool | Out-String) -match "was reinstalled with the latest stable version \(version \'(?<version>\d+\.\d+\.\d+)" | Out-Null
+        $toolsList += [PSCustomObject]@{
+            ToolInfo = "$dotnetTool v" + $Matches.Version
+        }
+    }
+}
+
 function Get-DotnetRuntimes {
     $runtimesRawList = dotnet --list-runtimes
     $runtimesRawList | Group-Object {$_.Split()[0]} | ForEach-Object {

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -207,7 +207,7 @@ function Get-DotnetTools {
     $toolsList = @()
 
     ForEach ($dotnetTool in $dotnetTools) {
-        $version = Invoke-Expression $dotnetTool.getversion
+        $version = ($dotnetTool.getversion)
         $toolsList += [PSCustomObject]@{
             ToolInfo = $dotnetTool.name + " v" + $version
         }

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -207,10 +207,10 @@ function Get-DotnetTools {
 
     $toolsList = @()
 
-    ForEach ($dotnetTool in $dotnetTools){
-        (dotnet tool update -g $dotnetTool | Out-String) -match "was reinstalled with the latest stable version \(version \'(?<version>\d+\.\d+\.\d+)" | Out-Null
+    ForEach ($dotnetTool in $dotnetTools) {
+        $version = $dotnetTool.getversion
         $toolsList += [PSCustomObject]@{
-            ToolInfo = "$dotnetTool v" + $Matches.Version
+            ToolInfo = "$dotnetTool.name v" + $version
         }
     }
 }

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -207,8 +207,7 @@ function Get-DotnetTools {
 
     $toolsList = @()
 
-    ForEach ($dotnetTool in $dotnetTools)
-    {
+    ForEach ($dotnetTool in $dotnetTools){
         (dotnet tool update -g $dotnetTool | Out-String) -match "was reinstalled with the latest stable version \(version \'(?<version>\d+\.\d+\.\d+)" | Out-Null
         $toolsList += [PSCustomObject]@{
             ToolInfo = "$dotnetTool v" + $Matches.Version

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -201,7 +201,6 @@ function Get-DotnetSdks {
 }
 
 function Get-DotnetTools {
-
     $dotnetToolset = (Get-ToolsetContent).dotnet
     $dotnetTools = $dotnetToolset.tools
 

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -207,9 +207,8 @@ function Get-DotnetTools {
     $toolsList = @()
 
     ForEach ($dotnetTool in $dotnetTools) {
-        $version = ($dotnetTool.getversion)
-        $toolsList += [PSCustomObject]@{
-            ToolInfo = $dotnetTool.name + " v" + $version
+        foreach  ($dotnetTool in $dotnetTools) {
+            $toolsList += $dotnetTool.name + " " + (Invoke-Expression $dotnetTool.getversion)
         }
     }
     return $toolsList

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -201,6 +201,7 @@ function Get-DotnetSdks {
 }
 
 function Get-DotnetTools {
+    $env:Path += ";C:\Users\Default.dotnet\tools"
     $dotnetTools = (Get-ToolsetContent).dotnet.tools
 
     $toolsList = @()

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -201,15 +201,12 @@ function Get-DotnetSdks {
 }
 
 function Get-DotnetTools {
-    $dotnetToolset = (Get-ToolsetContent).dotnet
-    $dotnetTools = $dotnetToolset.tools
+    $dotnetTools = (Get-ToolsetContent).dotnet.tools
 
     $toolsList = @()
 
-    ForEach ($dotnetTool in $dotnetTools) {
-        foreach  ($dotnetTool in $dotnetTools) {
-            $toolsList += $dotnetTool.name + " " + (Invoke-Expression $dotnetTool.getversion)
-        }
+    foreach  ($dotnetTool in $dotnetTools) {
+        $toolsList += $dotnetTool.name + " " + (Invoke-Expression $dotnetTool.getversion)
     }
     return $toolsList
 }

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -208,7 +208,7 @@ function Get-DotnetTools {
     $toolsList = @()
 
     ForEach ($dotnetTool in $dotnetTools) {
-        $version = $dotnetTool.getversion
+        $version = Invoke-Expression $dotnetTool.getversion
         $toolsList += [PSCustomObject]@{
             ToolInfo = $dotnetTool.name + " v" + $version
         }

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -210,9 +210,10 @@ function Get-DotnetTools {
     ForEach ($dotnetTool in $dotnetTools) {
         $version = $dotnetTool.getversion
         $toolsList += [PSCustomObject]@{
-            ToolInfo = "$dotnetTool.name v" + $version
+            ToolInfo = $dotnetTool.name + " v" + $version
         }
     }
+    return $toolsList
 }
 
 function Get-DotnetRuntimes {

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -264,7 +264,7 @@ $markdown += New-MDList -Lines $frameworks.Versions -Style Unordered
 $markdown += New-MDHeader ".NET tools" -Level 3
 $tools = Get-DotnetTools
 $markdown += New-MDNewLine
-$markdown += New-MDList -Lines $tools.ToolInfo -Style Unordered
+$markdown += New-MDList -Lines $tools -Style Unordered
 
 # PowerShell Tools
 $markdown += New-MDHeader "PowerShell Tools" -Level 3

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -263,7 +263,6 @@ $markdown += New-MDList -Lines $frameworks.Versions -Style Unordered
 
 $markdown += New-MDHeader ".NET tools" -Level 3
 $tools = Get-DotnetTools
-$markdown += New-MDNewLine
 $markdown += New-MDList -Lines $tools -Style Unordered
 
 # PowerShell Tools

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -261,6 +261,11 @@ $markdown += "``Location $($frameworks.Path)``"
 $markdown += New-MDNewLine
 $markdown += New-MDList -Lines $frameworks.Versions -Style Unordered
 
+$markdown += New-MDHeader ".NET tools" -Level 3
+$tools = Get-DotnetTools
+$markdown += New-MDNewLine
+$markdown += New-MDList -Lines $tools.ToolInfo -Style Unordered
+
 # PowerShell Tools
 $markdown += New-MDHeader "PowerShell Tools" -Level 3
 $markdown += New-MDList -Lines (Get-PowershellCoreVersion) -Style Unordered

--- a/images/win/scripts/Tests/DotnetSDK.Tests.ps1
+++ b/images/win/scripts/Tests/DotnetSDK.Tests.ps1
@@ -24,7 +24,6 @@ Describe "Dotnet SDK and tools" {
     }
 
     Context "Dotnet tools" {
-        $dotnetTools = (Get-ToolsetContent).dotnet.tools
         $env:Path += ";C:\Users\Default.dotnet\tools"
         $testCases = $dotnetTools | ForEach-Object { @{ ToolName = $_.name; TestInstance = $_.test }}
 

--- a/images/win/scripts/Tests/DotnetSDK.Tests.ps1
+++ b/images/win/scripts/Tests/DotnetSDK.Tests.ps1
@@ -26,7 +26,7 @@ Describe "Dotnet SDK and tools" {
     foreach ($dotnetTool in $dotnetTools) {
         Context "Dotnet tool $($dotnetTool.name)" {
             It "dotnet tool $($dotnetTool.name) is available" {
-                $dotnetTool.test | Should -Not -BeNullOrEmpty
+                Invoke-Expression $dotnetTool.test | Should -Not -BeNullOrEmpty
             }
         }
     }

--- a/images/win/scripts/Tests/DotnetSDK.Tests.ps1
+++ b/images/win/scripts/Tests/DotnetSDK.Tests.ps1
@@ -26,8 +26,7 @@ Describe "Dotnet SDK and tools" {
     foreach ($dotnetTool in $dotnetTools) {
         Context "Dotnet tool $($dotnetTool.name)" {
             It "dotnet tool $($dotnetTool.name) is available" {
-                $testResult = ($dotnetTool.test)
-                $testResult | Should -Not -BeNullOrEmpty
+                $dotnetTool.test | Should -ReturnZeroExitCode
             }
         }
     }

--- a/images/win/scripts/Tests/DotnetSDK.Tests.ps1
+++ b/images/win/scripts/Tests/DotnetSDK.Tests.ps1
@@ -24,8 +24,8 @@ Describe "Dotnet SDK and tools" {
     }
 
     foreach ($dotnetTool in $dotnetTools) {
-        Context "Dotnet tool $dotnetTool.name" {
-            It "dotnet tool '$dotnetTool.name' is available" {
+        Context "Dotnet tool " + $dotnetTool.name {
+            It "dotnet tool " + $dotnetTool.name + " is available" {
                 $dotnetTool.test | Should -Not -BeNullOrEmpty
             }
         }

--- a/images/win/scripts/Tests/DotnetSDK.Tests.ps1
+++ b/images/win/scripts/Tests/DotnetSDK.Tests.ps1
@@ -26,7 +26,8 @@ Describe "Dotnet SDK and tools" {
     foreach ($dotnetTool in $dotnetTools) {
         Context "Dotnet tool $($dotnetTool.name)" {
             It "dotnet tool $($dotnetTool.name) is available" {
-                Invoke-Expression $dotnetTool.test | Should -Not -BeNullOrEmpty
+                $testResult = ($dotnetTool.test)
+                $testResult | Should -Not -BeNullOrEmpty
             }
         }
     }

--- a/images/win/scripts/Tests/DotnetSDK.Tests.ps1
+++ b/images/win/scripts/Tests/DotnetSDK.Tests.ps1
@@ -24,8 +24,8 @@ Describe "Dotnet SDK and tools" {
     }
 
     foreach ($dotnetTool in $dotnetTools) {
-        Context "Dotnet tool " + $dotnetTool.name {
-            It "dotnet tool " + $dotnetTool.name + " is available" {
+        Context "Dotnet tool $($dotnetTool.name)" {
+            It "dotnet tool $($dotnetTool.name) is available" {
                 $dotnetTool.test | Should -Not -BeNullOrEmpty
             }
         }

--- a/images/win/scripts/Tests/DotnetSDK.Tests.ps1
+++ b/images/win/scripts/Tests/DotnetSDK.Tests.ps1
@@ -25,6 +25,7 @@ Describe "Dotnet SDK and tools" {
 
     Context "Dotnet tools" {
         $dotnetTools = (Get-ToolsetContent).dotnet.tools
+        $env:Path += ";C:\Users\Default.dotnet\tools"
         $testCases = $dotnetTools | ForEach-Object { @{ ToolName = $_.name; TestInstance = $_.test }}
 
         It "<ToolName> is available" -TestCases $testCases {

--- a/images/win/scripts/Tests/DotnetSDK.Tests.ps1
+++ b/images/win/scripts/Tests/DotnetSDK.Tests.ps1
@@ -1,6 +1,7 @@
 $dotnetVersions = (Get-ToolsetContent).dotnet.versions
+$dotnetTools = (Get-ToolsetContent).dotnet.tools
 
-Describe "Dotnet SDK" {
+Describe "Dotnet SDK and tools" {
 
     Context "Default" {
         It "Default Dotnet SDK is available" {
@@ -18,6 +19,15 @@ Describe "Dotnet SDK" {
 
             It "Runtime $version is available" -TestCases $dotnet {
                 (dotnet --list-runtimes | Where-Object { $_ -match "${dotnetVersion}\.[0-9]*" }).Count | Should -BeGreaterThan 0
+            }
+        }
+    }
+
+    foreach ($dotnetTool in $dotnetTools) {
+        Context "Dotnet tool $dotnetTool" {
+            It "dotnet tool '$dotnetTool' is available" {
+                
+                $dotnetTool
             }
         }
     }

--- a/images/win/scripts/Tests/DotnetSDK.Tests.ps1
+++ b/images/win/scripts/Tests/DotnetSDK.Tests.ps1
@@ -24,10 +24,9 @@ Describe "Dotnet SDK and tools" {
     }
 
     foreach ($dotnetTool in $dotnetTools) {
-        Context "Dotnet tool $dotnetTool" {
-            It "dotnet tool '$dotnetTool' is available" {
-                
-                $dotnetTool
+        Context "Dotnet tool $dotnetTool.name" {
+            It "dotnet tool '$dotnetTool.name' is available" {
+                $dotnetTool.test | Should -Not -BeNullOrEmpty
             }
         }
     }

--- a/images/win/scripts/Tests/DotnetSDK.Tests.ps1
+++ b/images/win/scripts/Tests/DotnetSDK.Tests.ps1
@@ -23,11 +23,12 @@ Describe "Dotnet SDK and tools" {
         }
     }
 
-    foreach ($dotnetTool in $dotnetTools) {
-        Context "Dotnet tool $($dotnetTool.name)" {
-            It "dotnet tool $($dotnetTool.name) is available" {
-                $dotnetTool.test | Should -ReturnZeroExitCode
-            }
+    Context "Dotnet tools" {
+        $dotnetTools = (Get-ToolsetContent).dotnet.tools
+        $testCases = $dotnetTools | ForEach-Object { @{ ToolName = $_.name; TestInstance = $_.test }}
+
+        It "<ToolName> is available" -TestCases $testCases {
+            "$TestInstance" | Should -ReturnZeroExitCode
         }
     }
 }

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -388,7 +388,7 @@
             "5.0"
         ],
         "tools": [
-             "nbgv"
+            { "name": "nbgv", "test": "nbgv --version", "getversion" : "nbgv --version" }
         ],
         "warmup": true
     },

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -387,6 +387,9 @@
             "3.1",
             "5.0"
         ],
+        "tools": [
+             "nbgv"
+        ],
         "warmup": true
     },
     "choco": {

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -388,7 +388,7 @@
             "5.0"
         ],
         "tools": [
-            { "name": "nbgv", "test": "nbgv --version", "getversion" : "nbgv --version" }
+            { "name": "nbgv", "test": "nbgv --version", "getversion": "nbgv --version" }
         ],
         "warmup": true
     },

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -423,7 +423,7 @@
             "5.0"
         ],
         "tools": [
-            { "name": "nbgv", "test": "nbgv --version", "getversion" : "nbgv --version" }
+            { "name": "nbgv", "test": "nbgv --version", "getversion": "nbgv --version" }
         ],
         "warmup": true
     },

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -423,7 +423,7 @@
             "5.0"
         ],
         "tools": [
-             "nbgv"
+            { "name": "nbgv", "test": "nbgv --version", "getversion" : "nbgv --version" }
         ],
         "warmup": true
     },

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -422,6 +422,9 @@
             "3.1",
             "5.0"
         ],
+        "tools": [
+             "nbgv"
+        ],
         "warmup": true
     },
     "choco": {

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -284,7 +284,7 @@
             "5.0"
         ],
         "tools": [
-             "nbgv"
+            { "name": "nbgv", "test": "nbgv --version", "getversion" : "nbgv --version" }
         ],
         "warmup": false
     },

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -283,6 +283,9 @@
             "3.1",
             "5.0"
         ],
+        "tools": [
+             "nbgv"
+        ],
         "warmup": false
     },
     "choco": {

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -284,7 +284,7 @@
             "5.0"
         ],
         "tools": [
-            { "name": "nbgv", "test": "nbgv --version", "getversion" : "nbgv --version" }
+            { "name": "nbgv", "test": "nbgv --version", "getversion": "nbgv --version" }
         ],
         "warmup": false
     },


### PR DESCRIPTION
# Description
- Add support to add dotnet tools to the toolset.
- Add new section under dotnet.
- Add installer for dotnet tools.
- Add tests for dotnet tools.
- Add installed dotnet tools to software report.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:
- Closes #4818 

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
