### PR TITLE
[Ubuntu] Rework podman and tools installation

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -149,10 +149,14 @@ $toolsList = @(
 
 if ((Test-IsUbuntu18) -or (Test-IsUbuntu20)) {
     $toolsList += @(
-        (Get-BuildahVersion),
         (Get-PhantomJSVersion),
         (Get-LeiningenVersion),
-        (Get-HHVMVersion),
+        (Get-HHVMVersion)
+    )
+}
+if (Test-IsUbuntu22) {
+    $toolsList += @(
+        (Get-BuildahVersion),
         (Get-PodManVersion),
         (Get-SkopeoVersion)
     )

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -42,20 +42,17 @@ function Get-CodeQLBundleVersion {
 
 function Get-PodManVersion {
     $podmanVersion = podman --version | Take-OutputPart -Part 2
-    $aptSourceRepo = Get-AptSourceRepository -PackageName "containers"
-    return "Podman $podmanVersion (apt source repository: $aptSourceRepo)"
+    return "Podman $podmanVersion"
 }
 
 function Get-BuildahVersion {
     $buildahVersion = buildah --version | Take-OutputPart -Part 2
-    $aptSourceRepo = Get-AptSourceRepository -PackageName "containers"
-    return "Buildah $buildahVersion (apt source repository: $aptSourceRepo)"
+    return "Buildah $buildahVersion"
 }
 
 function Get-SkopeoVersion {
     $skopeoVersion = skopeo --version | Take-OutputPart -Part 2
-    $aptSourceRepo = Get-AptSourceRepository -PackageName "containers"
-    return "Skopeo $skopeoVersion (apt source repository: $aptSourceRepo)"
+    return "Skopeo $skopeoVersion"
 }
 
 function Get-CMakeVersion {

--- a/images/linux/scripts/installers/containers.sh
+++ b/images/linux/scripts/installers/containers.sh
@@ -4,25 +4,11 @@
 ##  Desc:  Installs container tools: podman, buildah and skopeo onto the image
 ################################################################################
 
-source $HELPER_SCRIPTS/os.sh
-
 install_packages=(podman buildah skopeo)
-REPO_URL="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable"
 
-# Install podman, buildah, scopeo container's tools (on Ubuntu20 these tools can be installed without adding new repository)
-source /etc/os-release
-sh -c "echo 'deb ${REPO_URL}/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-wget -qnv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key -O Release.key
-apt-key add Release.key
-apt-get update -qq
+# Install podman, buildah, scopeo container's tools
 apt-get -qq -y install ${install_packages[@]}
 mkdir -p /etc/containers
 echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | tee /etc/containers/registries.conf
-
-# Remove source repo
-rm /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-
-# Document source repo
-echo "containers $REPO_URL" >> $HELPER_SCRIPTS/apt-sources.txt
 
 invoke_tests "Tools" "Containers"

--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -20,8 +20,7 @@ Describe "Rust" {
         $env:RUSTUP_HOME = "/etc/skel/.rustup"
         $env:CARGO_HOME = "/etc/skel/.cargo"
     }
-    
-   
+
     It "Rustup is installed" {
         "rustup --version" | Should -ReturnZeroExitCode
     }
@@ -121,7 +120,7 @@ Describe "clang" {
 
         "clang-$ClangVersion --version" | Should -ReturnZeroExitCode
         "clang++-$ClangVersion --version" | Should -ReturnZeroExitCode
-    }   
+    }
 }
 
 Describe "Cmake" {
@@ -336,7 +335,7 @@ Describe "GraalVM" -Skip:(Test-IsUbuntu18) {
     }
 }
 
-Describe "Containers" -Skip:(Test-IsUbuntu22) {
+Describe "Containers" -Skip:(-not (Test-IsUbuntu22)) {
     $testCases = @("podman", "buildah", "skopeo") | ForEach-Object { @{ContainerCommand = $_} }
 
     It "<ContainerCommand>" -TestCases $testCases {
@@ -345,7 +344,7 @@ Describe "Containers" -Skip:(Test-IsUbuntu22) {
         )
 
         "$ContainerCommand -v" | Should -ReturnZeroExitCode
-    }   
+    }
 }
 
 Describe "nvm" {

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -197,7 +197,6 @@
                 "{{template_dir}}/scripts/installers/swift.sh",
                 "{{template_dir}}/scripts/installers/cmake.sh",
                 "{{template_dir}}/scripts/installers/codeql-bundle.sh",
-                "{{template_dir}}/scripts/installers/containers.sh",
                 "{{template_dir}}/scripts/installers/dotnetcore-sdk.sh",
                 "{{template_dir}}/scripts/installers/erlang.sh",
                 "{{template_dir}}/scripts/installers/firefox.sh",

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -198,7 +198,6 @@
                 "{{template_dir}}/scripts/installers/swift.sh",
                 "{{template_dir}}/scripts/installers/cmake.sh",
                 "{{template_dir}}/scripts/installers/codeql-bundle.sh",
-                "{{template_dir}}/scripts/installers/containers.sh",
                 "{{template_dir}}/scripts/installers/dotnetcore-sdk.sh",
                 "{{template_dir}}/scripts/installers/erlang.sh",
                 "{{template_dir}}/scripts/installers/firefox.sh",

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -270,6 +270,7 @@ build {
                         "${path.root}/scripts/installers/clang.sh",
                         "${path.root}/scripts/installers/cmake.sh",
                         "${path.root}/scripts/installers/codeql-bundle.sh",
+                        "${path.root}/scripts/installers/containers.sh",
                         "${path.root}/scripts/installers/dotnetcore-sdk.sh",
                         "${path.root}/scripts/installers/gcc.sh",
                         "${path.root}/scripts/installers/gfortran.sh",


### PR DESCRIPTION
# Description

Given that OpenSuse is not going to provide its repo to host podman and co. anymore lets remove these packages from Ubuntu  older than 22.04 

#### Related issue: https://github.com/actions/virtual-environments/issues/5574

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
