### PR TITLE
fix SW report regarding VS for macOS

### DIFF
--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -244,13 +244,13 @@ $markdown += New-MDHeader "Xamarin" -Level 3
 $markdown += New-MDHeader "Visual Studio for Mac" -Level 4
 $markdown += Build-VSMacTable | New-MDTable
 $markdown += New-MDNewLine
-if (-not $os.Catalina) {
+if (-not $os.IsCatalina) {
 $markdown += New-MDHeader "Notes:" -Level 5
 $reportVS = @'
 ```
 To use Visual Studio 2019 by default rename the app:
-mv "/Applications/Visual Studio.app" "/Applications/Visual Studio 2022.app"
-mv "/Applications/Visual Studio 2019.app" "/Applications/Visual Studio.app"
+mv '/Applications/Visual Studio.app' '/Applications/Visual Studio 2022.app'
+mv '/Applications/Visual Studio 2019.app' '/Applications/Visual Studio.app'
 ```
 '@
 $markdown += New-MDParagraph -Lines $reportVS


### PR DESCRIPTION
# Description

Looks like we have problems with displaying the content, and it must not be a part of the Catalina SW reports, while it is.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
