### PR TITLE
[Ubuntu] Add automake autoconf libtool output version

### DIFF
--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -132,6 +132,8 @@
     ],
     "apt": {
         "common_packages": [
+            "autoconf",
+            "automake",
             "build-essential",
             "dbus",
             "dnsutils",
@@ -154,6 +156,7 @@
             "libmagickwand-dev",
             "libsecret-1-dev",
             "libsqlite3-dev",
+            "libtool",
             "libunwind8",
             "libxkbfile-dev",
             "libxss1",

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -130,6 +130,8 @@
     ],
     "apt": {
         "common_packages": [
+            "autoconf",
+            "automake",
             "build-essential",
             "dbus",
             "dnsutils",
@@ -153,6 +155,7 @@
             "libmagickwand-dev",
             "libsecret-1-dev",
             "libsqlite3-dev",
+            "libtool",
             "libunwind8",
             "libxkbfile-dev",
             "libxss1",


### PR DESCRIPTION
# Description
Add version output in docs file:
- automake
- autoconf
- litbool

#### Related issue:
https://github.com/actions/virtual-environments/issues/5360

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
