### PR TITLE
[macOS] Add a note about VS 2019 usage

### DIFF
--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -244,6 +244,17 @@ $markdown += New-MDHeader "Xamarin" -Level 3
 $markdown += New-MDHeader "Visual Studio for Mac" -Level 4
 $markdown += Build-VSMacTable | New-MDTable
 $markdown += New-MDNewLine
+if (-not $os.Catalina) {
+$markdown += New-MDHeader "Notes:" -Level 5
+$reportVS = @'
+```
+To use Visual Studio 2019 by default rename the app:
+mv "/Applications/Visual Studio.app" "/Applications/Visual Studio 2022.app"
+mv "/Applications/Visual Studio 2019.app" "/Applications/Visual Studio.app"
+```
+'@
+$markdown += New-MDParagraph -Lines $reportVS
+}
 
 $markdown += New-MDHeader "Xamarin bundles" -Level 4
 $markdown += Build-XamarinTable | New-MDTable


### PR DESCRIPTION
# Description
We have added VS for mac 2022 recently keeping VS 2019 on the images as well. However, it is not possible to use VS2019 directly without renaming the app. This PR adds a note on how to do that.

#### Related issue:
https://github.com/actions/virtual-environments/issues/5682#issuecomment-1147306237

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
