### PR TITLE
[Windows] Set WSLv1 version on Windows Server 2022

### DIFF
--- a/images/win/scripts/ImageHelpers/ImageHelpers.psm1
+++ b/images/win/scripts/ImageHelpers/ImageHelpers.psm1
@@ -17,6 +17,7 @@ Export-ModuleMember -Function @(
     'Set-DefaultPath'
     'Add-MachinePathItem'
     'Add-DefaultPathItem'
+    'Add-DefaultItem'
     'Get-SystemVariable'
     'Get-DefaultVariable'
     'Set-SystemVariable'

--- a/images/win/scripts/ImageHelpers/PathHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/PathHelpers.ps1
@@ -145,6 +145,11 @@ function Add-DefaultItem {
     )
 
     Connect-Hive
+    $regPath = Join-Path "HKLM:\" $Name
+    if (-not (Test-Path $Name)) {
+        Write-Host "Creating $regPath key"
+        New-Item -Path $regPath -Force | Out-Null
+    }
     Set-DefaultVariable -DefaultVariable $DefaultVariable -Value $Value -Name $Name -Kind $Kind -Writable $Writable
     Disconnect-Hive
 }

--- a/images/win/scripts/ImageHelpers/PathHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/PathHelpers.ps1
@@ -75,7 +75,7 @@ function Set-DefaultVariable {
 
     $key = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey($Name, $Writable)
     $key.SetValue($DefaultVariable, $Value, $Kind)
-    Get-DefaultVariable $DefaultVariable
+    Get-DefaultVariable -DefaultVariable $DefaultVariable -Name $Name
     $key.Handle.Close()
     [System.GC]::Collect()
 }
@@ -132,6 +132,20 @@ function Add-DefaultPathItem {
     $currentPath = Get-DefaultPath
     $newPath = $PathItem + ';' + $currentPath
     Set-DefaultPath -NewPath $newPath
+    Disconnect-Hive
+}
+
+function Add-DefaultItem {
+    param(
+        [string]$DefaultVariable,
+        [string]$Value,
+        [string]$Name = "DEFAULT\Environment",
+        [string]$Kind = "ExpandString",
+        [bool]$Writable = $true
+    )
+
+    Connect-Hive
+    Set-DefaultVariable -DefaultVariable $DefaultVariable -Value $Value -Name $Name -Kind $Kind -Writable $Writable
     Disconnect-Hive
 }
 

--- a/images/win/scripts/Installers/Finalize-VM.ps1
+++ b/images/win/scripts/Installers/Finalize-VM.ps1
@@ -6,6 +6,13 @@
 Write-Host "Cleanup WinSxS"
 Dism.exe /online /Cleanup-Image /StartComponentCleanup /ResetBase
 
+# Sets the default install version to v1 for new distributions
+# https://github.com/actions/virtual-environments/issues/5760
+if (Test-IsWin22) {
+    Write-Host "Sets the default install version to v1 for new distributions"
+    Add-DefaultItem -DefaultVariable "DefaultVersion" -Value 1 -Name "DEFAULT\Software\Microsoft\Windows\CurrentVersion\Lxss" -Kind "DWord"
+}
+
 Write-Host "Clean up various directories"
 @(
     "$env:SystemDrive\Recovery",


### PR DESCRIPTION
# Description
https://techcommunity.microsoft.com/t5/itops-talk-blog/wsl2-now-available-on-windows-server-2022/ba-p/3447570
WSL2 now available on Windows Server 2022 and installed  through the regular update process(Second, if you wait until June, you will get the update that is required for WSL2 to run properly on a Windows Server 2022, through the regular update process.) . We can't activate WSLv2 due to unsupported by Azure on the DSV2 spec nested virtualization.

#### Related issue:
https://github.com/actions/virtual-environments/issues/5760

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
