### PR TITLE
[macOS] Enable voiceover applescript defaults

### DIFF
--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -19,7 +19,7 @@ fi
 
 # Update VoiceOver Utility to allow VoiceOver to be controlled with AppleScript
 # by creating a special Accessibility DB file (SIP must be disabled) and
-# update the user defaults system to reflect this change.
+# updating the user defaults system to reflect this change.
 if csrutil status | grep -Eq  "System Integrity Protection status: (disabled|unknown)"; then
     sudo bash -c 'echo -n "a" > /private/var/db/Accessibility/.VoiceOverAppleScriptEnabled'
 fi

--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -17,12 +17,13 @@ if [ -d "/Library/Application Support/VMware Tools" ]; then
     sudo "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1176 885
 fi
 
-# Update VoiceOver Utility to allow VoiceOver to be controlled with AppleScript by updating defaults and creating a special file (SIP must be disabled)
-defaults write com.apple.VoiceOver4/default SCREnableAppleScript -bool YES
-
+# Update VoiceOver Utility to allow VoiceOver to be controlled with AppleScript
+# by creating a special Accessibility DB file (SIP must be disabled) and
+# update the user defaults system to reflect this change.
 if csrutil status | grep -Eq  "System Integrity Protection status: (disabled|unknown)"; then
     sudo bash -c 'echo -n "a" > /private/var/db/Accessibility/.VoiceOverAppleScriptEnabled'
 fi
+defaults write com.apple.VoiceOver4/default SCREnableAppleScript -bool YES
 
 # https://developer.apple.com/support/expiration/
 # Enterprise iOS Distribution Certificates generated between February 7 and September 1st, 2020 will expire on February 7, 2023.

--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -17,7 +17,9 @@ if [ -d "/Library/Application Support/VMware Tools" ]; then
     sudo "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1176 885
 fi
 
-# Update VoiceOver Utility to allow VoiceOver to be controlled with AppleScript by creating a special file (SIP must be disabled)
+# Update VoiceOver Utility to allow VoiceOver to be controlled with AppleScript by updating defaults and creating a special file (SIP must be disabled)
+defaults write com.apple.VoiceOver4/default SCREnableAppleScript -bool YES
+
 if csrutil status | grep -Eq  "System Integrity Protection status: (disabled|unknown)"; then
     sudo bash -c 'echo -n "a" > /private/var/db/Accessibility/.VoiceOverAppleScriptEnabled'
 fi


### PR DESCRIPTION
# Description

VoiceOver is a screen reader system application that provides auditory descriptions of elements help you easily navigate your screen with keyboard or gestures.

This PR extends the work of #4805 for enabling applescript control of voiceover by setting the required defaults for the key `SCREnableAppleScript` in `com.apple.VoiceOver4/default`.

#### Related issue:

Fixes #4770 

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
