### PR TITLE
[Ubuntu] Remove apt-key from GCP installer

### DIFF
--- a/images/linux/scripts/installers/google-cloud-sdk.sh
+++ b/images/linux/scripts/installers/google-cloud-sdk.sh
@@ -7,15 +7,15 @@
 REPO_URL="https://packages.cloud.google.com/apt"
 
 # Install the Google Cloud SDK
-echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] $REPO_URL cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-sudo apt-get update -y
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] $REPO_URL cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list
+wget -q https://packages.cloud.google.com/apt/doc/apt-key.gpg -O /usr/share/keyrings/cloud.google.gpg
+apt-get update -y
 # temporary downgrade google-cloud-sdk as python component has linking bugs
-sudo apt-get install -y google-cloud-sdk=369.0.0-0
+apt-get install -y google-cloud-sdk=369.0.0-0
 
 # remove apt
 rm /etc/apt/sources.list.d/google-cloud-sdk.list
-rm /usr/share/keyrings/cloud.google.gpg /usr/share/keyrings/cloud.google.gpg~
+rm /usr/share/keyrings/cloud.google.gpg
 
 # add repo to the apt-sources.txt
 echo "google-cloud-sdk $REPO_URL" >> $HELPER_SCRIPTS/apt-sources.txt


### PR DESCRIPTION
# Description

`apt-key` is deprecated

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/3808

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
