### PR TITLE
[Packer] Add client_cert_path option

### DIFF
--- a/docs/create-image-and-azure-resources.md
+++ b/docs/create-image-and-azure-resources.md
@@ -110,7 +110,8 @@ The Packer template includes `variables` section containing user variables used 
 - `build_resource_group_name` - Specify an existing resource group to run the build in it. By default, a temporary resource group will be created and destroyed as part of the build. If you do not have permission to do so, use build_resource_group_name to specify an existing resource group to run the build in it.
 - `client_id` - The application ID of the AAD Service Principal. Requires `client_secret`.
 - `object_id` - The object ID for the AAD SP. Will be derived from the oAuth token if empty.
-- `client_secret` - A password/secret registered for the AAD SP.
+- `client_secret` - The password or secret for your service principal.
+- `client_cert_path` - The location of a PEM file containing a certificate and private key for service principal.
 - `subscription_id` - The subscription to use.
 - `tenant_id` - The Active Directory tenant identifier with which your `client_id` and `subscription_id` are associated. If not specified, `tenant_id` will be looked up using `subscription_id`.
 - `resource_group` - Resource group under which the final artifact will be stored.

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -2,6 +2,7 @@
     "variables": {
         "client_id": "{{env `ARM_CLIENT_ID`}}",
         "client_secret": "{{env `ARM_CLIENT_SECRET`}}",
+        "client_cert_path": "{{env `ARM_CLIENT_CERT_PATH`}}",
         "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
         "tenant_id": "{{env `ARM_TENANT_ID`}}",
         "resource_group": "{{env `ARM_RESOURCE_GROUP`}}",
@@ -34,6 +35,7 @@
             "type": "azure-arm",
             "client_id": "{{user `client_id`}}",
             "client_secret": "{{user `client_secret`}}",
+            "client_cert_path": "{{user `client_cert_path`}}",
             "subscription_id": "{{user `subscription_id`}}",
             "tenant_id": "{{user `tenant_id`}}",
             "location": "{{user `location`}}",

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -2,6 +2,7 @@
     "variables": {
         "client_id": "{{env `ARM_CLIENT_ID`}}",
         "client_secret": "{{env `ARM_CLIENT_SECRET`}}",
+        "client_cert_path": "{{env `ARM_CLIENT_CERT_PATH`}}",
         "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
         "tenant_id": "{{env `ARM_TENANT_ID`}}",
         "resource_group": "{{env `ARM_RESOURCE_GROUP`}}",
@@ -34,6 +35,7 @@
             "type": "azure-arm",
             "client_id": "{{user `client_id`}}",
             "client_secret": "{{user `client_secret`}}",
+            "client_cert_path": "{{user `client_cert_path`}}",
             "subscription_id": "{{user `subscription_id`}}",
             "tenant_id": "{{user `tenant_id`}}",
             "location": "{{user `location`}}",

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -24,6 +24,11 @@ variable "client_secret" {
   sensitive = true
 }
 
+variable "client_cert_path" {
+  type      = string
+  default   = "${env("ARM_CLIENT_CERT_PATH")}"
+}
+
 variable "commit_url" {
   type      = string
   default   = ""
@@ -146,6 +151,7 @@ source "azure-arm" "build_vhd" {
   capture_name_prefix                    = "${var.capture_name_prefix}"
   client_id                              = "${var.client_id}"
   client_secret                          = "${var.client_secret}"
+  client_cert_path                       = "${var.client_cert_path}"
   image_offer                            = "0001-com-ubuntu-server-jammy"
   image_publisher                        = "canonical"
   image_sku                              = "22_04-lts"

--- a/images/win/windows2016.json
+++ b/images/win/windows2016.json
@@ -2,6 +2,7 @@
     "variables": {
         "client_id": "{{env `ARM_CLIENT_ID`}}",
         "client_secret": "{{env `ARM_CLIENT_SECRET`}}",
+        "client_cert_path": "{{env `ARM_CLIENT_CERT_PATH`}}",
         "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
         "tenant_id": "{{env `ARM_TENANT_ID`}}",
         "object_id": "{{env `ARM_OBJECT_ID`}}",
@@ -37,6 +38,7 @@
             "type": "azure-arm",
             "client_id": "{{user `client_id`}}",
             "client_secret": "{{user `client_secret`}}",
+            "client_cert_path": "{{user `client_cert_path`}}",
             "subscription_id": "{{user `subscription_id`}}",
             "object_id": "{{user `object_id`}}",
             "tenant_id": "{{user `tenant_id`}}",

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -2,6 +2,7 @@
     "variables": {
         "client_id": "{{env `ARM_CLIENT_ID`}}",
         "client_secret": "{{env `ARM_CLIENT_SECRET`}}",
+        "client_cert_path": "{{env `ARM_CLIENT_CERT_PATH`}}",
         "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
         "tenant_id": "{{env `ARM_TENANT_ID`}}",
         "object_id": "{{env `ARM_OBJECT_ID`}}",
@@ -36,6 +37,7 @@
             "type": "azure-arm",
             "client_id": "{{user `client_id`}}",
             "client_secret": "{{user `client_secret`}}",
+            "client_cert_path": "{{user `client_cert_path`}}",
             "subscription_id": "{{user `subscription_id`}}",
             "object_id": "{{user `object_id`}}",
             "tenant_id": "{{user `tenant_id`}}",

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -2,6 +2,7 @@
     "variables": {
         "client_id": "{{env `ARM_CLIENT_ID`}}",
         "client_secret": "{{env `ARM_CLIENT_SECRET`}}",
+        "client_cert_path": "{{env `ARM_CLIENT_CERT_PATH`}}",
         "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
         "tenant_id": "{{env `ARM_TENANT_ID`}}",
         "object_id": "{{env `ARM_OBJECT_ID`}}",
@@ -36,6 +37,7 @@
             "type": "azure-arm",
             "client_id": "{{user `client_id`}}",
             "client_secret": "{{user `client_secret`}}",
+            "client_cert_path": "{{user `client_cert_path`}}",
             "subscription_id": "{{user `subscription_id`}}",
             "object_id": "{{user `object_id`}}",
             "tenant_id": "{{user `tenant_id`}}",


### PR DESCRIPTION
# Description
We have to be able to set `client_secret` or `client_cert_path` during image generation as a packer option to authenticate in Azure with using a service principal - https://www.packer.io/plugins/builders/azure/arm

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3762

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
