### PR TITLE
[macOS] Update TCC.db to bypass Microsoft Defender installation

### DIFF
--- a/images/macos/provision/configuration/configure-tccdb-macos11.sh
+++ b/images/macos/provision/configuration/configure-tccdb-macos11.sh
@@ -16,6 +16,7 @@ systemValuesArray=(
     "'kTCCServiceAccessibility','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993"
     "'kTCCServiceMicrophone','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1576661342"
     "'kTCCServiceScreenCapture','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1599831148"
+    # Allow Full Disk Access for "Microsoft Defender for macOS" to bypass installation on-flight
     "'kTCCServiceSystemPolicyAllFiles','com.microsoft.wdav',0,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,0,1643970979"
     "'kTCCServiceSystemPolicyAllFiles','com.microsoft.wdav.epsext',0,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,0,1643970979"
 )

--- a/images/macos/provision/configuration/configure-tccdb-macos11.sh
+++ b/images/macos/provision/configuration/configure-tccdb-macos11.sh
@@ -16,6 +16,8 @@ systemValuesArray=(
     "'kTCCServiceAccessibility','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993"
     "'kTCCServiceMicrophone','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1576661342"
     "'kTCCServiceScreenCapture','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1599831148"
+    "'kTCCServiceSystemPolicyAllFiles','com.microsoft.wdav',0,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,0,1643970979"
+    "'kTCCServiceSystemPolicyAllFiles','com.microsoft.wdav.epsext',0,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,0,1643970979"
 )
 for values in "${systemValuesArray[@]}"; do
     configure_system_tccdb "$values"


### PR DESCRIPTION
# Description
Currently, Microsoft Defender for macOS can't be installed on Hosted Images because of multiple modal approval windows that will block installation.
We would like to pre-approve permission access for `com.microsoft.wdav` app.

## How it works
This PR adds a few more entries to `/Library/Application Support/com.apple.TCC/TCC.db` file via sqlite3:
```
kTCCServiceSystemPolicyAllFiles|com.microsoft.wdav.epsext|0|2|4|1||||UNUSED|||1643970979
kTCCServiceSystemPolicyAllFiles|com.microsoft.wdav|0|2|4|1|NULL|NULL|NULL|'UNUSED'|NULL|0|1643970979
```

## Explanation of fields
```
sqlite > PRAGMA table_info(access)
0|service|TEXT|1||1
1|client|TEXT|1||2
2|client_type|INTEGER|1||3
3|auth_value|INTEGER|1||0
4|auth_reason|INTEGER|1||0
5|auth_version|INTEGER|1||0
6|csreq|BLOB|0||0
7|policy_id|INTEGER|0||0
8|indirect_object_identifier_type|INTEGER|0||0
9|indirect_object_identifier|TEXT|1|'UNUSED'|4
10|indirect_object_code_identity|BLOB|0||0
11|flags|INTEGER|0||0
12|last_modified|INTEGER|1|CAST(strftime('%s','now') AS INTEGER)|0
```

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
