### PR TITLE
[Ubuntu] Add node toolcache to 22.04

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.CachedTools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.CachedTools.psm1
@@ -47,10 +47,8 @@ function Build-CachedToolsSection {
     $output += New-MDHeader "Go" -Level 4
     $output += New-MDList -Lines (Get-ToolcacheGoVersions) -Style Unordered
 
-    if ((Test-IsUbuntu18) -or (Test-IsUbuntu20)) {
-        $output += New-MDHeader "Node.js" -Level 4
-        $output += New-MDList -Lines (Get-ToolcacheNodeVersions) -Style Unordered
-    }
+    $output += New-MDHeader "Node.js" -Level 4
+    $output += New-MDList -Lines (Get-ToolcacheNodeVersions) -Style Unordered
 
     $output += New-MDHeader "PyPy" -Level 4
     $output += New-MDList -Lines (Get-ToolcachePyPyVersions) -Style Unordered

--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -24,6 +24,16 @@
             ]
         },
         {
+            "name": "node",
+            "url" : "https://raw.githubusercontent.com/actions/node-versions/main/versions-manifest.json",
+            "platform" : "linux",
+            "arch": "x64",
+            "versions": [
+                "14.*",
+                "16.*"
+            ]
+        },
+        {
             "name": "go",
             "url" : "https://raw.githubusercontent.com/actions/go-versions/main/versions-manifest.json",
             "arch": "x64",


### PR DESCRIPTION
# Description
Node does not depend on a specific Ubuntu version so we can add it back to toolcache (12 has been removed as it had been abandoned by the end of April).
#### Related issue: https://github.com/actions/virtual-environments-internal/issues/3640

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [X] Documentation is updated (if applicable)
- [X] Changes are tested and related VM images are successfully generated
