### PR TITLE
[Ubuntu] Implement helper to get GitHub package download URL

### DIFF
--- a/images/linux/scripts/helpers/install.sh
+++ b/images/linux/scripts/helpers/install.sh
@@ -66,3 +66,23 @@ get_toolset_value() {
     local query=$1
     echo "$(jq -r "$query" $toolset_path)"
 }
+
+get_github_package_download_url() {
+    local REPO_OWNER=$1
+    local REPO_NAME=$2
+    local FILTER=$3
+    local VERSION=$4
+    local SEARCH_IN_COUNT="100"
+
+    json=$(curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases?per_page=${SEARCH_IN_COUNT}")
+
+    if [ -n "$VERSION" ]; then
+        tagName=$(echo $json | jq -r '.[] | select(.prerelease==false).tag_name' | sort --unique --version-sort | egrep -v ".*-[a-z]" | egrep "\w*${VERSION}" | tail -1)
+    else
+        tagName=$(echo $json | jq -r '.[] | select(.prerelease==false).tag_name' | sort --unique --version-sort | egrep -v ".*-[a-z]" | tail -1)
+    fi    
+
+    downloadUrl=$(echo $json | jq -r ".[] | select(.tag_name==\"${tagName}\").assets[].browser_download_url | select(${FILTER})" | head -n 1)
+
+    echo $downloadUrl
+}

--- a/images/linux/scripts/installers/aliyun-cli.sh
+++ b/images/linux/scripts/installers/aliyun-cli.sh
@@ -8,8 +8,8 @@
 source $HELPER_SCRIPTS/install.sh
 
 # Install Alibaba Cloud CLI
-URL=$(curl -s https://api.github.com/repos/aliyun/aliyun-cli/releases/latest | jq -r '.assets[].browser_download_url | select(contains("aliyun-cli-linux") and endswith("amd64.tgz"))')
-download_with_retries $URL "/tmp"
+downloadUrl=$(get_github_package_download_url "aliyun" "aliyun-cli" "contains(\"aliyun-cli-linux\") and endswith(\"amd64.tgz\")")
+download_with_retries $downloadUrl "/tmp"
 tar xzf /tmp/aliyun-cli-linux-*-amd64.tgz
 mv aliyun /usr/local/bin
 

--- a/images/linux/scripts/installers/cmake.sh
+++ b/images/linux/scripts/installers/cmake.sh
@@ -9,10 +9,8 @@ echo "Checking to see if the installer script has already been run"
 if command -v cmake; then
     echo "cmake is already installed"
 else
-	json=$(curl -s "https://api.github.com/repos/Kitware/CMake/releases")
-	latest_tag=$(echo $json | jq -r '.[] | select(.prerelease==false).tag_name' | sort --unique --version-sort | grep -v "rc" | tail -1)
-	sh_url=$(echo $json | jq -r ".[] | select(.tag_name==\"${latest_tag}\").assets[].browser_download_url | select(endswith(\"inux-x86_64.sh\"))")
-	curl -sL ${sh_url} -o cmakeinstall.sh \
+	downloadUrl=$(get_github_package_download_url "Kitware" "CMake" "endswith(\"inux-x86_64.sh\")")
+	curl -sL ${downloadUrl} -o cmakeinstall.sh \
 	&& chmod +x cmakeinstall.sh \
 	&& ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir \
 	&& rm cmakeinstall.sh

--- a/images/linux/scripts/installers/firefox.sh
+++ b/images/linux/scripts/installers/firefox.sh
@@ -15,9 +15,9 @@ apt-get install -y firefox
 echo 'pref("intl.locale.requested","en_US");' >> "/usr/lib/firefox/browser/defaults/preferences/syspref.js"
 
 # Download and unpack latest release of geckodriver
-URL=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r '.assets[].browser_download_url | select(test("linux64.tar.gz$"))')
-echo "Downloading geckodriver $URL"
-download_with_retries "$URL" "/tmp" geckodriver.tar.gz
+downloadUrl=$(get_github_package_download_url "mozilla" "geckodriver" "test(\"linux64.tar.gz$\")")
+echo "Downloading geckodriver $downloadUrl"
+download_with_retries "$downloadUrl" "/tmp" geckodriver.tar.gz
 
 GECKODRIVER_DIR="/usr/local/share/gecko_driver"
 GECKODRIVER_BIN="$GECKODRIVER_DIR/geckodriver"

--- a/images/linux/scripts/installers/git.sh
+++ b/images/linux/scripts/installers/git.sh
@@ -34,8 +34,8 @@ echo "git-lfs $GIT_LFS_REPO" >> $HELPER_SCRIPTS/apt-sources.txt
 #Install hub
 tmp_hub="/tmp/hub"
 mkdir -p "$tmp_hub"
-url=$(curl -s https://api.github.com/repos/github/hub/releases/latest | jq -r '.assets[].browser_download_url | select(contains("hub-linux-amd64"))')
-download_with_retries "$url" "$tmp_hub"
+downloadUrl=$(get_github_package_download_url "github" "hub" "contains(\"hub-linux-amd64\")")
+download_with_retries "$downloadUrl" "$tmp_hub"
 tar xzf "$tmp_hub"/hub-linux-amd64-*.tgz --strip-components 1 -C "$tmp_hub"
 mv "$tmp_hub"/bin/hub /usr/local/bin
 

--- a/images/linux/scripts/installers/github-cli.sh
+++ b/images/linux/scripts/installers/github-cli.sh
@@ -9,8 +9,8 @@
 source $HELPER_SCRIPTS/install.sh
 
 # Install GitHub CLI
-url=$(curl -s https://api.github.com/repos/cli/cli/releases/latest | jq -r '.assets[].browser_download_url|select(contains("linux") and contains("amd64") and contains(".deb"))')
-download_with_retries $url "/tmp"
+downloadUrl=$(get_github_package_download_url "cli" "cli" "contains(\"linux\") and contains(\"amd64\") and contains(\".deb\")")
+download_with_retries $downloadUrl "/tmp"
 apt install /tmp/gh_*_linux_amd64.deb
 
 invoke_tests "CLI.Tools" "GitHub CLI"

--- a/images/linux/scripts/installers/graalvm.sh
+++ b/images/linux/scripts/installers/graalvm.sh
@@ -7,11 +7,8 @@ source $HELPER_SCRIPTS/etc-environment.sh
 GRAALVM_ROOT=/usr/local/graalvm
 export GRAALVM_11_ROOT=$GRAALVM_ROOT/graalvm-ce-java11*
 
-json=$(curl -s "https://api.github.com/repos/graalvm/graalvm-ce-builds/releases")
-latest_tag=$(echo $json | jq -r '.[] | select(.prerelease==false).tag_name' | sort --unique --version-sort | tail -1)
-url=$(echo $json | jq -r ".[] | select(.tag_name==\"${latest_tag}\").assets[].browser_download_url | select(contains(\"graalvm-ce-java11-linux-amd64\") and endswith(\"tar.gz\"))")
-
-download_with_retries "$url" "/tmp" "graalvm-archive.tar.gz"
+downloadUrl=$(get_github_package_download_url "graalvm" "graalvm-ce-builds" "contains(\"graalvm-ce-java11-linux-amd64\") and endswith(\"tar.gz\")")
+download_with_retries "$downloadUrl" "/tmp" "graalvm-archive.tar.gz"
 mkdir $GRAALVM_ROOT
 tar -xzf "/tmp/graalvm-archive.tar.gz" -C $GRAALVM_ROOT
 

--- a/images/linux/scripts/installers/kubernetes-tools.sh
+++ b/images/linux/scripts/installers/kubernetes-tools.sh
@@ -5,8 +5,8 @@
 ################################################################################
 
 # Install KIND
-URL=$(curl -s https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r '.assets[].browser_download_url | select(contains("kind-linux-amd64"))')
-curl -L -o /usr/local/bin/kind $URL
+downloadUrl=$(get_github_package_download_url "kubernetes-sig" "kind" "contains(\"kind-linux-amd64\")")
+curl -L -o /usr/local/bin/kind $downloadUrl
 chmod +x /usr/local/bin/kind
 
 ## Install kubectl

--- a/images/linux/scripts/installers/oras-cli.sh
+++ b/images/linux/scripts/installers/oras-cli.sh
@@ -7,8 +7,7 @@
 source $HELPER_SCRIPTS/install.sh
 
 # Determine latest ORAS CLI version
-ORAS_CLI_LATEST_VERSION_URL=https://api.github.com/repos/oras-project/oras/releases/latest
-ORAS_CLI_DOWNLOAD_URL=$(curl -sfL $ORAS_CLI_LATEST_VERSION_URL | jq -r '.assets[].browser_download_url | select(endswith("linux_amd64.tar.gz"))')
+ORAS_CLI_DOWNLOAD_URL=$(get_github_package_download_url "oras-project" "oras" "endswith(\"linux_amd64.tar.gz\")")
 ORAS_CLI_ARCHIVE=$(basename $ORAS_CLI_DOWNLOAD_URL)
 
 # Install ORAS CLI

--- a/images/linux/scripts/installers/selenium.sh
+++ b/images/linux/scripts/installers/selenium.sh
@@ -12,8 +12,7 @@ SELENIUM_MAJOR_VERSION=$(get_toolset_value '.selenium.version')
 SELENIUM_BINARY_NAME=$(get_toolset_value '.selenium.binary_name')
 SELENIUM_JAR_PATH="/usr/share/java"
 SELENIUM_JAR_NAME="$SELENIUM_BINARY_NAME.jar"
-json=$(curl -s "https://api.github.com/repos/SeleniumHQ/selenium/releases?per_page=100")
-SELENIUM_DOWNLOAD_URL=$(echo $json | jq -r ".[] | select(.prerelease==false).assets[].browser_download_url | select(contains(\"${SELENIUM_BINARY_NAME}-${SELENIUM_MAJOR_VERSION}\") and endswith(\".jar\"))" | head -1)
+SELENIUM_DOWNLOAD_URL=$(get_github_package_download_url "SeleniumHQ" "selenium" "contains(\"${SELENIUM_BINARY_NAME}-${SELENIUM_MAJOR_VERSION}\") and endswith(\".jar\")")
 download_with_retries $SELENIUM_DOWNLOAD_URL $SELENIUM_JAR_PATH $SELENIUM_JAR_NAME
 
 # Create an epmty file to retrive selenium version 

--- a/images/linux/scripts/installers/yq.sh
+++ b/images/linux/scripts/installers/yq.sh
@@ -6,7 +6,7 @@ source $HELPER_SCRIPTS/install.sh
 YQ_BINARY=yq_linux_amd64
 
 # As per https://github.com/mikefarah/yq#wget
-YQ_URL=$(curl -s https://api.github.com/repos/mikefarah/yq/releases/latest | jq -r ".assets[].browser_download_url | select(endswith(\"$YQ_BINARY.tar.gz\"))")
+YQ_URL=$(get_github_package_download_url "mikefarah" "yq" "endswith(\"$YQ_BINARY.tar.gz\")")
 echo "Downloading latest yq from $YQ_URL"
 
 download_with_retries "$YQ_URL" "/tmp" "${YQ_BINARY}.tar.gz"


### PR DESCRIPTION
# Description
In scope of this PR we are implementing helper to get GitHub package download URL as it was done for Windows in scope of [this PR](https://github.com/actions/virtual-environments/pull/4645/files#:~:text=function%20Get%2DGitHubPackageDownloadUrl%20%7B).

#### Related issue: [#3139](https://github.com/actions/virtual-environments-internal/issues/3139)

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
