### PR TITLE
[macOS] Remove hardcoded RubyGems version

### DIFF
--- a/images/macos/provision/core/rubygem.sh
+++ b/images/macos/provision/core/rubygem.sh
@@ -1,9 +1,8 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
 
-# Temporarily downgrade RubyGems version to 3.2.33 due to issue with RubyGems 3.3.3 (https://github.com/actions/virtual-environments-internal/issues/3162)
 echo Updating RubyGems...
-gem update --system 3.2.33
+gem update --system
 
 gemsToInstall=$(get_toolset_value '.ruby.rubygems | .[]')
 if [ -n "$gemsToInstall" ]; then


### PR DESCRIPTION
# Description
We can remove the hardcoded RubyGems version as the initial issue caused by the old CLAide package version brought by xcversion is now resolved here https://github.com/xcpretty/xcode-install/pull/454
This should help us install some other RubyGems, which can't be installed previously like this one https://github.com/actions/virtual-environments/issues/5642#issuecomment-1143357958
Previous PR for reference https://github.com/actions/virtual-environments/pull/4815

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/4001

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
