### PR TITLE
[macOS] fix kcpassword issue for passwords exactly 11 bytes long

### DIFF
--- a/images/macos/provision/bootstrap-provisioner/kcpassword.py
+++ b/images/macos/provision/bootstrap-provisioner/kcpassword.py
@@ -18,7 +18,9 @@ def kcpassword(passwd):
     passwd = [ord(x) for x in list(passwd)]
     # pad passwd length out to an even multiple of key length
     r = len(passwd) % key_len
-    if (r > 0):
+    if len(passwd) == 11:
+        passwd += [0]
+    elif (r > 0):
         passwd = passwd + [0] * (key_len - r)
 
     for n in range(0, len(passwd), len(key)):

--- a/images/macos/provision/bootstrap-provisioner/setAutoLogin.sh
+++ b/images/macos/provision/bootstrap-provisioner/setAutoLogin.sh
@@ -25,7 +25,7 @@ function kcpasswordEncode {
     #get padding by subtraction if under 11
     local r=$(( ${#thisStringHex_array[@]} % 11 ))
     local padding=0
-    if [  ${#thisStringHex_array[@]} -eq 11 ];
+    if [ ${#thisStringHex_array[@]} -eq 11 ];
         local padding=1
     elif [ $r -gt 0 ]; then
         local padding=$(( 11 - $r ))

--- a/images/macos/provision/bootstrap-provisioner/setAutoLogin.sh
+++ b/images/macos/provision/bootstrap-provisioner/setAutoLogin.sh
@@ -25,7 +25,9 @@ function kcpasswordEncode {
     #get padding by subtraction if under 11
     local r=$(( ${#thisStringHex_array[@]} % 11 ))
     local padding=0
-    if [ $r -gt 0 ]; then
+    if [  ${#thisStringHex_array[@]} -eq 11 ];
+        local padding=1
+    elif [ $r -gt 0 ]; then
         local padding=$(( 11 - $r ))
     fi
 


### PR DESCRIPTION
# Description
If the password is less than 11 characters, the current  script pads it to 11 bytes, XOR'ed and it works fine. With exactly 11 bytes, no null is added and this caused the autologin to fail.

E.g.:
_Current password: a1234567890_

### enable autologin and change password to the same a1234567890
![1](https://user-images.githubusercontent.com/47745270/160800939-0752a80a-a49d-4903-9e32-cdbfc5c7e58f.jpg)

### reboot and try to use the current password to unlock keychain and run change_password script - fails
![2](https://user-images.githubusercontent.com/47745270/160801207-f1cf07d9-7beb-4a35-9926-f4ad5d2c977c.jpg)

### change password to the current one using a fixed version and reboot
![3](https://user-images.githubusercontent.com/47745270/160801455-d761b849-bdf3-4ec2-9728-b4427c60a039.jpg)

### run change_password script and it works now
![4](https://user-images.githubusercontent.com/47745270/160801605-e9a4eed3-383c-4c07-b4ac-0e2f29b9931a.jpg)


#### Related issue:
https://github.com/actions/virtual-environments/issues/5231

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
