### PR TITLE
[Windows] Update cabal pester test

### DIFF
--- a/images/win/scripts/Tests/Haskell.Tests.ps1
+++ b/images/win/scripts/Tests/Haskell.Tests.ps1
@@ -49,9 +49,8 @@ Describe "Haskell" {
         "cabal --version" | Should -ReturnZeroExitCode
     }
 
-    It "cabal config was modified and exists" {
-        $env:CABAL_DIR | Should -Exist
-        "cabal user-config diff" | Should -ReturnZeroExitCode
+    It "cabal folder does not exist" {
+        $env:CABAL_DIR | Should -Not -Exist
     }
 
     It "ghcup is installed" {

--- a/images/win/scripts/Tests/Haskell.Tests.ps1
+++ b/images/win/scripts/Tests/Haskell.Tests.ps1
@@ -53,6 +53,10 @@ Describe "Haskell" {
         $env:CABAL_DIR | Should -Not -Exist
     }
 
+    It "CABAL_DIR environment variable exists" {
+        Get-EnvironmentVariable CABAL_DIR | Should -BeExactly "C:\cabal"
+    }
+
     It "ghcup is installed" {
         "ghcup --version" | Should -ReturnZeroExitCode
     }


### PR DESCRIPTION
# Description

```
2022-02-22T00:34:39.3388641Z  vhd:   [-] cabal config was modified and exists 166ms (164ms|2ms)
2022-02-22T00:34:39.3399886Z  vhd:    Expected path 'C:\cabal' to exist, but it did not exist.
2022-02-22T00:34:39.3400920Z  vhd:    at $env:CABAL_DIR | Should -Exist, C:\image\Tests\Haskell.Tests.ps1:53
2022-02-22T00:34:39.3405661Z  vhd:    at <ScriptBlock>, C:\image\Tests\Haskell.Tests.ps1:53
```


https://gitlab.haskell.org/haskell/ghcup-hs/-/commit/2c583bcae9e333693b9bd8fc353bb0dcb2af71df - Fix NoAdjustCabalConfig on windows

Fix:
- Add test to check cabal folder

#### Related issue:
https://github.com/actions/virtual-environments/issues/5119

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
