### PR TITLE
[macOS] Anka close Python 2.7 window

### DIFF
--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -13,7 +13,7 @@ sudo rm -f /var/vm/sleepimage
 defaults write NSGlobalDomain NSAppSleepDisabled -bool YES
 
 # Disable Keyboard Setup Assistant window
-if [ -d "/Library/Application Support/Veertu" ]; then
+if is_Veertu; then
     sudo defaults write /Library/Preferences/com.apple.keyboardtype "keyboardtype" -dict-add "3-7582-0" -int 40
 fi
 

--- a/images/macos/provision/configuration/finalize-vm.sh
+++ b/images/macos/provision/configuration/finalize-vm.sh
@@ -3,7 +3,7 @@
 source ~/utils/utils.sh
 
 # Close all finder windows because they can interfere with UI tests
-osascript -e 'tell application "Finder" to close windows'
+close_finder_window
 
 if is_Catalina; then
     # Ignore available updates to prevent system pop-ups

--- a/images/macos/provision/core/python.sh
+++ b/images/macos/provision/core/python.sh
@@ -12,6 +12,11 @@ pip install --upgrade pip
 echo "Install Python2 certificates"
 bash -c "/Applications/Python\ 2.7/Install\ Certificates.command"
 
+# Close Finder window
+if is_Veertu; then
+    close_finder_window
+fi
+
 # Explicitly overwrite symlinks created by Python2 such as /usr/local/bin/2to3 since they conflict with symlinks from Python3
 # https://github.com/actions/virtual-environments/issues/2322
 echo "Brew Installing Python 3"

--- a/images/macos/provision/utils/utils.sh
+++ b/images/macos/provision/utils/utils.sh
@@ -71,6 +71,14 @@ is_Less_Monterey() {
     fi
 }
 
+is_Veertu() {
+    if [ -d "/Library/Application Support/Veertu" ]; then
+        true
+    else
+        false
+    fi
+}
+
 get_toolset_path() {
     echo "$HOME/image-generation/toolset.json"
 }
@@ -192,4 +200,9 @@ get_github_package_download_url() {
     downloadUrl=$(echo $json | jq -r ".[] | select(.tag_name==\"${tagName}\").assets[].browser_download_url | select(${FILTER})" | head -n 1)
 
     echo $downloadUrl
+}
+
+# Close all finder windows because they can interfere with UI tests
+close_finder_window() {
+    osascript -e 'tell application "Finder" to close windows'
 }


### PR DESCRIPTION
# Description

During image generation we install python 2.7 package using installer due to use `anka run` transport after installing we get an open Finder window.
 
```
    veertu-anka-vm-clone.template:   [-] Opened windows not found 7.36s (7.35s|2ms)
    veertu-anka-vm-clone.template:    Expected $null or empty, but got window Python 2.7 of application process Finder.
    veertu-anka-vm-clone.template:    at $openWindows.Split(",").Trim() | Where-Object { $_ -notmatch "NotificationCenter" } | Should -BeNullOrEmpty, /Users/<sensitive>/image-generation/tests/System.Tests.ps1:54
    veertu-anka-vm-clone.template:    at <ScriptBlock>, /Users/<sensitive>/image-generation/tests/System.Tests.ps1:54
```

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3412

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
