### PR TITLE
Reverting ORAS CLI to version 0.12

### DIFF
--- a/images/linux/scripts/installers/oras-cli.sh
+++ b/images/linux/scripts/installers/oras-cli.sh
@@ -6,7 +6,7 @@
 
 source $HELPER_SCRIPTS/install.sh
 
-# Determine latest ORAS CLI version
+# Download ORAS CLI version 0.12 since it is the version compatible with GHCR
 ORAS_CLI_DOWNLOAD_URL=$(get_github_package_download_url "oras-project/oras" "endswith(\"linux_amd64.tar.gz\")" "0.12.0")
 ORAS_CLI_ARCHIVE=$(basename $ORAS_CLI_DOWNLOAD_URL)
 

--- a/images/linux/scripts/installers/oras-cli.sh
+++ b/images/linux/scripts/installers/oras-cli.sh
@@ -7,7 +7,7 @@
 source $HELPER_SCRIPTS/install.sh
 
 # Determine latest ORAS CLI version
-ORAS_CLI_DOWNLOAD_URL=$(get_github_package_download_url "oras-project/oras" "endswith(\"linux_amd64.tar.gz\")")
+ORAS_CLI_DOWNLOAD_URL=$(get_github_package_download_url "oras-project/oras" "endswith(\"linux_amd64.tar.gz\")" "0.12.0")
 ORAS_CLI_ARCHIVE=$(basename $ORAS_CLI_DOWNLOAD_URL)
 
 # Install ORAS CLI

--- a/images/linux/scripts/installers/oras-cli.sh
+++ b/images/linux/scripts/installers/oras-cli.sh
@@ -6,7 +6,7 @@
 
 source $HELPER_SCRIPTS/install.sh
 
-# Download ORAS CLI version 0.12 since it is the version compatible with GHCR
+# Download ORAS CLI version 0.12 since it is the version compatible with GHCR (Tracking issue to fix CLI for GHCR login https://github.com/oras-project/oras/issues/446)
 ORAS_CLI_DOWNLOAD_URL=$(get_github_package_download_url "oras-project/oras" "endswith(\"linux_amd64.tar.gz\")" "0.12.0")
 ORAS_CLI_ARCHIVE=$(basename $ORAS_CLI_DOWNLOAD_URL)
 


### PR DESCRIPTION
# Description
Bugfix: This PR reverts the ORAS CLI version to 0.12.0 which prevents the login bug from occurring with GHCR

Addresses: #5906 

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
