### PR TITLE
[Windows] Replace Win32_Product call to registry query

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -282,12 +282,12 @@ function Get-VisualCPPComponents {
         "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
     )
     $vcpp = Get-ItemProperty -Path $regKeys | Where-Object DisplayName -like "Microsoft Visual C++*"
-    $vcpp | Sort-Object Name, Version | ForEach-Object {
-        $isMatch = $_.Name -match "^(?<Name>Microsoft Visual C\+\+ \d{4})\s+(?<Arch>\w{3})\s+(?<Ext>.+)\s+-"
+    $vcpp | Sort-Object DisplayName, DisplayVersion | ForEach-Object {
+        $isMatch = $_.DisplayName -match "^(?<Name>Microsoft Visual C\+\+ \d{4})\s+(?<Arch>\w{3})\s+(?<Ext>.+)\s+-"
         if ($isMatch) {
             $name = '{0} {1}' -f $matches["Name"], $matches["Ext"]
             $arch = $matches["Arch"].ToLower()
-            $version = $_.Version
+            $version = $_.DisplayVersion
             [PSCustomObject]@{
                 Name = $name
                 Architecture = $arch

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -277,7 +277,11 @@ function Get-GHVersion {
 }
 
 function Get-VisualCPPComponents {
-    $vcpp = Get-CimInstance -ClassName Win32_Product -Filter "Name LIKE 'Microsoft Visual C++%'"
+    $regKeys = @(
+        "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*"
+        "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
+    )
+    $vcpp = Get-ItemProperty -Path $regKeys | Where-Object DisplayName -like "Microsoft Visual C++*"
     $vcpp | Sort-Object Name, Version | ForEach-Object {
         $isMatch = $_.Name -match "^(?<Name>Microsoft Visual C\+\+ \d{4})\s+(?<Arch>\w{3})\s+(?<Ext>.+)\s+-"
         if ($isMatch) {


### PR DESCRIPTION
# Description
Win32_product class isn't query optimized. Queries such as select * from Win32_Product where (name like 'Name%') require WMI to use the MSI provider to enumerate all of the installed products and then parse the full list sequentially to handle the where clause. This process also starts a consistency check of packages installed, verifying, and repairing the install.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3969

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
