### PR TITLE
fix Ubuntu 22.04 template extension

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -34,7 +34,7 @@ Function Get-PackerTemplatePath {
             $relativeTemplatePath = Join-Path "linux" "ubuntu2004.json"
         }
         ([ImageType]::Ubuntu2204) {
-            $relativeTemplatePath = Join-Path "linux" "ubuntu2204.json"
+            $relativeTemplatePath = Join-Path "linux" "ubuntu2204.pkr.hcl"
         }
         default { throw "Unknown type of image" }
     }


### PR DESCRIPTION
# Description


Template is not in the json format anymore.

#### Related issue: https://github.com/actions/virtual-environments/issues/5590

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
