### PR TITLE
[macOS] Add test to check opened windows

### DIFF
--- a/images/macos/provision/core/open_windows_check.sh
+++ b/images/macos/provision/core/open_windows_check.sh
@@ -8,8 +8,12 @@ if [ -n "${openwindows}" ]; then
 fi
 
 for window in "${windowslist[@]}"; do
-    echo " - ${window}" | xargs
-    scripterror=true
+    if [[ $window =~ "NotificationCenter" ]]; then
+        echo "[Warning] $window"
+    else
+        echo " - ${window}" | xargs
+        scripterror=true
+    fi
 done
 
 if [ "${scripterror}" = true ]; then

--- a/images/macos/provision/core/open_windows_check.sh
+++ b/images/macos/provision/core/open_windows_check.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e -o pipefail
+
+openwindows=$(osascript -e 'tell application "System Events" to get every window of (every process whose class of windows contains window)')
+IFS=',' read -r -a windowslist <<< "$openwindows"
+
+if [ -n "${openwindows}" ]; then
+    echo "Found opened window:"
+fi
+
+for window in "${windowslist[@]}"; do
+    echo " - ${window}" | xargs
+    scripterror=true
+done
+
+if [ "${scripterror}" = true ]; then
+    exit 1
+fi

--- a/images/macos/templates/macOS-10.15.json
+++ b/images/macos/templates/macOS-10.15.json
@@ -129,6 +129,7 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "pause_before": "30s",
             "scripts": [
+                "./provision/core/open_windows_check.sh",
                 "./provision/core/xcode-clt.sh",
                 "./provision/core/homebrew.sh",
                 "./provision/core/powershell.sh",

--- a/images/macos/templates/macOS-10.15.json
+++ b/images/macos/templates/macOS-10.15.json
@@ -131,6 +131,7 @@
             "scripts": [
                 "./provision/core/xcode-clt.sh",
                 "./provision/core/homebrew.sh",
+                "./provision/core/open_windows_check.sh",
                 "./provision/core/powershell.sh",
                 "./provision/core/dotnet.sh",
                 "./provision/core/python.sh",
@@ -139,8 +140,7 @@
                 "./provision/core/ruby.sh",
                 "./provision/core/rubygem.sh",
                 "./provision/core/git.sh",
-                "./provision/core/node.sh",
-                "./provision/core/open_windows_check.sh"
+                "./provision/core/node.sh"
             ],
             "environment_vars": [
                 "API_PAT={{user `github_api_pat`}}"

--- a/images/macos/templates/macOS-10.15.json
+++ b/images/macos/templates/macOS-10.15.json
@@ -129,7 +129,6 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "pause_before": "30s",
             "scripts": [
-                "./provision/core/open_windows_check.sh",
                 "./provision/core/xcode-clt.sh",
                 "./provision/core/homebrew.sh",
                 "./provision/core/powershell.sh",
@@ -140,7 +139,8 @@
                 "./provision/core/ruby.sh",
                 "./provision/core/rubygem.sh",
                 "./provision/core/git.sh",
-                "./provision/core/node.sh"
+                "./provision/core/node.sh",
+                "./provision/core/open_windows_check.sh"
             ],
             "environment_vars": [
                 "API_PAT={{user `github_api_pat`}}"

--- a/images/macos/templates/macOS-11.json
+++ b/images/macos/templates/macOS-11.json
@@ -136,6 +136,7 @@
             "pause_before": "30s",
             "scripts": [
                 "./provision/core/homebrew.sh",
+                "./provision/core/open_windows_check.sh",
                 "./provision/core/powershell.sh",
                 "./provision/core/dotnet.sh",
                 "./provision/core/python.sh",
@@ -144,8 +145,7 @@
                 "./provision/core/ruby.sh",
                 "./provision/core/rubygem.sh",
                 "./provision/core/git.sh",
-                "./provision/core/node.sh",
-                "./provision/core/open_windows_check.sh"
+                "./provision/core/node.sh"
             ],
             "environment_vars": [
                 "API_PAT={{user `github_api_pat`}}"

--- a/images/macos/templates/macOS-11.json
+++ b/images/macos/templates/macOS-11.json
@@ -135,6 +135,7 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "pause_before": "30s",
             "scripts": [
+                "./provision/core/open_windows_check.sh",
                 "./provision/core/homebrew.sh",
                 "./provision/core/powershell.sh",
                 "./provision/core/dotnet.sh",

--- a/images/macos/templates/macOS-11.json
+++ b/images/macos/templates/macOS-11.json
@@ -135,7 +135,6 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "pause_before": "30s",
             "scripts": [
-                "./provision/core/open_windows_check.sh",
                 "./provision/core/homebrew.sh",
                 "./provision/core/powershell.sh",
                 "./provision/core/dotnet.sh",
@@ -145,7 +144,8 @@
                 "./provision/core/ruby.sh",
                 "./provision/core/rubygem.sh",
                 "./provision/core/git.sh",
-                "./provision/core/node.sh"
+                "./provision/core/node.sh",
+                "./provision/core/open_windows_check.sh"
             ],
             "environment_vars": [
                 "API_PAT={{user `github_api_pat`}}"

--- a/images/macos/templates/macOS-11.pkr.hcl
+++ b/images/macos/templates/macOS-11.pkr.hcl
@@ -134,6 +134,7 @@ build {
   provisioner "shell" {
     pause_before = "30s"
     scripts = [
+      "./provision/core/open_windows_check.sh",
       "./provision/core/homebrew.sh",
       "./provision/core/powershell.sh",
       "./provision/core/dotnet.sh",

--- a/images/macos/templates/macOS-11.pkr.hcl
+++ b/images/macos/templates/macOS-11.pkr.hcl
@@ -135,6 +135,7 @@ build {
     pause_before = "30s"
     scripts = [
       "./provision/core/homebrew.sh",
+      "./provision/core/open_windows_check.sh",
       "./provision/core/powershell.sh",
       "./provision/core/dotnet.sh",
       "./provision/core/python.sh",
@@ -143,8 +144,7 @@ build {
       "./provision/core/ruby.sh",
       "./provision/core/rubygem.sh",
       "./provision/core/git.sh",
-      "./provision/core/node.sh",
-      "./provision/core/open_windows_check.sh"
+      "./provision/core/node.sh"
     ]
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
   }

--- a/images/macos/templates/macOS-11.pkr.hcl
+++ b/images/macos/templates/macOS-11.pkr.hcl
@@ -134,7 +134,6 @@ build {
   provisioner "shell" {
     pause_before = "30s"
     scripts = [
-      "./provision/core/open_windows_check.sh",
       "./provision/core/homebrew.sh",
       "./provision/core/powershell.sh",
       "./provision/core/dotnet.sh",
@@ -144,7 +143,8 @@ build {
       "./provision/core/ruby.sh",
       "./provision/core/rubygem.sh",
       "./provision/core/git.sh",
-      "./provision/core/node.sh"
+      "./provision/core/node.sh",
+      "./provision/core/open_windows_check.sh"
     ]
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
   }

--- a/images/macos/templates/macOS-12.json
+++ b/images/macos/templates/macOS-12.json
@@ -136,6 +136,7 @@
             "pause_before": "30s",
             "scripts": [
                 "./provision/core/homebrew.sh",
+                "./provision/core/open_windows_check.sh",
                 "./provision/core/powershell.sh",
                 "./provision/core/dotnet.sh",
                 "./provision/core/python.sh",
@@ -144,8 +145,7 @@
                 "./provision/core/ruby.sh",
                 "./provision/core/rubygem.sh",
                 "./provision/core/git.sh",
-                "./provision/core/node.sh",
-                "./provision/core/open_windows_check.sh"
+                "./provision/core/node.sh"
             ],
             "environment_vars": [
                 "API_PAT={{user `github_api_pat`}}"

--- a/images/macos/templates/macOS-12.json
+++ b/images/macos/templates/macOS-12.json
@@ -135,6 +135,7 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "pause_before": "30s",
             "scripts": [
+                "./provision/core/open_windows_check.sh",
                 "./provision/core/homebrew.sh",
                 "./provision/core/powershell.sh",
                 "./provision/core/dotnet.sh",

--- a/images/macos/templates/macOS-12.json
+++ b/images/macos/templates/macOS-12.json
@@ -135,7 +135,6 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "pause_before": "30s",
             "scripts": [
-                "./provision/core/open_windows_check.sh",
                 "./provision/core/homebrew.sh",
                 "./provision/core/powershell.sh",
                 "./provision/core/dotnet.sh",
@@ -145,7 +144,8 @@
                 "./provision/core/ruby.sh",
                 "./provision/core/rubygem.sh",
                 "./provision/core/git.sh",
-                "./provision/core/node.sh"
+                "./provision/core/node.sh",
+                "./provision/core/open_windows_check.sh"
             ],
             "environment_vars": [
                 "API_PAT={{user `github_api_pat`}}"

--- a/images/macos/tests/System.Tests.ps1
+++ b/images/macos/tests/System.Tests.ps1
@@ -51,6 +51,6 @@ Describe "Open windows" {
     It "Opened windows not found" {
         $cmd = "osascript -e 'tell application \""System Events\"" to get every window of (every process whose class of windows contains window)'"
         $openWindows = bash -c $cmd
-        $openWindows.Trim() | Should -BeNullOrEmpty
+        $openWindows.Split(",").Trim() -notmatch "NotificationCenter" | Should -BeNullOrEmpty
     }
 }

--- a/images/macos/tests/System.Tests.ps1
+++ b/images/macos/tests/System.Tests.ps1
@@ -51,6 +51,6 @@ Describe "Open windows" {
     It "Opened windows not found" {
         $cmd = "osascript -e 'tell application \""System Events\"" to get every window of (every process whose class of windows contains window)'"
         $openWindows = bash -c $cmd
-        $openWindows.Split(",").Trim() -notmatch "NotificationCenter" | Should -BeNullOrEmpty
+        $openWindows.Split(",").Trim() | Where-Object { $_ -notmatch "NotificationCenter" } | Should -BeNullOrEmpty
     }
 }

--- a/images/macos/tests/System.Tests.ps1
+++ b/images/macos/tests/System.Tests.ps1
@@ -46,3 +46,11 @@ Describe "Screen Resolution" {
         system_profiler SPDisplaysDataType | Select-String "Resolution" | Should -Match "1176 x 885|1920 x 1080"
     }
 }
+
+Describe "Open windows" {
+    It "Opened windows not found" {
+        $cmd = "osascript -e 'tell application \""System Events\"" to get every window of (every process whose class of windows contains window)'"
+        $openWindows = bash -c $cmd
+        $openWindows.Trim() | Should -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
# Description
Sometimes we forget to close some windows during macOS updates on the images. In scope of this PR we have implemented a pester test that check if there are any open windows on the image at the beginning and in the end of the image generation.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3348

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
