### PR TITLE
[Ubuntu] Use new Hashicorp Releases API

### DIFF
--- a/images/linux/scripts/installers/packer.sh
+++ b/images/linux/scripts/installers/packer.sh
@@ -4,10 +4,13 @@
 ##  Desc:  Installs packer
 ################################################################################
 
+source $HELPER_SCRIPTS/install.sh
+
 # Install Packer
 URL=$(curl -s https://api.releases.hashicorp.com/v1/releases/packer/latest | jq -r '.builds[] | select((.arch=="amd64") and (.os=="linux")).url')
-curl -L -o packer_linux_amd64.zip "${URL}"
-unzip -qq packer_linux_amd64.zip -d /usr/local/bin
-rm -f packer_linux_amd64.zip
+ZIP_NAME="packer_linux_amd64.zip"
+download_with_retries "${URL}" "/tmp" "${ZIP_NAME}"
+unzip -qq "/tmp/${ZIP_NAME}" -d /usr/local/bin
+rm -f "/tmp/${ZIP_NAME}"
 
 invoke_tests "Tools" "Packer"

--- a/images/linux/scripts/installers/packer.sh
+++ b/images/linux/scripts/installers/packer.sh
@@ -5,9 +5,9 @@
 ################################################################################
 
 # Install Packer
-PACKER_VERSION=$(curl -s https://api.releases.hashicorp.com/v1/releases/packer/latest | jq -r .version)
-curl -LO "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip"
-unzip -qq "packer_${PACKER_VERSION}_linux_amd64.zip" -d /usr/local/bin
-rm -f "packer_${PACKER_VERSION}_linux_amd64.zip"
+URL=$(curl -s https://api.releases.hashicorp.com/v1/releases/packer/latest | jq -r '.builds[] | select((.arch=="amd64") and (.os=="linux")).url')
+curl -L -o packer_linux_amd64.zip "${URL}"
+unzip -qq packer_linux_amd64.zip -d /usr/local/bin
+rm -f packer_linux_amd64.zip
 
 invoke_tests "Tools" "Packer"

--- a/images/linux/scripts/installers/packer.sh
+++ b/images/linux/scripts/installers/packer.sh
@@ -5,7 +5,7 @@
 ################################################################################
 
 # Install Packer
-PACKER_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/packer | jq -r .current_version)
+PACKER_VERSION=$(curl -s https://api.releases.hashicorp.com/v1/releases/packer/latest | jq -r .version)
 curl -LO "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip"
 unzip -qq "packer_${PACKER_VERSION}_linux_amd64.zip" -d /usr/local/bin
 rm -f "packer_${PACKER_VERSION}_linux_amd64.zip"

--- a/images/linux/scripts/installers/terraform.sh
+++ b/images/linux/scripts/installers/terraform.sh
@@ -4,10 +4,13 @@
 ##  Desc:  Installs terraform
 ################################################################################
 
+source $HELPER_SCRIPTS/install.sh
+
 # Install Terraform
 URL=$(curl -s https://api.releases.hashicorp.com/v1/releases/terraform/latest | jq -r '.builds[] | select((.arch=="amd64") and (.os=="linux")).url')
-curl -L -o terraform_linux_amd64.zip "${URL}"
-unzip -qq terraform_linux_amd64.zip -d /usr/local/bin
-rm -f terraform_linux_amd64.zip
+ZIP_NAME="terraform_linux_amd64.zip"
+download_with_retries "${URL}" "/tmp" "${ZIP_NAME}"
+unzip -qq "/tmp/${ZIP_NAME}" -d /usr/local/bin
+rm -f "/tmp/${ZIP_NAME}"
 
 invoke_tests "Tools" "Terraform"

--- a/images/linux/scripts/installers/terraform.sh
+++ b/images/linux/scripts/installers/terraform.sh
@@ -5,7 +5,7 @@
 ################################################################################
 
 # Install Terraform
-TERRAFORM_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r .current_version)
+TERRAFORM_VERSION=$(curl -s https://api.releases.hashicorp.com/v1/releases/terraform/latest | jq -r .version)
 curl -LO "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
 unzip -qq "terraform_${TERRAFORM_VERSION}_linux_amd64.zip" -d /usr/local/bin
 rm -f "terraform_${TERRAFORM_VERSION}_linux_amd64.zip"

--- a/images/linux/scripts/installers/terraform.sh
+++ b/images/linux/scripts/installers/terraform.sh
@@ -5,9 +5,9 @@
 ################################################################################
 
 # Install Terraform
-TERRAFORM_VERSION=$(curl -s https://api.releases.hashicorp.com/v1/releases/terraform/latest | jq -r .version)
-curl -LO "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
-unzip -qq "terraform_${TERRAFORM_VERSION}_linux_amd64.zip" -d /usr/local/bin
-rm -f "terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+URL=$(curl -s https://api.releases.hashicorp.com/v1/releases/terraform/latest | jq -r '.builds[] | select((.arch=="amd64") and (.os=="linux")).url')
+curl -L -o terraform_linux_amd64.zip "${URL}"
+unzip -qq terraform_linux_amd64.zip -d /usr/local/bin
+rm -f terraform_linux_amd64.zip
 
 invoke_tests "Tools" "Terraform"


### PR DESCRIPTION
# Description

Changing the legacy API endpoint URL to the new endpoint that was announced recently:
ref. https://www.hashicorp.com/blog/announcing-the-hashicorp-releases-api

### legacy

```sh
curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r .current_version
```
### new

```sh
curl -s https://api.releases.hashicorp.com/v1/releases/terraform/latest | jq -r .version
```

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
