### PR TITLE
Fix PHP8.0.x version in software report

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -234,7 +234,7 @@ function Get-SbtVersion {
 }
 
 function Get-PHPVersions {
-    $result = Get-CommandResult "apt list --installed | sed 's/1\://'" -Multiline
+    $result = Get-CommandResult "apt list --installed | sed 's/[0-9]\://'" -Multiline
     return $result.Output | Where-Object { $_ -match "^php\d+\.\d+/"} | ForEach-Object {
         $_ -match "now (?<version>\d+\.\d+\.\d+)-" | Out-Null
         $Matches.version

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -234,9 +234,9 @@ function Get-SbtVersion {
 }
 
 function Get-PHPVersions {
-    $result = Get-CommandResult "apt list --installed | sed 's/[0-9]\://'" -Multiline
+    $result = Get-CommandResult "apt list --installed" -Multiline
     return $result.Output | Where-Object { $_ -match "^php\d+\.\d+/"} | ForEach-Object {
-        $_ -match "now (?<version>\d+\.\d+\.\d+)-" | Out-Null
+        $_ -match "now (\d+:)?(?<version>\d+\.\d+\.\d+)-" | Out-Null
         $Matches.version
     }
 }

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -234,7 +234,7 @@ function Get-SbtVersion {
 }
 
 function Get-PHPVersions {
-    $result = Get-CommandResult "apt list --installed" -Multiline
+    $result = Get-CommandResult "apt list --installed | sed 's/1\://'" -Multiline
     return $result.Output | Where-Object { $_ -match "^php\d+\.\d+/"} | ForEach-Object {
         $_ -match "now (?<version>\d+\.\d+\.\d+)-" | Out-Null
         $Matches.version


### PR DESCRIPTION
# Description
Fix PHP8.0.x version in software report.
In version 8.0.19 version output changed to 1:8.0.19. In previous version it was 8.0.18, for example.

#### Related issue:

https://github.com/actions/virtual-environments-internal/issues/3806

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
