### PR TITLE
[Ubuntu] Add clang 13&14 instead of 10&11, make 14 default for Ubuntu22

### DIFF
--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -241,10 +241,11 @@
     },
     "clang": {
         "versions": [
-            "11",
-            "12"
+            "12",
+            "13",
+            "14"
         ],
-        "default_version": "11"
+        "default_version": "14"
     },
     "gcc": {
         "versions": [


### PR DESCRIPTION
# Description
According to our [oftware guidelines](https://github.com/actions/virtual-environments/blob/main/docs/software-and-images-guidelines.md#software-and-images-support-policy) we have to support 3 latest versions of Clang, which are 12, 13 and 14 for Ubuntu22.

#### Related issue:
https://github.com/actions/virtual-environments/issues/5608

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
