### PR TITLE
[Ubuntu] Disable motd updates metadata

### DIFF
--- a/images/linux/scripts/installers/configure-environment.sh
+++ b/images/linux/scripts/installers/configure-environment.sh
@@ -32,3 +32,7 @@ echo 'vm.max_map_count=262144' | tee -a /etc/sysctl.conf
 # Create symlink for tests running
 chmod +x $HELPER_SCRIPTS/invoke-tests.sh
 ln -s $HELPER_SCRIPTS/invoke-tests.sh /usr/local/bin/invoke_tests
+
+# Disable motd updates metadata
+sed -i 's/ENABLED=1/ENABLED=0/g' /etc/default/motd-news
+sed -i 's/UpdateMotd=true/UpdateMotd=false/g' /etc/fwupd/daemon.conf

--- a/images/linux/scripts/installers/configure-environment.sh
+++ b/images/linux/scripts/installers/configure-environment.sh
@@ -38,4 +38,5 @@ sed -i 's/ENABLED=1/ENABLED=0/g' /etc/default/motd-news
 
 if [[ -f "/etc/fwupd/daemon.conf" ]]; then
     sed -i 's/UpdateMotd=true/UpdateMotd=false/g' /etc/fwupd/daemon.conf
+    systemctl mask fwupd-refresh.timer
 fi

--- a/images/linux/scripts/installers/configure-environment.sh
+++ b/images/linux/scripts/installers/configure-environment.sh
@@ -35,4 +35,7 @@ ln -s $HELPER_SCRIPTS/invoke-tests.sh /usr/local/bin/invoke_tests
 
 # Disable motd updates metadata
 sed -i 's/ENABLED=1/ENABLED=0/g' /etc/default/motd-news
-sed -i 's/UpdateMotd=true/UpdateMotd=false/g' /etc/fwupd/daemon.conf
+
+if [[ -f "/etc/fwupd/daemon.conf" ]]; then
+    sed -i 's/UpdateMotd=true/UpdateMotd=false/g' /etc/fwupd/daemon.conf
+fi


### PR DESCRIPTION
# Description
In some workflows, we can observe traffic to cdn.fwupd.org and motd.ubuntu.com. It's not related to security issue due to installed and enabled by default on Ubuntu Server 18.04/20.04.

1. motd.ubuntu.com - https://ubuntu.com/legal/motd [motd-news.timer]

> This legal notice tells you about the information we collect using MOTD — Message of the Day. “motd-news” is a package that makes a call periodically to Canonical servers to get updated news for support and informational purposes. An example of an MOTD is shown at the end of this notice. As part of sending the message information is also collected by Canonical as set out below. 

2. cdn.fwupd.org - Update the message of the day (MOTD) on device and metadata changes [fwupd-refresh.timer]

Disable motd updates:
-  /etc/default/motd-news
- /etc/fwupd/daemon.conf

#### Related issue:
https://github.com/actions/virtual-environments/issues/4867

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
