### PR TITLE
Use `v2` branch to get the Linux CodeQL bundle too

### DIFF
--- a/images/linux/scripts/installers/codeql-bundle.sh
+++ b/images/linux/scripts/installers/codeql-bundle.sh
@@ -7,7 +7,7 @@
 source $HELPER_SCRIPTS/install.sh
 
 # Retrieve the name of the CodeQL bundle preferred by the Action (in the format codeql-bundle-YYYYMMDD).
-codeql_bundle_name="$(curl -sSL https://raw.githubusercontent.com/github/codeql-action/v1/src/defaults.json | jq -r .bundleVersion)"
+codeql_bundle_name="$(curl -sSL https://raw.githubusercontent.com/github/codeql-action/v2/src/defaults.json | jq -r .bundleVersion)"
 # Convert the bundle name to a version number (0.0.0-YYYYMMDD).
 codeql_bundle_version="0.0.0-${codeql_bundle_name##*-}"
 


### PR DESCRIPTION
# Description

https://github.com/actions/virtual-environments/pull/5307 updated the Windows installer to grab the CodeQL Bundle from the `v2` branch, since this is the branch we release the CodeQL Action from.  This PR updates the Linux installer to do the same thing.  Currently this is a no-op, however these branches could feasibly diverge going forward, at which point we'd want the bundle from `v2`.

#### Related issue: https://github.com/github/codeql-core/issues/2491

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
