### PR TITLE
[Ubuntu] put snap.sh upper environment cleanup

### DIFF
--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -296,6 +296,11 @@
         },
         {
             "type": "shell",
+            "script": "{{template_dir}}/scripts/base/snap.sh",
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
             "expect_disconnect": true,
             "scripts": [
                 "{{template_dir}}/scripts/base/reboot.sh"
@@ -314,11 +319,6 @@
         {
             "type": "shell",
             "script": "{{template_dir}}/scripts/base/apt-mock-remove.sh",
-            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
-            "type": "shell",
-            "script": "{{template_dir}}/scripts/base/snap.sh",
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -297,6 +297,11 @@
         },
         {
             "type": "shell",
+            "script": "{{template_dir}}/scripts/base/snap.sh",
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
             "expect_disconnect": true,
             "scripts": [
                 "{{template_dir}}/scripts/base/reboot.sh"
@@ -315,11 +320,6 @@
         {
             "type": "shell",
             "script": "{{template_dir}}/scripts/base/apt-mock-remove.sh",
-            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
-            "type": "shell",
-            "script": "{{template_dir}}/scripts/base/snap.sh",
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {


### PR DESCRIPTION
# Description

The following error can be observed in the logs:

```Provisioning with shell script: C:\agent\_work\6\s\images\linux/scripts/base/snap.sh
==> azure-arm: Failed to restart snapd.socket: Transaction for snapd.socket/restart is destructive (systemd-networkd.service has 'stop' job queued, but 'start' is included in transaction).
==> azure-arm: See system logs and 'systemctl status snapd.socket' for details.
```
Which means that the snapd restarting process is happening at the same time with the systemd-networkd stopping process which in turn causes systemd conflict, putting the `snap.sh` call above must mitigate the actual negative impact.

#### Related issue: n/a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
