### PR TITLE
[Windows] Stick image version to 20348.469.220106

### DIFF
--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -57,6 +57,7 @@
             "image_publisher": "MicrosoftWindowsServer",
             "image_offer": "WindowsServer",
             "image_sku": "2022-Datacenter",
+            "image_version": "20348.469.220106",
             "communicator": "winrm",
             "winrm_use_ssl": "true",
             "winrm_insecure": "true",


### PR DESCRIPTION
# Description
There is probably a bug in the latest image version in azure (`20348.473.220116`) — activating `NET-Framework-Features` doesn't work there. This PR sticks the image to the previous version (`20348.469.220106`) until the issue is fixed from the image side.

#### Related issue:
https://github.com/actions/virtual-environments/issues/4942

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
