### PR TITLE
[macOS] Set properties for device set list

### DIFF
--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -106,4 +106,4 @@ fi
 chmod +x $HOME/utils/invoke-tests.sh
 sudo ln -s $HOME/utils/invoke-tests.sh /usr/local/bin/invoke_tests
 
-plutil -replace SuggestionsAppLibraryEnabled -bool NO /Users/runner/Library/Developer/CoreSimulator/Devices/device_set.plist
+plutil -replace SuggestionsAppLibraryEnabled -bool NO $HOME/Library/Developer/CoreSimulator/Devices/device_set.plist

--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -106,4 +106,5 @@ fi
 chmod +x $HOME/utils/invoke-tests.sh
 sudo ln -s $HOME/utils/invoke-tests.sh /usr/local/bin/invoke_tests
 
+# Disable the App Library for fix overloaded cpu 
 plutil -replace SuggestionsAppLibraryEnabled -bool NO $HOME/Library/Developer/CoreSimulator/Devices/device_set.plist

--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -105,3 +105,5 @@ if [ ! -d "/usr/local/bin" ];then
 fi
 chmod +x $HOME/utils/invoke-tests.sh
 sudo ln -s $HOME/utils/invoke-tests.sh /usr/local/bin/invoke_tests
+
+plutil -replace SuggestionsAppLibraryEnabled -bool NO /Users/runner/Library/Developer/CoreSimulator/Devices/device_set.plist


### PR DESCRIPTION
# Description

After creating a virtual machine from the image, CPU growth immediately began to appear, this can be seen in the screenshot

![image](https://user-images.githubusercontent.com/102294679/177495078-34b95bef-f677-47b2-9a9c-27b0457a6d84.png)

After disabling SuggestionsAppLibraryEnabled, the CPU stabilized and further monitoring shows stable system operation

![image](https://user-images.githubusercontent.com/102294679/177495359-d4416de3-cc94-4c82-8dd9-6d50f06a850e.png)

Spotlight tries to find apps which are not present in the simulators and cpu is overloaded to 100%
#### Related issue: https://github.com/actions/virtual-environments-internal/issues/3358

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
