### PR TITLE
[macOS] fix operands order on miniconda

### DIFF
--- a/images/macos/provision/core/miniconda.sh
+++ b/images/macos/provision/core/miniconda.sh
@@ -6,7 +6,7 @@ chmod +x $MINICONDA_INSTALLER
 sudo $MINICONDA_INSTALLER -b -p /usr/local/miniconda
 
 # Chmod with full permissions recursively to avoid permissions restrictions
-sudo chmod 777 -R /usr/local/miniconda
+sudo chmod -R 777 /usr/local/miniconda
 
 sudo ln -s /usr/local/miniconda/bin/conda /usr/local/bin/conda
 


### PR DESCRIPTION
# Description

the order of mode calling is wrong now.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
