### PR TITLE
[macOS] Hardcode swiftlint 0.46.0

### DIFF
--- a/images/macos/provision/core/swiftlint.sh
+++ b/images/macos/provision/core/swiftlint.sh
@@ -2,7 +2,9 @@
 source ~/utils/utils.sh
 
 echo "Install SwiftLint"
-swiftlintUrl=$(curl -H "Authorization: token $API_PAT" -s "https://api.github.com/repos/realm/SwiftLint/releases/latest" | jq -r '.assets[].browser_download_url | select(contains("SwiftLint.pkg"))')
+# Temporary hardcode swiftlint version due to the issues with installer https://github.com/realm/SwiftLint/issues/3815
+swiftlintUrl="https://github.com/realm/SwiftLint/releases/download/0.46.0/SwiftLint.pkg"
+#swiftlintUrl=$(curl -H "Authorization: token $API_PAT" -s "https://api.github.com/repos/realm/SwiftLint/releases/latest" | jq -r '.assets[].browser_download_url | select(contains("SwiftLint.pkg"))')
 download_with_retries $swiftlintUrl "/tmp" "SwiftLint.pkg"
 sudo installer -pkg /tmp/SwiftLint.pkg -target /
 rm -rf /tmp/SwiftLint.pkg


### PR DESCRIPTION
# Description
There is an issue with swiftlint 0.46.1 installer that should be fixed in the next swiftlint version https://github.com/realm/SwiftLint/issues/3815. Hardcoding 0.46.0 for now

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3263

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
