### PR TITLE
[ImageGen] Fix allowed_inbound_ip_addresses error

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -119,7 +119,7 @@ Function GenerateResourcesAndImage {
         [Parameter(Mandatory = $False)]
         [bool] $EnableHttpsTrafficOnly = $False,
         [Parameter(Mandatory = $False)]
-        [Hashtable] $tags
+        [hashtable] $Tags
     )
 
     try {
@@ -260,15 +260,19 @@ Function GenerateResourcesAndImage {
             throw "'packer' binary is not found on PATH"
         }
 
-        if($RestrictToAgentIpAddress -eq $true) {
+        if($RestrictToAgentIpAddress) {
             $AgentIp = (Invoke-RestMethod http://ipinfo.io/json).ip
             Write-Host "Restricting access to packer generated VM to agent IP Address: $AgentIp"
         }
         
-        if ($tags) {
+        if ($builderScriptPath.Contains("pkr.hcl")) {
+            $AgentIp = '[ \"{0}\" ]' -f $AgentIp
+        }
+
+        if ($Tags) {
             $builderScriptPath_temp = $builderScriptPath.Replace(".json", "-temp.json")
             $packer_script = Get-Content -Path $builderScriptPath | ConvertFrom-Json
-            $packer_script.builders | Add-Member -Name "azure_tags" -Value $tags -MemberType NoteProperty
+            $packer_script.builders | Add-Member -Name "azure_tags" -Value $Tags -MemberType NoteProperty
             $packer_script | ConvertTo-Json -Depth 3 | Out-File $builderScriptPath_temp
             $builderScriptPath = $builderScriptPath_temp
         }

--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -260,7 +260,7 @@ Function GenerateResourcesAndImage {
             throw "'packer' binary is not found on PATH"
         }
 
-        if($RestrictToAgentIpAddress) {
+        if ($RestrictToAgentIpAddress) {
             $AgentIp = (Invoke-RestMethod http://ipinfo.io/json).ip
             Write-Host "Restricting access to packer generated VM to agent IP Address: $AgentIp"
         }

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -1,5 +1,6 @@
 
 variable "allowed_inbound_ip_addresses" {
+  type    = list(string)
   default = []
 }
 


### PR DESCRIPTION
# Description
If we run `GenerateResourcesAndImage` function we are getting an error message `Inappropriate value for attribute "allowed_inbound_ip_addresses"`.

#### Related issue:
https://github.com/actions/virtual-environments/issues/5593

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
