### PR TITLE
Add macOS-12, remove win-16 in the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/announcement.yml
+++ b/.github/ISSUE_TEMPLATE/announcement.yml
@@ -34,7 +34,7 @@ body:
         - label: Ubuntu 20.04
         - label: macOS 10.15
         - label: macOS 11
-        - label: Windows Server 2016
+        - label: macOS 12
         - label: Windows Server 2019
         - label: Windows Server 2022
     validations:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -16,7 +16,7 @@ body:
         - label: Ubuntu 20.04
         - label: macOS 10.15
         - label: macOS 11
-        - label: Windows Server 2016
+        - label: macOS 12
         - label: Windows Server 2019
         - label: Windows Server 2022
     validations:

--- a/.github/ISSUE_TEMPLATE/tool-request.yml
+++ b/.github/ISSUE_TEMPLATE/tool-request.yml
@@ -55,7 +55,7 @@ body:
         - label: Ubuntu 20.04
         - label: macOS 10.15
         - label: macOS 11
-        - label: Windows Server 2016
+        - label: macOS 12
         - label: Windows Server 2019
         - label: Windows Server 2022
     validations:


### PR DESCRIPTION
# Description
Windows-2016 is deprecated so we can remove it from the templates. macOS-12 is in private preview and more people will have access soon so we have to add it to the templates.

#### Related issue:
n\a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
