### PR TITLE
[Ubuntu] Update link to openssl

### DIFF
--- a/images/linux/scripts/installers/sqlpackage.sh
+++ b/images/linux/scripts/installers/sqlpackage.sh
@@ -10,7 +10,7 @@ source $HELPER_SCRIPTS/os.sh
 
 # Install libssl1.1 dependency
 if isUbuntu22; then
-    download_with_retries "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1l-1ubuntu1.5_amd64.deb" "/tmp"
+    download_with_retries "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1l-1ubuntu1.6_amd64.deb" "/tmp"
     dpkg -i /tmp/libssl1.1_1.1.1l-1ubuntu1.5_amd64.deb
 fi
 

--- a/images/linux/scripts/installers/sqlpackage.sh
+++ b/images/linux/scripts/installers/sqlpackage.sh
@@ -11,7 +11,7 @@ source $HELPER_SCRIPTS/os.sh
 # Install libssl1.1 dependency
 if isUbuntu22; then
     download_with_retries "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1l-1ubuntu1.6_amd64.deb" "/tmp"
-    dpkg -i /tmp/libssl1.1_1.1.1l-1ubuntu1.5_amd64.deb
+    dpkg -i /tmp/libssl1.1_1.1.1l-1ubuntu1.6_amd64.deb
 fi
 
 # Install SqlPackage


### PR DESCRIPTION
# Description
The new version is .6 http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1l-1ubuntu1.6_amd64.deb

#### Related issue:
n\a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
