### PR TITLE
[macOS] Migrating python 2 scripts to python 3

### DIFF
--- a/images/macos/provision/bootstrap-provisioner/change_password
+++ b/images/macos/provision/bootstrap-provisioner/change_password
@@ -4,17 +4,8 @@ OLD_PASSWD="$2"
 NEW_PASSWD="$3"
 UPDATE_LOGIN_KEYCHAIN="${4:-true}"
 
-export PATH=/usr/bin:/usr/sbin:/usr/local/bin:/bin:/sbin
-
-macosver="$(sw_vers | grep ProductVersion | awk {'print $2'})"
-
-if [[ $macosver =~ 10.13.* ]]; then
-    sudo /usr/bin/dscl . -passwd /Users/$USERNAME "$NEW_PASSWD"
-else
-    sudo /usr/sbin/sysadminctl -resetPasswordFor $USERNAME -newPassword "$NEW_PASSWD" -adminUser $USERNAME -adminPassword "$OLD_PASSWD"
-fi
-
-sudo /usr/bin/python /Users/$USERNAME/bootstrap/kcpassword.py "$NEW_PASSWD"
+sudo /usr/sbin/sysadminctl -resetPasswordFor $USERNAME -newPassword "$NEW_PASSWD" -adminUser $USERNAME -adminPassword "$OLD_PASSWD"
+sudo /usr/bin/python3 /Users/$USERNAME/bootstrap/kcpassword.py "$NEW_PASSWD"
 sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser "$USERNAME"
 
 if [[ $UPDATE_LOGIN_KEYCHAIN == "true" ]]; then

--- a/images/macos/provision/bootstrap-provisioner/kcpassword.py
+++ b/images/macos/provision/bootstrap-provisioner/kcpassword.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Port of Gavin Brock's Perl kcpassword generator to Python, by Tom Taylor
 # <tom@tomtaylor.co.uk>.

--- a/images/macos/provision/configuration/autologin.sh
+++ b/images/macos/provision/configuration/autologin.sh
@@ -5,7 +5,7 @@
 
 echo "Enabling automatic GUI login for the '$USERNAME' user.."
 
-python $HOME/bootstrap/kcpassword.py "$PASSWORD"
+python3 $HOME/bootstrap/kcpassword.py "$PASSWORD"
 
 /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser "$USERNAME"
 

--- a/images/macos/provision/configuration/configure-hostname.sh
+++ b/images/macos/provision/configuration/configure-hostname.sh
@@ -4,7 +4,7 @@
 tee -a /usr/local/bin/change_hostname.sh > /dev/null <<\EOF
 #!/bin/bash -e -o pipefail
 
-name="Mac-$(python -c 'from time import time; print int(round(time() * 1000))')"
+name="Mac-$(python3 -c 'from time import time; print(int(round(time() * 1000)))')"
 scutil --set HostName "${name}.local"
 scutil --set LocalHostName $name
 scutil --set ComputerName "${name}.local"

--- a/images/macos/templates/macOS-10.15.json
+++ b/images/macos/templates/macOS-10.15.json
@@ -92,6 +92,7 @@
             "type": "shell",
             "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}",
             "scripts": [
+                "./provision/core/xcode-clt.sh",
                 "./provision/configuration/add-network-interface-detection.sh",
                 "./provision/configuration/autologin.sh",
                 "./provision/configuration/disable-auto-updates.sh",
@@ -129,7 +130,6 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "pause_before": "30s",
             "scripts": [
-                "./provision/core/xcode-clt.sh",
                 "./provision/core/homebrew.sh",
                 "./provision/core/open_windows_check.sh",
                 "./provision/core/powershell.sh",

--- a/images/macos/templates/macOS-11.json
+++ b/images/macos/templates/macOS-11.json
@@ -97,6 +97,7 @@
             "type": "shell",
             "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}",
             "scripts": [
+                "./provision/core/xcode-clt.sh",
                 "./provision/configuration/add-network-interface-detection.sh",
                 "./provision/configuration/autologin.sh",
                 "./provision/configuration/disable-auto-updates.sh",
@@ -116,7 +117,6 @@
             "scripts": [
                 "./provision/configuration/preimagedata.sh",
                 "./provision/configuration/configure-ssh.sh",
-                "./provision/core/xcode-clt.sh",
                 "./provision/configuration/configure-machine.sh"
             ],
             "environment_vars": [

--- a/images/macos/templates/macOS-11.pkr.hcl
+++ b/images/macos/templates/macOS-11.pkr.hcl
@@ -98,6 +98,7 @@ build {
   }
   provisioner "shell" {
     scripts = [
+      "./provision/core/xcode-clt.sh",
       "./provision/configuration/configure-tccdb-macos11.sh",
       "./provision/configuration/add-network-interface-detection.sh",
       "./provision/configuration/autologin.sh",
@@ -117,7 +118,6 @@ build {
     scripts = [
       "./provision/configuration/preimagedata.sh",
       "./provision/configuration/configure-ssh.sh",
-      "./provision/core/xcode-clt.sh",
       "./provision/configuration/configure-machine.sh"
     ]
     environment_vars = [

--- a/images/macos/templates/macOS-12.json
+++ b/images/macos/templates/macOS-12.json
@@ -97,6 +97,7 @@
             "type": "shell",
             "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}",
             "scripts": [
+                "./provision/core/xcode-clt.sh",
                 "./provision/configuration/add-network-interface-detection.sh",
                 "./provision/configuration/autologin.sh",
                 "./provision/configuration/disable-auto-updates.sh",
@@ -116,7 +117,6 @@
             "scripts": [
                 "./provision/configuration/preimagedata.sh",
                 "./provision/configuration/configure-ssh.sh",
-                "./provision/core/xcode-clt.sh",
                 "./provision/configuration/configure-machine.sh"
             ],
             "environment_vars": [


### PR DESCRIPTION
# Description
https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes

![image](https://user-images.githubusercontent.com/47745270/154974233-b49c96c7-8669-401a-97dc-30f8fa27bc5d.png)

Fix:
- Install Xcode Command Line Developer Tools(python3 is a part of the package)
- Migrating python 2 scripts to python 3

#### Related issue:
https://github.com/actions/virtual-environments/issues/5101

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
