### PR TITLE
[Windows] Add dotfuscator component to VS2022

### DIFF
--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -179,6 +179,7 @@
         "edition" : "Enterprise",
         "channel": "release",
         "workloads": [
+            "Component.Dotfuscator",
             "Component.Linux.CMake",
             "Component.UnityEngine.x64",
             "Component.Unreal.Android",


### PR DESCRIPTION
# Description
Dotfuscator comes installed with VS in the windows-2019 image, but not in the windows-2022 image. Installation time in runtime varies from 4 to 6 minutes so better have it preinstalled.

#### Related issue:
https://github.com/actions/virtual-environments/issues/5936

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
