### PR TITLE
[Anka] Fix invoking confirm-identified-developers.scpt script

### DIFF
--- a/images/macos/provision/core/commonutils.sh
+++ b/images/macos/provision/core/commonutils.sh
@@ -19,6 +19,22 @@ done
 # Execute AppleScript to change security preferences for virtualbox
 # System Preferences -> Security & Privacy -> General -> Unlock -> Allow -> Not now
 if is_Monterey; then
+    if is_Veertu; then
+        retry=10
+        while [ $retry -gt 0 ]; do
+            {
+                osascript -e 'tell application "System Events" to get application processes where visible is true'
+            } && break
+
+            retry=$((retry-1))
+            if [ $retry -eq 0 ]; then
+                echo "No retry attempts left"
+                exit 1
+            fi
+            sleep 10
+        done
+    fi
+
     osascript $HOME/utils/confirm-identified-developers.scpt $USER_PASSWORD
 fi
 


### PR DESCRIPTION
# Description
```
    veertu-anka-vm-clone.template: 🍺  virtualbox was successfully installed!
==> veertu-anka-vm-clone.template: /Users/<sensitive>/utils/confirm-identified-developers.scpt:708:724: execution error: Application isn’t running. (-600)
```
Add retry warmup:
```
   veertu-anka-vm-clone.template: 🍺  virtualbox was successfully installed!
==> veertu-anka-vm-clone.template: 40:83: execution error: Application isn’t running. (-600)
    veertu-anka-vm-clone.template: application process Finder
    veertu-anka-vm-clone.template: button 5 of window Security & Privacy of application process System Preference
```

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3895

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
