### PR TITLE
[macOS] Install git 2.35.1 for macOS

### DIFF
--- a/images/macos/provision/core/git.sh
+++ b/images/macos/provision/core/git.sh
@@ -2,7 +2,11 @@
 source ~/utils/utils.sh
 
 echo Installing Git...
-brew_smart_install "git"
+# Temporary hardcode version 2.35.1 due to the issue with the actions\checkout https://github.com/actions/checkout/issues/76
+brew tap-new local/git
+brew extract --version=2.35.1 git local/git
+brew install git@2.35.1
+brew untap -f local/homebrew-git
 
 echo Installing Git LFS
 brew_smart_install "git-lfs"


### PR DESCRIPTION
# Description
Due to the issue with the https://github.com/actions/checkout we have to temporarily stick git version to 2.35.1 https://github.com/actions/checkout/issues/760

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3617

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
