### PR TITLE
[Ubuntu] Add python toolcache to 22.04

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.CachedTools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.CachedTools.psm1
@@ -55,10 +55,10 @@ function Build-CachedToolsSection {
     $output += New-MDHeader "PyPy" -Level 4
     $output += New-MDList -Lines (Get-ToolcachePyPyVersions) -Style Unordered
 
-    if ((Test-IsUbuntu18) -or (Test-IsUbuntu20)) {
-        $output += New-MDHeader "Python" -Level 4
-        $output += New-MDList -Lines (Get-ToolcachePythonVersions) -Style Unordered
+    $output += New-MDHeader "Python" -Level 4
+    $output += New-MDList -Lines (Get-ToolcachePythonVersions) -Style Unordered
 
+    if ((Test-IsUbuntu18) -or (Test-IsUbuntu20)) {
         $output += New-MDHeader "Ruby" -Level 4
         $output += New-MDList -Lines (Get-ToolcacheRubyVersions) -Style Unordered
     }

--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -1,6 +1,19 @@
 {
     "toolcache": [
         {
+            "name": "Python",
+            "url" : "https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json",
+            "platform" : "linux",
+            "platform_version": "22.04",
+            "arch": "x64",
+            "versions": [
+                "3.7.*",
+                "3.8.*",
+                "3.9.*",
+                "3.10.*"
+            ]
+        },
+        {
             "name": "PyPy",
             "arch": "x64",
             "platform" : "linux",


### PR DESCRIPTION
# Description
As we now have python generated for 22.04 lets add it back to the toolcache.

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/3639

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [X] Documentation is updated (if applicable)
- [X] Changes are tested and related VM images are successfully generated
