### PR TITLE
FIX: Write-Host Incorrect calls to variables.

### DIFF
--- a/helpers/CreateAzureVMFromPackerTemplate.ps1
+++ b/helpers/CreateAzureVMFromPackerTemplate.ps1
@@ -72,5 +72,5 @@ Function CreateAzureVMFromPackerTemplate {
     Write-Host "`nCreating the VM"
     az group deployment create -g $ResourceGroupName -n $VirtualMachineName --subscription $subscriptionId --template-file $templateFilePath --parameters vmSize=$vmSize vmName=$VirtualMachineName adminUserName=$AdminUsername adminPassword=$AdminPassword networkInterfaceId=$networkId
     
-    Write-Host "`nCreated in $(ResourceGroupName):`n  vnet $(vnetName)`n  subnet $(subnetName)`n  nic $(nicName)`n  publicip $(publicIpName)`n  vm $(VirtualMachineName)"
+    Write-Host "`nCreated in $($ResourceGroupName):`n  vnet $($vnetName)`n  subnet $($subnetName)`n  nic $($nicName)`n  publicip $($publicIpName)`n  vm $($VirtualMachineName)"
 }

--- a/helpers/CreateAzureVMFromPackerTemplate.ps1
+++ b/helpers/CreateAzureVMFromPackerTemplate.ps1
@@ -72,5 +72,5 @@ Function CreateAzureVMFromPackerTemplate {
     Write-Host "`nCreating the VM"
     az group deployment create -g $ResourceGroupName -n $VirtualMachineName --subscription $subscriptionId --template-file $templateFilePath --parameters vmSize=$vmSize vmName=$VirtualMachineName adminUserName=$AdminUsername adminPassword=$AdminPassword networkInterfaceId=$networkId
     
-    Write-Host "`nCreated in $($ResourceGroupName):`n  vnet $($vnetName)`n  subnet $($subnetName)`n  nic $($nicName)`n  publicip $($publicIpName)`n  vm $($VirtualMachineName)"
+    Write-Host "`nCreated in ${ResourceGroupName}:`n  vnet ${vnetName}`n  subnet ${subnetName}`n  nic ${nicName}`n  publicip ${publicIpName}`n  vm ${VirtualMachineName}"
 }


### PR DESCRIPTION
Error calling variables into last step of Azure VM creation. 

ResourceGroupName: The term 'ResourceGroupName' is not recognized as a name of a cmdlet, function, script file, or executable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.

# Description
Bug fixing

We get an error into the last step of creation of a VM Creation in Azure. Not retriving variables values because calls are incorrect. We should use $ResourceGroupName or ${ResourceGroupName} or $($ResourceGroupName) instead bad calling $(ResourceGroupName) 

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
