### PR TITLE
[Ubuntu] Get back container tools on Ubuntu 18&20

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -120,6 +120,9 @@ $toolsList = @(
     (Get-DockerComposeV2Version),
     (Get-DockerBuildxVersion),
     (Get-DockerAmazonECRCredHelperVersion),
+    (Get-BuildahVersion),
+    (Get-PodManVersion),
+    (Get-SkopeoVersion),
     (Get-GitVersion),
     (Get-GitLFSVersion),
     (Get-GitFTPVersion),
@@ -153,13 +156,6 @@ if ((Test-IsUbuntu18) -or (Test-IsUbuntu20)) {
         (Get-PhantomJSVersion),
         (Get-LeiningenVersion),
         (Get-HHVMVersion)
-    )
-}
-if (Test-IsUbuntu22) {
-    $toolsList += @(
-        (Get-BuildahVersion),
-        (Get-PodManVersion),
-        (Get-SkopeoVersion)
     )
 }
 

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -42,16 +42,28 @@ function Get-CodeQLBundleVersion {
 
 function Get-PodManVersion {
     $podmanVersion = podman --version | Take-OutputPart -Part 2
+    if ((Test-IsUbuntu18) -or (Test-IsUbuntu20)) {
+        $aptSourceRepo = Get-AptSourceRepository -PackageName "containers"
+        return "Podman $podmanVersion (apt source repository: $aptSourceRepo)"
+    }
     return "Podman $podmanVersion"
 }
 
 function Get-BuildahVersion {
     $buildahVersion = buildah --version | Take-OutputPart -Part 2
+    if ((Test-IsUbuntu18) -or (Test-IsUbuntu20)) {
+        $aptSourceRepo = Get-AptSourceRepository -PackageName "containers"
+        return "Buildah $buildahVersion (apt source repository: $aptSourceRepo)"
+    }
     return "Buildah $buildahVersion"
 }
 
 function Get-SkopeoVersion {
     $skopeoVersion = skopeo --version | Take-OutputPart -Part 2
+    if ((Test-IsUbuntu18) -or (Test-IsUbuntu20)) {
+        $aptSourceRepo = Get-AptSourceRepository -PackageName "containers"
+        return "Skopeo $skopeoVersion (apt source repository: $aptSourceRepo)"
+    }
     return "Skopeo $skopeoVersion"
 }
 

--- a/images/linux/scripts/installers/containers.sh
+++ b/images/linux/scripts/installers/containers.sh
@@ -4,11 +4,30 @@
 ##  Desc:  Installs container tools: podman, buildah and skopeo onto the image
 ################################################################################
 
+source $HELPER_SCRIPTS/os.sh
+
 install_packages=(podman buildah skopeo)
 
+# Packages is available in the official Ubuntu upstream starting from Ubuntu 21
+if isUbuntu18 || isUbuntu20; then
+    REPO_URL="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable"
+    source /etc/os-release
+    sh -c "echo 'deb ${REPO_URL}/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
+    wget -qnv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key -O Release.key
+    apt-key add Release.key
+fi
+
 # Install podman, buildah, scopeo container's tools
-apt-get -qq -y install ${install_packages[@]}
+apt-get update
+apt-get -y install ${install_packages[@]}
 mkdir -p /etc/containers
 echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | tee /etc/containers/registries.conf
+
+if isUbuntu18 || isUbuntu20; then
+    # Remove source repo
+    rm /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+    # Document source repo
+    echo "containers $REPO_URL" >> $HELPER_SCRIPTS/apt-sources.txt
+fi
 
 invoke_tests "Tools" "Containers"

--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -338,7 +338,7 @@ Describe "GraalVM" -Skip:(Test-IsUbuntu18) {
     }
 }
 
-Describe "Containers" -Skip:(-not (Test-IsUbuntu22)) {
+Describe "Containers" {
     $testCases = @("podman", "buildah", "skopeo") | ForEach-Object { @{ContainerCommand = $_} }
 
     It "<ContainerCommand>" -TestCases $testCases {

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -199,6 +199,7 @@
                 "{{template_dir}}/scripts/installers/swift.sh",
                 "{{template_dir}}/scripts/installers/cmake.sh",
                 "{{template_dir}}/scripts/installers/codeql-bundle.sh",
+                "{{template_dir}}/scripts/installers/containers.sh",
                 "{{template_dir}}/scripts/installers/dotnetcore-sdk.sh",
                 "{{template_dir}}/scripts/installers/erlang.sh",
                 "{{template_dir}}/scripts/installers/firefox.sh",

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -200,6 +200,7 @@
                 "{{template_dir}}/scripts/installers/swift.sh",
                 "{{template_dir}}/scripts/installers/cmake.sh",
                 "{{template_dir}}/scripts/installers/codeql-bundle.sh",
+                "{{template_dir}}/scripts/installers/containers.sh",
                 "{{template_dir}}/scripts/installers/dotnetcore-sdk.sh",
                 "{{template_dir}}/scripts/installers/erlang.sh",
                 "{{template_dir}}/scripts/installers/firefox.sh",


### PR DESCRIPTION
# Description
There were lots of pushback on the kubic repo deletion and the packages are now restored so we can get them back to the Ubuntu18 & 20.

#### Related issue:
https://github.com/actions/virtual-environments/issues/5578

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
