### PR TITLE
Update MinGW on Windows 2022

### DIFF
--- a/images/win/Windows2022-Readme.md
+++ b/images/win/Windows2022-Readme.md
@@ -69,7 +69,7 @@
 - Kind 0.14.0
 - Kubectl 1.24.1
 - Mercurial 5.0
-- Mingw-w64 11.2.0-07112021 
+- Mingw-w64 8.1.0
 - Newman 5.3.2
 - NSIS v3.08
 - OpenSSL 1.1.1

--- a/images/win/Windows2022-Readme.md
+++ b/images/win/Windows2022-Readme.md
@@ -69,7 +69,7 @@
 - Kind 0.14.0
 - Kubectl 1.24.1
 - Mercurial 5.0
-- Mingw-w64 8.1.0
+- Mingw-w64 11.2.0-07112021 
 - Newman 5.3.2
 - NSIS v3.08
 - OpenSSL 1.1.1

--- a/images/win/scripts/Installers/Install-Mingw64.ps1
+++ b/images/win/scripts/Installers/Install-Mingw64.ps1
@@ -3,7 +3,8 @@
 ##  Desc:  Install GNU tools for Windows
 ################################################################################
 
-Choco-Install -PackageName mingw -ArgumentList "--version=8.1.0"
+$toolsetVersion = (Get-ToolsetContent).mingw.version
+Choco-Install -PackageName mingw -ArgumentList "--version=$toolsetVersion"
 
 # Make a copy of mingw32-make.exe to make.exe, which is a more discoverable name
 # and so the same command line can be used on Windows as on macOS and Linux

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -102,7 +102,7 @@ function Get-KindVersion {
 }
 
 function Get-MinGWVersion {
-    (gcc --version | Select-String -Pattern "MinGW-W64 project") -match "(?<version>\d+\.\d+\.\d+)" | Out-Null
+    (gcc --version | Select-String -Pattern "MinGW-W64") -match "(?<version>\d+\.\d+\.\d+)" | Out-Null
     $mingwVersion = $Matches.Version
     return "Mingw-w64 $mingwVersion"
 }

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -187,6 +187,9 @@
             ]
         }
     },
+    "mingw": {
+	"version": "8.1.0"
+    },
     "MsysPackages": {
         "msys2": [
             "base-devel",

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -189,6 +189,9 @@
             ]
         }
     },
+    "mingw": {
+	"version": "8.1.0"
+    },
     "MsysPackages": {
         "msys2": [
             "base-devel",

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -159,6 +159,9 @@
             ]
         }
     },
+    "mingw": {
+	"version": "11.2.0.07112021"
+    },
     "MsysPackages": {
         "msys2": [],
         "mingw": []


### PR DESCRIPTION
# Description

Previously, the GitHub virtual environments only had MinGW v8.1.0
installed. That version was released in October of 2018 and, since then,
MinGW has released versions all the way up to v11.2.0. This change
updates the MinGW version to the latest available on Chocolatey for the
Windows 2022 environment. Windows 2019 retains the current v8.1.0
version. Fixes #5530.

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
