### PR TITLE
[macOS] Add GraalVM into Anka template

### DIFF
--- a/images/macos/templates/macOS-11.pkr.hcl
+++ b/images/macos/templates/macOS-11.pkr.hcl
@@ -191,7 +191,8 @@ build {
                 "./provision/core/firefox.sh",
                 "./provision/core/pypy.sh",
                 "./provision/core/pipx-packages.sh",
-                "./provision/core/bicep.sh"
+                "./provision/core/bicep.sh",
+                "./provision/core/graalvm.sh"
     ]
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
   }


### PR DESCRIPTION
# Description
In scope of the https://github.com/actions/virtual-environments/pull/4959 PR we added GraalVM also we should add this script into the Anka template.
