### PR TITLE
[Ubuntu] Add musl-dev and musl-tools to 22.04

### DIFF
--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -145,6 +145,8 @@
             "libssl-dev",
             "locales",
             "mercurial",
+            "musl-dev",
+            "musl-tools",
             "openssh-client",
             "p7zip-rar",
             "pkg-config",


### PR DESCRIPTION
This allows compiling (including cross-compiling) to musl targets.

# Description
New tool, Bug fixing, or Improvement?  New tool.

Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.

This adds the `musl-dev` and `musl-tools` packages to Ubuntu 22.04, allowing
compilation (including cross-compilation) to musl targets. This is helpful for
both C and Rust code.

**For new tools, please provide total size and installation time.**

Approximate total size: 3MB

#### Related issue:

https://github.com/actions/virtual-environments/issues/5770

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
