### PR TITLE
[Packer] Remove ssh legacy fix for Ubuntu Server 22.04

### DIFF
--- a/images.CI/linux-and-win/build-image.ps1
+++ b/images.CI/linux-and-win/build-image.ps1
@@ -19,9 +19,6 @@ if (-not (Test-Path $TemplatePath))
     exit 1
 }
 
-# Set Image repository path env variable, this is a workaround for Ubuntu 22.04 until this is fixed https://github.com/hashicorp/packer/issues/11733
-$env:ImageRepositoryPath = "."
-
 $Image = [io.path]::GetFileName($TemplatePath).Split(".")[0]
 $TempResourceGroupName = "${ResourcesNamePrefix}_${Image}"
 $InstallPassword = [System.GUID]::NewGuid().ToString().ToUpper()

--- a/images/linux/scripts/base/configure-legacy-ssh.sh
+++ b/images/linux/scripts/base/configure-legacy-ssh.sh
@@ -1,4 +1,0 @@
-#!/bin/bash -e
-# https://github.com/hashicorp/packer/issues/11656
-echo PubkeyAcceptedKeyTypes=+ssh-rsa >> /etc/ssh/sshd_config
-systemctl reload sshd.service

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -60,11 +60,6 @@ variable "image_os" {
   default = "ubuntu22"
 }
 
-variable "image_repository_path" {
-  type    = string
-  default = "${env("IMAGEREPOSITORYPATH")}"
-}
-
 variable "image_version" {
   type    = string
   default = "dev"
@@ -165,7 +160,6 @@ source "azure-arm" "build_vhd" {
   subscription_id                        = "${var.subscription_id}"
   temp_resource_group_name               = "${var.temp_resource_group_name}"
   tenant_id                              = "${var.tenant_id}"
-  user_data_file                         = "${var.image_repository_path}/images/linux/scripts/base/configure-legacy-ssh.sh"
   virtual_network_name                   = "${var.virtual_network_name}"
   virtual_network_resource_group_name    = "${var.virtual_network_resource_group_name}"
   virtual_network_subnet_name            = "${var.virtual_network_subnet_name}"


### PR DESCRIPTION
# Description
The [Packer v1.8.0 can't SSH to AWS Ubuntu 22.04 #11733](https://github.com/hashicorp/packer/issues/11733) issue was fixed in [packer 1.8.1](https://github.com/hashicorp/packer/releases/tag/v1.8.1) version.

- All bundled plugins have been updated to their latest release to address any
open issues pertaining to the legacy SSH key algorithm fix made to the
Packer plugin SDK.
https://github.com/hashicorp/packer/pull/11761
https://github.com/hashicorp/packer/pull/11802
- This release contains the latest golang.org/x/crypto/ssh module which
implements client authentication support for signature algorithms based on
SHA-2 for use with existing RSA keys. Previously, a client would fail to
authenticate with RSA keys to servers that reject signature algorithms
based on SHA-1.


#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3804

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
