### PR TITLE
[macOS] Pass build_id as an argument to ImageName

### DIFF
--- a/images/macos/templates/macOS-11.pkr.hcl
+++ b/images/macos/templates/macOS-11.pkr.hcl
@@ -205,7 +205,7 @@ build {
   }
   provisioner "shell" {
     inline = [
-      "pwsh -File \"$HOME/image-generation/software-report/SoftwareReport.Generator.ps1\" -OutputDirectory \"$HOME/image-generation/output/software-report\" -ImageName UUID=${build.PackerRunUUID}",
+      "pwsh -File \"$HOME/image-generation/software-report/SoftwareReport.Generator.ps1\" -OutputDirectory \"$HOME/image-generation/output/software-report\" -ImageName ${var.build_id}",
       "pwsh -File \"$HOME/image-generation/tests/RunAll-Tests.ps1\""
     ]
     execute_command = "source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"


### PR DESCRIPTION
# Description
We should pass  `build_id` variable as an argument to the ImageName parameter instead of `UUID=${build.PackerRunUUID}` value.