### PR TITLE
Fix "invalid value $ for flag -on-error"

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -286,7 +286,7 @@ Function GenerateResourcesAndImage {
             $builderScriptPath = $builderScriptPath_temp
         }
 
-        & $packerBinary build -on-error=$($OnError) `
+        & $packerBinary build -on-error="$($OnError)" `
             -var "client_id=$($spClientId)" `
             -var "client_secret=$($ServicePrincipalClientSecret)" `
             -var "subscription_id=$($SubscriptionId)" `


### PR DESCRIPTION
# Description
Fixes #5643 

Fixes the following error when running `GenerateResourcesAndImage` on Windows:

```
invalid value "$" for flag -on-error: expected one of ["cleanup" "abort" "ask" "run-cleanup-provisioner"]
```

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated

Tested the fix locally.