### PR TITLE
[CI] Set TLS12

### DIFF
--- a/images.CI/linux-and-win/create-release.ps1
+++ b/images.CI/linux-and-win/create-release.ps1
@@ -26,6 +26,7 @@ $headers = @{
     Authorization = "Basic ${base64AuthInfo}"
 }
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 -bor [Net.SecurityProtocolType]::Tls13
 $NewRelease = Invoke-RestMethod $URL -Body $Body -Method "POST" -Headers $headers -ContentType "application/json"
 
 Write-Host "Created release: $($NewRelease._links.web.href)"


### PR DESCRIPTION
# Description
We should set up Tls12 as the default one to prevent an error  - `The underlying connection was closed: An unexpected error occurred on a send.`
