### PR TITLE
[macOS] Run osascript with retry

### DIFF
--- a/images/macos/provision/core/open_windows_check.sh
+++ b/images/macos/provision/core/open_windows_check.sh
@@ -1,6 +1,16 @@
 #!/bin/bash -e -o pipefail
 
-openwindows=$(osascript -e 'tell application "System Events" to get every window of (every process whose class of windows contains window)')
+retry=10
+while [ $retry -gt 0 ]; do
+    openwindows=$(osascript -e 'tell application "System Events" to get every window of (every process whose class of windows contains window)') && break
+
+    retry=$((retry-1))
+    if [ $retry -eq 0 ]; then
+        echo "No retry attempts left"
+        exit 1
+    fi
+    sleep 30
+done
 IFS=',' read -r -a windowslist <<< "$openwindows"
 
 if [ -n "${openwindows}" ]; then


### PR DESCRIPTION
# Description
Run osascript with retry to bypass -600 error.
```
==> veertu-anka-vm-clone.template: Provisioning with shell script: ./provision/core/open_windows_check.sh
==> veertu-anka-vm-clone.template: 40:52: execution error: Application isn’t running. (-600)
    veertu-anka-vm-clone.template: Found opened window:
    veertu-anka-vm-clone.template: [Warning] window Notification Center of application process NotificationCenter
```

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3393

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
