### PR TITLE
[macOS] Move homebrew installation after xcode_clt

### DIFF
--- a/images/macos/templates/macOS-10.15.json
+++ b/images/macos/templates/macOS-10.15.json
@@ -90,9 +90,17 @@
         },
         {
             "type": "shell",
-            "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}",
+            "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
+            "pause_before": "30s",
             "scripts": [
                 "./provision/core/xcode-clt.sh",
+                "./provision/core/homebrew.sh"
+            ]
+        },
+        {
+            "type": "shell",
+            "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}",
+            "scripts": [
                 "./provision/configuration/add-network-interface-detection.sh",
                 "./provision/configuration/autologin.sh",
                 "./provision/configuration/disable-auto-updates.sh",
@@ -130,7 +138,6 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "pause_before": "30s",
             "scripts": [
-                "./provision/core/homebrew.sh",
                 "./provision/core/open_windows_check.sh",
                 "./provision/core/powershell.sh",
                 "./provision/core/dotnet.sh",

--- a/images/macos/templates/macOS-11.json
+++ b/images/macos/templates/macOS-11.json
@@ -95,6 +95,14 @@
         },
         {
             "type": "shell",
+            "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
+            "scripts": [
+                "./provision/core/xcode-clt.sh",
+                "./provision/core/homebrew.sh"
+            ]
+        },
+        {
+            "type": "shell",
             "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}",
             "scripts": [
                 "./provision/core/xcode-clt.sh",
@@ -135,7 +143,6 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "pause_before": "30s",
             "scripts": [
-                "./provision/core/homebrew.sh",
                 "./provision/core/open_windows_check.sh",
                 "./provision/core/powershell.sh",
                 "./provision/core/dotnet.sh",

--- a/images/macos/templates/macOS-11.pkr.hcl
+++ b/images/macos/templates/macOS-11.pkr.hcl
@@ -99,6 +99,12 @@ build {
   provisioner "shell" {
     scripts = [
       "./provision/core/xcode-clt.sh",
+      "./provision/core/homebrew.sh"
+    ]
+    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+  }
+  provisioner "shell" {
+    scripts = [
       "./provision/configuration/configure-tccdb-macos11.sh",
       "./provision/configuration/add-network-interface-detection.sh",
       "./provision/configuration/autologin.sh",
@@ -134,7 +140,6 @@ build {
   provisioner "shell" {
     pause_before = "30s"
     scripts = [
-      "./provision/core/homebrew.sh",
       "./provision/core/open_windows_check.sh",
       "./provision/core/powershell.sh",
       "./provision/core/dotnet.sh",

--- a/images/macos/templates/macOS-12.json
+++ b/images/macos/templates/macOS-12.json
@@ -95,9 +95,16 @@
         },
         {
             "type": "shell",
-            "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}",
+            "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "scripts": [
                 "./provision/core/xcode-clt.sh",
+                "./provision/core/homebrew.sh"
+            ]
+        },
+        {
+            "type": "shell",
+            "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}",
+            "scripts": [
                 "./provision/configuration/add-network-interface-detection.sh",
                 "./provision/configuration/autologin.sh",
                 "./provision/configuration/disable-auto-updates.sh",
@@ -136,7 +143,6 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "pause_before": "30s",
             "scripts": [
-                "./provision/core/homebrew.sh",
                 "./provision/core/open_windows_check.sh",
                 "./provision/core/powershell.sh",
                 "./provision/core/dotnet.sh",


### PR DESCRIPTION
# Description
There is a rare bug when installing homebrew on macOS Monterey — when calling `if [[ -z "${HOMEBREW_ON_LINUX-}" ]] && ! output="$(/usr/bin/xcrun clang 2>&1)" && [[ "${output}" == *"license"* ]]
` from the https://github.com/Homebrew/install/blob/master/install.sh script macOS gatekeeper is stuck verifying clang.
This PR moves homebrew installation right after Xcode tools one, which seems to help. Also, we don't need sudo to install the Xcode command-line tools.

#### Related issue:
[[macOS] Investigate an opened window on Monterey after the image update #3469](https://github.com/actions/virtual-environments-internal/issues/3469)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
