### PR TITLE
[Windows] Remove ndk-bundle

### DIFF
--- a/images/win/scripts/Installers/Install-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Install-AndroidSDK.ps1
@@ -109,7 +109,6 @@ Install-AndroidSDKPackages -AndroidSDKManagerPath $sdkManager `
 
 # NDKs
 $ndkMajorVersions = $androidToolset.ndk.versions
-$ndkDefaultMajorVersion = $androidToolset.ndk.default
 $ndkLatestMajorVersion = $ndkMajorVersions | Select-Object -Last 1
 
 $androidNDKs = $ndkMajorVersions | Foreach-Object {
@@ -120,27 +119,11 @@ Install-AndroidSDKPackages -AndroidSDKManagerPath $sdkManager `
                 -AndroidSDKRootPath $sdkRoot `
                 -AndroidPackages $androidNDKs
 
-$ndkDefaultVersion = ($androidNDKs | Where-Object { $_ -match "ndk;$ndkDefaultMajorVersion" }).Split(';')[1]
 $ndkLatestVersion = ($androidNDKs | Where-Object { $_ -match "ndk;$ndkLatestMajorVersion" }).Split(';')[1]
 
-# Android NDK root path.
-$ndkRoot = "$sdkRoot\ndk-bundle"
-# This changes were added due to incompatibility with android ndk-bundle (ndk;22.0.7026061).
-# Link issue virtual-environments: https://github.com/actions/virtual-environments/issues/2481
-# Link issue xamarin-android: https://github.com/xamarin/xamarin-android/issues/5526
-New-Item -Path $ndkRoot -ItemType SymbolicLink -Value "$sdkRoot\ndk\$ndkDefaultVersion"
-
-if (Test-Path $ndkRoot) {
-    setx ANDROID_HOME $sdkRoot /M
-    setx ANDROID_SDK_ROOT $sdkRoot /M
-    setx ANDROID_NDK_HOME $ndkRoot /M
-    setx ANDROID_NDK_PATH $ndkRoot /M
-    setx ANDROID_NDK_ROOT $ndkRoot /M
-    (Get-Content -Encoding UTF8 "${ndkRoot}\ndk-build.cmd").replace('%~dp0\build\ndk-build.cmd','"%~dp0\build\ndk-build.cmd"')|Set-Content -Encoding UTF8 "${ndkRoot}\ndk-build.cmd"
-} else {
-    Write-Host "Default NDK $ndkDefaultVersion is not installed at path $ndkRoot"
-    exit 1
-}
+# Create env variables
+setx ANDROID_HOME $sdkRoot /M
+setx ANDROID_SDK_ROOT $sdkRoot /M
 
 $ndkLatestPath = "$sdkRoot\ndk\$ndkLatestVersion"
 if (Test-Path $ndkLatestPath) {

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -173,7 +173,7 @@ function Get-AndroidNdkVersions {
 function Build-AndroidEnvironmentTable {
     $androidVersions = Get-Item env:ANDROID_*
 
-    $shoulddResolveLink = 'ANDROID_NDK_PATH', 'ANDROID_NDK_HOME', 'ANDROID_NDK_ROOT', 'ANDROID_NDK_LATEST_HOME'
+    $shoulddResolveLink = 'ANDROID_NDK_LATEST_HOME'
     return $androidVersions | Sort-Object -Property Name | ForEach-Object {
         [PSCustomObject] @{
             "Name" = $_.Name

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -164,21 +164,14 @@ function Get-AndroidNdkVersions {
         [object] $PackageInfo
     )
 
-    $ndkLinkTarget = (Get-Item $env:ANDROID_NDK_HOME).Target
-    $ndkDefaultFullVersion = Split-Path -Path $ndkLinkTarget -Leaf
-
     $versions = $packageInfo | Where-Object { $_ -Match "ndk;" } | ForEach-Object {
-        $version = (Split-TableRowByColumns $_)[1]
-        if ($version -eq $ndkDefaultFullVersion) {
-            $version += " (default)"
-        }
-        $version
+        (Split-TableRowByColumns $_)[1]
     }
     return ($versions -Join "<br>")
 }
 
 function Build-AndroidEnvironmentTable {
-    $androidVersions = Get-Item env:ANDROID_*	
+    $androidVersions = Get-Item env:ANDROID_*
 
     $shoulddResolveLink = 'ANDROID_NDK_PATH', 'ANDROID_NDK_HOME', 'ANDROID_NDK_ROOT', 'ANDROID_NDK_LATEST_HOME'
     return $androidVersions | Sort-Object -Property Name | ForEach-Object {

--- a/images/win/scripts/Tests/Android.Tests.ps1
+++ b/images/win/scripts/Tests/Android.Tests.ps1
@@ -96,11 +96,5 @@ Describe "Android SDK" {
         It "NDK <ndkPackage> is installed" -TestCases $ndkPackagesTestCases {
             "$installedPackages" | Should -Match "ndk;$ndkPackage"
         }
-
-        It "ndk-bundle points to the default NDK version" -TestCases @{ ndkDefaultVersion = $ndkDefaultFullVersion } {
-            $ndkLinkTarget = (Get-Item $env:ANDROID_NDK_HOME).Target
-            $ndkVersion = Split-Path -Path $ndkLinkTarget -Leaf
-            $ndkVersion | Should -BeExactly $ndkDefaultVersion
-        }
     }
 }

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -183,7 +183,6 @@
             "patcher;v4"
         ],
         "ndk": {
-            "default": "23",
             "versions": [
                 "21", "23", "24"
             ]

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -153,7 +153,6 @@
             "patcher;v4"
         ],
         "ndk": {
-            "default": "23",
             "versions": [
                 "21", "23", "24"
             ]


### PR DESCRIPTION
# Description
ndk-bundle was explicitly marked as "Obsolete" by Google and no one should be using it anymore. The current symlink creation process breaks the Android SDK package manager. More details can be found here https://github.com/actions/virtual-environments/issues/2689#issuecomment-1172129050

#### Related issue:
https://github.com/actions/virtual-environments/issues/5879

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
