### PR TITLE
[macOS] Update dotnet-install.sh download link

### DIFF
--- a/images/macos/provision/core/dotnet.sh
+++ b/images/macos/provision/core/dotnet.sh
@@ -11,7 +11,7 @@ source ~/utils/utils.sh
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 
 # Download installer from dot.net and keep it locally
-DOTNET_INSTALL_SCRIPT="https://dotnet.microsoft.com/download/dotnet-core/scripts/v1/dotnet-install.sh"
+DOTNET_INSTALL_SCRIPT=" https://dot.net/v1/dotnet-install.sh"
 curl -L -o "dotnet-install.sh" "$DOTNET_INSTALL_SCRIPT"
 chmod +x ./dotnet-install.sh
 


### PR DESCRIPTION
# Description
https://dotnet.microsoft.com/en-us/download/dotnet/scripts/v1/dotnet-install.sh - is not valid link for downloading dotnet install script. As a fix we should replace it to the - https://dot.net/v1/dotnet-install.sh

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
