### PR TITLE
[Ubuntu] Add safe directory setting to git config

### DIFF
--- a/images/linux/scripts/installers/git.sh
+++ b/images/linux/scripts/installers/git.sh
@@ -15,6 +15,11 @@ add-apt-repository $GIT_REPO -y
 apt-get update
 apt-get install git -y
 git --version
+# Git version 2.35.2 introduces security fix that breaks action\checkout https://github.com/actions/checkout/issues/760
+cat <<EOF >> /etc/skel/.gitconfig
+[safe]
+        directory = *
+EOF
 
 # Install git-lfs
 curl -s $GIT_LFS_REPO/script.deb.sh | bash

--- a/images/linux/scripts/installers/git.sh
+++ b/images/linux/scripts/installers/git.sh
@@ -16,7 +16,7 @@ apt-get update
 apt-get install git -y
 git --version
 # Git version 2.35.2 introduces security fix that breaks action\checkout https://github.com/actions/checkout/issues/760
-cat <<EOF >> /etc/skel/.gitconfig
+cat <<EOF >> /etc/gitconfig
 [safe]
         directory = *
 EOF


### PR DESCRIPTION
# Description
Due to the recent security changes in git actions\checkout task is experiencing issues https://github.com/actions/checkout/issues/760. The workaround is to set `git config --global --add safe.directory "*"` setting. This PR adds this setting in `/etc/skel` as the user is different between image generation VM and VM in production.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3617

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
