### PR TITLE
[macOS] Add exit 1 to each error case in move-vm script

### DIFF
--- a/images.CI/macos/move-vm.ps1
+++ b/images.CI/macos/move-vm.ps1
@@ -71,6 +71,7 @@ if ($env:AGENT_JOBSTATUS -eq 'Failed') {
         Write-Host "VM has been successfully powered off and renamed to [${VMName}_failed]"
     } catch {
         Write-Host "##vso[task.LogIssue type=error;]Failed to power off and rename VM '$VMName'"
+        exit 1
     }
 }
 
@@ -79,6 +80,7 @@ try {
     Write-Host "VM has been moved successfully to target datastore '$TargetDataStore'"
 } catch {
     Write-Host "##vso[task.LogIssue type=error;]Failed to move VM '$VMName' to target datastore '$TargetDataStore'"
+    exit 1
 }
 
 try {
@@ -86,4 +88,5 @@ try {
     $vm | Set-VM -NumCPU $CpuCount -CoresPerSocket $CoresPerSocketCount -MemoryMB $Memory -Confirm:$false -ErrorAction Stop | Out-Null
 } catch {
     Write-Host "##vso[task.LogIssue type=error;]Failed to change specs for VM '$VMName'"
+    exit 1
 }


### PR DESCRIPTION
# Description
It turned out that builds didn't fail even though there was an error moving the VM to the cold storage. We need to add exit 1 to each error case.
<img width="705" alt="image" src="https://user-images.githubusercontent.com/48208649/154315513-82956425-0a36-4071-81dc-50a26c600de3.png">

#### Related issue:
n\a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
