### PR TITLE
[Windows] Change pattern for Rscript output

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -31,7 +31,7 @@ function Get-BicepVersion {
 }
 
 function Get-RVersion {
-    ($(cmd /c "Rscript --version 2>&1")  | Out-String) -match  "R scripting front-end version (?<version>\d+\.\d+\.\d+)" | Out-Null
+    ($(cmd /c "Rscript --version 2>&1") | Out-String) -match "Rscript .* version (?<version>\d+\.\d+\.\d+)" | Out-Null
     $rVersion = $Matches.Version
     return "R $rVersion"
 }


### PR DESCRIPTION
# Description
R version output changed from 
```
R scripting front-end version 4.1.3 (2022-03-10)
```
to
```
Rscript (R) version 4.2.0 (2022-04-22)
```
Thus we need to change the software report according to the changes.

#### Related issue:
https://github.com/actions/virtual-environments/issues/5435

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
