### PR TITLE
Add ubuntu 22 to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/announcement.yml
+++ b/.github/ISSUE_TEMPLATE/announcement.yml
@@ -32,6 +32,7 @@ body:
       options:
         - label: Ubuntu 18.04
         - label: Ubuntu 20.04
+        - label: Ubuntu 22.04
         - label: macOS 10.15
         - label: macOS 11
         - label: macOS 12

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -14,6 +14,7 @@ body:
       options:
         - label: Ubuntu 18.04
         - label: Ubuntu 20.04
+        - label: Ubuntu 22.04
         - label: macOS 10.15
         - label: macOS 11
         - label: macOS 12

--- a/.github/ISSUE_TEMPLATE/tool-request.yml
+++ b/.github/ISSUE_TEMPLATE/tool-request.yml
@@ -53,6 +53,7 @@ body:
       options:
         - label: Ubuntu 18.04
         - label: Ubuntu 20.04
+        - label: Ubuntu 22.04
         - label: macOS 10.15
         - label: macOS 11
         - label: macOS 12


### PR DESCRIPTION
# Description
We need to add Ubuntu22 as the image is now available in GitHub.

#### Related issue:
n\a

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
