### PR TITLE
[macOS] Add SwiftFormat for macOS 12

### DIFF
--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -176,14 +176,9 @@ $toolsList += @(
     (Get-GHCupVersion),
     (Get-GHCVersion),
     (Get-CabalVersion),
-    (Get-StackVersion)
+    (Get-StackVersion),
+    (Get-SwiftFormatVersion)
 )
-
-if($os.IsLessThanMonterey) {
-    $toolsList += @(
-        (Get-SwiftFormatVersion)
-    )
-}
 
 $markdown += New-MDList -Style Unordered -Lines ($toolsList | Sort-Object)
 

--- a/images/macos/tests/BasicTools.Tests.ps1
+++ b/images/macos/tests/BasicTools.Tests.ps1
@@ -30,7 +30,7 @@ Describe "Subversion" {
     }
 }
 
-Describe "SwiftFormat" -Skip:($os.IsMonterey) {
+Describe "SwiftFormat" {
     It "SwiftFormat" {
         "swiftformat --version" | Should -ReturnZeroExitCode
     }

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -127,6 +127,7 @@
             "perl",
             "sbt",
             "subversion",
+            "swiftformat",
             "swig",
             "zstd",
             "gmp",


### PR DESCRIPTION
# Description
SwiftFormat is a code library and command-line tool for reformatting Swift code on macOS or Linux.

#### Related issue:
https://github.com/actions/virtual-environments/issues/5494

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
