### PR TITLE
[macOS] Install Azure DevOps extension for AZ CLI

### DIFF
--- a/images/macos/provision/core/commonutils.sh
+++ b/images/macos/provision/core/commonutils.sh
@@ -19,6 +19,9 @@ done
 # Invoke bazel to download bazel version via bazelisk
 bazel
 
+# Install Azure DevOps extension for Azure Command Line Interface
+az extension add -n azure-devops
+
 # Workaround https://github.com/actions/virtual-environments/issues/4931
 # by making Tcl/Tk paths the same on macOS 10.15 and macOS 11
 if is_BigSur; then

--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -422,6 +422,11 @@ function Get-AzureCLIVersion {
     return "Azure CLI $azureCLIVersion"
 }
 
+function Get-AzureDevopsVersion {
+    $azdevopsVersion = (az version | ConvertFrom-Json).extensions.'azure-devops'
+    return "Azure CLI (azure-devops) $azdevopsVersion"
+}
+
 function Get-AWSCLIVersion {
     $awsVersion = Run-Command "aws --version" | Take-Part -Part 0 | Take-Part -Delimiter "/" -Part 1
     return "AWS CLI $awsVersion"

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -155,6 +155,7 @@ $toolsList = @(
     (Get-CmakeVersion),
     (Get-AppCenterCLIVersion),
     (Get-AzureCLIVersion),
+    (Get-AzureDevopsVersion),
     (Get-AWSCLIVersion),
     (Get-AWSSAMCLIVersion),
     (Get-AWSSessionManagerCLIVersion)

--- a/images/macos/tests/BasicTools.Tests.ps1
+++ b/images/macos/tests/BasicTools.Tests.ps1
@@ -6,6 +6,12 @@ Describe "Azure CLI" {
     }
 }
 
+Describe "Azure DevOps CLI" {
+    It "az devops" {
+        "az devops -h" | Should -ReturnZeroExitCode
+    }
+}
+
 Describe "Carthage" {
     It "Carthage" {
         "carthage version" | Should -ReturnZeroExitCode


### PR DESCRIPTION
# Description
Install Azure DevOps extension for Azure Command Line Interface.

#### Related issue:
https://github.com/actions/virtual-environments/issues/5053

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
