### PR TITLE
Fixed Composer "empty" version

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -158,7 +158,7 @@ function Get-CondaVersion {
 }
 
 function Get-ComposerVersion {
-    composer --version | Take-Part -Part 0,1
+    composer --version | Take-Part -Part 0,2
 }
 
 function Get-NugetVersion {


### PR DESCRIPTION
# Description
Bug fixing

Although https://github.com/actions/virtual-environments/commit/137c29497d4b02e00551c45bc94e469bc90f12c0 fixed the previous issue, they've done something: 

Previously: 
- They used [parent::getLongVersion](https://github.com/composer/composer/blob/af3e67e7458f4da460ecb394e724413e78d2169e/src/Composer/Console/Application.php#L570), which is: [`sprintf('%s <info>%s</info>', $this->getName(), $this->getVersion())`](https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/Console/Application.php#L451), which indeed yields "Composer 2.3.3"

Now:
- They committed https://github.com/composer/composer/commit/03b7882ac231d19e9373ed33a8e71d7bb5b280c1, [which is a custom format](https://github.com/composer/composer/blob/03b7882ac231d19e9373ed33a8e71d7bb5b280c1/src/Composer/Console/Application.php#L565-L570).
- The latest triggered build in main now has issues that are not related to his commits. See https://github.visualstudio.com/virtual-environments/_build/results?buildId=124134&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=5431112d-2b61-5a5f-7042-ef698f761043&l=8522, it is detected as a "blank" version.

My commit should fix it: The current output in my console for `composer --version` yields `Composer version 2.3.3 2022-04-01 22:15:35`, therefore, taking part 0 and 2 should return `Composer 2.3.3` as intended.

#### Related issue:

## Check list
- [X] Related issue / work item is attached
- ~Tests are written (if applicable)~
- ~Documentation is updated (if applicable)~
- [ ] Changes are tested and related VM images are successfully generated
