### PR TITLE
[Ubuntu] Fix composer output version

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -236,8 +236,7 @@ function Get-PHPVersions {
 }
 
 function Get-ComposerVersion {
-    $(composer --version) -match "Composer version (?<version>\d+\.\d+\.\d+)\s" | Out-Null
-    return $Matches.version
+    composer --version | Take-OutputPart -Part 0,1
 }
 
 function Get-PHPUnitVersion {


### PR DESCRIPTION
# Description
The composer version output format has been changed, e.g. from Composer version `2.2.9 2022-03-15 22:13:37` to `Composer 2.3.2 2022-03-30 20:45:25`.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3521

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
