### PR TITLE
[Windows] Add VC v141 ATL ARM/64 components to windows 2019

### DIFF
--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -327,6 +327,8 @@
             "Microsoft.VisualStudio.Component.VC.v141.ARM.Spectre",
             "Microsoft.VisualStudio.Component.VC.v141.ARM64.Spectre",
             "Microsoft.VisualStudio.Component.VC.v141.ATL",
+            "Microsoft.VisualStudio.Component.VC.v141.ATL.ARM",
+            "Microsoft.VisualStudio.Component.VC.v141.ATL.ARM64",
             "Microsoft.VisualStudio.Component.VC.v141.ATL.ARM.Spectre",
             "Microsoft.VisualStudio.Component.VC.v141.ATL.ARM64.Spectre",
             "Microsoft.VisualStudio.Component.VC.v141.ATL.Spectre",


### PR DESCRIPTION
# Description
Adding following components to windows 2019:
- "Microsoft.VisualStudio.Component.VC.v141.ATL.ARM"
- "Microsoft.VisualStudio.Component.VC.v141.ATL.ARM64"

#### Related issue: https://github.com/actions/virtual-environments/issues/4828

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
