### PR TITLE
[Windows] Add DslTools Component

### DIFF
--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -183,6 +183,7 @@
             "Microsoft.VisualStudio.Component.Azure.ServiceFabric.Tools",
             "Microsoft.VisualStudio.Component.Debugger.JustInTime",
             "Microsoft.VisualStudio.Component.EntityFramework",
+            "Microsoft.VisualStudio.Component.DslTools",
             "Microsoft.VisualStudio.Component.LinqToSql",
             "Microsoft.VisualStudio.Component.SQL.SSDT",
             "Microsoft.VisualStudio.Component.Sharepoint.Tools",


### PR DESCRIPTION
# Description
Add Visual Studio 2022  `Microsoft.VisualStudio.Component.DslTools` component on Windows Server 2022.

#### Related issue:
https://github.com/actions/virtual-environments/issues/4946

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
