### PR TITLE
[Ubuntu] Fix composer version

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -236,13 +236,7 @@ function Get-PHPVersions {
 }
 
 function Get-ComposerVersion {
-    $rawVersion = composer --version
-    if (Test-IsUbuntu18) {
-        $rawVersion -match "Composer version (?<version>\d+\.\d+\.\d+)\s" | Out-Null
-        $composerVersion = $Matches.version
-    } else {
-        $composerVersion = $rawVersion | Take-OutputPart -Part 1
-    }
+    $composerVersion = (composer --version) -replace " version" | Take-OutputPart -Part 1
     return $composerVersion
 }
 


### PR DESCRIPTION
# Description
The output format compose version has been changed: https://github.com/composer/composer/commit/03b7882ac231d19e9373ed33a8e71d7bb5b280c1, [which is a custom format](https://github.com/composer/composer/blob/03b7882ac231d19e9373ed33a8e71d7bb5b280c1/src/Composer/Console/Application.php#L565-L570).

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
