### PR TITLE
[Ubuntu] Apply esl-erlang workaround for 20.04

### DIFF
--- a/images/linux/scripts/installers/erlang.sh
+++ b/images/linux/scripts/installers/erlang.sh
@@ -6,6 +6,7 @@
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
+source $HELPER_SCRIPTS/os.sh
 
 source_list=/etc/apt/sources.list.d/eslerlang.list
 source_key=/usr/share/keyrings/eslerlang.gpg
@@ -13,8 +14,28 @@ source_key=/usr/share/keyrings/eslerlang.gpg
 # Install Erlang
 wget -q -O - https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | gpg --dearmor > $source_key
 echo "deb [signed-by=$source_key]  https://packages.erlang-solutions.com/ubuntu $(lsb_release -cs) contrib" > $source_list
+
 apt-get update
-apt-get install -y --no-install-recommends esl-erlang
+
+if isUbuntu20; then
+    # https://github.com/actions/virtual-environments/issues/5859
+    # hashes mismatch is going to happen due to not updated release file
+    # on the server side,
+    # pulling all the dependencies first without apt-cache parsing
+    # but ignore the error
+    apt-get install --no-install-recommends esl-erlang || true
+
+    # Downoloading and installing a deb file manually, ignore deptree errors
+    esl_url="https://packages.erlang-solutions.com/ubuntu/pool/esl-erlang_25.0.2-1~ubuntu~focal_amd64.deb"
+    download_with_retries $esl_url  "/tmp"
+    dpkg -i /tmp/esl-erlang_25.0.2-1~ubuntu~focal_amd64.deb || true
+
+    # Restore a proper deptree which brings esl-erlang back in the loop
+    # but eleminate unwanted X.org dependencies
+    apt --no-install-recommends --fix-broken install
+else
+   apt-get install --no-install-recommends esl-erlang
+fi
 
 # Install rebar3
 rebar3_url="https://github.com/erlang/rebar3/releases/latest/download/rebar3"


### PR DESCRIPTION
# Description

Use usual apt-get to grab the deptree, then install the package using `dpkg -i` to bypass mismatch, then restore broken deptree to fully bring esl-erlang on board (errors ignored on purpose, not relevant to resulting installation).

#### Related issue: https://github.com/actions/virtual-environments/issues/5859

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
