### PR TITLE
[Ubuntu] OpenSSL disable to load providers

### DIFF
--- a/images/linux/scripts/installers/configure-environment.sh
+++ b/images/linux/scripts/installers/configure-environment.sh
@@ -40,3 +40,6 @@ if [[ -f "/etc/fwupd/daemon.conf" ]]; then
     sed -i 's/UpdateMotd=true/UpdateMotd=false/g' /etc/fwupd/daemon.conf
     systemctl mask fwupd-refresh.timer
 fi
+
+# Disable to load providers
+sed -i 's/openssl_conf = openssl_init/#openssl_conf = openssl_init/g' /etc/ssl/openssl.cnf

--- a/images/linux/scripts/installers/configure-environment.sh
+++ b/images/linux/scripts/installers/configure-environment.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/os.sh
+
 # Set ImageVersion and ImageOS env variables
 echo ImageVersion=$IMAGE_VERSION | tee -a /etc/environment
 echo ImageOS=$IMAGE_OS | tee -a /etc/environment
@@ -43,4 +46,6 @@ fi
 
 # Disable to load providers
 # https://github.com/microsoft/azure-pipelines-agent/issues/3834
-sed -i 's/openssl_conf = openssl_init/#openssl_conf = openssl_init/g' /etc/ssl/openssl.cnf
+if isUbuntu22; then
+    sed -i 's/openssl_conf = openssl_init/#openssl_conf = openssl_init/g' /etc/ssl/openssl.cnf
+fi

--- a/images/linux/scripts/installers/configure-environment.sh
+++ b/images/linux/scripts/installers/configure-environment.sh
@@ -42,4 +42,5 @@ if [[ -f "/etc/fwupd/daemon.conf" ]]; then
 fi
 
 # Disable to load providers
+# https://github.com/microsoft/azure-pipelines-agent/issues/3834
 sed -i 's/openssl_conf = openssl_init/#openssl_conf = openssl_init/g' /etc/ssl/openssl.cnf


### PR DESCRIPTION
# Description
Unable to install vsts-agent in runtime with openssl configuration by default.

#### Related issue:
https://github.com/microsoft/azure-pipelines-agent/issues/3834#issuecomment-1118836249

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
