### PR TITLE
[Ubuntu] Enable systemd lingering

### DIFF
--- a/images/linux/post-generation/systemd-linger.sh
+++ b/images/linux/post-generation/systemd-linger.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Enable user session on boot, not on login
+UserId=$(cut -d: -f3 /etc/passwd | tail -1)
+loginctl enable-linger $UserId


### PR DESCRIPTION
# Description

`loginctl enable-linger` allows us to enable user services on a machine boot and not on a user login, which in turn allows us having user sockets activated on every machine boot prior to further communication. In practice it sets up some user-specific variables (like the dbus ones)  needed for the `systemctl --user` calls.

I have tested it on:

* mpd
* dirmngr/gpg
* emacs
* snapd (this one is extremely essential as there is snapd in our images and some packages like firefox slowly migrate to the snap-only distribution approach).

More info: https://www.freedesktop.org/software/systemd/man/loginctl.html

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/3893

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
