### PR TITLE
[Windows] Install latest 8.0.* mysql version for windows 2022

### DIFF
--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -331,7 +331,7 @@
         "default": "16"
     },
     "mysql": {
-        "version": "8.0.26"
+        "version": "8.0"
     },
     "mongodb": {
         "version": "5.0"


### PR DESCRIPTION
# Description
There was a bug in the mysql preventing us from updating the version from 8.0.26 — https://bugs.mysql.com/bug.php?id=105288
The bug is now fixed and we can install the latest version.

#### Related issue:
https://github.com/actions/virtual-environments/issues/4799

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
