### PR TITLE
Fix match regex in Kubernetes tools downloads.

### DIFF
--- a/images/win/scripts/Installers/Install-KubernetesTools.ps1
+++ b/images/win/scripts/Installers/Install-KubernetesTools.ps1
@@ -6,7 +6,7 @@
 Write-Host "Install Kind"
 # Choco installation can't be used because it depends on docker-desktop
 $url = 'https://api.github.com/repos/kubernetes-sigs/kind/releases/latest'
-[System.String] $kindDownloadLink = (Invoke-RestMethod -Uri $url).assets.browser_download_url -match "kind-windows-amd64"
+[System.String] $kindDownloadLink = (Invoke-RestMethod -Uri $url).assets.browser_download_url -match "kind-windows-amd64$"
 $destFilePath = "C:\ProgramData\kind"
 $null = New-Item -Path $destFilePath -ItemType Directory -Force
 Start-DownloadWithRetry -Url $kindDownloadLink -Name "kind.exe" -DownloadPath $destFilePath


### PR DESCRIPTION
# Description
This fixes a bug that was causing the kubernetes tools download to fail since the match was finding two lines (one with chksum, the other with binaries).