### PR TITLE
[macOS] Add xcode 13.4.1 to macOS12 image

### DIFF
--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -2,6 +2,7 @@
     "xcode": {
         "default": "13.3.1",
         "versions": [
+            { "link": "13.4.1", "version": "13.4.1" },
             { "link": "13.4", "version": "13.4.0" },
             { "link": "13.3.1", "version": "13.3.1", "symlinks": ["13.3"] },
             { "link": "13.2.1", "version": "13.2.1", "symlinks": ["13.2"] },


### PR DESCRIPTION
# Description
Xcode 13.4.1 has been released https://developer.apple.com/news/releases/?id=06022022a

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3829

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
