### PR TITLE
[macOS] Update Clang/LLVM test to use absolute path

### DIFF
--- a/images/macos/tests/LLVM.Tests.ps1
+++ b/images/macos/tests/LLVM.Tests.ps1
@@ -3,7 +3,7 @@ $os = Get-OSVersion
 Describe "Clang/LLVM" {
     It "Clang/LLVM is installed and version is correct" {
         $toolsetVersion = Get-ToolsetValue 'llvm.version'
-        $clangVersion = & "$(brew --prefix llvm)/bin/clang" --version
+        $clangVersion = & "$(brew --prefix llvm@$toolsetVersion)/bin/clang" --version
         $clangVersion[0] | Should -BeLike "*${toolsetVersion}*"
     }
 }


### PR DESCRIPTION
# Description
After https://github.com/Homebrew/homebrew-core/commit/34db45964ce662aba85cfd830c6bd5b11e517147 commit was merged there is no anymore the `/usr/local/opt/llvm` symlink.

Before:
```
lrwxr-xr-x  1 runner  admin  23 Jun 22 16:15 /usr/local/opt/llvm -> ../Cellar/llvm/13.0.1_1
lrwxr-xr-x  1 runner  admin  23 Jun 22 16:15 /usr/local/opt/llvm@13 -> ../Cellar/llvm/13.0.1_1
```

After:
```
lrwxr-xr-x  1 runner  admin  24 Jun 27 02:43 /usr/local/opt/llvm@13 -> ../Cellar/llvm@13/13.0.1

vsphere-clone: llvm@13 is keg-only, which means it was not symlinked into /usr/local,
vsphere-clone: because this is an alternate version of another formula.
```


#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3917

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
