### PR TITLE
Update Install-KubernetesTools.ps1

### DIFF
--- a/images/win/scripts/Installers/Install-KubernetesTools.ps1
+++ b/images/win/scripts/Installers/Install-KubernetesTools.ps1
@@ -6,7 +6,7 @@
 Write-Host "Install Kind"
 # Choco installation can't be used because it depends on docker-desktop
 $url = 'https://api.github.com/repos/kubernetes-sigs/kind/releases/latest'
-[System.String] $kindDownloadLink = (Invoke-RestMethod -Uri $url).assets.browser_download_url -match "kind-windows-amd64"
+[System.String] $kindDownloadLink = (Invoke-RestMethod -Uri $url).assets.browser_download_url -match "kind-windows-amd64$"
 $destFilePath = "C:\ProgramData\kind"
 $null = New-Item -Path $destFilePath -ItemType Directory -Force
 Start-DownloadWithRetry -Url $kindDownloadLink -Name "kind.exe" -DownloadPath $destFilePath


### PR DESCRIPTION
# Description
When `Install-KubernetesTools.ps1` is ran through the Packer provisioner on Windows 2019/ Windows 2022 the provisioner responses with a 404 not found because of the introduction kind v0.12.0 and an additional url of a checksum 256sha found by the PowerShell -match operator.

## Issue

```powershell
$url = 'https://api.github.com/repos/kubernetes-sigs/kind/releases/latest'
[System.String] $kindDownloadLink = (Invoke-RestMethod -Uri $url).assets.browser_download_url -match "kind-windows-amd64$"
```
***$kindDownloadLink*** returns 2 urls that match off **kind-windows-amd64**

```powershell
https://github.com/kubernetes-sigs/kind/releases/download/v0.12.0/kind-windows-amd64 https://github.com/kubernetes-sigs/kind/releases/download/v0.12.0/kind-windows-amd64.sha256sum
```
## Terminal Output

```powershell
==> vhd: Provisioning with powershell script: /agent/_work/1/s/images/win/scripts/Installers/Install-KubernetesTools.ps1
    vhd: Install Kind
    vhd: Downloading package from: https://github.com/kubernetes-sigs/kind/releases/download/v0.12.0/kind-windows-amd64 https://github.com/kubernetes-sigs/kind/releases/download/v0.12.0/kind-windows-amd64.sha256sum to path C:\ProgramData\kind\kind.exe .
    vhd: There is an error encounterd after 0.25 seconds during package downloading:
    vhd:  Exception calling "DownloadFile" with "2" argument(s): "The request was aborted: The connection was closed unexpectedly."
    vhd: Waiting 30 seconds before retrying. Retries left: 19
```

## Solution 

Add regex `$` to terminate the match not allowing for the checksum url return;

```powershell
[System.String] $kindDownloadLink = (Invoke-RestMethod -Uri $url).assets.browser_download_url -match "kind-windows-amd64$"
```

## Check list
- [ ] Related issue / work item is attached
- [X] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [X] Changes are tested and related VM images are successfully generated

## Credits
@mahony raised the issue this morning as we were building our Windows 2019 / Windows 2022 agents and hoped on at the end of the day to quickly recommend the -match replacement to regex.
