### PR TITLE
[Ubuntu] Do not add adoptopenjdk ppa to Ubuntu Server 22.04

### DIFF
--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -42,7 +42,7 @@ enableRepositories() {
         # Add Adopt PPA
         wget -qO - "https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public" | apt-key add -
         add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-    then
+    fi
 
     # Add Addoptium PPA
     wget -qO - "https://packages.adoptium.net/artifactory/api/gpg/key/public" | apt-key add -

--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -38,9 +38,11 @@ createJavaEnvironmentalVariable() {
 }
 
 enableRepositories() {
-    # Add Adopt PPA
-    wget -qO - "https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public" | apt-key add -
-    add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
+    if isUbuntu18 || isUbuntu20; then
+        # Add Adopt PPA
+        wget -qO - "https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public" | apt-key add -
+        add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
+    then
 
     # Add Addoptium PPA
     wget -qO - "https://packages.adoptium.net/artifactory/api/gpg/key/public" | apt-key add -


### PR DESCRIPTION
# Description
We shouldn't add adoptopenjdk ppa to Ubuntu Server 22.04 because there are no packages for one:
```
    azure-arm.build_vhd: Err:7 https://adoptopenjdk.jfrog.io/adoptopenjdk/deb jammy Release
    azure-arm.build_vhd:   404   [IP: 34.139.10.89 443]
```

#### Related issue:
https://github.com/actions/virtual-environments/issues/5656

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
