### PR TITLE
[Ubuntu] Remove hard-coded composer version

### DIFF
--- a/images/linux/scripts/installers/php.sh
+++ b/images/linux/scripts/installers/php.sh
@@ -86,12 +86,7 @@ apt-get install -y --no-install-recommends snmp
 # Install composer
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 php -r "if (hash_file('sha384', 'composer-setup.php') === file_get_contents('https://composer.github.io/installer.sig')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-# Composer 2.3 increased the required PHP version to >=7.2.5 and thus stop supporting PHP 5.3.2 - 7.2.4
-if isUbuntu18; then
-    php composer-setup.php --version=2.2.9
-else
-    php composer-setup.php
-fi
+php composer-setup.php
 sudo mv composer.phar /usr/bin/composer
 php -r "unlink('composer-setup.php');"
 

--- a/images/linux/scripts/tests/Common.Tests.ps1
+++ b/images/linux/scripts/tests/Common.Tests.ps1
@@ -20,10 +20,6 @@ Describe "PHP" {
         "composer --version" | Should -ReturnZeroExitCode
     }
 
-    It "Composer 2.2.9 on Ubuntu Server 18" -Skip:(-not (Test-IsUbuntu18)) {
-        composer --version | Should -Match "2.2.9"
-    }
-
     It "Pear" {
         "pear" | Should -ReturnZeroExitCode
     }


### PR DESCRIPTION
# Description
In scope of this https://github.com/actions/virtual-environments/pull/5390 PR we have removed  php-7.1 which is unsupported by php composer 2.3 and above.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
