### PR TITLE
[macOS] Add miniconda to macOS 12

### DIFF
--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -63,6 +63,7 @@ $packageManagementList = @(
     (Get-PipxVersion),
     (Get-BundlerVersion),
     (Get-CocoaPodsVersion),
+    (Get-CondaVersion),
     (Get-HomebrewVersion),
     (Get-NPMVersion),
     (Get-YarnVersion),
@@ -73,18 +74,11 @@ $packageManagementList = @(
     (Get-VcpkgVersion)
 )
 
-if ($os.IsLessThanMonterey) {
-    $packageManagementList += @(
-        (Get-CondaVersion)
-    )
-}
-
 $markdown += New-MDList -Style Unordered -Lines ($packageManagementList | Sort-Object)
-if ($os.IsLessThanMonterey) {
-    $markdown += New-MDHeader "Environment variables" -Level 4
-    $markdown += Build-PackageManagementEnvironmentTable | New-MDTable
-    $markdown += New-MDNewLine
-}
+$markdown += New-MDHeader "Environment variables" -Level 4
+$markdown += Build-PackageManagementEnvironmentTable | New-MDTable
+$markdown += New-MDNewLine
+
 # Project Management
 $markdown += New-MDHeader "Project Management" -Level 3
 $markdown += New-MDList -Style Unordered -Lines (@(

--- a/images/macos/templates/macOS-12.json
+++ b/images/macos/templates/macOS-12.json
@@ -200,6 +200,7 @@
                 "./provision/core/mongodb.sh",
                 "./provision/core/audiodevice.sh",
                 "./provision/core/vcpkg.sh",
+                "./provision/core/miniconda.sh",
                 "./provision/core/safari.sh",
                 "./provision/core/chrome.sh",
                 "./provision/core/edge.sh",

--- a/images/macos/tests/Common.Tests.ps1
+++ b/images/macos/tests/Common.Tests.ps1
@@ -58,7 +58,7 @@ Describe "AzCopy" {
     }
 }
 
-Describe "Miniconda" -Skip:($os.IsMonterey) {
+Describe "Miniconda" {
     It "Conda" {
         Get-EnvironmentVariable "CONDA" | Should -Not -BeNullOrEmpty
         $condaBinPath = Join-Path $env:CONDA "bin" "conda"


### PR DESCRIPTION
# Description
- Install miniconda to macOS 12 as we do for macOS 10.15 and macOS 11

#### Related issue:
https://github.com/actions/virtual-environments/issues/5623

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
