### PR TITLE
Add link to specific yq github repo

### DIFF
--- a/images/linux/Ubuntu2004-Readme.md
+++ b/images/linux/Ubuntu2004-Readme.md
@@ -100,7 +100,7 @@
 - SVN 1.13.0
 - Terraform 1.1.4
 - yamllint 1.26.3
-- yq 4.16.2
+- [yq](https://github.com/mikefarah/yq) 4.16.2
 - zstd 1.5.1 (homebrew)
 
 ### CLI Tools


### PR DESCRIPTION
There are two widely-used versions of `yq`, one written by [mikefarah](https://github.com/mikefarah/yq) and another written by [kislyuk](https://github.com/kislyuk/yq). This adds a link to the specific version used in this runner.

# Description
New tool, Bug fixing, or Improvement?  
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.  
**For new tools, please provide total size and installation time.**

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
