### PR TITLE
[Ubuntu] bind google-cloud-sdk version

### DIFF
--- a/images/linux/scripts/installers/google-cloud-sdk.sh
+++ b/images/linux/scripts/installers/google-cloud-sdk.sh
@@ -10,7 +10,7 @@ REPO_URL="https://packages.cloud.google.com/apt"
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] $REPO_URL cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 sudo apt-get update -y
-sudo apt-get install -y google-cloud-sdk
+sudo apt-get install -y google-cloud-sdk=369.0.0-0
 
 # remove apt
 rm /etc/apt/sources.list.d/google-cloud-sdk.list


### PR DESCRIPTION
# Description

google-cloud-sdk 370.0.0-0 (the latest one) is buggy in terms of bundled python component, whenever you call the `gcloud components copy-bundled-python` command it is installing the python component (bundled python's interpreter and co.)
An attempt to call this installed python leads to python's interpreter unable to load the `libpython` library, quick glance over ldd:

```PS /home/testadm2> ldd /tmp/tmp5n94aqv5/python/python3
linux-vdso.so.1 (0x00007ffc3455e000)
/tmp/tmp5n94aqv5/python/../lib/libpython3.8.so.1.0 => not found
libcrypt.so.1 => /lib/x86_64-linux-gnu/libcrypt.so.1 (0x00007fe14867d000)
libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fe14865a000)
libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fe148654000)
libutil.so.1 => /lib/x86_64-linux-gnu/libutil.so.1 (0x00007fe14864f000)
libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fe148500000)
librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fe1484f3000)
libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fe148301000)
/lib64/ld-linux-x86-64.so.2 (0x00007fe1486c1000)
```

Shows that `libpython3.8.so.1.0 ` is being searched in `/tmp` which is a binary's bug per se (I have reported this to google privately and  am going to create a public ticket soon-ish).

Downgrade helps.

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/3283

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
