### PR TITLE
Use `v2` branch to get CodeQL bundle

### DIFF
--- a/images/win/scripts/Installers/Install-CodeQLBundle.ps1
+++ b/images/win/scripts/Installers/Install-CodeQLBundle.ps1
@@ -4,7 +4,7 @@
 ################################################################################
 
 # Retrieve the name of the CodeQL bundle preferred by the Action (in the format codeql-bundle-YYYYMMDD).
-$CodeQLBundleName = (Invoke-RestMethod "https://raw.githubusercontent.com/github/codeql-action/v1/src/defaults.json").bundleVersion
+$CodeQLBundleName = (Invoke-RestMethod "https://raw.githubusercontent.com/github/codeql-action/v2/src/defaults.json").bundleVersion
 # Convert the bundle name to a version number (0.0.0-YYYYMMDD).
 $CodeQLBundleVersion = "0.0.0-" + $CodeQLBundleName.split("-")[-1]
 


### PR DESCRIPTION
# Description

We're now using the `v2` branch as the main release branch for CodeQL, so that's the best place to get an up to date bundle version from to put into the toolcache.

#### Related issue:  https://github.com/github/codeql-core/issues/2182

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
