### PR TITLE
Add htmlq to the runners

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -118,6 +118,7 @@ $toolsList = @(
     (Get-HerokuVersion),
     (Get-HHVMVersion),
     (Get-SVNVersion),
+    (Get-HtmlqVersion),
     (Get-JqVersion),
     (Get-YqVersion),
     (Get-KindVersion),

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -194,6 +194,11 @@ function Get-TerraformVersion {
     return (terraform version | Select-String "^Terraform").Line.Replace('v','')
 }
 
+function Get-HtmlqVersion {
+    $htmlqVersion = htmlq --version | Take-OutputPart -Part 1
+    return "htmlq $htmlqVersion"
+}
+
 function Get-JqVersion {
     $jqVersion = jq --version | Take-OutputPart -Part 1 -Delimiter "-"
     return "jq $jqVersion"

--- a/images/linux/scripts/installers/rust.sh
+++ b/images/linux/scripts/installers/rust.sh
@@ -17,7 +17,7 @@ source $CARGO_HOME/env
 
 # Install common tools
 rustup component add rustfmt clippy
-cargo install --locked bindgen cbindgen cargo-audit cargo-outdated
+cargo install --locked bindgen cbindgen cargo-audit cargo-outdated htmlq
 
 # Cleanup Cargo cache
 rm -rf ${CARGO_HOME}/registry/*

--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -62,6 +62,10 @@ Describe "Rust" {
         It "Cargo outdated" {
             "cargo outdated --version" | Should -ReturnZeroExitCode
         }
+
+        It "Htmlq" {
+            "htmlq --version" | Should -ReturnZeroExitCode
+        }
     }
 }
 Describe "Docker" {

--- a/images/macos/provision/core/rust.sh
+++ b/images/macos/provision/core/rust.sh
@@ -12,7 +12,7 @@ CARGO_HOME=$HOME/.cargo
 
 echo Install common tools...
 rustup component add rustfmt clippy
-cargo install --locked bindgen cbindgen cargo-audit cargo-outdated
+cargo install --locked bindgen cbindgen cargo-audit cargo-outdated htmlq
 
 echo Cleanup Cargo registry cached data...
 rm -rf $CARGO_HOME/registry/*

--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -307,6 +307,11 @@ function Get-OpenSSLVersion {
     return $opensslVersion
 }
 
+function Get-HtmlqVersion {
+    $htmlqVersion = Run-Command "htmlq --version" | Select-Object -First 1 | Take-Part -Part 1
+    return "htmlq $htmlqVersion"
+}
+
 function Get-JqVersion {
     $jqVersion = Run-Command "jq --version" | Take-Part -Part 1 -Delimiter "-"
     return "jq $jqVersion"

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -107,6 +107,7 @@ $utilitiesList = @(
     (Get-SVNVersion),
     (Get-PackerVersion),
     (Get-OpenSSLVersion),
+    (Get-HtmlqVersion),
     (Get-JqVersion),
     (Get-PostgresClientVersion),
     (Get-PostgresServerVersion),

--- a/images/macos/tests/Rust.Tests.ps1
+++ b/images/macos/tests/Rust.Tests.ps1
@@ -10,7 +10,7 @@ Describe "Rust" {
             "rustc --version" | Should -ReturnZeroExitCode
         }
     }
-    
+
     Context "Cargo" {
         It "Cargo is installed" {
             "cargo --version" | Should -ReturnZeroExitCode
@@ -32,6 +32,10 @@ Describe "Rust" {
 
         It "Cargo outdated" {
             "cargo outdated --version" | Should -ReturnZeroExitCode
+        }
+
+        It "Htmlq" {
+            "htmlq --version" | Should -ReturnZeroExitCode
         }
     }
 }

--- a/images/win/scripts/Installers/Install-Rust.ps1
+++ b/images/win/scripts/Installers/Install-Rust.ps1
@@ -24,7 +24,7 @@ rustup target add i686-pc-windows-msvc
 
 # Install common tools
 rustup component add rustfmt clippy
-cargo install --locked bindgen cbindgen cargo-audit cargo-outdated
+cargo install --locked bindgen cbindgen cargo-audit cargo-outdated htmlq
 
 # Cleanup Cargo crates cache
 Remove-Item "${env:CARGO_HOME}\registry\*" -Recurse -Force

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -98,6 +98,7 @@ $toolsList = @(
     (Get-GHCVersion),
     (Get-GitVersion),
     (Get-GitLFSVersion),
+    (Get-HtmlqVersion),
     (Get-InnoSetupVersion),
     (Get-JQVersion),
     (Get-KindVersion),

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -81,6 +81,12 @@ function Get-InnoSetupVersion {
     return $(choco list --local-only innosetup) | Select-String -Pattern "InnoSetup"
 }
 
+function Get-HtmlqVersion {
+    (htmlq --version | Out-String) -match "(?<version>(\d+\.){1,}\d+)" | Out-Null
+    $htmlqVersion = $Matches.Version
+    return "htqml $htmlqVersion"
+}
+
 function Get-JQVersion {
     $jqVersion = ($(jq --version) -Split "jq-")[1]
     return "jq $jqVersion"

--- a/images/win/scripts/Tests/Rust.Tests.ps1
+++ b/images/win/scripts/Tests/Rust.Tests.ps1
@@ -11,6 +11,7 @@ Describe "Rust" {
         @{ToolName = "cargo"; binPath = "C:\Users\Default\.cargo\bin\cargo.exe"}
         @{ToolName = "cargo audit"; binPath = "C:\Users\Default\.cargo\bin\cargo-audit.exe"}
         @{ToolName = "cargo outdated"; binPath = "C:\Users\Default\.cargo\bin\cargo-outdated.exe"}
+        @{ToolName = "htmlq"; binPath = "C:\Users\Default\.cargo\bin\htmlq.exe"}
     )
 
     $rustEnvNotExists = @(


### PR DESCRIPTION
# Description

- Fixes #5169

New tool: add **htmlq** to the runners.

https://github.com/mgdm/htmlq

This is a CLI utility written in rust (and installed via cargo) that does the same than **jq** but for HTML/XML.

Takes about 20s to install via `cargo install htmlq`, weights 14.1 MB.


#### Related issue:

## Check list

- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
