### PR TITLE
[Windows] Set condition to install 98.0.1108.50 instead of 98.0.1108.51

### DIFF
--- a/images/win/scripts/Installers/Install-Edge.ps1
+++ b/images/win/scripts/Installers/Install-Edge.ps1
@@ -27,6 +27,14 @@ $EdgeDriverVersionFile = Start-DownloadWithRetry -Url $EdgeDriverVersionUrl -Nam
 Write-Host "Download Microsoft Edge WebDriver..."
 $EdgeDriverLatestVersion = Get-Content -Path $EdgeDriverVersionFile
 $EdgeDriverArchName = "edgedriver_win64.zip"
+
+# A temporary workaround to install the previous driver version because 98.0.1108.51 for win64 doesn't exist
+if ($EdgeDriverLatestVersion -eq "98.0.1108.51")
+{
+    $EdgeDriverLatestVersion = "98.0.1108.50"
+    Set-Content -Path "${EdgeDriverPath}\versioninfo.txt" -Value $EdgeDriverLatestVersion
+}
+
 $EdgeDriverDownloadUrl = "https://msedgedriver.azureedge.net/${EdgeDriverLatestVersion}/${EdgeDriverArchName}"
 
 $EdgeDriverArchPath = Start-DownloadWithRetry -Url $EdgeDriverDownloadUrl -Name $EdgeDriverArchName


### PR DESCRIPTION
# Description
Webdriver win64 for version 98.0.1108.51 doesn't exist thus all windows builds are broken. Temporary hardcode98.0.1108.50 installation.

![image](https://user-images.githubusercontent.com/47745270/153808295-4d09f021-803e-40f7-8c11-c48294b49e5a.png)

#### Related issue:
https://github.com/actions/virtual-environments/issues/5066

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
