### PR TITLE
[macOS] Allow using GitHub PAT to enlarge api requests limit

### DIFF
--- a/images/macos/provision/core/nvm.sh
+++ b/images/macos/provision/core/nvm.sh
@@ -5,7 +5,7 @@
 ###########################################################################
 source ~/utils/utils.sh
 
-VERSION=$(curl -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r '.tag_name')
+VERSION=$(curl -H "Authorization: token $API_PAT" -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r '.tag_name')
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$VERSION/install.sh | bash
 
 if [ $? -eq 0 ]; then

--- a/images/macos/provision/core/powershell.sh
+++ b/images/macos/provision/core/powershell.sh
@@ -2,7 +2,7 @@
 source ~/utils/utils.sh
 
 echo Installing PowerShell...
-psRelease=$(curl -s "https://api.github.com/repos/PowerShell/PowerShell/releases/latest")
+psRelease=$(curl -H "Authorization: token $API_PAT" -s "https://api.github.com/repos/PowerShell/PowerShell/releases/latest")
 psDownloadUrl=$(echo $psRelease | jq -r '.assets[].browser_download_url | select(contains("osx-x64.pkg"))' | head -n 1)
 download_with_retries $psDownloadUrl "/tmp" "powershell.pkg"
 

--- a/images/macos/provision/core/ruby.sh
+++ b/images/macos/provision/core/ruby.sh
@@ -10,7 +10,7 @@ echo "GEM_PATH=$GEM_PATH" >> "$HOME/.bashrc"
 echo 'export PATH="$GEM_PATH:/usr/local/opt/ruby@'${DEFAULT_RUBY_VERSION}'/bin:$PATH"'  >> "$HOME/.bashrc"
 
 echo "Install Ruby from toolset..."
-PACKAGE_TAR_NAMES=$(curl -s "https://api.github.com/repos/ruby/ruby-builder/releases/latest" | jq -r '.assets[].name')
+PACKAGE_TAR_NAMES=$(curl -H "Authorization: token $API_PAT" -s "https://api.github.com/repos/ruby/ruby-builder/releases/latest" | jq -r '.assets[].name')
 TOOLSET_VERSIONS=$(get_toolset_value '.toolcache[] | select(.name | contains("Ruby")) | .versions[]')
 RUBY_PATH="$AGENT_TOOLSDIRECTORY/Ruby"
 

--- a/images/macos/provision/core/stack.sh
+++ b/images/macos/provision/core/stack.sh
@@ -2,7 +2,7 @@
 source ~/utils/utils.sh
 
 echo "Get the latest Stack version..."
-StackRelease=$(curl -s "https://api.github.com/repos/commercialhaskell/stack/releases/latest")
+StackRelease=$(curl -H "Authorization: token $API_PAT" -s "https://api.github.com/repos/commercialhaskell/stack/releases/latest")
 DownloadUrl=$(echo $StackRelease | jq -r '.assets[].browser_download_url | select(contains("osx-x86_64.tar.gz"))' | head -n 1)
 StackVersion=$(echo $StackRelease | jq -r '.name' | cut -c2-)
 StackArchive="/tmp/stack.tar.gz"

--- a/images/macos/provision/core/swiftlint.sh
+++ b/images/macos/provision/core/swiftlint.sh
@@ -2,7 +2,7 @@
 source ~/utils/utils.sh
 
 echo "Install SwiftLint"
-swiftlintUrl=$(curl -s "https://api.github.com/repos/realm/SwiftLint/releases/latest" | jq -r '.assets[].browser_download_url | select(contains("SwiftLint.pkg"))')
+swiftlintUrl=$(curl -H "Authorization: token $API_PAT" -s "https://api.github.com/repos/realm/SwiftLint/releases/latest" | jq -r '.assets[].browser_download_url | select(contains("SwiftLint.pkg"))')
 download_with_retries $swiftlintUrl "/tmp" "SwiftLint.pkg"
 sudo installer -pkg /tmp/SwiftLint.pkg -target /
 rm -rf /tmp/SwiftLint.pkg

--- a/images/macos/templates/macOS-10.15.json
+++ b/images/macos/templates/macOS-10.15.json
@@ -11,6 +11,7 @@
         "output_folder": null,
         "vm_username": null,
         "vm_password": null,
+        "github_api_pat": null,
         "xcode_install_user": null,
         "xcode_install_password": null,
         "image_os": "macos1015"
@@ -138,6 +139,9 @@
                 "./provision/core/rubygem.sh",
                 "./provision/core/git.sh",
                 "./provision/core/node.sh"
+            ],
+            "environment_vars": [
+                "API_PAT={{user `github_api_pat`}}"
             ]
         },
         {
@@ -191,12 +195,15 @@
                 "./provision/core/pypy.sh",
                 "./provision/core/pipx-packages.sh",
                 "./provision/core/bicep.sh"
+            ],
+            "environment_vars": [
+                "API_PAT={{user `github_api_pat`}}"
             ]
         },
         {
             "type": "shell",
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}",
-            "scripts": [ 
+            "scripts": [
                 "./provision/core/toolset.ps1",
                 "./provision/core/configure-toolset.ps1"
             ]

--- a/images/macos/templates/macOS-11.json
+++ b/images/macos/templates/macOS-11.json
@@ -11,6 +11,7 @@
         "output_folder": null,
         "vm_username": null,
         "vm_password": null,
+        "github_api_pat": null,
         "xcode_install_user": null,
         "xcode_install_password": null,
         "image_os": "macos11"
@@ -143,6 +144,9 @@
                 "./provision/core/rubygem.sh",
                 "./provision/core/git.sh",
                 "./provision/core/node.sh"
+            ],
+            "environment_vars": [
+                "API_PAT={{user `github_api_pat`}}"
             ]
         },
         {
@@ -194,6 +198,9 @@
                 "./provision/core/pypy.sh",
                 "./provision/core/pipx-packages.sh",
                 "./provision/core/bicep.sh"
+            ],
+            "environment_vars": [
+                "API_PAT={{user `github_api_pat`}}"
             ]
         },
         {

--- a/images/macos/templates/macOS-12.json
+++ b/images/macos/templates/macOS-12.json
@@ -11,6 +11,7 @@
         "output_folder": null,
         "vm_username": null,
         "vm_password": null,
+        "github_api_pat": null,
         "xcode_install_user": null,
         "xcode_install_password": null,
         "image_os": "macos12"
@@ -143,6 +144,9 @@
                 "./provision/core/rubygem.sh",
                 "./provision/core/git.sh",
                 "./provision/core/node.sh"
+            ],
+            "environment_vars": [
+                "API_PAT={{user `github_api_pat`}}"
             ]
         },
         {
@@ -193,12 +197,15 @@
                 "./provision/core/pypy.sh",
                 "./provision/core/pipx-packages.sh",
                 "./provision/core/bicep.sh"
+            ],
+            "environment_vars": [
+                "API_PAT={{user `github_api_pat`}}"
             ]
         },
         {
             "type": "shell",
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}",
-            "scripts": [ 
+            "scripts": [
                 "./provision/core/toolset.ps1",
                 "./provision/core/configure-toolset.ps1"
             ]


### PR DESCRIPTION
# Description
For unauthenticated requests, the rate limit allows for up to 60 requests per hour thus we sometimes face this limitation and the build fails on API requests. Authenticated requests have a 5000 limit but we need to use a token. If no token is provided the standard limit of 60 requests will be used.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3222

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
