### PR TITLE
[Windows] Use mode:vm in sysprep to skip modules installation during the first boot

### DIFF
--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -317,7 +317,7 @@
             "type": "powershell",
             "inline": [
                 "if( Test-Path $Env:SystemRoot\\System32\\Sysprep\\unattend.xml ){ rm $Env:SystemRoot\\System32\\Sysprep\\unattend.xml -Force}",
-                "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /quiet /quit",
+                "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /mode:vm /quiet /quit",
                 "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }"
             ]
         }


### PR DESCRIPTION
# Description
It looks like windows-2022 images are stuck sometimes on the Installing modules step for quite a long time (> 5min) during the first boot. Using `sysprep mode:VM` seems to solve the issue https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep-command-line-options?view=windows-11#modevm
![image](https://user-images.githubusercontent.com/48208649/155574416-c5d7ac14-7054-4481-827b-75027ef8cf88.png)

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3403

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
