### PR TITLE
[Ubuntu] Add java tools installation to Ubuntu22

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -187,11 +187,9 @@ $markdown += New-MDList -Style Unordered -Lines (@(
     ) | Sort-Object
 )
 
-if ((Test-IsUbuntu18) -or (Test-IsUbuntu20)) {
-    $markdown += New-MDHeader "Java" -Level 3
-    $markdown += Get-JavaVersions | New-MDTable
-    $markdown += New-MDNewLine
-}
+$markdown += New-MDHeader "Java" -Level 3
+$markdown += Get-JavaVersions | New-MDTable
+$markdown += New-MDNewLine
 
 if ((Test-IsUbuntu20) -or (Test-IsUbuntu22)) {
     $markdown += New-MDHeader "GraalVM" -Level 3

--- a/images/linux/scripts/tests/Java.Tests.ps1
+++ b/images/linux/scripts/tests/Java.Tests.ps1
@@ -1,6 +1,6 @@
 Import-Module "$PSScriptRoot/../helpers/Common.Helpers.psm1" -DisableNameChecking
 
-Describe "Java" -Skip:(Test-IsUbuntu22) {
+Describe "Java" {
     $toolsetJava = (Get-ToolsetContent).java
     $defaultVersion = $toolsetJava.default
     $defaultVendor = $toolsetJava.default_vendor
@@ -50,7 +50,7 @@ Describe "Java" -Skip:(Test-IsUbuntu22) {
       "`"$javaPath`" -version" | Should -MatchCommandOutput ([regex]::Escape("openjdk version `"${Version}."))
     }
 
-    It "Java Adopt <Version>" -TestCases $adoptJdkVersions {
+    It "Java Adopt <Version>" -TestCases $adoptJdkVersions -Skip:(Test-IsUbuntu22) {
         $javaPath = Join-Path (Get-ChildItem ${env:AGENT_TOOLSDIRECTORY}\Java_Adopt_jdk\${Version}*) "x64\bin\java"
         "`"$javaPath`" -version" | Should -ReturnZeroExitCode
 

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -287,6 +287,7 @@ build {
                         "${path.root}/scripts/installers/google-cloud-sdk.sh",
                         "${path.root}/scripts/installers/haskell.sh",
                         "${path.root}/scripts/installers/heroku.sh",
+                        "${path.root}/scripts/installers/java-tools.sh",
                         "${path.root}/scripts/installers/kubernetes-tools.sh",
                         "${path.root}/scripts/installers/oc.sh",
                         "${path.root}/scripts/installers/miniconda.sh",


### PR DESCRIPTION
# Description
Eclipse Temurin Java is now available for Ubuntu 22 so we can add java-tools installation to the image.

#### Related issue:
https://github.com/actions/virtual-environments/issues/5490

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
