### PR TITLE
[Ubuntu] Update libssl for Ubuntu22

### DIFF
--- a/images/linux/scripts/installers/powershellcore.sh
+++ b/images/linux/scripts/installers/powershellcore.sh
@@ -10,8 +10,8 @@ source $HELPER_SCRIPTS/install.sh
 
 if isUbuntu22; then
     # Install libssl1.1
-    download_with_retries "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1l-1ubuntu1.2_amd64.deb" "/tmp"
-    dpkg -i /tmp/libssl1.1_1.1.1l-1ubuntu1.2_amd64.deb
+    download_with_retries "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb" "/tmp"
+    dpkg -i /tmp/libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb
 
     # Install Powershell
     download_with_retries "https://github.com/PowerShell/PowerShell/releases/download/v7.2.3/powershell-lts_7.2.3-1.deb_amd64.deb" "/tmp"


### PR DESCRIPTION
# Description
Could not download http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1l-1ubuntu1.2_amd64.deb

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3696

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
