### PR TITLE
[Windows] Add InnoSetup to windows-2022

### DIFF
--- a/images/win/scripts/Tests/ChocoPackages.Tests.ps1
+++ b/images/win/scripts/Tests/ChocoPackages.Tests.ps1
@@ -28,7 +28,7 @@ Describe "GitVersion" -Skip:(Test-IsWin22) {
     }
 }
 
-Describe "InnoSetup" -Skip:(Test-IsWin22) {
+Describe "InnoSetup" {
     It "InnoSetup" {
         (Get-Command -Name iscc).CommandType | Should -BeExactly "Application"
     }

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -297,6 +297,7 @@
             { "name": "aria2" },
             { "name": "azcopy10" },
             { "name": "Bicep" },
+            { "name": "innosetup" },
             { "name": "jq" },
             { "name": "llvm" },
             { "name": "NuGet.CommandLine" },


### PR DESCRIPTION
# Description
Given the high demand for InnoSetup on windows-2022 image and tool popularity we decided to add it to the image.

#### Related issue:
https://github.com/actions/virtual-environments/issues/5006

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
