### PR TITLE
[macOS] Add DeveloperIDG2CA.cer certificate

### DIFF
--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -30,16 +30,30 @@ defaults write com.apple.VoiceOver4/default SCREnableAppleScript -bool YES
 # Rotate the certificate before expiration to ensure your apps are installed and signed with an active certificate.
 # Confirm that the correct intermediate certificate is installed by verifying the expiration date is set to 2030.
 # sudo security delete-certificate -Z FF6797793A3CD798DC5B2ABEF56F73EDC9F83A64 /Library/Keychains/System.keychain
-curl https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer --output $HOME/AppleWWDRCAG3.cer --silent
 # Big Sur requires user interaction to add a cert https://developer.apple.com/forums/thread/671582, we need to use a workaround with SecItemAdd swift method
-if is_Catalina; then
-    sudo security add-trusted-cert -d -r unspecified -k /Library/Keychains/System.keychain $HOME/AppleWWDRCAG3.cer
-else
-    swiftc $HOME/image-generation/add-certificate.swift
-    sudo ./add-certificate $HOME/AppleWWDRCAG3.cer
-    rm add-certificate
+if ! is_Catalina; then
+    swiftc "${HOME}/image-generation/add-certificate.swift"
 fi
-rm $HOME/AppleWWDRCAG3.cer
+
+certs=(
+    AppleWWDRCAG3.cer
+    DeveloperIDG2CA.cer
+)
+for cert in ${certs[@]}; do
+    echo "Adding ${cert} certificate"
+    cert_path="${HOME}/${cert}"
+    curl "https://www.apple.com/certificateauthority/${cert}" --output ${cert_path} --silent
+
+    if is_Catalina; then
+        sudo security add-trusted-cert -d -r unspecified -k /Library/Keychains/System.keychain ${cert_path}
+    else
+        sudo ./add-certificate ${cert_path}
+    fi
+
+    rm ${cert_path}
+done
+
+rm -f ./add-certificate
 
 # Create symlink for tests running
 if [ ! -d "/usr/local/bin" ];then

--- a/images/macos/tests/System.Tests.ps1
+++ b/images/macos/tests/System.Tests.ps1
@@ -15,6 +15,12 @@ Describe "Certificate" {
         $certs = security find-certificate -a -c Worldwide -p -Z | Out-String
         $certs | Should -Match $sha1Hash
     }
+
+    It "Developer ID Certification Authority[expired: 2031-09] is installed" {
+        $sha1Hash = "5B45F61068B29FCC8FFFF1A7E99B78DA9E9C4635"
+        $certs = security find-certificate -a -c "Developer ID" -p -Z | Out-String
+        $certs | Should -Match $sha1Hash
+    }
 }
 
 Describe "Audio device" {


### PR DESCRIPTION
# Description
Add [Developer ID - G2 (Expiring 09/17/2031 00:00:00 UTC)](https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer) certificate to the macOS images. 

#### Related issue:
https://github.com/actions/virtual-environments/issues/5037

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
