### PR TITLE
[Ubuntu] Install latest Android cmdline-tools

### DIFF
--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -86,6 +86,7 @@
         "maven": "3.8.5"
     },
     "android": {
+        "cmdline-tools": "latest",
         "platform_min_version": "23",
         "build_tools_min_version": "23.0.1",
         "extra_list": [

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -87,6 +87,7 @@
         "maven": "3.8.5"
     },
     "android": {
+        "cmdline-tools": "latest",
         "platform_min_version": "27",
         "build_tools_min_version": "27.0.0",
         "extra_list": [

--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -73,6 +73,7 @@
         "maven": "3.8.5"
     },
     "android": {
+        "cmdline-tools": "latest",
         "platform_min_version": "27",
         "build_tools_min_version": "27.0.0",
         "extra_list": [

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -242,8 +242,8 @@
                 "{{template_dir}}/scripts/installers/vcpkg.sh",
                 "{{template_dir}}/scripts/installers/dpkg-config.sh",
                 "{{template_dir}}/scripts/installers/mongodb.sh",
-                "{{template_dir}}/scripts/installers/android.sh",
                 "{{template_dir}}/scripts/installers/yq.sh",
+                "{{template_dir}}/scripts/installers/android.sh",
                 "{{template_dir}}/scripts/installers/pypy.sh",
                 "{{template_dir}}/scripts/installers/python.sh",
                 "{{template_dir}}/scripts/installers/aws.sh"

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -243,8 +243,8 @@
                 "{{template_dir}}/scripts/installers/vcpkg.sh",
                 "{{template_dir}}/scripts/installers/dpkg-config.sh",
                 "{{template_dir}}/scripts/installers/mongodb.sh",
-                "{{template_dir}}/scripts/installers/android.sh",
                 "{{template_dir}}/scripts/installers/yq.sh",
+                "{{template_dir}}/scripts/installers/android.sh",
                 "{{template_dir}}/scripts/installers/pypy.sh",
                 "{{template_dir}}/scripts/installers/python.sh",
                 "{{template_dir}}/scripts/installers/graalvm.sh"

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -313,8 +313,8 @@ build {
                         "${path.root}/scripts/installers/packer.sh",
                         "${path.root}/scripts/installers/vcpkg.sh",
                         "${path.root}/scripts/installers/dpkg-config.sh",
-                        "${path.root}/scripts/installers/android.sh",
                         "${path.root}/scripts/installers/yq.sh",
+                        "${path.root}/scripts/installers/android.sh",
                         "${path.root}/scripts/installers/pypy.sh",
                         "${path.root}/scripts/installers/python.sh",
                         "${path.root}/scripts/installers/graalvm.sh"


### PR DESCRIPTION
# Description
Remove Android cmdline-tools and try to parse latest version from google repository.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3784

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
