### PR TITLE
[Ubuntu] add out-of-the-box SourceKitten support

### DIFF
--- a/images/linux/scripts/installers/swift.sh
+++ b/images/linux/scripts/installers/swift.sh
@@ -16,13 +16,18 @@ swift_tar_url="https://swift.org/builds/swift-$swift_version-release/ubuntu${ima
 download_with_retries $swift_tar_url "/tmp" "$swift_tar_name"
 
 tar xzf /tmp/$swift_tar_name
-mv swift-$swift_version-RELEASE-ubuntu$image_label /usr/share/swift
 
-SWIFT_PATH="/usr/share/swift/usr/bin"
-SWIFT_BIN="$SWIFT_PATH/swift"
-SWIFTC_BIN="$SWIFT_PATH/swiftc"
-ln -s "$SWIFT_BIN" /usr/local/bin/swift
-ln -s "$SWIFTC_BIN" /usr/local/bin/swiftc
-echo "SWIFT_PATH=$SWIFT_PATH" | tee -a /etc/environment
+SWIFT_INSTALL_ROOT="/usr/share/swift"
+SWIFT_BIN_ROOT="$SWIFT_INSTALL_ROOT/usr/bin"
+SWIFT_LIB_ROOT="$SWIFT_INSTALL_ROOT/usr/lib"
+
+mv swift-$swift_version-RELEASE-ubuntu$image_label $SWIFT_INSTALL_ROOT
+mkdir -p /usr/local/lib
+
+ln -s "$SWIFT_BIN_ROOT/swift" /usr/local/bin/swift
+ln -s "$SWIFT_BIN_ROOT/swiftc" /usr/local/bin/swiftc
+ln -s "$SWIFT_LIB_ROOT/libsourcekitdInProc.so" /usr/local/lib/libsourcekitdInProc.so
+
+echo "SWIFT_PATH=$SWIFT_BIN_ROOT" | tee -a /etc/environment
 
 invoke_tests "Common" "Swift"

--- a/images/linux/scripts/tests/Common.Tests.ps1
+++ b/images/linux/scripts/tests/Common.Tests.ps1
@@ -37,6 +37,10 @@ Describe "Swift" -Skip:(Test-IsUbuntu22) {
     It "swiftc" {
         "swiftc --version" | Should -ReturnZeroExitCode
     }
+
+    It "libsourcekitd" {
+        "/usr/local/lib/libsourcekitdInProc.so" | Should -Exist
+    }
 }
 
 Describe "PipxPackages" {


### PR DESCRIPTION
This change allows SourceKitten-based tools (eg SwiftLint, Sourcery) to work out of the box on the ubuntu images.

## Explanation

[SourceKitten](https://github.com/jpsim/SourceKitten), a popular Swift library for interacting with SourceKit, needs to know (or be told) the location of the sourcekitd framework. SourceKitten is somewhat [ubiquitous](https://github.com/jpsim/SourceKitten#projects-built-with-sourcekitten); most Swift projects I've seen or worked on used SourceKitten in some way.

On macOS, the sourcekit framework is baked-in to the Xcode toolchain(s) and therefore its location is generally known. On Linux, the location of the sourcekit framework is wherever swift is installed, which is unknown to libraries like SourceKitten.

SourceKitten searches for the sourcekit framework in [a few locations](https://github.com/jpsim/SourceKitten/blob/f7cf1e3b6328f21e344e83450ae1298af69de281/Source/SourceKittenFramework/library_wrapper.swift#L51-L104), but it's unable to infer the location of the framework on these ubuntu images. The result when attempting to run any SourceKitten-based tool in Github Actions on an ubuntu VM is the following error:

```
SourceKittenFramework/library_wrapper.swift:31: Fatal error: Loading libsourcekitdInProc.so failed
/home/runner/work/_temp/cb002a5e-1916-4e05-ba4d-f70ad3bb2266.sh: line 1:  3944 Illegal instruction     (core dumped) mint run swiftlint .
```

(to be clear, this error is not specific to the Github Actions ubuntu VMs. The same error occurs on any Ubuntu system).

Individual users can work around this by setting the following environment variable:

```
LINUX_SOURCEKIT_LIB_PATH="/usr/share/swift/usr/lib"
```

This is not a good workaround for the following reasons:

1. The end user doesn't necessarily know where swift is installed.
2. A change to the location of the swift installation would break this workaround.
3. The error will occur virtually 100% of the time on a user's first attempt to run SourceKitten on ubuntu, and takes at least a few minutes to troubleshoot. This will quickly add up to a non-trivial amount of lost productivity.

So, anyways, my proposal is to just link sourcekitd to a location where SourceKitten will find it, so most developers don't have to think about it. `LINUX_SOURCEKIT_LIB_PATH` can be defined by the user if they have an unusual setup.

Alternative:

- Don't symlink, add `LINUX_SOURCEKIT_LIB_PATH` to `/etc/environment`.

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
