### PR TITLE
[Windows] Add ARM/ARM64 libraries to windows-2022 (#5056)

### DIFF
--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -211,6 +211,8 @@
             "Microsoft.VisualStudio.Component.VC.Tools.ARM64EC",
             "Microsoft.VisualStudio.Component.VC.v141.x86.x64",
             "Microsoft.VisualStudio.Component.VC.v141.x86.x64.Spectre",
+            "Microsoft.VisualStudio.Component.VC.v141.ARM.Spectre",
+            "Microsoft.VisualStudio.Component.VC.v141.ARM64.Spectre",
             "Microsoft.VisualStudio.Component.VC.v141.MFC",
             "Microsoft.VisualStudio.Component.VC.v141.MFC.Spectre",
             "Microsoft.VisualStudio.Component.VC.14.29.16.11.ARM",


### PR DESCRIPTION
# Description
Adds missing ARM/ARM64 libraries to windows-2022 image.

Fixes #5056 

#### Related issue:

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
