### PR TITLE
[macOS] Make auth optional for nvm and ruby scripts

### DIFF
--- a/images/macos/provision/core/nvm.sh
+++ b/images/macos/provision/core/nvm.sh
@@ -5,7 +5,8 @@
 ###########################################################################
 source ~/utils/utils.sh
 
-VERSION=$(curl -H "Authorization: token $API_PAT" -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r '.tag_name')
+[ -n "$API_PAT" ] && authString=(-H "Authorization: token ${API_PAT}")
+VERSION=$(curl "${authString[@]}" -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r '.tag_name')
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$VERSION/install.sh | bash
 
 if [ $? -eq 0 ]; then

--- a/images/macos/provision/core/ruby.sh
+++ b/images/macos/provision/core/ruby.sh
@@ -10,7 +10,8 @@ echo "GEM_PATH=$GEM_PATH" >> "$HOME/.bashrc"
 echo 'export PATH="$GEM_PATH:/usr/local/opt/ruby@'${DEFAULT_RUBY_VERSION}'/bin:$PATH"'  >> "$HOME/.bashrc"
 
 echo "Install Ruby from toolset..."
-PACKAGE_TAR_NAMES=$(curl -H "Authorization: token $API_PAT" -s "https://api.github.com/repos/ruby/ruby-builder/releases/latest" | jq -r '.assets[].name')
+[ -n "$API_PAT" ] && authString=(-H "Authorization: token ${API_PAT}")
+PACKAGE_TAR_NAMES=$(curl "${authString[@]}" -s "https://api.github.com/repos/ruby/ruby-builder/releases/latest" | jq -r '.assets[].name')
 TOOLSET_VERSIONS=$(get_toolset_value '.toolcache[] | select(.name | contains("Ruby")) | .versions[]')
 RUBY_PATH="$AGENT_TOOLSDIRECTORY/Ruby"
 


### PR DESCRIPTION
# Description
This is an addition to https://github.com/actions/virtual-environments/pull/4923 to make auth optional for Ruby and Nvm installation scripts, all the other github API calls are covered with the helper.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3139

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
