### PR TITLE
[Ubuntu] Install aws-cli v2 on 18.04

### DIFF
--- a/images/linux/scripts/installers/aws.sh
+++ b/images/linux/scripts/installers/aws.sh
@@ -8,18 +8,9 @@
 source $HELPER_SCRIPTS/os.sh
 source $HELPER_SCRIPTS/install.sh
 
-# Install the AWS CLI v1 Ubuntu18 and AWS CLI v2 on Ubuntu20, Ubuntu22
-# The installation should be run after python3 is installed as aws-cli V1 dropped python2 support
-# 1.25.0+ Dropped support for Python 3.6 - https://github.com/aws/aws-cli/blob/develop/CHANGELOG.rst
-if isUbuntu18 ; then
-    download_with_retries "https://s3.amazonaws.com/aws-cli/awscli-bundle-1.24.10.zip" "/tmp" "awscli-bundle.zip"
-    unzip -qq /tmp/awscli-bundle.zip -d /tmp
-    python3 /tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
-else
-    download_with_retries "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" "/tmp" "awscliv2.zip"
-    unzip -qq /tmp/awscliv2.zip -d /tmp
-    /tmp/aws/install -i /usr/local/aws-cli -b /usr/local/bin
-fi
+download_with_retries "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" "/tmp" "awscliv2.zip"
+unzip -qq /tmp/awscliv2.zip -d /tmp
+/tmp/aws/install -i /usr/local/aws-cli -b /usr/local/bin
 
 download_with_retries "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" "/tmp" "session-manager-plugin.deb"
 apt install /tmp/session-manager-plugin.deb


### PR DESCRIPTION
# Description

AWS CLI v1 installer stopped working on Ubuntu18 as it now requires Python 3.7 ([changelog](https://github.com/aws/aws-cli/blob/develop/CHANGELOG.rst)) while Ubuntu18 has python 3.6. V2 installer doesn't require system python to operate so can be installed on the Ubuntu18.

#### Related issue: https://github.com/actions/virtual-environments/issues/5679

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
