### PR TITLE
[Windows] Do not run oledb test on win16

### DIFF
--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -202,7 +202,7 @@ Describe "Kotlin" {
     }
 }
 
-Describe "SQL OLEDB Driver" {
+Describe "SQL OLEDB Driver" -Skip:(Test-IsWin16) {
     It "SQL OLEDB Driver" {
         "HKLM:\SOFTWARE\Microsoft\MSOLEDBSQL" | Should -Exist
     }


### PR DESCRIPTION
# Description
MS OLEDB driver was recently added to windows 19 and 22 with test to check driver installation. Windows 16 wasn't excluded from testing though.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
