### PR TITLE
Fix setAutoLogin.sh script

### DIFF
--- a/images/macos/provision/bootstrap-provisioner/setAutoLogin.sh
+++ b/images/macos/provision/bootstrap-provisioner/setAutoLogin.sh
@@ -22,15 +22,11 @@ function kcpasswordEncode {
     #converted to hex representation with spaces
     local thisStringHex_array=( $(echo -n "${thisString}" | xxd -p -u | sed 's/../& /g') )
 
-    #get padding by subtraction if under 12
-    if [ "${#thisStringHex_array[@]}" -lt 12 ]; then
-        local padding=$(( 12 -  ${#thisStringHex_array[@]} ))
-    #get padding by subtracting remainder of modulo 12 if over 12
-    elif [ "$(( ${#thisStringHex_array[@]} % 12 ))" -ne 0 ]; then
-        local padding=$(( (12 - ${#thisStringHex_array[@]} % 12) ))
-    #otherwise even multiples of 12 still need 12 padding
-    else
-        local padding=12
+    #get padding by subtraction if under 11
+    local r=$(( ${#thisStringHex_array[@]} % 11 ))
+    local padding=0
+    if [ $r -gt 0 ]; then
+        local padding=$(( 11 - $r ))
     fi
 
     #cycle through each element of the array + padding
@@ -44,7 +40,7 @@ function kcpasswordEncode {
         #use $(( shell Aritmethic )) to ^ XOR the two 0x## values (extra padding is 0x00) 
         #take decimal value and printf convert to two char hex value
         #use xxd to convert hex to actual value and append to the encodedString variable
-        local encodedString+=$(printf "%02X" "$(( 0x${charHex_cipher} ^ 0x${charHex:-00} ))" | xxd -r -p)
+        local encodedString+=$(printf "%02X" "$(( 0x${charHex_cipher} ^ 0x${charHex:-00} ))")
     done
 
     #return the string without a newline
@@ -52,7 +48,7 @@ function kcpasswordEncode {
 }
 
 #encode password and write file
-kcpasswordEncode "${PW}" > /etc/kcpassword
+kcpasswordEncode "${PW}" | xxd -r -p > /etc/kcpassword
 
 #ensure ownership and permissions (600)
 chown root:wheel /etc/kcpassword


### PR DESCRIPTION
# Description
Fix /etc/kcpasswd generation script on Bash.

```
Example 1
~$ bash ./setAutoLogin.sh test "wVI=" | base64
Ct8bHtK83eqjuR8=

Example 2
~$ bash ./setAutoLogin.sh test "}_R#" | base64
ANYAANK83eqjuR8=

Example 3
~$ bash ./setAutoLogin.sh test 0000000000 | base64
TbliE+KM7dqTiR8=

Example 4
~$ bash ./setAutoLogin.sh test "111111111111" | base64
TLhjEuON7NuSiC5MiVIj0rzd6qO5Hw==
```

#### Related issue:
https://github.com/actions/virtual-environments/issues/5231

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
