### PR TITLE
[macOS] Fix kcpassword compatibility issue with Python 3

### DIFF
--- a/images/macos/provision/bootstrap-provisioner/kcpassword.py
+++ b/images/macos/provision/bootstrap-provisioner/kcpassword.py
@@ -27,13 +27,13 @@ def kcpassword(passwd):
             passwd[j] = passwd[j] ^ key[ki]
             ki += 1
 
-    passwd = [chr(x) for x in passwd]
-    return "".join(passwd)
+    return bytearray(passwd)
 
 if __name__ == "__main__":
     passwd = kcpassword(sys.argv[1])
     fd = os.open('/etc/kcpassword', os.O_WRONLY | os.O_CREAT, 0o600)
-    file = os.fdopen(fd, 'w')
+    file = os.fdopen(fd, 'wb')
+    file.truncate(0)
     file.write(passwd)
     file.close()
 


### PR DESCRIPTION
# Description
In scope of https://github.com/actions/virtual-environments/pull/5115, we switched `kcpassword` script to use Python 3 instead of Python 2 because Python 2 was removed from macOS 12.
After that, kcpassword started to produce incorrect results. See https://github.com/actions/virtual-environments/issues/5231 for details.

### Root cause
`chr` function was changed in Python 3 and don't produce char by number anymore.
More details can be found in https://python-future.org/compatible_idioms.html#chr

### Fix
- I have removed converting to string completely and convert to byte array instead
- Writing byte array directly to file

### How it was tested
I have compared all test cases reported in https://github.com/actions/virtual-environments/issues/5231 and after my changes script product correct result for both Python 2 & 3

### Related issue: https://github.com/actions/virtual-environments/issues/5231
