### PR TITLE
Add `ecdsa` & `ed25519` GitHub host keys

### DIFF
--- a/images/linux/scripts/installers/git.sh
+++ b/images/linux/scripts/installers/git.sh
@@ -45,7 +45,7 @@ tar xzf "$tmp_hub"/hub-linux-amd64-*.tgz --strip-components 1 -C "$tmp_hub"
 mv "$tmp_hub"/bin/hub /usr/local/bin
 
 # Add well-known SSH host keys to known_hosts
-ssh-keyscan -t rsa github.com >> /etc/ssh/ssh_known_hosts
+ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> /etc/ssh/ssh_known_hosts
 ssh-keyscan -t rsa ssh.dev.azure.com >> /etc/ssh/ssh_known_hosts
 
 invoke_tests "Tools" "Git"

--- a/images/macos/provision/configuration/configure-ssh.sh
+++ b/images/macos/provision/configuration/configure-ssh.sh
@@ -3,5 +3,5 @@
 [[ ! -d ~/.ssh ]] && mkdir ~/.ssh 2>/dev/null
 chmod 777 ~/.ssh
 
-ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> ~/.ssh/known_hosts
 ssh-keyscan -t rsa ssh.dev.azure.com >> ~/.ssh/known_hosts

--- a/images/win/scripts/Installers/Install-Git.ps1
+++ b/images/win/scripts/Installers/Install-Git.ps1
@@ -21,7 +21,7 @@ if (Test-IsWin16) {
 }
 
 # Add well-known SSH host keys to ssh_known_hosts
-ssh-keyscan -t rsa github.com >> "C:\Program Files\Git\etc\ssh\ssh_known_hosts"
+ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> "C:\Program Files\Git\etc\ssh\ssh_known_hosts"
 ssh-keyscan -t rsa ssh.dev.azure.com >> "C:\Program Files\Git\etc\ssh\ssh_known_hosts"
 
 Invoke-PesterTests -TestFile "Git"


### PR DESCRIPTION
# Description

GitHub has `ecdsa` and `ed25519` host keys, they should be present in the known hosts as well:
- https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints

The new keys have been usable since Nov 16, 2021:
- https://github.blog/2021-09-01-improving-git-protocol-security-github/

#### Related issue:

n/a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
