### PR TITLE
Remove ProBITools.MicrosoftAnalysisServicesModelingProjects2022

### DIFF
--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -276,8 +276,7 @@
         "vsix": [
             "VisualStudioClient.MicrosoftVisualStudio2022InstallerProjects",
             "WixToolset.WixToolsetVisualStudio2022Extension",
-            "ProBITools.MicrosoftReportProjectsforVisualStudio2022",
-            "ProBITools.MicrosoftAnalysisServicesModelingProjects2022"
+            "ProBITools.MicrosoftReportProjectsforVisualStudio2022"
         ]
     },
     "docker": {


### PR DESCRIPTION
# Description
Unable to exit VS via X or File | Exit after running `devenv /RootSuffix Exp /ResetSettings General.vssettings /Command File.Exit` - will be fixed in AS 3.0.4

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/4004

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
