### PR TITLE
[Anka] Fix output file

### DIFF
--- a/images/macos/templates/macOS-12.anka.pkr.hcl
+++ b/images/macos/templates/macOS-12.anka.pkr.hcl
@@ -111,7 +111,7 @@ build {
       "./provision/core/xcode-clt.sh",
       "./provision/core/homebrew.sh"
     ]
-     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
   }
   provisioner "shell" {
     scripts = [
@@ -241,7 +241,7 @@ build {
   provisioner "file" {
     destination = "../image-output/"
     direction = "download"
-    source = "./image-generation/output/*"
+    source = "./image-generation/output/"
   }
   provisioner "shell" {
     scripts = [


### PR DESCRIPTION
# Description
```
==> veertu-anka-vm-clone.template: Downloading ./image-generation/output/* => ../image-output/
./image-generation/output/*: No such file or directory
```

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3947

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
