### PR TITLE
[Windows] Update cobertura link

### DIFF
--- a/images/win/scripts/Installers/Install-JavaTools.ps1
+++ b/images/win/scripts/Installers/Install-JavaTools.ps1
@@ -148,7 +148,7 @@ setx M2_REPO $m2_repo /M
 setx MAVEN_OPTS $maven_opts /M
 
 # Download cobertura jars
-$uri = 'https://downloads.sourceforge.net/project/cobertura/cobertura/2.1.1/cobertura-2.1.1-bin.zip'
+$uri = 'https://repo1.maven.org/maven2/net/sourceforge/cobertura/cobertura/2.1.1/cobertura-2.1.1-bin.zip'
 $coberturaPath = "C:\cobertura-2.1.1"
 
 $archivePath = Start-DownloadWithRetry -Url $uri -Name "cobertura.zip"


### PR DESCRIPTION
# Description
Unable to download [cobertura-2.1.1-bin.zip](https://downloads.sourceforge.net/project/cobertura/cobertura/2.1.1/cobertura-2.1.1-bin.zip) archive due to broken link.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3701

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
