### PR TITLE
[Ubuntu] Downgrade aws cli v1 to 1.24.10

### DIFF
--- a/images/linux/scripts/installers/aws.sh
+++ b/images/linux/scripts/installers/aws.sh
@@ -10,8 +10,9 @@ source $HELPER_SCRIPTS/install.sh
 
 # Install the AWS CLI v1 Ubuntu18 and AWS CLI v2 on Ubuntu20, Ubuntu22
 # The installation should be run after python3 is installed as aws-cli V1 dropped python2 support
+# 1.25.0+ Dropped support for Python 3.6 - https://github.com/aws/aws-cli/blob/develop/CHANGELOG.rst
 if isUbuntu18 ; then
-    download_with_retries "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" "/tmp" "awscli-bundle.zip"
+    download_with_retries "https://s3.amazonaws.com/aws-cli/awscli-bundle-1.24.10.zip" "/tmp" "awscli-bundle.zip"
     unzip -qq /tmp/awscli-bundle.zip -d /tmp
     python3 /tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
 else


### PR DESCRIPTION
# Description
In aws cli v1 1.25.0 release has been dropped support for Python 3.6. We are planning to downgrade aws cli v1 from 1.25.0 to 1.24.10 version and migrate to aws cli v2 for Ubuntu Server 18.04 within a short time.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3807

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
