### PR TITLE
[windows] When installing Rust, add the i686 target to enable building 32-bit binaries

### DIFF
--- a/images/win/scripts/Installers/Install-Rust.ps1
+++ b/images/win/scripts/Installers/Install-Rust.ps1
@@ -13,13 +13,14 @@ $rustupPath = Start-DownloadWithRetry -Url "https://win.rustup.rs/x86_64" -Name 
 
 # Install Rust by running rustup-init.exe (disabling the confirmation prompt with -y)
 & $rustupPath -y --default-toolchain=stable --profile=minimal
-# Add i686 target for building 32-bit binaries
-rustup target add i686-pc-windows-msvc
 
 # Add %USERPROFILE%\.cargo\bin to USER PATH
 Add-DefaultPathItem "%USERPROFILE%\.cargo\bin"
 # Add Rust binaries to the path
 $env:Path += ";$env:CARGO_HOME\bin"
+
+# Add i686 target for building 32-bit binaries
+rustup target add i686-pc-windows-msvc
 
 # Install common tools
 rustup component add rustfmt clippy

--- a/images/win/scripts/Installers/Install-Rust.ps1
+++ b/images/win/scripts/Installers/Install-Rust.ps1
@@ -13,6 +13,8 @@ $rustupPath = Start-DownloadWithRetry -Url "https://win.rustup.rs/x86_64" -Name 
 
 # Install Rust by running rustup-init.exe (disabling the confirmation prompt with -y)
 & $rustupPath -y --default-toolchain=stable --profile=minimal
+# Add i686 target for building 32-bit binaries
+rustup target add i686-pc-windows-msvc
 
 # Add %USERPROFILE%\.cargo\bin to USER PATH
 Add-DefaultPathItem "%USERPROFILE%\.cargo\bin"


### PR DESCRIPTION
# Description

Currently when rust is installed on windows, it only includes the default target (`x86_64-pc-windows-msvc`). This change adds the equivalent i686 target so that 32-bit binaries may be built out of the box. Unfortunately 32-bit windows is still extremely common, so many (most?) projects that want to test and ship windows artifacts will need both 32-bit and 64-bit support.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
