### PR TITLE
[All OS] Output full version of git to software report

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -89,7 +89,7 @@ function Get-DockerBuildxVersion {
 }
 
 function Get-GitVersion {
-    $gitVersion = Run-Command "git --version" | Take-OutputPart -Part -1
+    $gitVersion = git --version | Take-OutputPart -Part -1
     $aptSourceRepo = Get-AptSourceRepository -PackageName "git-core"
     return "Git $gitVersion (apt source repository: $aptSourceRepo)"
 }

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -89,8 +89,7 @@ function Get-DockerBuildxVersion {
 }
 
 function Get-GitVersion {
-    $result = Get-CommandResult "git --version"
-    $gitVersion = $result.Output | Take-OutputPart -Part 2
+    $gitVersion = Run-Command "git --version" | Take-OutputPart -Part -1
     $aptSourceRepo = Get-AptSourceRepository -PackageName "git-core"
     return "Git $gitVersion (apt source repository: $aptSourceRepo)"
 }

--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -266,7 +266,7 @@ function Get-CurlVersion {
 }
 
 function Get-GitVersion {
-    $gitVersion = Run-Command "git --version" | Take-Part -Part 2
+    $gitVersion = Run-Command "git --version" | Take-Part -Part -1
     return "Git: $gitVersion"
 }
 

--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -267,7 +267,7 @@ function Get-CurlVersion {
 
 function Get-GitVersion {
     $gitVersion = Run-Command "git --version" | Take-Part -Part -1
-    return "Git: $gitVersion"
+    return "Git $gitVersion"
 }
 
 function Get-GitLFSVersion {

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Helpers.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Helpers.psm1
@@ -161,3 +161,15 @@ function Test-BlankElement {
         exit 1
     }
 }
+
+function Take-Part {
+    param (
+        [Parameter(ValueFromPipeline)]
+        [string] $toolOutput,
+        [string] $Delimiter = " ",
+        [int[]] $Part
+    )
+    $parts = $toolOutput.Split($Delimiter, [System.StringSplitOptions]::RemoveEmptyEntries)
+    $selectedParts = $parts[$Part]
+    return [string]::Join($Delimiter, $selectedParts)
+}

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -67,8 +67,7 @@ function Get-DockerWincredVersion {
 }
 
 function Get-GitVersion {
-    $(git version) -match "git version (?<version>\d+\.\d+\.\d+)" | Out-Null
-    $gitVersion = $Matches.Version
+    $gitVersion = Run-Command "git --version" | Take-Part -Part -1
     return "Git $gitVersion"
 }
 

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -67,7 +67,7 @@ function Get-DockerWincredVersion {
 }
 
 function Get-GitVersion {
-    $gitVersion = Run-Command "git --version" | Take-Part -Part -1
+    $gitVersion = git --version | Take-Part -Part -1
     return "Git $gitVersion"
 }
 


### PR DESCRIPTION
# Description
We output not the full version in the image readme's that can confuse customers.
Also unifying function "Get-GitVersion" on all OS.
#### Related issue: https://github.com/actions/virtual-environments/issues/5054

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
