### PR TITLE
[macOS] Add vagrant to macOS-12

### DIFF
--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -135,13 +135,13 @@ if ($os.IsLessThanMonterey) {
 
 if ($os.IsCatalina) {
     $utilitiesList += @(
-        (Get-VagrantVersion),
         (Get-ParallelVersion)
     )
 }
 
 if (-not $os.IsBigSur) {
     $utilitiesList += @(
+        (Get-VagrantVersion),
         (Get-VirtualBoxVersion)
     )
 }

--- a/images/macos/tests/BasicTools.Tests.ps1
+++ b/images/macos/tests/BasicTools.Tests.ps1
@@ -138,7 +138,7 @@ Describe "wget" {
     }
 }
 
-Describe "vagrant" -Skip:($os.IsHigherThanCatalina) {
+Describe "vagrant" -Skip:($os.IsBigSur) {
     It "vagrant" {
         "vagrant --version" | Should -ReturnZeroExitCode
     }

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -161,6 +161,7 @@
         ],
         "cask_packages": [
             "julia",
+            "vagrant",
             "virtualbox"
         ]
     },


### PR DESCRIPTION
# Description
As we get virualbox back to macOS-12 we can also install vagrant.

#### Related issue:
https://github.com/actions/virtual-environments/issues/5583#issuecomment-1171886280

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
