### PR TITLE
[MacOS]  Add safe directory setting to git config

### DIFF
--- a/images/macos/provision/core/git.sh
+++ b/images/macos/provision/core/git.sh
@@ -8,6 +8,11 @@ brew extract --version=2.35.1 git local/git
 brew install git@2.35.1
 brew untap -f local/homebrew-git
 
+cat <<EOF >> /etc/gitconfig
+[safe]
+        directory = *
+EOF
+
 echo Installing Git LFS
 brew_smart_install "git-lfs"
 


### PR DESCRIPTION
# Description
Due to the recent security changes in git actions\checkout task is experiencing issues https://github.com/actions/checkout/issues/760. The workaround is to set git config --global --add safe.directory "*" setting. This PR adds this setting in /etc/gitconfig as it is used globally for every OS user.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3617 

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
