### PR TITLE
[macOS] Update get_github_package_download_url helper

### DIFF
--- a/images/macos/provision/core/powershell.sh
+++ b/images/macos/provision/core/powershell.sh
@@ -2,7 +2,7 @@
 source ~/utils/utils.sh
 
 echo Installing PowerShell...
-psDownloadUrl=$(get_github_package_download_url "PowerShell" "PowerShell" "contains(\"osx-x64.pkg\")" "latest" "$API_PAT")
+psDownloadUrl=$(get_github_package_download_url "PowerShell/PowerShell" "contains(\"osx-x64.pkg\")" "latest" "$API_PAT")
 download_with_retries $psDownloadUrl "/tmp" "powershell.pkg"
 
 # Work around the issue on macOS Big Sur 11.5 or higher for possible error message ("can't be opened because Apple cannot check it for malicious software") when installing the package

--- a/images/macos/provision/core/stack.sh
+++ b/images/macos/provision/core/stack.sh
@@ -2,7 +2,7 @@
 source ~/utils/utils.sh
 
 echo "Get the latest Stack version..."
-stackDownloadUrl=$(get_github_package_download_url "commercialhaskell" "stack" "contains(\"osx-x86_64.tar.gz\")" "latest" "$API_PAT")
+stackDownloadUrl=$(get_github_package_download_url "commercialhaskell/stack" "contains(\"osx-x86_64.tar.gz\")" "latest" "$API_PAT")
 stackVersion=$(echo $stackDownloadUrl | cut -d "/" -f8 | tr -d "v")
 stackArchive="/tmp/stack.tar.gz"
 

--- a/images/macos/provision/core/swiftlint.sh
+++ b/images/macos/provision/core/swiftlint.sh
@@ -2,7 +2,7 @@
 source ~/utils/utils.sh
 
 echo "Install SwiftLint"
-swiftlintUrl=$(get_github_package_download_url "realm" "SwiftLint" "contains(\"portable_swiftlint.zip\")" "latest" "$API_PAT")
+swiftlintUrl=$(get_github_package_download_url "realm/SwiftLint" "contains(\"portable_swiftlint.zip\")" "latest" "$API_PAT")
 download_with_retries $swiftlintUrl "/tmp" "portable_swiftlint.zip"
 unzip -q "/tmp/portable_swiftlint.zip" -d /usr/local/bin
 # Remove the LICENSE file that comes along with the binary and the downloaded archive

--- a/images/macos/provision/utils/utils.sh
+++ b/images/macos/provision/utils/utils.sh
@@ -173,16 +173,15 @@ configure_user_tccdb () {
 }
 
 get_github_package_download_url() {
-    local REPO_OWNER=$1
-    local REPO_NAME=$2
-    local FILTER=$3
-    local VERSION=$4
-    local API_PAT=$5
+    local REPO_ORG=$1
+    local FILTER=$2
+    local VERSION=$3
+    local API_PAT=$4
     local SEARCH_IN_COUNT="100"
 
     [ -n "$API_PAT" ] && authString=(-H "Authorization: token ${API_PAT}")
 
-    json=$(curl "${authString[@]}" -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases?per_page=${SEARCH_IN_COUNT}")
+    json=$(curl "${authString[@]}" -s "https://api.github.com/repos/${REPO_ORG}/releases?per_page=${SEARCH_IN_COUNT}")
 
     if [[ "$VERSION" == "latest" ]]; then
         tagName=$(echo $json | jq -r '.[] | select(.prerelease==false).tag_name' | sort --unique --version-sort | egrep -v ".*-[a-z]" | tail -1)


### PR DESCRIPTION
# Description
Let's combine two variables (`REPO_NAME` and `REPO_OWNER`) into one (`REPO_ORG`) as it was done [for helper on Ubuntu](https://github.com/actions/virtual-environments/pull/4947/commits/5da9040f295b1e391a9d07ae37d94c3357b6416b).

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
