### PR TITLE
[Anka] Check vm in failed status

### DIFF
--- a/images.CI/macos/anka/Anka.Helpers.psm1
+++ b/images.CI/macos/anka/Anka.Helpers.psm1
@@ -197,7 +197,14 @@ function Wait-AnkaVMIPAddress {
         [int] $Seconds = 60
     )
 
-    $condition = { Get-AnkaVMIPAddress -VMName $VMName }
+    $condition = {
+        $vmStatus = Get-AnkaVMStatus -VMName $VMName
+        if ($vmStatus -eq "failed") {
+            Write-Host "`t    [-] $VMName is in failed status"
+            exit 1
+        }
+        Get-AnkaVMIPAddress -VMName $VMName
+    }
     $null = Invoke-WithRetry -BreakCondition $condition -RetryCount $RetryCount -Seconds $Seconds
 }
 


### PR DESCRIPTION
# Description
We should stop an image generation workflow if a vm is in failed status.

```
	[*] Waiting for 'clean_macos_12_300gb' VM to get an IP address
	    [-] clean_macos_12_300gb is in failed status

```
#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3970

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
