### PR TITLE
[macOS] Install Az module latest version

### DIFF
--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -182,12 +182,7 @@
         }
     },
     "powershellModules": [
-        {
-            "name": "Az",
-            "versions": [
-                "7.1.0"
-            ]
-        },
+        {"name": "Az"},
         {"name": "MarkdownPS"},
         {"name": "Pester"},
         {"name": "PSScriptAnalyzer"}

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -167,12 +167,7 @@
         }
     },
     "powershellModules": [
-        {
-            "name": "Az",
-            "versions": [
-                "7.1.0"
-            ]
-        },
+        {"name": "Az"},
         {"name": "MarkdownPS"},
         {"name": "Pester"},
         {"name": "PSScriptAnalyzer"}


### PR DESCRIPTION
# Description
- Install Az module latest version for macOS 10.15, 11 like we do for macOS-12

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3531

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
