### PR TITLE
Add windows/server docker image for Server2022

### DIFF
--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -300,6 +300,7 @@
     },
     "docker": {
         "images": [
+            "mcr.microsoft.com/windows/server:ltsc2022",
             "mcr.microsoft.com/windows/servercore:ltsc2022",
             "mcr.microsoft.com/windows/nanoserver:ltsc2022",
             "mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2022",


### PR DESCRIPTION
# Description
This pr adds **Windows Server** docker image for Server2022
[**Windows** - contains the full set of Windows APIs and system services (minus server roles).
**Windows Server** - contains the full set of Windows APIs and system services.
**Windows Server Core** - a smaller image that contains a subset of the Windows Server APIs–namely the full .NET framework. It also includes most but not all server roles (for example Fax Server is not included).
**Nano Server** - the smallest Windows Server image and includes support for the .NET Core APIs and some server roles.](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/container-base-images)

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
