### PR TITLE
[Windows] Use Chrome standalone installer (#5203)

### DIFF
--- a/images/win/scripts/Installers/Install-Chrome.ps1
+++ b/images/win/scripts/Installers/Install-Chrome.ps1
@@ -4,9 +4,9 @@
 ################################################################################
 
 # Download and install latest Chrome browser
-$ChromeInstallerFile = "chrome_installer.exe"
-$ChromeInstallerUrl = "https://dl.google.com/chrome/install/375.126/${ChromeInstallerFile}"
-Install-Binary -Url $ChromeInstallerUrl -Name $ChromeInstallerFile -ArgumentList ("/silent", "/install")
+$ChromeInstallerFile = "googlechromestandaloneenterprise64.msi"
+$ChromeInstallerUrl = "https://dl.google.com/tag/s/dl/chrome/install/${ChromeInstallerFile}"
+Install-Binary -Url $ChromeInstallerUrl -Name $ChromeInstallerFile -ArgumentList @()
 
 # Prepare firewall rules
 Write-Host "Adding the firewall rule for Google update blocking..."


### PR DESCRIPTION
# Description

Instead of the Google Chrome online installer, this change, uses the standalone (offline) version.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

- Fixes #5203

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
