### PR TITLE
[Windows] Add Microsoft Analysis Services Projects 2022

### DIFF
--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -240,10 +240,15 @@ function Get-VsixExtenstionFromMarketplace {
     $fileName = $Matches.filename
     $downloadUri = $assetUri + "/" + $fileName
     # ProBITools.MicrosoftReportProjectsforVisualStudio2022 has different URL https://github.com/actions/virtual-environments/issues/5340
-    if ($ExtensionMarketPlaceName -eq "ProBITools.MicrosoftReportProjectsforVisualStudio2022")
-    {
-        $fileName = "Microsoft.DataTools.ReportingServices.vsix"
-        $downloadUri = "https://download.microsoft.com/download/b/b/5/bb57be7e-ae72-4fc0-b528-d0ec224997bd/Microsoft.DataTools.ReportingServices.vsix"
+    switch ($ExtensionMarketPlaceName) {
+        "ProBITools.MicrosoftReportProjectsforVisualStudio2022" {
+            $fileName = "Microsoft.DataTools.ReportingServices.vsix"
+            $downloadUri = "https://download.microsoft.com/download/b/b/5/bb57be7e-ae72-4fc0-b528-d0ec224997bd/Microsoft.DataTools.ReportingServices.vsix"
+        }
+        "ProBITools.MicrosoftAnalysisServicesModelingProjects2022" {
+            $fileName = "Microsoft.DataTools.AnalysisServices.vsix"
+            $downloadUri = "https://download.microsoft.com/download/b/b/e/bbe90a41-d7c0-432b-9866-89f698405683/Microsoft.DataTools.AnalysisServices.vsix"
+        }
     }
 
     return [PSCustomObject] @{

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -276,7 +276,8 @@
         "vsix": [
             "VisualStudioClient.MicrosoftVisualStudio2022InstallerProjects",
             "WixToolset.WixToolsetVisualStudio2022Extension",
-            "ProBITools.MicrosoftReportProjectsforVisualStudio2022"
+            "ProBITools.MicrosoftReportProjectsforVisualStudio2022",
+            "ProBITools.MicrosoftAnalysisServicesModelingProjects2022"
         ]
     },
     "docker": {


### PR DESCRIPTION
# Description
The extension is now available https://devblogs.microsoft.com/visualstudio/analysis-services-and-reporting-services-extensions-for-visual-studio-2022-are-here/

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/3974

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
