### PR TITLE
[MacOS] Update Xcode to 13.2.1 on macOS 11

### DIFF
--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -1,6 +1,6 @@
 {
     "xcode": {
-        "default": "13.1",
+        "default": "13.2.1",
         "versions": [
             { "link": "13.2.1", "version": "13.2.1" },
             { "link": "13.2", "version": "13.2.0" },

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -25,7 +25,7 @@
         "android-versions": [
             "12.0.0.3", "11.3.0.4", "11.2.2.1", "11.1.0.26", "11.0.2.0"
         ],
-        "bundle-default": "6_12_10",
+        "bundle-default": "6_12_12",
         "bundles": [
             {
                 "symlink": "6_12_12",

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -1,6 +1,6 @@
 {
     "xcode": {
-        "default": "13.1",
+        "default": "13.2.1",
         "versions": [
             { "link": "13.2.1", "version": "13.2.1" },
             { "link": "13.2", "version": "13.2.0" },
@@ -21,7 +21,7 @@
         "android-versions": [
             "12.0.0.3", "11.3.0.4"
         ],
-        "bundle-default": "6_12_10",
+        "bundle-default": "6_12_12",
         "bundles": [
             {
                 "symlink": "6_12_12",


### PR DESCRIPTION
# Description
This PR contains updates of Xcode to  13.2.1 on the macOS 11 

#### Related issue: https://github.com/actions/virtual-environments/issues/4800

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
