### PR TITLE
Added tfsec installation to linux and windows images

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -150,8 +150,8 @@ $toolsList = @(
     (Get-SphinxVersion),
     (Get-TerraformVersion),
     (Get-YamllintVersion),
-    (Get-ZstdVersion)
-)
+    (Get-ZstdVersion),
+    (Get-TfsecVersion)
 
 if ((Test-IsUbuntu18) -or (Test-IsUbuntu20)) {
     $toolsList += @(

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -306,3 +306,7 @@ function Get-YqVersion {
     $yqVersion = ($(yq -V) -Split " ")[-1]
     return "yq $yqVersion"
 }
+
+function Get-TfsecVersion {
+    return "Tfsec $(tfsec --version).replace('v','')"
+}

--- a/images/linux/scripts/installers/tfsec.sh
+++ b/images/linux/scripts/installers/tfsec.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+################################################################################
+##  File:  tfsec.sh
+##  Desc:  Installs tfsec cli
+################################################################################
+
+source $HELPER_SCRIPTS/install.sh
+
+# Install Tfsec
+download_with_retries "https://github.com/aquasecurity/tfsec/releases/latest/download/tfsec-linux-amd64" "." "tfsec.bin"
+
+# Mark it as executable
+chmod +x ./tfsec.bin
+# Add tfsec to PATH (requires admin)
+sudo mv ./tfsec.bin /usr/local/bin/tfsec
+
+invoke_tests "Tools" "tfsec"

--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -422,3 +422,9 @@ Describe "Kotlin" {
         "kotlin-dce-js -version"| Should -ReturnZeroExitCode
     }
 }
+
+Describe "Tfsec" {
+    It "tfsec" {
+        "tfsec --version" | Should -ReturnZeroExitCode
+    }
+}

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -246,7 +246,8 @@
                 "{{template_dir}}/scripts/installers/android.sh",
                 "{{template_dir}}/scripts/installers/pypy.sh",
                 "{{template_dir}}/scripts/installers/python.sh",
-                "{{template_dir}}/scripts/installers/aws.sh"
+                "{{template_dir}}/scripts/installers/aws.sh",
+                "{{template_dir}}/scripts/installers/tfsec.sh"
             ],
             "environment_vars": [
                 "HELPER_SCRIPTS={{user `helper_script_folder`}}",

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -247,7 +247,8 @@
                 "{{template_dir}}/scripts/installers/android.sh",
                 "{{template_dir}}/scripts/installers/pypy.sh",
                 "{{template_dir}}/scripts/installers/python.sh",
-                "{{template_dir}}/scripts/installers/graalvm.sh"
+                "{{template_dir}}/scripts/installers/graalvm.sh",
+                "{{template_dir}}/scripts/installers/tfsec.sh"
             ],
             "environment_vars": [
                 "HELPER_SCRIPTS={{user `helper_script_folder`}}",

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -311,7 +311,8 @@ build {
                         "${path.root}/scripts/installers/android.sh",
                         "${path.root}/scripts/installers/pypy.sh",
                         "${path.root}/scripts/installers/python.sh",
-                        "${path.root}/scripts/installers/graalvm.sh"
+                        "${path.root}/scripts/installers/graalvm.sh",
+                        "${path.root}/scripts/installers/tfsec.sh"
                         ]
   }
 

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -119,7 +119,9 @@ $toolsList = @(
     (Get-WinAppDriver),
     (Get-WixVersion),
     (Get-ZstdVersion),
-    (Get-YAMLLintVersion)
+    (Get-YAMLLintVersion),
+    (Get-TfsecVersion)
+
 )
 if ((Test-IsWin16) -or (Test-IsWin19)) {
     $toolsList += @(

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -303,3 +303,7 @@ function Get-SwigVersion {
     $swigVersion = $Matches.Version
     return "Swig $swigVersion"
 }
+
+function Get-TfsecVersion {
+    return "Tfsec $(tfsec --version).replace('v','')"
+}

--- a/images/win/scripts/Tests/ChocoPackages.Tests.ps1
+++ b/images/win/scripts/Tests/ChocoPackages.Tests.ps1
@@ -103,3 +103,9 @@ Describe "CMake" {
         "cmake --version" | Should -ReturnZeroExitCode
     }
 }
+
+Describe "Tfsec" {
+    It "tfsec" {
+        "tfsec --version" | Should -ReturnZeroExitCode
+    }
+}

--- a/images/win/toolsets/toolset-2016.json
+++ b/images/win/toolsets/toolset-2016.json
@@ -423,7 +423,8 @@
             {
                 "name": "cmake.install",
                 "args": [ "--installargs", "ADD_CMAKE_TO_PATH=\"System\"" ]
-            }
+            },
+            { "name": "tfsec" }
         ]
     },
     "node": {

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -459,7 +459,8 @@
             {
                 "name": "cmake.install",
                 "args": [ "--installargs", "ADD_CMAKE_TO_PATH=\"System\"" ]
-            }
+            },
+            { "name": "tfsec" }
         ]
     },
     "node": {

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -343,7 +343,9 @@
             {
                 "name": "cmake.install",
                 "args": [ "--installargs", "ADD_CMAKE_TO_PATH=\"System\"" ]
-            }
+            },
+            { "name": "tfsec" }
+
         ]
     },
     "node": {


### PR DESCRIPTION
# Description
Added installation of tfsec to Windows and Linux images (https://github.com/aquasecurity/tfsec).
Tfsec size about 40Mb, installation time is less than 1min.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [*] Tests are written (if applicable)
- [*] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
