### PR TITLE
[Windows] Fix composer output version

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -158,9 +158,7 @@ function Get-CondaVersion {
 }
 
 function Get-ComposerVersion {
-    ($(composer --version)) -match "Composer version (?<version>\d+\.\d+\.\d+)" | Out-Null
-    $composerVersion = $Matches.Version
-    return "Composer $composerVersion"
+    composer --version | Take-Part -Part 0,1
 }
 
 function Get-NugetVersion {


### PR DESCRIPTION
# Description
The composer version output format has been changed, e.g. from `Composer version 2.2.9 2022-03-15 22:13:37` to `Composer 2.3.1 2022-03-30 15:41:28`.

#### Related issue:
https://github.com/actions/virtual-environments/discussions/5310

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
