### PR TITLE
[macOS] Change swiftlint installation method to portable distribution

### DIFF
--- a/images/macos/provision/core/swiftlint.sh
+++ b/images/macos/provision/core/swiftlint.sh
@@ -2,9 +2,11 @@
 source ~/utils/utils.sh
 
 echo "Install SwiftLint"
-swiftlintUrl=$(curl -H "Authorization: token $API_PAT" -s "https://api.github.com/repos/realm/SwiftLint/releases/latest" | jq -r '.assets[].browser_download_url | select(contains("SwiftLint.pkg"))')
-download_with_retries $swiftlintUrl "/tmp" "SwiftLint.pkg"
-sudo installer -pkg /tmp/SwiftLint.pkg -target /
-rm -rf /tmp/SwiftLint.pkg
+swiftlintUrl=$(curl -H "Authorization: token $API_PAT" -s "https://api.github.com/repos/realm/SwiftLint/releases/latest" | jq -r '.assets[].browser_download_url | select(contains("portable_swiftlint.zip"))')
+download_with_retries $swiftlintUrl "/tmp" "portable_swiftlint.zip"
+unzip -q "/tmp/portable_swiftlint.zip" -d /usr/local/bin
+# Remove the LICENSE file that comes along with the binary and the downloaded archive
+rm -rf "/usr/local/bin/LICENSE"
+rm -rf "/tmp/portable_swiftlint.zip"
 
 invoke_tests "Linters" "SwiftLint"


### PR DESCRIPTION
# Description
There is an issue with the .pkg file that is not yet fixed https://github.com/realm/SwiftLint/issues/3815#issuecomment-1024019219
It's safer to use the portable archive distribution as it contains only one binary and the license file.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3263

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
