### PR TITLE
[Packer] Add azure_tag

### DIFF
--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -4,6 +4,11 @@ variable "allowed_inbound_ip_addresses" {
   default = []
 }
 
+variable "azure_tag" {
+  type    = map(string)
+  default = {}
+}
+
 variable "build_resource_group_name" {
   type    = string
   default = "${env("BUILD_RESOURCE_GROUP_NAME")}"
@@ -164,6 +169,14 @@ source "azure-arm" "build_vhd" {
   virtual_network_resource_group_name    = "${var.virtual_network_resource_group_name}"
   virtual_network_subnet_name            = "${var.virtual_network_subnet_name}"
   vm_size                                = "${var.vm_size}"
+
+  dynamic "azure_tag" {
+    for_each = var.azure_tag
+    content {
+      name = azure_tag.key
+      value = azure_tag.value
+    }
+  }
 }
 
 build {


### PR DESCRIPTION
# Description
https://www.packer.io/plugins/builders/azure/arm#azure_tags

> azure_tag ([]{name string, value string}) - Same as azure_tags but defined as a singular repeatable block containing a name and a value field. In HCL2 mode the dynamic_block will allow you to create those programatically.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/4056

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
