### PR TITLE
[Ubuntu] Tight composer version to 2.2.9 for Ubuntu Server 18

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -236,8 +236,14 @@ function Get-PHPVersions {
 }
 
 function Get-ComposerVersion {
-    $(composer --version) -match "Composer version (?<version>\d+\.\d+\.\d+)\s" | Out-Null
-    return $Matches.version
+    $rawVersion = composer --version
+    if (Test-IsUbuntu18) {
+        $rawVersion -match "Composer version (?<version>\d+\.\d+\.\d+)\s" | Out-Null
+        $composerVersion = $Matches.version
+    } else {
+        $composerVersion = $rawVersion | Take-OutputPart -Part 1
+    }
+    return $composerVersion
 }
 
 function Get-PHPUnitVersion {

--- a/images/linux/scripts/installers/php.sh
+++ b/images/linux/scripts/installers/php.sh
@@ -105,7 +105,6 @@ fi
 sudo mv composer.phar /usr/bin/composer
 php -r "unlink('composer-setup.php');"
 
-
 # Add composer bin folder to path
 prependEtcEnvironmentPath '$HOME/.config/composer/vendor/bin'
 

--- a/images/linux/scripts/installers/php.sh
+++ b/images/linux/scripts/installers/php.sh
@@ -96,9 +96,15 @@ apt-get install -y --no-install-recommends snmp
 # Install composer
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 php -r "if (hash_file('sha384', 'composer-setup.php') === file_get_contents('https://composer.github.io/installer.sig')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-php composer-setup.php
+# Composer 2.3 increased the required PHP version to >=7.2.5 and thus stop supporting PHP 5.3.2 - 7.2.4
+if isUbuntu18; then
+    php composer-setup.php --version=2.2.9
+else
+    php composer-setup.php
+fi
 sudo mv composer.phar /usr/bin/composer
 php -r "unlink('composer-setup.php');"
+
 
 # Add composer bin folder to path
 prependEtcEnvironmentPath '$HOME/.config/composer/vendor/bin'

--- a/images/linux/scripts/tests/Common.Tests.ps1
+++ b/images/linux/scripts/tests/Common.Tests.ps1
@@ -20,6 +20,10 @@ Describe "PHP" {
         "composer --version" | Should -ReturnZeroExitCode
     }
 
+    It "Composer 2.2.9 on Ubuntu Server 18" -Skip:(-not (Test-IsUbuntu18)) {
+        "composer --version" | Should -Match "2.2.9"
+    }
+
     It "Pear" {
         "pear" | Should -ReturnZeroExitCode
     }

--- a/images/linux/scripts/tests/Common.Tests.ps1
+++ b/images/linux/scripts/tests/Common.Tests.ps1
@@ -21,7 +21,7 @@ Describe "PHP" {
     }
 
     It "Composer 2.2.9 on Ubuntu Server 18" -Skip:(-not (Test-IsUbuntu18)) {
-        "composer --version" | Should -Match "2.2.9"
+        composer --version | Should -Match "2.2.9"
     }
 
     It "Pear" {


### PR DESCRIPTION
# Description
https://github.com/composer/composer/issues/10340 - **Composer 2.3 increased the required PHP version to >=7.2.5 and thus stop supporting PHP 5.3.2 - 7.2.4.**

We should use composer LTS version for Ubuntu Server 18.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3521
https://github.com/actions/virtual-environments-internal/issues/3520

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
