### PR TITLE
[Windows] Set core.longpaths option

### DIFF
--- a/images/win/scripts/Installers/Install-Git.ps1
+++ b/images/win/scripts/Installers/Install-Git.ps1
@@ -19,6 +19,10 @@ if (Test-IsWin16) {
     $env:Path += ";$env:ProgramFiles\Git\usr\bin\"
 }
 
+# Set core.longpaths option to true in the system-wide [path]/etc/gitconfig file
+# https://github.com/git-for-windows/git/blob/main/Documentation/config/core.txt
+git config --system core.longpaths true
+
 # Add well-known SSH host keys to ssh_known_hosts
 ssh-keyscan -t rsa github.com >> "C:\Program Files\Git\etc\ssh\ssh_known_hosts"
 ssh-keyscan -t rsa ssh.dev.azure.com >> "C:\Program Files\Git\etc\ssh\ssh_known_hosts"

--- a/images/win/scripts/Installers/Install-Git.ps1
+++ b/images/win/scripts/Installers/Install-Git.ps1
@@ -14,6 +14,7 @@ Choco-Install -PackageName hub
 
 # Add to PATH
 Add-MachinePathItem "C:\Program Files\Git\bin"
+$env:Path = Get-MachinePath
 
 if (Test-IsWin16) {
     $env:Path += ";$env:ProgramFiles\Git\usr\bin\"

--- a/images/win/scripts/Tests/Git.Tests.ps1
+++ b/images/win/scripts/Tests/Git.Tests.ps1
@@ -19,6 +19,10 @@ Describe "Git" {
         git config core.symlinks | Should -BeExactly true
     }
 
+    It "Git core.longpaths=true option is enabled" {
+        git config core.longpaths | Should -BeExactly true
+    }
+
     It "GCM_INTERACTIVE environment variable should be equal Never" {
         $env:GCM_INTERACTIVE | Should -BeExactly Never
     }


### PR DESCRIPTION
# Description
https://github.com/git-for-windows/git/blob/main/Documentation/config/core.txt
```
core.longpaths::
	Enable long path (> 260) support for builtin commands in Git for
	Windows. This is disabled by default, as long paths are not supported
	by Windows Explorer, cmd.exe and the Git for Windows tool chain
	(msys, bash, tcl, perl...). Only enable this if you know what you're
	doing and are prepared to live with a few quirks.
```

#### Related issue:
https://github.com/actions/virtual-environments/issues/4913

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
