### PR TITLE
Rework issue templates, add platform field, rework some points

### DIFF
--- a/.github/ISSUE_TEMPLATE/announcement.yml
+++ b/.github/ISSUE_TEMPLATE/announcement.yml
@@ -28,6 +28,12 @@ body:
       required: true
   - type: checkboxes
     attributes:
+      label: Platforms affected
+      options:
+        - label: Azure DevOps
+        - label: GitHub Actions
+  - type: checkboxes
+    attributes:
       label: Virtual environments affected
       options:
         - label: Ubuntu 18.04
@@ -38,8 +44,6 @@ body:
         - label: macOS 12
         - label: Windows Server 2019
         - label: Windows Server 2022
-    validations:
-      required: true
   - type: textarea
     attributes:
       label: Mitigation ways

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -10,6 +10,12 @@ body:
       required: true
   - type: checkboxes
     attributes:
+      label: Platforms affected
+      options:
+        - label: Azure DevOps
+        - label: GitHub Actions
+  - type: checkboxes
+    attributes:
       label: Virtual environments affected
       options:
         - label: Ubuntu 18.04
@@ -20,8 +26,6 @@ body:
         - label: macOS 12
         - label: Windows Server 2019
         - label: Windows Server 2022
-    validations:
-      required: true
   - type: textarea
     attributes:
       label: Image version and build link
@@ -37,14 +41,20 @@ body:
     attributes:
       label: Is it regression?
       description: If yes, please, provide the latest image version where the issue didn't persist, and a link to the latest successful build.
+    validations:
+        required: true
   - type: textarea
     attributes:
       label: Expected behavior
       description: A description of what you expected to happen.
+    validations:
+        required: true
   - type: textarea
     attributes:
       label: Actual behavior
       description: A description of what is actually happening.
+    validations:
+        required: true
   - type: textarea
     attributes:
       label: Repro steps

--- a/.github/ISSUE_TEMPLATE/tool-request.yml
+++ b/.github/ISSUE_TEMPLATE/tool-request.yml
@@ -44,12 +44,18 @@ body:
       label: URL for tool's homepage
   - type: textarea
     attributes:
-      label: Provide a basic test case to validate the tool's functionality. 
+      label: Provide a basic test case to validate the tool's functionality.
       description: This will be automatically formatted into code.
       render: bash
   - type: checkboxes
     attributes:
-      label: Virtual environments affected
+      label: Platforms where you need the tool
+      options:
+        - label: Azure DevOps
+        - label: GitHub Actions
+  - type: checkboxes
+    attributes:
+      label: Virtual environments where you need the tool
       options:
         - label: Ubuntu 18.04
         - label: Ubuntu 20.04
@@ -59,8 +65,6 @@ body:
         - label: macOS 12
         - label: Windows Server 2019
         - label: Windows Server 2022
-    validations:
-      required: true
   - type: textarea
     attributes:
       label: Can this tool be installed during the build?


### PR DESCRIPTION
# Description
- It is useful to have the platform filed in issue templates as sometimes there is an action available for GH Actions but no alternatives from the Azure DevOps side or the bug occurs on only one platform.
- There is no validation option for checkboxes so it can be removed.
- Some fields are usually ignored so let's set validation on them as well

#### Related issue:
n\a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
