### PR TITLE
[macOS] Improve github releases parser

### DIFF
--- a/images/macos/provision/utils/utils.sh
+++ b/images/macos/provision/utils/utils.sh
@@ -192,13 +192,16 @@ get_github_package_download_url() {
     json=$(curl "${authString[@]}" -s "https://api.github.com/repos/${REPO_ORG}/releases?per_page=${SEARCH_IN_COUNT}")
 
     if [[ "$VERSION" == "latest" ]]; then
-        tagName=$(echo $json | jq -r '.[] | select(.prerelease==false).tag_name' | sort --unique --version-sort | egrep -v ".*-[a-z]" | tail -1)
+        tagName=$(echo $json | jq -r '.[] | select((.prerelease==false) and (.assets | length > 0)).tag_name' | sort --unique --version-sort | egrep -v ".*-[a-z]" | tail -1)
     else
         tagName=$(echo $json | jq -r '.[] | select(.prerelease==false).tag_name' | sort --unique --version-sort | egrep -v ".*-[a-z]" | egrep "\w*${VERSION}" | tail -1)
     fi
 
     downloadUrl=$(echo $json | jq -r ".[] | select(.tag_name==\"${tagName}\").assets[].browser_download_url | select(${FILTER})" | head -n 1)
-
+    if [ -z "$downloadUrl" ]; then
+        echo "Failed to parse a download url for the '${tagName}' tag using '${FILTER}' filter"
+        exit 1
+    fi
     echo $downloadUrl
 }
 


### PR DESCRIPTION
# Description
Changes:
- Add filter into the  `get_github_package_download_url` function to ignore releases without assets
- Add check if a downloadUrl is empty using a filter


#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3473

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
