### PR TITLE
[Anka] Add setup autologin bash script

### DIFF
--- a/images.CI/macos/anka/Service.Helpers.psm1
+++ b/images.CI/macos/anka/Service.Helpers.psm1
@@ -13,12 +13,10 @@ function Enable-AutoLogon {
         [string] $Password
     )
 
-    $url = "https://raw.githubusercontent.com/actions/virtual-environments/main/images/macos/provision/bootstrap-provisioner/kcpassword.py"
+    $url = "https://raw.githubusercontent.com/actions/virtual-environments/main/images/macos/provision/bootstrap-provisioner/setAutoLogin.sh"
     $script = Invoke-RestMethod -Uri $url
     $base64 = [Convert]::ToBase64String($script.ToCharArray())
-    $kcpassword = "echo $base64 | base64 --decode > ~/kcpassword;sudo python ./kcpassword '${Password}';rm ./kcpassword"
-    $loginwindow = "sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser '${UserName}';sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUserScreenLocked -bool false"
-    $command = "${kcpassword};$loginwindow"
+    $command = "echo $base64 | base64 --decode > ./setAutoLogin.sh;sudo bash ./setAutoLogin.sh '${UserName}' '${Password}';rm ./setAutoLogin.sh"
     Invoke-SSHPassCommand -HostName $HostName -Command $command
 }
 

--- a/images/macos/provision/bootstrap-provisioner/setAutoLogin.sh
+++ b/images/macos/provision/bootstrap-provisioner/setAutoLogin.sh
@@ -1,0 +1,64 @@
+#!/bin/bash -e -o pipefail
+: <<-LICENSE_BLOCK
+setAutoLogin (20210911) - Copyright (c) 2021 Joel Bruner (https://github.com/brunerd)
+Licensed under the MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+LICENSE_BLOCK
+
+USERNAME="${1}"
+PW="${2}"
+
+function kcpasswordEncode {
+    #ascii string
+    local thisString="${1}"
+    local i
+
+    #macOS cipher hex ascii representation array
+    local cipherHex_array=( 7D 89 52 23 D2 BC DD EA A3 B9 1F )
+
+    #converted to hex representation with spaces
+    local thisStringHex_array=( $(echo -n "${thisString}" | xxd -p -u | sed 's/../& /g') )
+
+    #get padding by subtraction if under 12
+    if [ "${#thisStringHex_array[@]}" -lt 12 ]; then
+        local padding=$(( 12 -  ${#thisStringHex_array[@]} ))
+    #get padding by subtracting remainder of modulo 12 if over 12
+    elif [ "$(( ${#thisStringHex_array[@]} % 12 ))" -ne 0 ]; then
+        local padding=$(( (12 - ${#thisStringHex_array[@]} % 12) ))
+    #otherwise even multiples of 12 still need 12 padding
+    else
+        local padding=12
+    fi
+
+    #cycle through each element of the array + padding
+    for ((i=0; i < $(( ${#thisStringHex_array[@]} + ${padding})); i++)); do
+        #use modulus to loop through the cipher array elements
+        local charHex_cipher=${cipherHex_array[$(( $i % 11 ))]}
+
+        #get the current hex representation element
+        local charHex=${thisStringHex_array[$i]}
+
+        #use $(( shell Aritmethic )) to ^ XOR the two 0x## values (extra padding is 0x00) 
+        #take decimal value and printf convert to two char hex value
+        #use xxd to convert hex to actual value and append to the encodedString variable
+        local encodedString+=$(printf "%02X" "$(( 0x${charHex_cipher} ^ 0x${charHex:-00} ))" | xxd -r -p)
+    done
+
+    #return the string without a newline
+    echo -n "${encodedString}"
+}
+
+#encode password and write file
+kcpasswordEncode "${PW}" > /etc/kcpassword
+
+#ensure ownership and permissions (600)
+chown root:wheel /etc/kcpassword
+chmod u=rw,go= /etc/kcpassword
+
+#turn on auto login
+/usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser -string "${USERNAME}"
+/usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUserScreenLocked -bool false
+echo "Auto login enabled for '${USERNAME}'"


### PR DESCRIPTION
# Description
In scope of this https://github.com/actions/virtual-environments/pull/5115 we have migrated some scripts from python 2 -> 3, but python is part of the xcode tools which are not available on the clean image, that's why we decided to add bash script.

Fix
- Add setup autologin bash script

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3449

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
