### PR TITLE
[Ubuntu] Switch java default back to 11 on 20.04

### DIFF
--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -71,7 +71,7 @@
         }
     ],
     "java": {
-        "default": "8",
+        "default": "11",
         "default_vendor": "Temurin-Hotspot",
         "vendors": [
             {


### PR DESCRIPTION
# Description

Accidentally we switched java default version from 11 to 8 in [this](https://github.com/actions/virtual-environments/pull/4868/files) pull request, lets get it back as expected.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
