### PR TITLE
[macOS] get double quotes back in sw report for VS

### DIFF
--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -249,8 +249,8 @@ $markdown += New-MDHeader "Notes:" -Level 5
 $reportVS = @'
 ```
 To use Visual Studio 2019 by default rename the app:
-mv '/Applications/Visual Studio.app' '/Applications/Visual Studio 2022.app'
-mv '/Applications/Visual Studio 2019.app' '/Applications/Visual Studio.app'
+mv "/Applications/Visual Studio.app" "/Applications/Visual Studio 2022.app"
+mv "/Applications/Visual Studio 2019.app" "/Applications/Visual Studio.app"
 ```
 '@
 $markdown += New-MDParagraph -Lines $reportVS


### PR DESCRIPTION
# Description
Looks like we must wrap it within a pipeline itself, otherwise while sw report is correct image diff stage is broken

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
