### PR TITLE
[macOS] Install latest Android cmdline-tools

### DIFF
--- a/images/macos/provision/core/android-toolsets.sh
+++ b/images/macos/provision/core/android-toolsets.sh
@@ -35,7 +35,23 @@ ANDROID_NDK_MAJOR_VERSIONS=($(get_toolset_value '.android.ndk."versions"[]'))
 ANDROID_NDK_MAJOR_DEFAULT=$(get_toolset_value '.android.ndk.default')
 ANDROID_NDK_MAJOR_LATEST=$(get_toolset_value '.android.ndk."versions"[-1]')
 # Get the latest command line tools from https://developer.android.com/studio#cmdline-tools
-ANDROID_OSX_SDK_URL="https://dl.google.com/android/repository/commandlinetools-mac-7302050_latest.zip"
+ANDROID_CMDLINE_TOOL_VERSION=$(get_toolset_value '.android."cmdline-tools"')
+if [[ $ANDROID_CMDLINE_TOOL_VERSION == "latest" ]]; then
+    repositoryXmlUrl="https://dl.google.com/android/repository/repository2-1.xml"
+    download_with_retries $repositoryXmlUrl "/tmp" "repository2-1.xml"
+    cmdlineToolsVersion=$(
+      yq -p=xml \
+      '.sdk-repository.remotePackage[] | select(."+path" == "cmdline-tools;latest").archives.archive[].complete.url | select(contains("commandlinetools-mac"))' \
+      /tmp/repository2-1.xml
+    )
+
+    if [[ -z $cmdlineToolsVersion ]]; then
+        echo "Failed to parse latest command-line tools version"
+        exit 1
+    fi
+fi
+
+ANDROID_OSX_SDK_URL="https://dl.google.com/android/repository/${ANDROID_CMDLINE_TOOL_VERSION}"
 ANDROID_HOME=$HOME/Library/Android/sdk
 ANDROID_OSX_SDK_FILE=tools-macosx.zip
 

--- a/images/macos/provision/core/android-toolsets.sh
+++ b/images/macos/provision/core/android-toolsets.sh
@@ -35,8 +35,8 @@ ANDROID_NDK_MAJOR_VERSIONS=($(get_toolset_value '.android.ndk."versions"[]'))
 ANDROID_NDK_MAJOR_DEFAULT=$(get_toolset_value '.android.ndk.default')
 ANDROID_NDK_MAJOR_LATEST=$(get_toolset_value '.android.ndk."versions"[-1]')
 # Get the latest command line tools from https://developer.android.com/studio#cmdline-tools
-ANDROID_CMDLINE_TOOL_VERSION=$(get_toolset_value '.android."cmdline-tools"')
-if [[ $ANDROID_CMDLINE_TOOL_VERSION == "latest" ]]; then
+cmdlineToolsVersion=$(get_toolset_value '.android."cmdline-tools"')
+if [[ $cmdlineToolsVersion == "latest" ]]; then
     repositoryXmlUrl="https://dl.google.com/android/repository/repository2-1.xml"
     download_with_retries $repositoryXmlUrl "/tmp" "repository2-1.xml"
     cmdlineToolsVersion=$(
@@ -51,7 +51,7 @@ if [[ $ANDROID_CMDLINE_TOOL_VERSION == "latest" ]]; then
     fi
 fi
 
-ANDROID_OSX_SDK_URL="https://dl.google.com/android/repository/${ANDROID_CMDLINE_TOOL_VERSION}"
+ANDROID_OSX_SDK_URL="https://dl.google.com/android/repository/${cmdlineToolsVersion}"
 ANDROID_HOME=$HOME/Library/Android/sdk
 ANDROID_OSX_SDK_FILE=tools-macosx.zip
 

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -165,6 +165,7 @@
         ]
     },
     "android": {
+        "cmdline-tools": "latest",
         "platform_min_version": "24",
         "build_tools_min_version": "24.0.0",
         "extra-list": [

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -165,6 +165,7 @@
         ]
     },
     "android": {
+        "cmdline-tools": "latest",
         "platform_min_version": "27",
         "build_tools_min_version": "27.0.0",
         "extra-list": [

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -93,6 +93,7 @@
         ]
     },
     "android": {
+        "cmdline-tools": "latest",
         "platform_min_version": "27",
         "build_tools_min_version": "27.0.0",
         "extra-list": [


### PR DESCRIPTION
# Description
Remove Android cmdline-tools and try to parse latest version from google repository.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3784

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
