### PR TITLE
[Windows] Add Microsoft.VisualStudio.Component.VC.Redist.MSM component for VS 2019 to windows-2022 (#5143)

### DIFF
--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -211,6 +211,7 @@
             "Microsoft.VisualStudio.Component.VC.Modules.x86.x64",
             "Microsoft.VisualStudio.Component.VC.Tools.ARM64",
             "Microsoft.VisualStudio.Component.VC.Tools.ARM64EC",
+            "Microsoft.VisualStudio.Component.VC.Redist.MSM",
             "Microsoft.VisualStudio.Component.VC.v141.x86.x64",
             "Microsoft.VisualStudio.Component.VC.v141.x86.x64.Spectre",
             "Microsoft.VisualStudio.Component.VC.v141.ARM.Spectre",


### PR DESCRIPTION
Description
Adds missing component Microsoft.VisualStudio.Component.VC.Redist.MSM to windows-2022 image.

Fixes https://github.com/actions/virtual-environments/issues/5143

Related issue:
Check list
 Related issue / work item is attached
 Tests are written (if applicable)
 Documentation is updated (if applicable)
 Changes are tested and related VM images are successfully generated