### PR TITLE
[Ubuntu] Remove microsoft.gpg public key

### DIFF
--- a/images/linux/scripts/base/repos.sh
+++ b/images/linux/scripts/base/repos.sh
@@ -9,12 +9,8 @@ LSB_RELEASE=$(lsb_release -rs)
 # Install Microsoft repository
 wget https://packages.microsoft.com/config/ubuntu/$LSB_RELEASE/packages-microsoft-prod.deb
 dpkg -i packages-microsoft-prod.deb
-apt-get install -y apt-transport-https ca-certificates curl software-properties-common
-
-# Install Microsoft GPG public key
-wget -qO - https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
-mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
 
 # update
+apt-get install -y apt-transport-https ca-certificates curl software-properties-common
 apt-get -yq update
 apt-get -yq dist-upgrade


### PR DESCRIPTION
# Description
The microsoft.gpg public key is part of the packages-microsoft-prod.deb package, no need to update it manually.

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
