### PR TITLE
Add docs for macOS 12 private preview

### DIFF
--- a/images/macos/macos-12-Readme.md
+++ b/images/macos/macos-12-Readme.md
@@ -1,0 +1,289 @@
+| Announcements |
+|-|
+| [[All OSs] .NET 2.1 will be removed from the images on February, 21](https://github.com/actions/virtual-environments/issues/4871) |
+***
+# macOS 12.2 info
+- System Version: macOS 12.2.1 (21D62)
+- Kernel Version: Darwin 21.3.0
+- Image Version: 20220220.1
+
+## Installed Software
+### Language and Runtime
+- .NET SDK 3.1.101 3.1.201 3.1.302 3.1.416 5.0.102 5.0.202 5.0.302 5.0.405
+- Bash 3.2.57(1)-release
+- Clang/LLVM 13.0.0 is default
+- Clang/LLVM 13.0.1 is available on `'$(brew --prefix llvm)/bin/clang'`
+- gcc-11 (Homebrew GCC 11.2.0_3) 11.2.0 - available by `gcc-11` alias
+- GNU Fortran (Homebrew GCC 11.2.0_3) 11.2.0 - available by `gfortran-11` alias
+- Go 1.17.6
+- julia 1.7.2
+- Kotlin 1.6.10-release-923
+- MSBuild 16.10.1.58001 (from /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/15.0/bin/MSBuild.dll)
+- Node.js v16.14.0
+- NVM 0.39.1
+- NVM - Cached node versions: v12.22.10 v14.19.0 v16.14.0
+- Perl 5.34.0
+- PHP 8.1.3
+- Python 2.7.18
+- Python 3.9.10
+- R 4.1.2
+- Ruby 3.0.3p157
+
+### Package Management
+- Bundler version 2.3.7
+- Carthage 0.38.0
+- CocoaPods 1.11.2
+- Composer 2.2.6
+- Homebrew 3.3.15
+- NPM 8.3.1
+- NuGet 5.9.0.7134
+- Pip 20.3.4 (python 2.7)
+- Pip 21.3.1 (python 3.9)
+- Pipx 1.0.0
+- RubyGems 3.2.33
+- Vcpkg 2022 (build from master \<5cf60186a>)
+- Yarn 1.22.17
+
+### Project Management
+- Apache Ant(TM) 1.10.12
+- Apache Maven 3.8.4
+- Gradle 7.4
+- Sbt 1.6.2
+
+### Utilities
+- 7-Zip 17.04
+- aria2 1.36.0
+- azcopy 10.13.0
+- bazel 5.0.0
+- bazelisk 1.11.0
+- bsdtar 3.5.1 - available by 'tar' alias
+- Curl 7.81.0
+- Git 2.35.1
+- Git LFS: 3.1.2
+- GitHub CLI: 2.5.1
+- GNU Tar 1.34 - available by 'gtar' alias
+- GNU Wget 1.21.2
+- gpg (GnuPG) 2.3.4
+- Hub CLI: 2.14.2
+- jq 1.6
+- mongo v5.0.6
+- mongod v5.0.6
+- OpenSSL 1.1.1m  14 Dec 2021 `(/usr/local/opt/openssl@1.1 -> ../Cellar/openssl@1.1/1.1.1m)`
+- Packer 1.7.10
+- PostgreSQL 14.2
+- psql (PostgreSQL) 14.2
+- Sox 14.4.2
+- Subversion (SVN) 1.14.1
+- Switchaudio-osx 1.1.0
+- zstd 1.5.2
+
+### Tools
+- App Center CLI command
+- AWS CLI 2.4.19
+- AWS SAM CLI 1.38.1
+- AWS Session Manager CLI 1.2.295.0
+- Azure CLI (azure-devops) 0.23.0
+- Azure CLI 2.33.1
+- Bicep CLI 0.4.1272
+- Cabal 3.6.2.0
+- Cmake 3.22.2
+- Fastlane 2.204.3
+- GHC 9.2.1
+- GHCup 0.1.17.4
+- Jazzy 0.14.1
+- Stack 2.7.3
+- Swig 4.0.2
+- Xcode Command Line Tools 13.2.0.0.1.1638488800
+
+### Linters
+- SwiftLint 0.46.2
+- yamllint 1.26.3
+
+### Browsers
+- Safari 15.3 (17612.4.9.1.8)
+- SafariDriver 15.3 (17612.4.9.1.8)
+- Google Chrome 98.0.4758.102 
+- ChromeDriver 98.0.4758.102
+- Microsoft Edge 98.0.1108.56 
+- MSEdgeDriver 98.0.1108.56
+- Mozilla Firefox 97.0.1
+- geckodriver 0.30.0
+- Selenium server 4.1.2
+
+#### Environment variables
+| Name            | Value                                          |
+| --------------- | ---------------------------------------------- |
+| CHROMEWEBDRIVER | /usr/local/Caskroom/chromedriver/98.0.4758.102 |
+| EDGEWEBDRIVER   | /usr/local/share/edge_driver                   |
+| GECKOWEBDRIVER  | /usr/local/opt/geckodriver/bin                 |
+
+### Java
+| Version             | Vendor          | Environment Variable |
+| ------------------- | --------------- | -------------------- |
+| 8.0.322+6 (default) | Eclipse Temurin | JAVA_HOME_8_X64      |
+| 11.0.14+101         | Eclipse Temurin | JAVA_HOME_11_X64     |
+| 17.0.2+8            | Eclipse Temurin | JAVA_HOME_17_X64     |
+
+### GraalVM
+| Version     | Environment variables |
+| ----------- | --------------------- |
+| CE 22.0.0.2 | GRAALVM_11_ROOT       |
+
+### Cached Tools
+#### Ruby
+- 2.7.5
+- 3.0.3
+
+#### Python
+- 3.7.12
+- 3.8.12
+- 3.9.10
+- 3.10.2
+
+#### PyPy
+- 2.7.18 [PyPy 7.3.8]
+- 3.7.12 [PyPy 7.3.8]
+- 3.8.12 [PyPy 7.3.8]
+
+#### Node.js
+- 12.22.10
+- 14.19.0
+- 16.14.0
+
+#### Go
+| Version | Architecture | Environment Variable |
+| ------- | ------------ | -------------------- |
+| 1.15.15 | x64          | GOROOT_1_15_X64      |
+| 1.16.14 | x64          | GOROOT_1_16_X64      |
+| 1.17.7  | x64          | GOROOT_1_17_X64      |
+
+### Rust Tools
+- Cargo 1.58.0
+- Rust 1.58.1
+- Rustdoc 1.58.1
+- Rustup 1.24.3
+
+#### Packages
+- Bindgen 0.59.2
+- Cargo-audit 0.16.0
+- Cargo-outdated v0.10.2
+- Cbindgen 0.20.0
+- Clippy 0.1.58
+- Rustfmt 1.4.38-stable
+
+### PowerShell Tools
+- PowerShell 7.2.1
+
+#### PowerShell Modules
+| Module           | Version |
+| ---------------- | ------- |
+| Az               | 7.2.1   |
+| MarkdownPS       | 1.9     |
+| Pester           | 5.3.1   |
+| PSScriptAnalyzer | 1.20.0  |
+
+### Web Servers
+| Name  | Version | ConfigFile                      | ServiceStatus | ListenPort |
+| ----- | ------- | ------------------------------- | ------------- | ---------- |
+| httpd | 2.4.52  | /usr/local/etc/httpd/httpd.conf | none          | 80         |
+| nginx | 1.21.6  | /usr/local/etc/nginx/nginx.conf | none          | 80         |
+
+### Xamarin
+#### Visual Studio for Mac
+- 8.10.19.2
+
+#### Xamarin bundles
+| symlink           | Xamarin.Mono | Xamarin.iOS | Xamarin.Mac | Xamarin.Android |
+| ----------------- | ------------ | ----------- | ----------- | --------------- |
+| 6_12_13           | 6.12         | 15.6        | 8.6         | 12.0            |
+| 6_12_12 (default) | 6.12         | 15.4        | 8.4         | 12.0            |
+| 6_12_11           | 6.12         | 15.2        | 8.2         | 12.0            |
+| 6_12_10           | 6.12         | 15.0        | 7.14        | 11.3            |
+
+#### Unit Test Framework
+- NUnit 3.6.1
+
+### Xcode
+| Version          | Build    | Path                           |
+| ---------------- | -------- | ------------------------------ |
+| 13.3 (beta)      | 13E5095k | /Applications/Xcode_13.3.app   |
+| 13.2.1 (default) | 13C100   | /Applications/Xcode_13.2.1.app |
+| 13.2             | 13C90    | /Applications/Xcode_13.2.app   |
+| 13.1             | 13A1030d | /Applications/Xcode_13.1.app   |
+
+#### Xcode Support Tools
+- xcpretty 0.3.0
+- xcversion 2.8.0
+
+#### Installed SDKs
+| SDK                     | SDK Name             | Xcode Version |
+| ----------------------- | -------------------- | ------------- |
+| macOS 12.0              | macosx12.0           | 13.1          |
+| macOS 12.1              | macosx12.1           | 13.2, 13.2.1  |
+| macOS 12.3              | macosx12.3           | 13.3          |
+| iOS 15.0                | iphoneos15.0         | 13.1          |
+| iOS 15.2                | iphoneos15.2         | 13.2, 13.2.1  |
+| iOS 15.4                | iphoneos15.4         | 13.3          |
+| Simulator - iOS 15.0    | iphonesimulator15.0  | 13.1          |
+| Simulator - iOS 15.2    | iphonesimulator15.2  | 13.2, 13.2.1  |
+| Simulator - iOS 15.4    | iphonesimulator15.4  | 13.3          |
+| tvOS 15.0               | appletvos15.0        | 13.1          |
+| tvOS 15.2               | appletvos15.2        | 13.2, 13.2.1  |
+| tvOS 15.4               | appletvos15.4        | 13.3          |
+| Simulator - tvOS 15.0   | appletvsimulator15.0 | 13.1          |
+| Simulator - tvOS 15.2   | appletvsimulator15.2 | 13.2, 13.2.1  |
+| Simulator - tvOS 15.4   | appletvsimulator15.4 | 13.3          |
+| watchOS 8.0             | watchos8.0           | 13.1          |
+| watchOS 8.3             | watchos8.3           | 13.2, 13.2.1  |
+| watchOS 8.5             | watchos8.5           | 13.3          |
+| Simulator - watchOS 8.0 | watchsimulator8.0    | 13.1          |
+| Simulator - watchOS 8.3 | watchsimulator8.3    | 13.2, 13.2.1  |
+| Simulator - watchOS 8.5 | watchsimulator8.5    | 13.3          |
+| DriverKit 21.0.1        | driverkit21.0.1      | 13.1          |
+| DriverKit 21.2          | driverkit21.2        | 13.2, 13.2.1  |
+| DriverKit 21.4          | driverkit21.4        | 13.3          |
+
+#### Installed Simulators
+| OS          | Xcode Version  | Simulators                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| ----------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| iOS 15.0    | 13.1           | iPod touch (7th generation)<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPhone 12<br>iPhone 12 mini<br>iPhone 12 Pro<br>iPhone 12 Pro Max<br>iPhone 13<br>iPhone 13 mini<br>iPhone 13 Pro<br>iPhone 13 Pro Max<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE (2nd generation)<br>iPad (9th generation)<br>iPad Air (4th generation)<br>iPad mini (6th generation)<br>iPad Pro (11-inch) (3rd generation)<br>iPad Pro (12.9-inch) (5th generation)<br>iPad Pro (9.7-inch) |
+| iOS 15.2    | 13.2<br>13.2.1 | iPod touch (7th generation)<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPhone 12<br>iPhone 12 mini<br>iPhone 12 Pro<br>iPhone 12 Pro Max<br>iPhone 13<br>iPhone 13 mini<br>iPhone 13 Pro<br>iPhone 13 Pro Max<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE (2nd generation)<br>iPad (9th generation)<br>iPad Air (4th generation)<br>iPad mini (6th generation)<br>iPad Pro (11-inch) (3rd generation)<br>iPad Pro (12.9-inch) (5th generation)<br>iPad Pro (9.7-inch) |
+| iOS 15.4    | 13.3           | iPod touch (7th generation)<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPhone 12<br>iPhone 12 mini<br>iPhone 12 Pro<br>iPhone 12 Pro Max<br>iPhone 13<br>iPhone 13 mini<br>iPhone 13 Pro<br>iPhone 13 Pro Max<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE (2nd generation)<br>iPad (9th generation)<br>iPad Air (4th generation)<br>iPad mini (6th generation)<br>iPad Pro (11-inch) (3rd generation)<br>iPad Pro (12.9-inch) (5th generation)<br>iPad Pro (9.7-inch) |
+| tvOS 15.0   | 13.1           | Apple TV<br>Apple TV 4K (2nd generation)<br>Apple TV 4K (at 1080p) (2nd generation)                                                                                                                                                                                                                                                                                                                                                                                            |
+| tvOS 15.2   | 13.2<br>13.2.1 | Apple TV<br>Apple TV 4K (2nd generation)<br>Apple TV 4K (at 1080p) (2nd generation)                                                                                                                                                                                                                                                                                                                                                                                            |
+| tvOS 15.4   | 13.3           | Apple TV<br>Apple TV 4K (2nd generation)<br>Apple TV 4K (at 1080p) (2nd generation)                                                                                                                                                                                                                                                                                                                                                                                            |
+| watchOS 8.0 | 13.1           | Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm<br>Apple Watch Series 6 - 40mm<br>Apple Watch Series 6 - 44mm<br>Apple Watch Series 7 - 41mm<br>Apple Watch Series 7 - 45mm                                                                                                                                                                                                                                                                                         |
+| watchOS 8.3 | 13.2<br>13.2.1 | Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm<br>Apple Watch Series 6 - 40mm<br>Apple Watch Series 6 - 44mm<br>Apple Watch Series 7 - 41mm<br>Apple Watch Series 7 - 45mm                                                                                                                                                                                                                                                                                         |
+| watchOS 8.5 | 13.3           | Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm<br>Apple Watch Series 6 - 40mm<br>Apple Watch Series 6 - 44mm<br>Apple Watch Series 7 - 41mm<br>Apple Watch Series 7 - 45mm                                                                                                                                                                                                                                                                                         |
+
+### Android
+| Package Name               | Version                                                                                                                                      |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Android Command Line Tools | 4.0                                                                                                                                          |
+| Android Emulator           | 31.2.8                                                                                                                                       |
+| Android SDK Build-tools    | 32.0.0<br>31.0.0<br>30.0.0 30.0.1 30.0.2 30.0.3<br>29.0.0 29.0.1 29.0.2 29.0.3<br>28.0.0 28.0.1 28.0.2 28.0.3<br>27.0.0 27.0.1 27.0.2 27.0.3 |
+| Android SDK Platforms      | android-32 (rev 1)<br>android-31 (rev 1)<br>android-30 (rev 3)<br>android-29 (rev 5)<br>android-28 (rev 6)<br>android-27 (rev 3)             |
+| Android SDK Platform-Tools | 32.0.0                                                                                                                                       |
+| Android Support Repository | 47.0.0                                                                                                                                       |
+| CMake                      | 3.18.1                                                                                                                                       |
+| Google Play services       | 49                                                                                                                                           |
+| Google Repository          | 58                                                                                                                                           |
+| NDK                        | 21.4.7075529 (default)<br>22.1.7171670<br>23.1.7779620                                                                                       |
+| SDK Patch Applier v4       | 1                                                                                                                                            |
+
+#### Environment variables
+| Name                    | Value                                                                                              |
+| ----------------------- | -------------------------------------------------------------------------------------------------- |
+| ANDROID_HOME            | /Users/runner/Library/Android/sdk                                                                  |
+| ANDROID_NDK_HOME        | /Users/runner/Library/Android/sdk/ndk-bundle -> /Users/runner/Library/Android/sdk/ndk/21.4.7075529 |
+| ANDROID_NDK_LATEST_HOME | /Users/runner/Library/Android/sdk/ndk/23.1.7779620                                                 |
+| ANDROID_NDK_ROOT        | /Users/runner/Library/Android/sdk/ndk-bundle -> /Users/runner/Library/Android/sdk/ndk/21.4.7075529 |
+| ANDROID_SDK_ROOT        | /Users/runner/Library/Android/sdk                                                                  |
+
+### Miscellaneous
+- libXext 1.3.4
+- libXft 2.3.4
+- Tcl/Tk 8.6.12
+- Zlib 1.2.11
+
+


### PR DESCRIPTION
# Description
Currently, macOS 12 is available in private preview. Let's put its docs to repo

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
