### PR TITLE
Install llvm version correctly

### DIFF
--- a/images/win/scripts/Installers/Install-LLVM.ps1
+++ b/images/win/scripts/Installers/Install-LLVM.ps1
@@ -5,6 +5,6 @@
 
 $llvmVersion = (Get-ToolsetContent).llvm.version
 $latestChocoVersion = Get-LatestChocoPackageVersion -TargetVersion $llvmVersion -PackageName "llvm"
-Choco-Install -PackageName llvm -ArgumentList "--version $latestChocoVersion"
+Choco-Install -PackageName llvm -ArgumentList '--version', $latestChocoVersion
 
 Invoke-PesterTests -TestFile "LLVM"

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -305,7 +305,6 @@
             { "name": "Bicep" },
             { "name": "innosetup" },
             { "name": "jq" },
-            { "name": "llvm" },
             { "name": "NuGet.CommandLine" },
             {
                 "name": "openssl.light",
@@ -338,6 +337,9 @@
     },
     "nsis": {
         "version": "3.08"
+    },
+    "llvm": {
+        "version": "13"
     },
     "php": {
         "version": "8.1"

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -255,7 +255,8 @@
                 "{{ template_dir }}/scripts/Installers/Configure-DynamicPort.ps1",
                 "{{ template_dir }}/scripts/Installers/Configure-GDIProcessHandleQuota.ps1",
                 "{{ template_dir }}/scripts/Installers/Configure-Shell.ps1",
-                "{{ template_dir }}/scripts/Installers/Enable-DeveloperMode.ps1"
+                "{{ template_dir }}/scripts/Installers/Enable-DeveloperMode.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-LLVM.ps1"
             ],
             "elevated_user": "{{user `install_user`}}",
             "elevated_password": "{{user `install_password`}}"


### PR DESCRIPTION
# Description
Currently, llvm version from the toolset is ignored because we should pass the params separately.
This PR also sticks windows 2022 llvm to version 13.

#### Related issue
https://github.com/actions/virtual-environments/issues/5285

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
