### PR TITLE
[Ubuntu] Update erlang repo

### DIFF
--- a/images/linux/scripts/installers/erlang.sh
+++ b/images/linux/scripts/installers/erlang.sh
@@ -8,20 +8,21 @@
 source $HELPER_SCRIPTS/install.sh
 
 source_list=/etc/apt/sources.list.d/eslerlang.list
+source_key=/usr/share/keyrings/eslerlang.gpg
 
 # Install Erlang
-echo "deb https://binaries.erlang-solutions.com/debian $(lsb_release -cs) contrib" > $source_list
-wget -q -O - https://binaries.erlang-solutions.com/debian/erlang_solutions.asc | apt-key add -
+wget -q -O - https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | gpg --dearmor > $source_key
+echo "deb [signed-by=$source_key]  https://packages.erlang-solutions.com/ubuntu $(lsb_release -cs) contrib" > $source_list
 apt-get update
 apt-get install -y --no-install-recommends esl-erlang
 
 # Install rebar3
-rebar3DownloadUrl=$(get_github_package_download_url "erlang/rebar3" "endswith(\"rebar3\")")
-download_with_retries $rebar3DownloadUrl "/tmp"
-mv /tmp/rebar3 /usr/local/bin/rebar3
+rebar3_url="https://github.com/erlang/rebar3/releases/latest/download/rebar3"
+download_with_retries $rebar3_url "/usr/local/bin" "rebar3"
 chmod +x /usr/local/bin/rebar3
 
 # Clean up source list
 rm $source_list
+rm $source_key
 
 invoke_tests "Tools" "erlang"


### PR DESCRIPTION
# Description
Issue:
```
==> azure-arm: E: Failed to fetch https://binaries.erlang-solutions.com/debian/dists/focal/contrib/binary-amd64/Packages.bz2  File has unexpected size (246813 != 246791). Mirror sync in progress? [IP: 18.65.229.111 443]
==> azure-arm:    Hashes of expected file:
==> azure-arm:     - Filesize:246791 [weak]
==> azure-arm:     - SHA256:f579214f2084e5e48a75dbf11f064f64b89a3389777a4b439c26b4a969d2699b
==> azure-arm:     - SHA1:09e5daf0d42ff37e41afd8f1aed1111b92a1d9a3 [weak]
==> azure-arm:     - MD5Sum:650a796bcf40b18ba5d363026c3798ba [weak]
==> azure-arm:    Release file created at: Fri, 10 Jun 2022 10:30:52 +0000
```

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3859

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
