### PR TITLE
[Ubuntu] Remove apt-key from rlang install script

### DIFF
--- a/images/linux/scripts/installers/r.sh
+++ b/images/linux/scripts/installers/r.sh
@@ -6,10 +6,13 @@ source $HELPER_SCRIPTS/os.sh
 # install R
 osLabel=$(getOSVersionLabel)
 
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
-sudo add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $osLabel-cran40/"
+wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | gpg --dearmor > /usr/share/keyrings/rlang.gpg
+echo "deb [signed-by=/usr/share/keyrings/rlang.gpg] https://cloud.r-project.org/bin/linux/ubuntu $osLabel-cran40/" > /etc/apt/sources.list.d/rlang.list
 
-sudo apt update
-sudo apt install r-base
+apt-get update
+apt-get install r-base
+
+rm /etc/apt/sources.list.d/rlang.list
+rm /usr/share/keyrings/rlang.gpg
 
 invoke_tests "Tools" "R"


### PR DESCRIPTION
# Description

Do not use `apt-key` as this is deprecated

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/3808

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
