### PR TITLE
[macOS] create tcl/tk symlinks for cached python

### DIFF
--- a/images/macos/provision/core/commonutils.sh
+++ b/images/macos/provision/core/commonutils.sh
@@ -19,5 +19,13 @@ done
 # Invoke bazel to download bazel version via bazelisk
 bazel
 
+# Workaround https://github.com/actions/virtual-environments/issues/4931
+# by making Tcl/Tk paths the same on macOS 10.15 and macOS 11
+if is_BigSur; then
+    version=$(brew info tcl-tk --json | jq -r '.[].installed[].version')
+    ln -s /usr/local/Cellar/tcl-tk/$version/lib/libtcl8.6.dylib /usr/local/lib/libtcl8.6.dylib
+    ln -s /usr/local/Cellar/tcl-tk/$version/lib/libtk8.6.dylib /usr/local/lib/libtk8.6.dylib
+fi
+
 # Invoke tests for all basic tools
 invoke_tests "BasicTools"

--- a/images/macos/provision/core/python.sh
+++ b/images/macos/provision/core/python.sh
@@ -27,6 +27,8 @@ echo "export PIPX_BIN_DIR=${PIPX_BIN_DIR}" >> "${HOME}/.bashrc"
 echo "export PIPX_HOME=${PIPX_HOME}" >> "${HOME}/.bashrc"
 echo 'export PATH="$PIPX_BIN_DIR:$PATH"' >> "${HOME}/.bashrc"
 
+# Workaround https://github.com/actions/virtual-environments/issues/4931
+# by making Tcl/Tk paths the same on macOS 10.15 and macOS 11
 if is_BigSur; then
     version=$(brew info tcl-tk --json | jq -r '.[].installed[].version')
     ln -s /usr/local/Cellar/tcl-tk/$version/lib/libtcl8.6.dylib /usr/local/lib/libtcl8.6.dylib

--- a/images/macos/provision/core/python.sh
+++ b/images/macos/provision/core/python.sh
@@ -27,4 +27,10 @@ echo "export PIPX_BIN_DIR=${PIPX_BIN_DIR}" >> "${HOME}/.bashrc"
 echo "export PIPX_HOME=${PIPX_HOME}" >> "${HOME}/.bashrc"
 echo 'export PATH="$PIPX_BIN_DIR:$PATH"' >> "${HOME}/.bashrc"
 
+if is_BigSur; then
+    version=$(brew info tcl-tk --json | jq -r '.[].installed[].version')
+    ln -s /usr/local/Cellar/tcl-tk/$version/lib/libtcl8.6.dylib /usr/local/lib/libtcl8.6.dylib
+    ln -s /usr/local/Cellar/tcl-tk/$version/lib/libtk8.6.dylib /usr/local/lib/libtk8.6.dylib
+fi
+
 invoke_tests "Python"

--- a/images/macos/provision/core/python.sh
+++ b/images/macos/provision/core/python.sh
@@ -27,12 +27,4 @@ echo "export PIPX_BIN_DIR=${PIPX_BIN_DIR}" >> "${HOME}/.bashrc"
 echo "export PIPX_HOME=${PIPX_HOME}" >> "${HOME}/.bashrc"
 echo 'export PATH="$PIPX_BIN_DIR:$PATH"' >> "${HOME}/.bashrc"
 
-# Workaround https://github.com/actions/virtual-environments/issues/4931
-# by making Tcl/Tk paths the same on macOS 10.15 and macOS 11
-if is_BigSur; then
-    version=$(brew info tcl-tk --json | jq -r '.[].installed[].version')
-    ln -s /usr/local/Cellar/tcl-tk/$version/lib/libtcl8.6.dylib /usr/local/lib/libtcl8.6.dylib
-    ln -s /usr/local/Cellar/tcl-tk/$version/lib/libtk8.6.dylib /usr/local/lib/libtk8.6.dylib
-fi
-
 invoke_tests "Python"


### PR DESCRIPTION
# Description
tcl/tk installation paths are different on macOS 11 and 10.15, given that our hosted toolcache python binaries are compiled on 10.15 and then are used on 11 customers are unable to import the python tk module as python is looking for 10.15 specific path being run on 11.
We have discussed the long term solution with @dmitry-shibanov and @MaksimZhukov and decided to apply symlinks as a temporary solution.

#### Related issue: https://github.com/actions/virtual-environments/issues/4931

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
