### PR TITLE
[Windows] Add docker-compose v2

### DIFF
--- a/images/win/scripts/Installers/Install-Docker.ps1
+++ b/images/win/scripts/Installers/Install-Docker.ps1
@@ -11,7 +11,7 @@ Write-Host "Install-Package Docker"
 Install-Package -Name docker -ProviderName DockerMsftProvider -RequiredVersion 20.10.7 -Force
 Start-Service docker
 
-Write-Host "Install-Package Docker-Compose"
+Write-Host "Install-Package Docker-Compose v1"
 Choco-Install -PackageName docker-compose
 
 Write-Host "Install-Package Docker-Compose v2"

--- a/images/win/scripts/Installers/Install-Docker.ps1
+++ b/images/win/scripts/Installers/Install-Docker.ps1
@@ -14,6 +14,10 @@ Start-Service docker
 Write-Host "Install-Package Docker-Compose"
 Choco-Install -PackageName docker-compose
 
+Write-Host "Install-Package Docker-Compose v2"
+$dockerComposev2Url = "https://github.com/docker/compose/releases/latest/download/docker-compose-windows-x86_64.exe"
+Start-DownloadWithRetry -Url $dockerComposev2Url -Name docker-compose.exe -DownloadPath "C:\Program Files\Docker\cli-plugins"
+
 Write-Host "Install docker-wincred"
 $dockerCredLatestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/docker/docker-credential-helpers/releases/latest"
 $dockerCredDownloadUrl = $dockerCredLatestRelease.assets.browser_download_url -match "docker-credential-wincred-.+\.zip" | Select-Object -First 1

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -94,6 +94,7 @@ $toolsList = @(
     (Get-CodeQLBundleVersion),
     (Get-DockerVersion),
     (Get-DockerComposeVersion),
+    (Get-DockerComposeVersionV2),
     (Get-DockerWincredVersion),
     (Get-GHCVersion),
     (Get-GitVersion),

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -56,9 +56,14 @@ function Get-DockerVersion {
 }
 
 function Get-DockerComposeVersion {
-    $(docker-compose --version) -match "docker-compose version (?<version>\d+\.\d+\.\d+)" | Out-Null
-    $dockerComposeVersion = $Matches.Version
-    return "Docker-compose $dockerComposeVersion"
+    $dockerComposeVersion = docker-compose version --short
+    return "Docker Compose v1 $dockerComposeVersion"
+}
+
+
+function Get-DockerComposeVersionV2 {
+    $dockerComposeVersion = docker compose version --short
+    return "Docker Compose v2 $dockerComposeVersion"
 }
 
 function Get-DockerWincredVersion {

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -60,7 +60,6 @@ function Get-DockerComposeVersion {
     return "Docker Compose v1 $dockerComposeVersion"
 }
 
-
 function Get-DockerComposeVersionV2 {
     $dockerComposeVersion = docker compose version --short
     return "Docker Compose v2 $dockerComposeVersion"

--- a/images/win/scripts/Tests/Docker.Tests.ps1
+++ b/images/win/scripts/Tests/Docker.Tests.ps1
@@ -10,6 +10,10 @@ Describe "Docker" {
         "docker-credential-wincred version" | Should -ReturnZeroExitCode
     }
 
+    It "docker compose v2" {
+        "docker compose version" | Should -ReturnZeroExitCode
+    }
+
     It "docker service is up" {
         "docker images" | Should -ReturnZeroExitCode
     }


### PR DESCRIPTION
# Description
[Announcing Compose V2 General Availability](https://www.docker.com/blog/announcing-compose-v2-general-availability/#:~:text=April%2026%2C%202022%20marks%20the,developer%20default%20on%20Docker%20Desktop.)

**When is Compose V2 GA and what does it mean?**
_April 26, 2022 marks the GA of Docker Compose V2. Starting today, Compose V2 is the standard across all documentation, and Compose V2 will become the developer default on Docker Desktop._

**What’ll happen to Compose V1?**
_We’ve now marked Compose V1 as deprecated. Only high-priority security patches and critical bug fixes_


How to use?
v1:
```
PS > docker-compose version --short
1.29.2
```

v2:
```
PS > docker compose version --short
2.5.0
```

#### Related issue:
https://github.com/actions/virtual-environments/issues/4657

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
