### PR TITLE
[macOS] Remove workaround for Mono download url

### DIFF
--- a/images/macos/provision/utils/xamarin-utils.sh
+++ b/images/macos/provision/utils/xamarin-utils.sh
@@ -19,11 +19,7 @@ buildVSMacDownloadUrl() {
 }
 
 buildMonoDownloadUrl() {
-if [[ $1 -eq 6.12.0.182 ]]; then 
-    echo "https://download.mono-project.com/archive/6.12.0/macos-10-universal/MonoFramework-MDK-${1}.macos10.xamarin.universal.pkg"
-else
-    echo "https://dl.xamarin.com/MonoFrameworkMDK/Macx86/MonoFramework-MDK-${1}.macos10.xamarin.universal.pkg"    
-fi
+    echo "https://dl.xamarin.com/MonoFrameworkMDK/Macx86/MonoFramework-MDK-${1}.macos10.xamarin.universal.pkg"
 }
 
 buildXamariniIOSDownloadUrl() {


### PR DESCRIPTION
# Description
The 6.12.0.182 mono version has been uploaded to dl.xamarin.com so we don't need the workaround anymore — https://dl.xamarin.com/MonoFrameworkMDK/Macx86/MonoFramework-MDK-6.12.0.182.macos10.xamarin.universal.pkg

#### Related issue:
n\a

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
