### PR TITLE
Update default Go version to 1.16 or higher

### DIFF
--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -42,12 +42,11 @@
             "arch": "x64",
             "platform" : "linux",
             "versions": [
-                "1.15.*",
                 "1.16.*",
                 "1.17.*",
                 "1.18.*"
             ],
-            "default": "1.15.*"
+            "default": "1.17.*"
         },
         {
             "name": "Ruby",

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -44,12 +44,11 @@
             "arch": "x64",
             "platform" : "linux",
             "versions": [
-                "1.15.*",
                 "1.16.*",
                 "1.17.*",
                 "1.18.*"
             ],
-            "default": "1.15.*"
+            "default": "1.17.*"
         },
         {
             "name": "Ruby",

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -290,7 +290,6 @@
             "platform" : "darwin",
             "variable_template" : "GOROOT_{0}_{1}_X64",
             "versions": [
-                "1.15.*",
                 "1.16.*",
                 "1.17.*",
                 "1.18.*"
@@ -333,7 +332,7 @@
         ]
     },
     "go": {
-        "default": "1.15"
+        "default": "1.17"
     },
     "node": {
         "default": "16",

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -266,7 +266,6 @@
             "platform" : "darwin",
             "variable_template" : "GOROOT_{0}_{1}_X64",
             "versions": [
-                "1.15.*",
                 "1.16.*",
                 "1.17.*",
                 "1.18.*"
@@ -309,7 +308,7 @@
         ]
     },
     "go": {
-        "default": "1.15"
+        "default": "1.17"
     },
     "node": {
         "default": "16",

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -180,7 +180,6 @@
             "platform" : "darwin",
             "variable_template" : "GOROOT_{0}_{1}_X64",
             "versions": [
-                "1.15.*",
                 "1.16.*",
                 "1.17.*",
                 "1.18.*"

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -70,12 +70,11 @@
             "arch": "x64",
             "platform" : "win32",
             "versions": [
-                "1.15.*",
                 "1.16.*",
                 "1.17.*",
                 "1.18.*"
             ],
-            "default": "1.15.*"
+            "default": "1.17.*"
         }
     ],
     "powershellModules": [

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -71,12 +71,11 @@
             "arch": "x64",
             "platform" : "win32",
             "versions": [
-                "1.15.*",
                 "1.16.*",
                 "1.17.*",
                 "1.18.*"
             ],
-            "default": "1.15.*"
+            "default": "1.17.*"
         }
     ],
     "powershellModules": [

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -63,12 +63,11 @@
             "arch": "x64",
             "platform" : "win32",
             "versions": [
-                "1.15.*",
                 "1.16.*",
                 "1.17.*",
                 "1.18.*"
             ],
-            "default": "1.16.*"
+            "default": "1.17.*"
         }
     ],
     "powershellModules": [


### PR DESCRIPTION
# Description
Update default go version to 1.17 since it is most popular
#### Related issue:
#5208
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
