### PR TITLE
[Ubuntu] Add Ruby 3.1 to 22.04 toolcache

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.CachedTools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.CachedTools.psm1
@@ -56,10 +56,8 @@ function Build-CachedToolsSection {
     $output += New-MDHeader "Python" -Level 4
     $output += New-MDList -Lines (Get-ToolcachePythonVersions) -Style Unordered
 
-    if ((Test-IsUbuntu18) -or (Test-IsUbuntu20)) {
-        $output += New-MDHeader "Ruby" -Level 4
-        $output += New-MDList -Lines (Get-ToolcacheRubyVersions) -Style Unordered
-    }
+    $output += New-MDHeader "Ruby" -Level 4
+    $output += New-MDList -Lines (Get-ToolcacheRubyVersions) -Style Unordered
 
     return $output
 }

--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -45,6 +45,14 @@
             "default": "1.18.*"
         },
         {
+            "name": "Ruby",
+            "platform_version": "22.04",
+            "arch": "x64",
+            "versions": [
+                "3.1.*"
+            ]
+        },
+        {
             "name": "CodeQL",
             "platform" : "linux",
             "arch": "x64",


### PR DESCRIPTION
# Description

I am in touch with @eregon and he has generated 3.1 for 22.04, 2.7/3.0 is pending as there is strong openssl-1.x dependency.

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/3642

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
