### PR TITLE
[Windows] Skip preview versions of android sdk platforms installation

### DIFF
--- a/images/win/scripts/Installers/Install-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Install-AndroidSDK.ps1
@@ -58,14 +58,11 @@ $androidPackages = Get-AndroidPackages -AndroidSDKManagerPath $sdkManager
 
 # platforms
 [int]$platformMinVersion = $androidToolset.platform_min_version
-$platformListByVersion = Get-AndroidPackagesByVersion -AndroidPackages $androidPackages `
+$platformList = Get-AndroidPackagesByVersion -AndroidPackages $androidPackages `
                 -PrefixPackageName "platforms;" `
                 -MinimumVersion $platformMinVersion `
                 -Delimiter "-" `
                 -Index 1
-$platformListByName = Get-AndroidPackagesByName -AndroidPackages $androidPackages `
-                -PrefixPackageName "platforms;" | Where-Object {$_ -match "-\D+$"}
-$platformList = $platformListByVersion + $platformListByName
 
 # build-tools
 [version]$buildToolsMinVersion = $androidToolset.build_tools_min_version

--- a/images/win/scripts/Tests/Android.Tests.ps1
+++ b/images/win/scripts/Tests/Android.Tests.ps1
@@ -14,14 +14,12 @@ Describe "Android SDK" {
 
     $platformTestCases = @()
     [int]$platformMinVersion = $androidToolset.platform_min_version
-    $platformListByVersion = Get-AndroidPackagesByVersion -AndroidPackages $androidPackages `
+    $platformList = Get-AndroidPackagesByVersion -AndroidPackages $androidPackages `
                     -PrefixPackageName "platforms;" `
                     -MinimumVersion $platformMinVersion `
                     -Delimiter "-" `
                     -Index 1
-    $platformListByName = Get-AndroidPackagesByName -AndroidPackages $androidPackages `
-                    -PrefixPackageName "platforms;" | Where-Object {$_ -match "-\D+$"}
-    $platformList = $platformListByVersion + $platformListByName 
+
     $platformList | ForEach-Object {
         $platformTestCases += @{ platformVersion = $_; installedPackages = $androidInstalledPackages }
     }


### PR DESCRIPTION
# Description
We do not install the rc version of build-tools thus we should not install the correspondent platform preview versions, which names start with a letter instead of a number. For example, the `android-Tiramisu` platform will be `android-33` once the version is released.
We have previously done the same for macOS https://github.com/actions/virtual-environments/pull/4372

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3410

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
