### PR TITLE
[Ubuntu] remove apt-fast for good

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -98,7 +98,6 @@ $markdown += New-MDList -Style Unordered -Lines ($projectManagementList | Sort-O
 $markdown += New-MDHeader "Tools" -Level 3
 $toolsList = @(
     (Get-AnsibleVersion),
-    (Get-AptFastVersion),
     (Get-AzCopyVersion),
     (Get-BazelVersion),
     (Get-BazeliskVersion),

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -3,13 +3,6 @@ function Get-AnsibleVersion {
     return "Ansible $ansibleVersion"
 }
 
-function Get-AptFastVersion {
-    $versionFileContent = Get-Content (which apt-fast) -Raw
-    $match = [Regex]::Match($versionFileContent, '# apt-fast v(.+)\n')
-    $aptFastVersion = $match.Groups[1].Value
-    return "apt-fast $aptFastVersion"
-}
-
 function Get-AzCopyVersion {
     $azcopyVersion = azcopy --version | Take-OutputPart -Part 2
     return "AzCopy $azcopyVersion (available by ``azcopy`` and ``azcopy10`` aliases)"

--- a/images/linux/scripts/base/apt-mock-remove.sh
+++ b/images/linux/scripts/base/apt-mock-remove.sh
@@ -2,6 +2,6 @@
 
 prefix=/usr/local/bin
 
-for tool in apt apt-get apt-fast apt-key;do
+for tool in apt apt-get apt-key;do
   sudo rm -f $prefix/$tool
 done

--- a/images/linux/scripts/base/apt-mock.sh
+++ b/images/linux/scripts/base/apt-mock.sh
@@ -4,7 +4,7 @@
 
 prefix=/usr/local/bin
 
-for real_tool in /usr/bin/apt /usr/bin/apt-get /usr/bin/apt-fast /usr/bin/apt-key;do
+for real_tool in /usr/bin/apt /usr/bin/apt-get /usr/bin/apt-key;do
   tool=`basename $real_tool`
   cat >$prefix/$tool <<EOT
 #!/bin/sh

--- a/images/linux/scripts/base/apt.sh
+++ b/images/linux/scripts/base/apt.sh
@@ -34,7 +34,3 @@ cat /etc/apt/sources.list
 apt-get update
 # Install jq
 apt-get install jq
-
-# Install apt-fast using quick-install.sh
-# https://github.com/ilikenwf/apt-fast
-bash -c "$(curl -sL https://raw.githubusercontent.com/ilikenwf/apt-fast/master/quick-install.sh)"


### PR DESCRIPTION
# Description
Improvement

`apt-fast` is no longer used in any of the installers, so removing it from the system makes sense.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
