### PR TITLE
[macOS] deprecate xcode 13.2 on Big Sur

### DIFF
--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -2,8 +2,7 @@
     "xcode": {
         "default": "13.2.1",
         "versions": [
-            { "link": "13.2.1", "version": "13.2.1" },
-            { "link": "13.2", "version": "13.2.0" },
+            { "link": "13.2.1", "version": "13.2.1", "symlinks": ["13.2"] },
             { "link": "13.1", "version": "13.1.0" },
             { "link": "13.0", "version": "13.0.0" },
             { "link": "12.5.1", "version": "12.5.1", "symlinks": ["12.5"] },


### PR DESCRIPTION
# Description

Looks like we forgot about it. Big Sur has 13.2 as well

#### Related issue: https://github.com/actions/virtual-environments/issues/5463

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
