### PR TITLE
[macOS] change miniconda directory permissions

### DIFF
--- a/images/macos/provision/core/miniconda.sh
+++ b/images/macos/provision/core/miniconda.sh
@@ -5,6 +5,9 @@ curl -sL https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh 
 chmod +x $MINICONDA_INSTALLER
 sudo $MINICONDA_INSTALLER -b -p /usr/local/miniconda
 
+# Chmod with full permissions recursively to avoid permissions restrictions
+chmod 777 -R /usr/local/miniconda
+
 sudo ln -s /usr/local/miniconda/bin/conda /usr/local/bin/conda
 
 if [ -d "$HOME/.conda" ]; then

--- a/images/macos/provision/core/miniconda.sh
+++ b/images/macos/provision/core/miniconda.sh
@@ -6,7 +6,7 @@ chmod +x $MINICONDA_INSTALLER
 sudo $MINICONDA_INSTALLER -b -p /usr/local/miniconda
 
 # Chmod with full permissions recursively to avoid permissions restrictions
-chmod 777 -R /usr/local/miniconda
+sudo chmod 777 -R /usr/local/miniconda
 
 sudo ln -s /usr/local/miniconda/bin/conda /usr/local/bin/conda
 


### PR DESCRIPTION
# Description
# Description

Making miniconda accessible by anyone so customers do not hit permission denied error if no setup-miniconda used (the action itself also chmods the installation directory recursively).

#### Related issue: https://github.com/actions/virtual-environments/issues/4955

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated