### PR TITLE
Revert "[macOS] Hardcode swiftlint 0.46.0"

### DIFF
--- a/images/macos/provision/core/swiftlint.sh
+++ b/images/macos/provision/core/swiftlint.sh
@@ -2,9 +2,7 @@
 source ~/utils/utils.sh
 
 echo "Install SwiftLint"
-# Temporary hardcode swiftlint version due to the issues with installer https://github.com/realm/SwiftLint/issues/3815
-swiftlintUrl="https://github.com/realm/SwiftLint/releases/download/0.46.0/SwiftLint.pkg"
-#swiftlintUrl=$(curl -H "Authorization: token $API_PAT" -s "https://api.github.com/repos/realm/SwiftLint/releases/latest" | jq -r '.assets[].browser_download_url | select(contains("SwiftLint.pkg"))')
+swiftlintUrl=$(curl -H "Authorization: token $API_PAT" -s "https://api.github.com/repos/realm/SwiftLint/releases/latest" | jq -r '.assets[].browser_download_url | select(contains("SwiftLint.pkg"))')
 download_with_retries $swiftlintUrl "/tmp" "SwiftLint.pkg"
 sudo installer -pkg /tmp/SwiftLint.pkg -target /
 rm -rf /tmp/SwiftLint.pkg


### PR DESCRIPTION
Reverts actions/virtual-environments#4953 as the package is fixed in the new SwiftLint release https://github.com/realm/SwiftLint/releases/tag/0.46.2
![image](https://user-images.githubusercontent.com/48208649/151427503-8b48ce68-bea7-43b6-bf7a-f3775fedf7f9.png)
