### PR TITLE
Revert "[macOS] Set properties for device set list"

### DIFF
--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -106,6 +106,3 @@ if [ ! -d "/usr/local/bin" ];then
 fi
 chmod +x $HOME/utils/invoke-tests.sh
 sudo ln -s $HOME/utils/invoke-tests.sh /usr/local/bin/invoke_tests
-
-# Disable the App Library for fix overloaded cpu 
-plutil -replace SuggestionsAppLibraryEnabled -bool NO $HOME/Library/Developer/CoreSimulator/Devices/device_set.plist


### PR DESCRIPTION
Reverts actions/virtual-environments#5700 because it is breaking all the macOS builds:

/Users/runner/Library/Developer/CoreSimulator/Devices/device_set.plist: file does not exist or is not readable or is not a regular file