### PR TITLE
[Windows] Stick to git 2.35.1

### DIFF
--- a/images/win/scripts/Installers/Install-Git.ps1
+++ b/images/win/scripts/Installers/Install-Git.ps1
@@ -4,7 +4,8 @@
 ################################################################################
 
 # Install git
-Choco-Install -PackageName git -ArgumentList '--installargs="/VERYSILENT /NORESTART /NOCANCEL /SP- /CLOSEAPPLICATIONS /RESTARTAPPLICATIONS /o:PathOption=CmdTools /o:BashTerminalOption=ConHost /o:EnableSymlinks=Enabled /COMPONENTS=gitlfs"'
+# Temporary hardcode version 2.35.1 due to the issue with the actions\checkout https://github.com/actions/checkout/issues/760
+Choco-Install -PackageName git -ArgumentList '--version', "2.35.1.2", '--installargs="/VERYSILENT /NORESTART /NOCANCEL /SP- /CLOSEAPPLICATIONS /RESTARTAPPLICATIONS /o:PathOption=CmdTools /o:BashTerminalOption=ConHost /o:EnableSymlinks=Enabled /COMPONENTS=gitlfs"'
 
 # Install hub
 Choco-Install -PackageName hub


### PR DESCRIPTION
# Description
Due to the issue with the https://github.com/actions/checkout we have to temporarily stick git version to 2.35.1 https://github.com/actions/checkout/issues/760

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3617

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
