### PR TITLE
[Windows] Add Windows10SDK.17763 to Win22

### DIFF
--- a/images/win/scripts/Installers/Install-VS.ps1
+++ b/images/win/scripts/Installers/Install-VS.ps1
@@ -44,4 +44,12 @@ if (Test-IsWin19) {
 	Install-Binary -Url $sdkUrl -Name $sdkFileName -ArgumentList $argumentList
 }
 
+if (Test-IsWin22) {
+    # Install Windows 10 SDK version 10.0.17763
+    $sdkUrl = "https://go.microsoft.com/fwlink/p/?LinkID=2033908"
+    $sdkFileName = "sdksetup17763.exe"
+    $argumentList = ("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64")
+    Install-Binary -Url $sdkUrl -Name $sdkFileName -ArgumentList $argumentList
+}
+
 Invoke-PesterTests -TestFile "VisualStudio"

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -244,6 +244,12 @@ $markdown += New-MDHeader "Microsoft Visual C++:" -Level 4
 $markdown += Get-VisualCPPComponents | New-MDTable
 $markdown += New-MDNewLine
 
+$markdown += New-MDHeader "Additional Windows SDKs" -Level 4
+$sdk = Get-WindowsSDKs
+$markdown += "``Location $($sdk.Path)``"
+$markdown += New-MDNewLine
+$markdown += New-MDList -Lines $sdk.Versions -Style Unordered
+
 $markdown += New-MDHeader ".NET Core SDK" -Level 3
 $sdk = Get-DotnetSdks
 $markdown += "``Location $($sdk.Path)``"

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -244,7 +244,7 @@ $markdown += New-MDHeader "Microsoft Visual C++:" -Level 4
 $markdown += Get-VisualCPPComponents | New-MDTable
 $markdown += New-MDNewLine
 
-$markdown += New-MDHeader "Additional Windows SDKs" -Level 4
+$markdown += New-MDHeader "Installed Windows SDKs" -Level 4
 $sdk = Get-WindowsSDKs
 $markdown += "``Location $($sdk.Path)``"
 $markdown += New-MDNewLine

--- a/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
@@ -91,7 +91,7 @@ function Get-VisualStudioExtensions {
 }
 
 function Get-WindowsSDKs {
-    [PSCustomObject]@{
+    return [PSCustomObject]@{
         path = "${env:ProgramFiles(x86)}\Windows Kits\10\Extension SDKs\WindowsDesktop"
         versions = $(Get-ChildItem $path).Name
     }

--- a/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
@@ -91,8 +91,9 @@ function Get-VisualStudioExtensions {
 }
 
 function Get-WindowsSDKs {
+    $path = "${env:ProgramFiles(x86)}\Windows Kits\10\Extension SDKs\WindowsDesktop"
     return [PSCustomObject]@{
-        path = "${env:ProgramFiles(x86)}\Windows Kits\10\Extension SDKs\WindowsDesktop"
+        path = $path
         versions = $(Get-ChildItem $path).Name
     }
 }

--- a/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
@@ -89,3 +89,10 @@ function Get-VisualStudioExtensions {
         [PSCustomObject]$_
     } | Select-Object Package, Version | Sort-Object Package
 }
+
+function Get-WindowsSDKs {
+    [PSCustomObject]@{
+        path = "${env:ProgramFiles(x86)}\Windows Kits\10\Extension SDKs\WindowsDesktop"
+        versions = $(Get-ChildItem $path).Name
+    }
+}

--- a/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.VisualStudio.psm1
@@ -93,7 +93,7 @@ function Get-VisualStudioExtensions {
 function Get-WindowsSDKs {
     $path = "${env:ProgramFiles(x86)}\Windows Kits\10\Extension SDKs\WindowsDesktop"
     return [PSCustomObject]@{
-        path = $path
-        versions = $(Get-ChildItem $path).Name
+        Path = $path
+        Versions = $(Get-ChildItem $path).Name
     }
 }

--- a/images/win/scripts/Tests/VisualStudio.Tests.ps1
+++ b/images/win/scripts/Tests/VisualStudio.Tests.ps1
@@ -23,3 +23,9 @@ Describe "Visual Studio" {
         }
     }
 }
+
+Describe "Windows 10 SDK" {
+    It "Verifies 17763 SDK is installed" -Skip:((Test-IsWin16) -or (Test-IsWin19)) {
+        "${env:ProgramFiles(x86)}\Windows Kits\10\DesignTime\CommonConfiguration\Neutral\UAP\10.0.17763.0\UAP.props" | Should -Exist
+    }
+}


### PR DESCRIPTION
## Description
This PR adds Visual Studio component "Windows10SDK.17763" to Windows 2022 image.

## Related issue: 
https://github.com/actions/virtual-environments/issues/4825

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
