### PR TITLE
[Ubuntu] Add Eclipse Temurin (Adoptium) to Java installer

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Java.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Java.psm1
@@ -1,19 +1,22 @@
 function Get-JavaVersions {
-    $toolcachePath = Join-Path $env:AGENT_TOOLSDIRECTORY "Java_Adopt_jdk"
-    $javaToolcacheVersions = Get-ChildItem $toolcachePath -Name | Sort-Object { [int]$_.Split(".")[0] }
+    $javaToolcacheVersions = Get-ChildItem $env:AGENT_TOOLSDIRECTORY/Java*/* -Directory | Sort-Object { [int]$_.Name.Split(".")[0] }
 
-    return $javaToolcacheVersions | ForEach-Object {
-        $majorVersion = $_.split(".")[0]
-        $fullVersion = $_.Replace("-", "+")
+    $existingVersions = $javaToolcacheVersions | ForEach-Object {
+        $majorVersion = $_.Name.split(".")[0]
+        $fullVersion = $_.Name.Replace("-", "+")
         $defaultJavaPath = $env:JAVA_HOME
         $javaPath = Get-Item env:JAVA_HOME_${majorVersion}_X64
 
         $defaultPostfix = ($javaPath.Value -eq $defaultJavaPath) ? " (default)" : ""
+        $vendorName = ($_.FullName -like '*Java_Adopt_jdk*') ? "Adopt OpenJDK" :  "Eclipse Temurin"
 
         [PSCustomObject] @{
             "Version" = $fullVersion + $defaultPostfix
-            "Vendor" = "Adopt OpenJDK"
+            "Vendor" = $vendorName
             "Environment Variable" = $javaPath.Name
         }
     }
+    # Return all the vendors which are not Adopt, also look for version 12 of Adopt (Eclipse Temurin does not have this version)
+    $versionsToReturn = $existingVersions | Where-Object {$_.Vendor -notlike "Adopt*" -or $_.Version.Split(".")[0] -eq 12}
+    return $versionsToReturn
 }

--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -8,50 +8,120 @@ source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 source $HELPER_SCRIPTS/etc-environment.sh
 
-JAVA_VERSIONS_LIST=$(get_toolset_value '.java.versions | .[]')
-DEFAULT_JDK_VERSION=$(get_toolset_value '.java.default')
-JAVA_TOOLCACHE_PATH="$AGENT_TOOLSDIRECTORY/Java_Adopt_jdk"
+createJavaEnvironmentalVariable() {
+    local JAVA_VERSION=$1
+    local VENDOR_NAME=$2
+    local DEFAULT=$3
 
-# Install GPG Key for Adopt Open JDK. See https://adoptopenjdk.net/installation.html
-wget -qO - "https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public" | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
+    case ${VENDOR_NAME} in
 
-if isUbuntu18 ; then
-    # Install GPG Key for Azul Open JDK. See https://www.azul.com/downloads/azure-only/zulu/
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9
-    apt-add-repository "deb https://repos.azul.com/azure-only/zulu/apt stable main"
-fi
+        "Adopt" )
+            INSTALL_PATH_PATTERN="/usr/lib/jvm/adoptopenjdk-${JAVA_VERSION}-hotspot-amd64" ;;
 
-apt-get update
+        "Temurin-Hotspot" )
+            INSTALL_PATH_PATTERN="/usr/lib/jvm/temurin-${JAVA_VERSION}-jdk-amd64" ;;
+        *)
+            echo "Unknown vendor"
+            exit 1
 
-for JAVA_VERSION in ${JAVA_VERSIONS_LIST[@]}; do
-    apt-get -y install adoptopenjdk-$JAVA_VERSION-hotspot=\*
-    javaVersionPath="/usr/lib/jvm/adoptopenjdk-${JAVA_VERSION}-hotspot-amd64"
-    echo "JAVA_HOME_${JAVA_VERSION}_X64=$javaVersionPath" | tee -a /etc/environment
-    fullJavaVersion=$(cat "$javaVersionPath/release" | grep "^SEMANTIC" | cut -d "=" -f 2 | tr -d "\"" | tr "+" "-")
+    esac
 
-    # If there is no semver in java release, then extract java version from -fullversion
-    if [[ -z $fullJavaVersion ]]; then
-        fullJavaVersion=$(java -fullversion 2>&1 | tr -d "\"" | tr "+" "-" | awk '{print $4}')
+    if [[ ${DEFAULT} == "True" ]]; then
+        echo "Setting up JAVA_HOME variable to ${INSTALL_PATH_PATTERN}"
+        addEtcEnvironmentVariable JAVA_HOME ${INSTALL_PATH_PATTERN}
+        echo "Setting up default symlink"
+        update-java-alternatives -s ${INSTALL_PATH_PATTERN}
     fi
 
-    javaToolcacheVersionPath="$JAVA_TOOLCACHE_PATH/$fullJavaVersion"
-    mkdir -p "$javaToolcacheVersionPath"
+    echo "Setting up JAVA_HOME_${JAVA_VERSION}_X64 variable to ${INSTALL_PATH_PATTERN}"
+    addEtcEnvironmentVariable JAVA_HOME_${JAVA_VERSION}_X64 ${INSTALL_PATH_PATTERN}
+}
+
+enableRepositories() {
+    # Add Adopt PPA
+    wget -qO - "https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public" | apt-key add -
+    add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
+
+    # Add Addoptium PPA
+    wget -qO - "https://packages.adoptium.net/artifactory/api/gpg/key/public" | apt-key add -
+    add-apt-repository --yes https://packages.adoptium.net/artifactory/deb/
+
+    if isUbuntu18 ; then
+        # Install GPG Key for Azul Open JDK. See https://www.azul.com/downloads/azure-only/zulu/
+        apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9
+        apt-add-repository "deb https://repos.azul.com/azure-only/zulu/apt stable main"
+    fi
+}
+
+installOpenJDK() {
+    local JAVA_VERSION=$1
+    local VENDOR_NAME=$2
+
+    # Install Java from PPA repositories.
+    if [[ ${VENDOR_NAME} == "Temurin-Hotspot" ]]; then
+        apt-get -y install temurin-${JAVA_VERSION}-jdk=\*
+        javaVersionPath="/usr/lib/jvm/temurin-${JAVA_VERSION}-jdk-amd64"
+    elif [[ ${VENDOR_NAME} == "Adopt" ]]; then
+        apt-get -y install adoptopenjdk-${JAVA_VERSION}-hotspot=\*
+        javaVersionPath="/usr/lib/jvm/adoptopenjdk-${JAVA_VERSION}-hotspot-amd64"
+    else
+        echo "${VENDOR_NAME} is invalid, valid names are: Temurin-Hotspot and Adopt"
+        exit 1
+    fi
+
+    JAVA_TOOLCACHE_PATH="${AGENT_TOOLSDIRECTORY}/Java_${VENDOR_NAME}_jdk"
+
+    fullJavaVersion=$(cat "${javaVersionPath}/release" | grep "^SEMANTIC" | cut -d "=" -f 2 | tr -d "\"" | tr "+" "-")
+
+    # If there is no semver in java release, then extract java version from -fullversion
+    [[ -z ${fullJavaVersion} ]] && fullJavaVersion=$(${javaVersionPath}/bin/java -fullversion 2>&1 | tr -d "\"" | tr "+" "-" | awk '{print $4}')
+
+    javaToolcacheVersionPath="${JAVA_TOOLCACHE_PATH}/${fullJavaVersion}"
+    mkdir -p "${javaToolcacheVersionPath}"
 
     # Create a complete file
-    touch "$javaToolcacheVersionPath/x64.complete"
+    touch "${javaToolcacheVersionPath}/x64.complete"
 
     # Create symlink for Java
-    ln -s $javaVersionPath "$javaToolcacheVersionPath/x64"
+    ln -s ${javaVersionPath} "${javaToolcacheVersionPath}/x64"
+
+    # add extra permissions to be able execute command without sudo
+    chmod -R 777 /usr/lib/jvm
+}
+
+# Fetch repositories data
+enableRepositories
+
+# Get all the updates from enabled repositories.
+apt-get update
+
+defaultVersion=$(get_toolset_value '.java.default')
+defaultVendor=$(get_toolset_value '.java.default_vendor')
+jdkVendors=($(get_toolset_value '.java.vendors[].name'))
+
+for jdkVendor in ${jdkVendors[@]}; do
+
+     # get vendor-specific versions
+     jdkVersionsToInstall=($(get_toolset_value ".java.vendors[] | select (.name==\"${jdkVendor}\") | .versions[]"))
+
+     for jdkVersionToInstall in ${jdkVersionsToInstall[@]}; do
+
+        installOpenJDK ${jdkVersionToInstall} ${jdkVendor}
+
+        isDefaultVersion=False; [[ ${jdkVersionToInstall} == ${defaultVersion} ]] && isDefaultVersion=True
+
+        if [[ ${jdkVendor} == ${defaultVendor} ]]; then
+            createJavaEnvironmentalVariable ${jdkVersionToInstall} ${jdkVendor} ${isDefaultVersion}
+        fi
+
+    done
 done
 
-# Set Default Java version
-update-java-alternatives -s /usr/lib/jvm/adoptopenjdk-${DEFAULT_JDK_VERSION}-hotspot-amd64
+# Adopt 12 is only available for Ubuntu 18.04
+if isUbuntu18; then
+    createJavaEnvironmentalVariable "12" "Adopt"
+fi
 
-echo "JAVA_HOME=/usr/lib/jvm/adoptopenjdk-${DEFAULT_JDK_VERSION}-hotspot-amd64" | tee -a /etc/environment
-
-# add extra permissions to be able execute command without sudo
-chmod -R 777 /usr/lib/jvm
 # Install Ant
 apt-get install -y --no-install-recommends ant ant-optional
 echo "ANT_HOME=/usr/share/ant" | tee -a /etc/environment
@@ -67,11 +137,11 @@ ln -s /usr/share/apache-maven-${mavenVersion}/bin/mvn /usr/bin/mvn
 # This script founds the latest gradle release from https://services.gradle.org/versions/all
 # The release is downloaded, extracted, a symlink is created that points to it, and GRADLE_HOME is set.
 gradleJson=$(curl -s https://services.gradle.org/versions/all)
-gradleLatestVersion=$(echo $gradleJson | jq -r '.[] | select(.version | contains("-") | not).version' | sort -V | tail -n1)
-gradleDownloadUrl=$(echo $gradleJson | jq -r ".[] | select(.version==\"$gradleLatestVersion\") | .downloadUrl")
-echo "gradleUrl=$gradleDownloadUrl"
-echo "gradleVersion=$gradleLatestVersion"
-download_with_retries $gradleDownloadUrl "/tmp" "gradleLatest.zip"
+gradleLatestVersion=$(echo ${gradleJson} | jq -r '.[] | select(.version | contains("-") | not).version' | sort -V | tail -n1)
+gradleDownloadUrl=$(echo ${gradleJson} | jq -r ".[] | select(.version==\"$gradleLatestVersion\") | .downloadUrl")
+echo "gradleUrl=${gradleDownloadUrl}"
+echo "gradleVersion=${gradleLatestVersion}"
+download_with_retries ${gradleDownloadUrl} "/tmp" "gradleLatest.zip"
 unzip -qq -d /usr/share /tmp/gradleLatest.zip
 ln -s /usr/share/gradle-"${gradleLatestVersion}"/bin/gradle /usr/bin/gradle
 echo "GRADLE_HOME=$(find /usr/share -depth -maxdepth 1 -name "gradle*")" | tee -a /etc/environment

--- a/images/linux/scripts/tests/Java.Tests.ps1
+++ b/images/linux/scripts/tests/Java.Tests.ps1
@@ -1,10 +1,15 @@
 Import-Module "$PSScriptRoot/../helpers/Common.Helpers.psm1" -DisableNameChecking
 
 Describe "Java" {
-    [array]$jdkVersions = (Get-ToolsetContent).java.versions | ForEach-Object { @{Version = $_} }
-    $defaultJavaVersion = (Get-ToolsetContent).java.default
+    $toolsetJava = (Get-ToolsetContent).java
+    $defaultVersion = $toolsetJava.default
+    $defaultVendor = $toolsetJava.default_vendor
+    $javaVendors = $toolsetJava.vendors
 
-    It "Java <DefaultJavaVersion> is default" -TestCases @{ DefaultJavaVersion = $defaultJavaVersion } {
+    [array]$jdkVersions = ($javaVendors | Where-Object {$_.name -eq $defaultVendor}).versions | ForEach-Object { @{Version = $_} }
+    [array]$adoptJdkVersions = ($javaVendors | Where-Object {$_.name -eq "Adopt"}).versions | ForEach-Object { @{Version = $_} }
+
+    It "Java <DefaultJavaVersion> is default" -TestCases @{ DefaultJavaVersion = $defaultVersion } {
         $actualJavaPath = Get-EnvironmentVariable "JAVA_HOME"
         $expectedJavaPath = Get-EnvironmentVariable "JAVA_HOME_${DefaultJavaVersion}_X64"
 
@@ -42,6 +47,16 @@ Describe "Java" {
         if ($Version -eq 8) {
             $Version = "1.${Version}"
         }
-        "`"$javaPath`" -version" | Should -MatchCommandOutput ([regex]::Escape("openjdk version `"${Version}."))
+      "`"$javaPath`" -version" | Should -MatchCommandOutput ([regex]::Escape("openjdk version `"${Version}."))
+    }
+
+    It "Java Adopt <Version>" -TestCases $adoptJdkVersions {
+        $javaPath = Join-Path (Get-ChildItem ${env:AGENT_TOOLSDIRECTORY}\Java_Adopt_jdk\${Version}*) "x64\bin\java"
+        "`"$javaPath`" -version" | Should -ReturnZeroExitCode
+
+        if ($Version -eq 8) {
+            $Version = "1.${Version}"
+        }
+       "`"$javaPath`" -version" | Should -MatchCommandOutput ([regex]::Escape("openjdk version `"${Version}."))
     }
 }

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -71,8 +71,16 @@
     ],
     "java": {
         "default": "8",
-        "versions": [
-            "8", "11", "12"
+        "default_vendor": "Temurin-Hotspot",
+        "vendors": [
+            {
+                "name": "Temurin-Hotspot",
+                "versions": [ "8", "11", "17" ]
+            },
+            {
+                "name": "Adopt",
+                "versions": [ "8", "11", "12" ]
+            }
         ],
         "maven": "3.8.4"
     },

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -71,9 +71,17 @@
         }
     ],
     "java": {
-        "default": "11",
-        "versions": [
-            "8", "11"
+        "default": "8",
+        "default_vendor": "Temurin-Hotspot",
+        "vendors": [
+            {
+                "name": "Temurin-Hotspot",
+                "versions": [ "8", "11", "17" ]
+            },
+            {
+                "name": "Adopt",
+                "versions": [ "8", "11" ]
+            }
         ],
         "maven": "3.8.4"
     },


### PR DESCRIPTION
# Description

As Adoptium has finally [released](https://blog.adoptium.net/2021/12/eclipse-temurin-linux-installers-available) the deb packages we must add the Eclipse Temurin distribution into our images as it is highly desired successor of deprecated Adopt OpenJDK. The installer itself uses lots of ideas taken from the appropriate macOS java installation. As a result we have:

* `JAVA_HOME` (and default java symlinks) is is set to Eclipse Temurin 8
* `JAVA_HOME_8_X64` is set to Eclipse Temurin 8
* `JAVA_HOME_11_X64` is set to Eclipse Temurin 11
* `JAVA_HOME_12_X64` is set to Adopt OpenJDK 12 (the only version of adopt remaining in the environment, available only on Ubuntu 18.04)
* `JAVA_HOME_17_X64` is set to Eclipse Temurin 17

Apart from that:

- Adopt OpenJDK 12 calls have been hardcoded both in the environment variables installation function and the software report (no elegant way to retrieve the full versions from the env. variables as done on macOS/Windows)
- Adopt was added to the pester testsuite (as done on macOS/Windows)


#### Related issue: https://github.com/actions/virtual-environments/issues/3859 https://github.com/actions/virtual-environments/issues/4085

## Check list
- [X] Related issue / work item is attached
- [X] Tests are written (if applicable)
- [X] Documentation is updated (if applicable)
- [X] Changes are tested and related VM images are successfully generated
