### PR TITLE
[Windows] Add Microsoft.VisualStudio.Component.VC.Redist.MSM component for VS 2019 to windows-2022 (#5143)

### DIFF
--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -228,7 +228,8 @@
             "zlib",
             "libxext",
             "libxft",
-            "tcl-tk"
+            "tcl-tk",
+            "yq"
         ],
         "cask_packages": [
             "julia",

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -203,7 +203,8 @@
             "libxext",
             "libxft",
             "tcl-tk",
-            "r"
+            "r",
+            "yq"
         ],
         "cask_packages": [
             "julia"

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -209,6 +209,7 @@
             "Microsoft.VisualStudio.Component.VC.MFC.ARM64",
             "Microsoft.VisualStudio.Component.VC.MFC.ARM64EC",
             "Microsoft.VisualStudio.Component.VC.Modules.x86.x64",
+            "Microsoft.VisualStudio.Component.VC.Redist.MSM",
             "Microsoft.VisualStudio.Component.VC.Tools.ARM64",
             "Microsoft.VisualStudio.Component.VC.Tools.ARM64EC",
             "Microsoft.VisualStudio.Component.VC.v141.x86.x64",


### PR DESCRIPTION
# Description
Adds missing component Microsoft.VisualStudio.Component.VC.Redist.MSM to windows-2022 image.

Fixes https://github.com/actions/virtual-environments/issues/5143

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
