### PR TITLE
[Ubuntu] Apt Always-Include-Phased-Updates

### DIFF
--- a/images/linux/scripts/base/apt.sh
+++ b/images/linux/scripts/base/apt.sh
@@ -14,6 +14,13 @@ echo "APT::Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries
 # Configure apt to always assume Y
 echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
 
+# APT understands a field called Phased-Update-Percentage which can be used to control the rollout of a new version. It is an integer between 0 and 100.
+# In case you have multiple systems that you want to receive the same set of updates, 
+# you can set APT::Machine-ID to a UUID such that they all phase the same, 
+# or set APT::Get::Never-Include-Phased-Updates or APT::Get::Always-Include-Phased-Updates to true such that APT will never/always consider phased updates.
+# apt-cache policy pkgname
+echo 'APT::Get::Always-Include-Phased-Updates "true";' > /etc/apt/apt.conf.d/99-phased-updates
+
 # Fix bad proxy and http headers settings
 cat <<EOF >> /etc/apt/apt.conf.d/99bad_proxy
 Acquire::http::Pipeline-Depth 0;


### PR DESCRIPTION
# Description
[StableReleaseUpdates](https://wiki.ubuntu.com/StableReleaseUpdates) will no longer appear in update-manager at the same time for all machines. Instead a subset of machines will be selected at random to receive the update first. The update will only be made available to everyone if there are no serious regressions encountered by the first set of users. There is still a testing process completed by Ubuntu developers before any users receive the update.

```
libsystemd-dev:
  Installed: (none)
  Candidate: 249.11-0ubuntu3
  Version table:
     249.11-0ubuntu3.3 1 (phased 0%)
        [5](https://github.com/roasted-eggplant/alcheb-test/runs/7230018773?check_suite_focus=true#step:2:6)00 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd[6](https://github.com/roasted-eggplant/alcheb-test/runs/7230018773?check_suite_focus=true#step:2:7)4 Packages
     24[9](https://github.com/roasted-eggplant/alcheb-test/runs/7230018773?check_suite_focus=true#step:2:10).11-0ubuntu3 500
        500 http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 Packages
```

#### Related issue:
https://github.com/actions/virtual-environments/issues/5872

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
