### PR TITLE
[Windows] Skip oledb test for windows2016

### DIFF
--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -202,7 +202,7 @@ Describe "Kotlin" {
     }
 }
 
-Describe "SQL OLEDB Driver" {
+Describe "SQL OLEDB Driver" -Skip:(Test-IsWin16) {
     It "SQL OLEDB Driver" {
         "HKLM:\SOFTWARE\Microsoft\MSOLEDBSQL" | Should -Exist
     }


### PR DESCRIPTION
# Description
It was forgotten to skip the test for windows 2016 in the https://github.com/actions/virtual-environments/pull/4893

#### Related issue:
https://github.com/actions/virtual-environments/issues/4881

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
