### PR TITLE
[Windows] Improve Get-GitHubPackageDownloadUrl function

### DIFF
--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -590,12 +590,19 @@ function Get-GitHubPackageDownloadUrl {
     if ($Version -eq "latest") {
         $Version = "*"
     }
+
     $json = Invoke-RestMethod -Uri "https://api.github.com/repos/${RepoOwner}/${RepoName}/releases?per_page=${SearchInCount}"
-    $versionToDownload = ($json.Where{ $_.prerelease -eq $IsPrerelease }.tag_name |
-        Select-String -Pattern "\d+.\d+.\d+").Matches.Value |
-            Where-Object {$_ -Like "${Version}.*" -or $_ -eq ${Version}} |
-            Sort-Object {[version]$_} |
+    $tags = $json.Where{ $_.prerelease -eq $IsPrerelease -and $_.assets }.tag_name
+    $versionToDownload = $tags |
+            Where-Object { $_ -match "\d+.\d+.\d+" } |
+            Where-Object { $_ -like "$Version.*" -or $_ -eq $Version } |
+            Sort-Object { [version]$_ } |
             Select-Object -Last 1
+
+    if (-not $versionToDownload) {
+        Write-Host "Failed to get a tag name from ${RepoOwner}/${RepoName} releases"
+        exit 1
+    }
 
     $UrlFilter = $UrlFilter -replace "{BinaryName}",$BinaryName -replace "{Version}",$versionToDownload
     $downloadUrl = $json.assets.browser_download_url -like $UrlFilter

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -594,7 +594,8 @@ function Get-GitHubPackageDownloadUrl {
     $json = Invoke-RestMethod -Uri "https://api.github.com/repos/${RepoOwner}/${RepoName}/releases?per_page=${SearchInCount}"
     $tags = $json.Where{ $_.prerelease -eq $IsPrerelease -and $_.assets }.tag_name
     $versionToDownload = $tags |
-            Where-Object { $_ -match "\d+.\d+.\d+" } |
+            Select-String -Pattern "\d+.\d+.\d+" |
+            ForEach-Object { $_.Matches.Value } |
             Where-Object { $_ -like "$Version.*" -or $_ -eq $Version } |
             Sort-Object { [version]$_ } |
             Select-Object -Last 1


### PR DESCRIPTION
# Description
Changes:
- Add filter into theGet-GitHubPackageDownloadUrl function to ignore releases without assets
- Add check if a $versionToDownload is empty using a filter


#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3473

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
