### PR TITLE
[macOS] Fix utils.sh: line 130: null: command not found

### DIFF
--- a/images/macos/provision/utils/utils.sh
+++ b/images/macos/provision/utils/utils.sh
@@ -136,10 +136,10 @@ should_build_from_source() {
     if [[ "$tool_bottle" == "null" ]]; then
         echo "true"
         return
+    else
+        echo "false"
+        return
     fi
-
-    echo "false"
-    return
 }
 
 # brew provides package bottles for different macOS versions

--- a/images/macos/provision/utils/utils.sh
+++ b/images/macos/provision/utils/utils.sh
@@ -127,7 +127,7 @@ should_build_from_source() {
 
     # No need to build from source if a bottle is disabled
     # Use the simple 'brew install' command to download a package
-    if $bottle_disabled; then
+    if [[ $bottle_disabled == "true" ]]; then
         echo "false"
         return
     fi
@@ -136,10 +136,10 @@ should_build_from_source() {
     if [[ "$tool_bottle" == "null" ]]; then
         echo "true"
         return
-    else
-        echo "false"
-        return
     fi
+
+    echo "false"
+    return
 }
 
 # brew provides package bottles for different macOS versions


### PR DESCRIPTION
# Description
Fix condition:
`==> vsphere-clone: /Users/runner/utils/utils.sh: line 130: null: command not found`

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3894

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
