### PR TITLE
[Windows] Add pip.exe alias if missing

### DIFF
--- a/images/win/scripts/Installers/Install-PyPy.ps1
+++ b/images/win/scripts/Installers/Install-PyPy.ps1
@@ -52,6 +52,14 @@ function Install-PyPy
             cmd.exe /c "cd /d $pypyArchPath && mklink python.exe $pypyName && python.exe -m ensurepip && python.exe -m pip install --upgrade pip"
         }
 
+        # Create pip.exe if missing
+        $pipPath = Join-Path -Path $pypyArchPath -ChildPath "Scripts/pip.exe"
+        if (-not (Test-Path $pipPath))
+        {
+            $pip3Path = Join-Path -Path $pypyArchPath -ChildPath "Scripts/pip3.exe"
+            Copy-Item -Path $pip3Path -Destination $pipPath 
+        }
+
         if ($LASTEXITCODE -ne 0)
         {
             Throw "Error happened during PyPy installation"


### PR DESCRIPTION
# Description
PyPy3.7 pester test throws an exception because where no pip.exe alias. As a fix we should create an alias pip3.exe -> pip.exe

```
 vhd:    [-] Scripts\pip.exe --version 70ms (68ms|3ms)
2022-03-30T09:44:51.1200222Z vhd:    [-] Scripts\pip.exe --version 70ms (68ms|3ms)
2022-03-30T09:44:51.1200222Z         vhd:     Command 'C:\hostedtoolcache\windows\PyPy\3.7.13\x86\Scripts\pip.exe --version' has finished with exit code
2022-03-30T09:44:51.1205501Z         vhd:         'C:\hostedtoolcache\windows\PyPy\3.7.13\x86\Scripts\pip.exe' is not recognized as an internal or external command,
2022-03-30T09:44:51.1206602Z         vhd:         operable program or batch file.
2022-03-30T09:44:51.1215041Z         vhd:     at "$binaryFullPath $Arguments" | Should -ReturnZeroExitCode, C:\image\Tests\Toolset.Tests.ps1:39
2022-03-30T09:44:51.1215778Z         vhd:     at <ScriptBlock>, C:\image\Tests\Toolset.Tests.ps1:39
         vhd:     Command 'C:\hostedtoolcache\windows\PyPy\3.7.13\x86\Scripts\pip.exe --version' has finished with exit code
```
#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3516

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
