### PR TITLE
Revert "[macOS] Add Xcode 14 to macOS 12 image"

### DIFF
--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -2,7 +2,6 @@
     "xcode": {
         "default": "13.3.1",
         "versions": [
-            { "link": "14.0", "version": "14.0.0" },
             { "link": "13.4.1", "version": "13.4.1" },
             { "link": "13.4", "version": "13.4.0" },
             { "link": "13.3.1", "version": "13.3.1", "symlinks": ["13.3"] },


### PR DESCRIPTION
Reverts actions/virtual-environments#5703 as we faced an issue with simulators with Xcode 14 on the image. We will remove the Xcode 14 until further investigation