### PR TITLE
[Windows] CPack command alias is not part of Choco anymore

### DIFF
--- a/images/win/scripts/Installers/Install-Choco.ps1
+++ b/images/win/scripts/Installers/Install-Choco.ps1
@@ -23,10 +23,6 @@ Invoke-Expression ((new-object net.webclient).DownloadString('https://chocolatey
 # Turn off confirmation
 choco feature enable -n allowGlobalConfirmation
 
-# https://github.com/chocolatey/choco/issues/89
-# Remove some of the command aliases, like `cpack` #89
-Remove-Item -Path $env:ChocolateyInstall\bin\cpack.exe -Force
-
 # Initialize environmental variable ChocolateyToolsLocation by invoking choco Get-ToolsLocation function
 Import-Module "$env:ChocolateyInstall\helpers\chocolateyInstaller.psm1" -Force
 Get-ToolsLocation


### PR DESCRIPTION
# Description

Choco does not ship CPack anymore. `Remove-Item` fails with the latest Choco release:

```
Remove-Item : Cannot find path 'C:\ProgramData\chocolatey\bin\cpack.exe' because it does not exist.
```

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

- https://github.com/chocolatey/choco/issues/89

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
