### PR TITLE
[Windows] hardcode alyuin-cli version

### DIFF
--- a/images/win/scripts/Installers/Install-AliyunCli.ps1
+++ b/images/win/scripts/Installers/Install-AliyunCli.ps1
@@ -4,10 +4,8 @@
 ################################################################################
 
 Write-Host "Download Latest aliyun-cli archive"
-$url = 'https://api.github.com/repos/aliyun/aliyun-cli/releases/latest'
-# Explicitly set type to string since match returns array by default
-[System.String] $aliyunLatest = (Invoke-RestMethod -Uri $url).assets.browser_download_url -match "aliyun-cli-windows"
-$aliyunArchivePath = Start-DownloadWithRetry -Url $aliyunLatest -Name "aliyun-cli.zip"
+$ZipballUrl = 'https://aliyuncli.alicdn.com/aliyun-cli-windows-latest-amd64.zip'
+$aliyunArchivePath = Start-DownloadWithRetry -Url $ZipballUrl -Name "aliyun-cli.zip"
 
 Write-Host "Expand aliyun-cli archive"
 $aliyunPath = "C:\aliyun-cli"


### PR DESCRIPTION
# Description

The latest alyuin-cli release is broken (the upstream has only released the source code but no appropriate versions for Windows/Linux), given that we were determining the version to download from the archive name, it is now all broken.
The most simple way to bypass it is to hardcode the working version's url straight in the installer for the time being.


#### Related issue: https://github.com/actions/virtual-environments-internal/issues/3468

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
