### PR TITLE
Adds the Windows SDK (10.0.22621) for Windows 11, version 22H2

### DIFF
--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -239,6 +239,7 @@
             "Microsoft.VisualStudio.Component.Windows10SDK.19041",
             "Microsoft.VisualStudio.Component.Windows10SDK.20348",
             "Microsoft.VisualStudio.Component.Windows11SDK.22000",
+            "Microsoft.VisualStudio.Component.Windows11SDK.22621",
             "Microsoft.VisualStudio.Component.Workflow",
             "Microsoft.VisualStudio.ComponentGroup.Azure.CloudServices",
             "Microsoft.VisualStudio.ComponentGroup.Azure.ResourceManager.Tools",


### PR DESCRIPTION
# Description
This PR adds the the Windows SDK (10.0.22621) for Windows 11, version 22H2 optional component available in VS 2022 Update 17.2.3:, see https://docs.microsoft.com/en-us/visualstudio/releases/2022/release-notes#17.2.3
