### PR TITLE
Limit storageaccount name length to 24 characters

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -195,7 +195,9 @@ Function GenerateResourcesAndImage {
     
     
     # Storage Account Name can only be 24 characters long
-    $storageAccountName = $storageAccountName.Substring(0, 24)
+    if ($storageAccountName.Length -gt 24){
+        $storageAccountName = $storageAccountName.Substring(0, 24)
+    }
 
     New-AzStorageAccount -ResourceGroupName $ResourceGroupName -AccountName $storageAccountName -Location $AzureLocation -SkuName "Standard_LRS" -AllowBlobPublicAccess $AllowBlobPublicAccess -EnableHttpsTrafficOnly $EnableHttpsTrafficOnly
 

--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -192,6 +192,10 @@ Function GenerateResourcesAndImage {
     # Resource group names may contain special characters, that are not allowed in the storage account name
     $storageAccountName = $storageAccountName.Replace("-", "").Replace("_", "").Replace("(", "").Replace(")", "").ToLower()
     $storageAccountName += "001"
+    
+    
+    # Storage Account Name can only be 24 characters long
+    $storageAccountName = $storageAccountName.Substring(0, 24)
 
     New-AzStorageAccount -ResourceGroupName $ResourceGroupName -AccountName $storageAccountName -Location $AzureLocation -SkuName "Standard_LRS" -AllowBlobPublicAccess $AllowBlobPublicAccess -EnableHttpsTrafficOnly $EnableHttpsTrafficOnly
 


### PR DESCRIPTION
# Description
If resource group name is long then the script will generate storage account name that's longer than 24 characters.
This change will limit the generated storageaccountname to 24 characters.

[Document about limits](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-overview#:~:text=Storage%20account%20names%20must%20be,must%20be%20unique%20within%20Azure.)
