### PR TITLE
[Ubuntu] Use OpenSSL package version in output

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -83,7 +83,7 @@ function Get-NodeVersion {
 }
 
 function Get-OpensslVersion {
-    return $(openssl version)
+    return "OpenSSL $(dpkg-query -W -f '${Version}' openssl)"
 }
 
 function Get-PerlVersion {


### PR DESCRIPTION
# Description
Currently we use openssl version which doesn't provide info about security updates:
Ubuntu Server 20.04 - `OpenSSL 1.1.1f 31 Mar 2020`  -> `OpenSSL 1.1.1f-1ubuntu2.12` - https://launchpad.net/ubuntu/+source/openssl/1.1.1f-1ubuntu2.12

Ubuntu Server 18.04 - `OpenSSL 1.1.1 11 Sep 2018`  -> `OpenSSL 1.1.1-1ubuntu2.1~18.04.15` https://launchpad.net/ubuntu/+source/openssl/1.1.1f-1ubuntu2.12


#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3569

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
