### PR TITLE
[Ubuntu] Convert non valid java semver

### DIFF
--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -61,7 +61,7 @@ installOpenJDK() {
     if [[ ${VENDOR_NAME} == "Temurin-Hotspot" ]]; then
         apt-get -y install temurin-${JAVA_VERSION}-jdk=\*
         javaVersionPath="/usr/lib/jvm/temurin-${JAVA_VERSION}-jdk-amd64"
-    elif [[ ${VENDOR_NAME} == "Adopt" ]]; then
+   elif [[ ${VENDOR_NAME} == "Adopt" ]]; then
         apt-get -y install adoptopenjdk-${JAVA_VERSION}-hotspot=\*
         javaVersionPath="/usr/lib/jvm/adoptopenjdk-${JAVA_VERSION}-hotspot-amd64"
     else
@@ -75,6 +75,10 @@ installOpenJDK() {
 
     # If there is no semver in java release, then extract java version from -fullversion
     [[ -z ${fullJavaVersion} ]] && fullJavaVersion=$(${javaVersionPath}/bin/java -fullversion 2>&1 | tr -d "\"" | tr "+" "-" | awk '{print $4}')
+
+    # Convert non valid semver like 11.0.14.1+9 -> 11.0.14+9
+    # https://github.com/adoptium/temurin-build/issues/2248
+    [[ ${fullJavaVersion} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ ]] && fullJavaVersion=$(echo $fullJavaVersion | sed -E 's/\.[0-9]+\+/+/')
 
     javaToolcacheVersionPath="${JAVA_TOOLCACHE_PATH}/${fullJavaVersion}"
     mkdir -p "${javaToolcacheVersionPath}"

--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -61,7 +61,7 @@ installOpenJDK() {
     if [[ ${VENDOR_NAME} == "Temurin-Hotspot" ]]; then
         apt-get -y install temurin-${JAVA_VERSION}-jdk=\*
         javaVersionPath="/usr/lib/jvm/temurin-${JAVA_VERSION}-jdk-amd64"
-   elif [[ ${VENDOR_NAME} == "Adopt" ]]; then
+    elif [[ ${VENDOR_NAME} == "Adopt" ]]; then
         apt-get -y install adoptopenjdk-${JAVA_VERSION}-hotspot=\*
         javaVersionPath="/usr/lib/jvm/adoptopenjdk-${JAVA_VERSION}-hotspot-amd64"
     else

--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -76,9 +76,9 @@ installOpenJDK() {
     # If there is no semver in java release, then extract java version from -fullversion
     [[ -z ${fullJavaVersion} ]] && fullJavaVersion=$(${javaVersionPath}/bin/java -fullversion 2>&1 | tr -d "\"" | tr "+" "-" | awk '{print $4}')
 
-    # Convert non valid semver like 11.0.14.1+9 -> 11.0.14+9
+    # Convert non valid semver like 11.0.14.1-9 -> 11.0.14-9
     # https://github.com/adoptium/temurin-build/issues/2248
-    [[ ${fullJavaVersion} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ ]] && fullJavaVersion=$(echo $fullJavaVersion | sed -E 's/\.[0-9]+\+/+/')
+    [[ ${fullJavaVersion} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ ]] && fullJavaVersion=$(echo $fullJavaVersion | sed -E 's/\.[0-9]+-/-/')
 
     javaToolcacheVersionPath="${JAVA_TOOLCACHE_PATH}/${fullJavaVersion}"
     mkdir -p "${javaToolcacheVersionPath}"


### PR DESCRIPTION
# Description
 The 'actions/setup-java' task can't resolve a java version from the toolcache if semver(release file, property SEMANTIC_VERSION) of java is not valid. For e.g.:
 semver can only consist of three elements but in our case it contains  four elements - `11.0.14.1+1`  .
 
#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3434

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
