### PR TITLE
[macOS] install tcl-tk explicitly

### DIFF
--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -532,6 +532,11 @@ function Get-LibXextVersion {
     return "libXext $libXextVersion"
 }
 
+function Get-TclTkVersion {
+    $tcltkVersion = (brew info tcl-tk)[0] | Take-Part -Part
+    return "Tcl/Tk $tcltkVersion"
+}
+
 function Build-PackageManagementEnvironmentTable {
     return @(
         @{

--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -533,7 +533,7 @@ function Get-LibXextVersion {
 }
 
 function Get-TclTkVersion {
-    $tcltkVersion = (brew info tcl-tk)[0] | Take-Part -Part
+    $tcltkVersion = (brew info tcl-tk)[0] | Take-Part -Part 2
     return "Tcl/Tk $tcltkVersion"
 }
 

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -293,7 +293,8 @@ $markdown += New-MDHeader "Miscellaneous" -Level 3
 $markdown += New-MDList -Style Unordered -Lines (@(
     (Get-ZlibVersion),
     (Get-LibXextVersion),
-    (Get-LibXftVersion)
+    (Get-LibXftVersion),
+    (Get-TclTkVersion)
     ) | Sort-Object
 )
 

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -227,7 +227,8 @@
             "zstd",
             "zlib",
             "libxext",
-            "libxft"
+            "libxft",
+            "tcl-tk"
         ],
         "cask_packages": [
             "julia",

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -194,7 +194,8 @@
             "zstd",
             "zlib",
             "libxext",
-            "libxft"
+            "libxft",
+            "tcl-tk"
         ],
         "cask_packages": [
             "julia"

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -110,7 +110,8 @@
             "gmp",
             "zlib",
             "libxext",
-            "libxft"
+            "libxft",
+            "tcl-tk"
         ],
         "cask_packages": [
             "julia"


### PR DESCRIPTION
# Description

While the workaround described in the attached issue works perfectly well, the actual symlinks creation happens much earlier than we have the Tcl/Tk package installed, as a result we are having broken symlinks created, to avoid this we need to install the tcl/tk package right in the place of the symlinks creation.


#### Related issue: https://github.com/actions/virtual-environments/issues/4931

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
