### PR TITLE
[macOS] Fix msedge driver output in readme

### DIFF
--- a/images/macos/software-report/SoftwareReport.Browsers.psm1
+++ b/images/macos/software-report/SoftwareReport.Browsers.psm1
@@ -40,7 +40,7 @@ function Get-EdgeVersion {
 }
 
 function Get-EdgeDriverVersion {
-    return Run-Command "msedgedriver --version" | Take-Part -Part 0,1
+    return Run-Command "msedgedriver --version" | Take-Part -Part 0,1,2,3
 }
 
 function Get-FirefoxVersion {


### PR DESCRIPTION
# Description
Starting from driver version 102 the output is different.
Was:
`MSEdgeDriver 101.0.1210.53`
Now:
`Microsoft Edge WebDriver 102.0.1245.2`

#### Related issue:
https://github.com/actions/virtual-environments/pull/5662/files#r886712455

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
