### PR TITLE
Revert "Reverting ORAS CLI to version 0.12"

### DIFF
--- a/images/linux/scripts/installers/oras-cli.sh
+++ b/images/linux/scripts/installers/oras-cli.sh
@@ -6,8 +6,8 @@
 
 source $HELPER_SCRIPTS/install.sh
 
-# Download ORAS CLI version 0.12 since it is the version compatible with GHCR (Tracking issue to fix CLI for GHCR login https://github.com/oras-project/oras/issues/446)
-ORAS_CLI_DOWNLOAD_URL=$(get_github_package_download_url "oras-project/oras" "endswith(\"linux_amd64.tar.gz\")" "0.12.0")
+# Determine latest ORAS CLI version
+ORAS_CLI_DOWNLOAD_URL=$(get_github_package_download_url "oras-project/oras" "endswith(\"linux_amd64.tar.gz\")")
 ORAS_CLI_ARCHIVE=$(basename $ORAS_CLI_DOWNLOAD_URL)
 
 # Install ORAS CLI


### PR DESCRIPTION
Reverts actions/virtual-environments#5907 as this is expected behavior https://github.com/oras-project/oras/issues/446#issuecomment-1185164710