### PR TITLE
[Ubuntu] Update openssl 1.1 on Ubuntu 22.04

### DIFF
--- a/images/linux/scripts/installers/sqlpackage.sh
+++ b/images/linux/scripts/installers/sqlpackage.sh
@@ -8,10 +8,10 @@
 source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 
-# Install libssl1.1 dependency 
+# Install libssl1.1 dependency
 if isUbuntu22; then
-    download_with_retries "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb" "/tmp"
-    dpkg -i /tmp/libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb
+    download_with_retries "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1l-1ubuntu1.5_amd64.deb" "/tmp"
+    dpkg -i /tmp/libssl1.1_1.1.1l-1ubuntu1.5_amd64.deb
 fi
 
 # Install SqlPackage


### PR DESCRIPTION
# Description
The `libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb` package was updated to  libssl1.1_1.1.1l-1ubuntu1.5:

> 'http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb' is wrong - '404' or exit code is not 0 - '0'

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
