### PR TITLE
Add option to auto clean up packer resources if there is an error during packer image creation

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -88,6 +88,8 @@ Function GenerateResourcesAndImage {
         
         .PARAMETER AllowBlobPublicAccess
             The Azure storage account will be created with this option.
+        .PARAMETER OnErrorCleanup
+            If an error occurs during packager image generation, do not prompt and clean up resources automatically.
         .EXAMPLE
             GenerateResourcesAndImage -SubscriptionId {YourSubscriptionId} -ResourceGroupName "shsamytest1" -ImageGenerationRepositoryRoot "C:\virtual-environments" -ImageType Ubuntu1804 -AzureLocation "East US"
     #>
@@ -118,6 +120,8 @@ Function GenerateResourcesAndImage {
         [bool] $AllowBlobPublicAccess = $False,
         [Parameter(Mandatory = $False)]
         [bool] $EnableHttpsTrafficOnly = $False,
+        [Parameter(Mandatory = $False)]
+        [Switch] $OnErrorCleanup,
         [Parameter(Mandatory = $False)]
         [hashtable] $Tags
     )
@@ -281,7 +285,12 @@ Function GenerateResourcesAndImage {
             $builderScriptPath = $builderScriptPath_temp
         }
 
-        & $packerBinary build -on-error=ask `
+        $onError = "ask"
+        if ($OnErrorCleanup) {
+          $onError = "cleanup"
+        }
+
+        & $packerBinary build -on-error=$($onError) `
             -var "client_id=$($spClientId)" `
             -var "client_secret=$($ServicePrincipalClientSecret)" `
             -var "subscription_id=$($SubscriptionId)" `


### PR DESCRIPTION
Add option to auto clean up packer resources if there is an error during packer image creation

# Description
New tool, Bug fixing, or Improvement?  
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.  
**For new tools, please provide total size and installation time.**

#5630 Would like to auto clean up the resources packer generates so this script is more suitable for automation

No tests need to be updated. No documentation needs to be updated (although better documentation on this script would be a nice to have). 

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ X ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ X ] Changes are tested and related VM images are successfully generated
