### PR TITLE
[Scripts] Fix az cli warnings

### DIFF
--- a/helpers/CreateAzureVMFromPackerTemplate.ps1
+++ b/helpers/CreateAzureVMFromPackerTemplate.ps1
@@ -28,7 +28,7 @@ Function CreateAzureVMFromPackerTemplate {
             The location where the Azure virtual machine will be provisioned. Example: "eastus"
 
         .EXAMPLE
-            CreateAzureVMFromPackerTemplate -SubscriptionId {YourSubscriptionId}  -ResourceGroupName {ResourceGroupName} -TemplateFile "C:\BuildVmImages\temporaryTemplate.json" -VirtualMachineName "testvm1" -AdminUsername "shady1" -AdminPassword "SomeSecurePassword1" -AzureLocation "eastus"
+            CreateAzureVMFromPackerTemplate -SubscriptionId {YourSubscriptionId} -ResourceGroupName {ResourceGroupName} -TemplateFile "C:\BuildVmImages\temporaryTemplate.json" -VirtualMachineName "testvm1" -AdminUsername "shady1" -AdminPassword "SomeSecurePassword1" -AzureLocation "eastus"
     #>
     param (
         [Parameter(Mandatory = $True)]
@@ -63,14 +63,14 @@ Function CreateAzureVMFromPackerTemplate {
     $networkId = ($nic | ConvertFrom-Json).NewNIC.id
 
     Write-Host "`nCreating a public IP address"
-    ($publicIp = az network public-ip create -g $ResourceGroupName -l $AzureLocation -n $publicIpName --allocation-method Static --sku Standard --version IPv4 --subscription $subscriptionId -o json)
+    ($publicIp = az network public-ip create -g $ResourceGroupName -l $AzureLocation -n $publicIpName --allocation-method Static --sku Basic --version IPv4 --subscription $subscriptionId -o json)
     $publicIpId = ($publicIp | ConvertFrom-Json).publicIp.id
 
     Write-Host "`nAdding the public IP to the NIC"
     az network nic ip-config update -g $ResourceGroupName -n ipconfig1 --nic-name $nicName --public-ip-address $publicIpId --subscription $subscriptionId
 
     Write-Host "`nCreating the VM"
-    az group deployment create -g $ResourceGroupName -n $VirtualMachineName --subscription $subscriptionId --template-file $templateFilePath --parameters vmSize=$vmSize vmName=$VirtualMachineName adminUserName=$AdminUsername adminPassword=$AdminPassword networkInterfaceId=$networkId
-    
+    az deployment group create -g $ResourceGroupName -n $VirtualMachineName --subscription $subscriptionId --template-file $templateFilePath --parameters vmSize=$vmSize vmName=$VirtualMachineName adminUserName=$AdminUsername adminPassword=$AdminPassword networkInterfaceId=$networkId
+
     Write-Host "`nCreated in ${ResourceGroupName}:`n  vnet ${vnetName}`n  subnet ${subnetName}`n  nic ${nicName}`n  publicip ${publicIpName}`n  vm ${VirtualMachineName}"
 }

--- a/images.CI/linux-and-win/cleanup.ps1
+++ b/images.CI/linux-and-win/cleanup.ps1
@@ -14,7 +14,7 @@ $TempResourceGroupName = "${ResourcesNamePrefix}_${Image}"
 
 $groupExist = az group exists --name $TempResourceGroupName --subscription $SubscriptionId
 if ($groupExist -eq "true") {
-    $osDiskName = az group deployment list --resource-group $TempResourceGroupName --query "[].properties.parameters.osDiskName.value" -o tsv
+    $osDiskName = az deployment group list --resource-group $TempResourceGroupName --query "[].properties.parameters.osDiskName.value" -o tsv
     Write-Host "Found a match, deleting temporary files"
     az group delete --name $TempResourceGroupName --subscription $SubscriptionId --yes | Out-Null
     Write-Host "Temporary group was deleted successfully"


### PR DESCRIPTION
# Description
Fix:
- Creating a public IP address
WARNING: [Coming breaking change] In the coming release, the default behavior will be changed as follows when sku is Standard and zone is not provided: For zonal regions, you will get a zone-redundant IP indicated by zones:["1","2","3"]; For non-zonal regions, you will get a non zone-redundant IP indicated by zones:null.

- This command is implicitly deprecated because command group 'group deployment' is deprecated and will be removed in a future release. Use 'deployment group' instead.

#### Related issue:
https://github.com/actions/virtual-environments/issues/5802
https://github.com/actions/virtual-environments/issues/5799

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
