### PR TITLE
[Ubuntu] Add mono package to ubuntu 22

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -88,6 +88,11 @@ function Get-MsbuildVersion {
     return "MSBuild $msbuildVersion (from $msbuildPath)"
 }
 
+function Get-NuGetVersion {
+    $nugetVersion = nuget help | Select-Object -First 1 | Take-OutputPart -Part 2
+    return "NuGet $nugetVersion"
+}
+
 function Get-NodeVersion {
     $nodeVersion = $(node --version).Substring(1)
     return "Node $nodeVersion"

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -42,6 +42,8 @@ $runtimesList = @(
     (Get-DashVersion),
     (Get-CPPVersions),
     (Get-FortranVersions),
+    (Get-MsbuildVersion),
+    (Get-MonoVersion),
     (Get-NodeVersion),
     (Get-PerlVersion),
     (Get-PythonVersion),
@@ -56,8 +58,6 @@ $runtimesList = @(
 
 if ((Test-IsUbuntu18) -or (Test-IsUbuntu20)) {
     $runtimesList += @(
-        (Get-MsbuildVersion),
-        (Get-MonoVersion),
         (Get-ErlangVersion),
         (Get-ErlangRebar3Version),
         (Get-SwiftVersion)
@@ -73,6 +73,7 @@ $packageManagementList = @(
     (Get-CpanVersion),
     (Get-GemVersion),
     (Get-MinicondaVersion),
+    (Get-NuGetVersion),
     (Get-HelmVersion),
     (Get-NpmVersion),
     (Get-YarnVersion),

--- a/images/linux/scripts/installers/mono.sh
+++ b/images/linux/scripts/installers/mono.sh
@@ -4,7 +4,14 @@
 ##  Desc:  Installs Mono
 ################################################################################
 
+source $HELPER_SCRIPTS/os.sh
+
 LSB_CODENAME=$(lsb_release -cs)
+
+# There are no packages for Ubuntu 22 in the repo, but developers confirmed that packages from Ubuntu 20 should work
+if isUbuntu22; then
+    LSB_CODENAME="focal"
+fi
 
 # Test to see if the software in question is already installed, if not install it
 # wget "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF" -O out && sudo apt-key add out && rm out

--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -168,7 +168,7 @@ Describe "gfortran" {
     }
 }
 
-Describe "Mono" -Skip:(Test-IsUbuntu22) {
+Describe "Mono" {
     It "mono" {
         "mono --version" | Should -ReturnZeroExitCode
     }

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -300,6 +300,7 @@ build {
                         "${path.root}/scripts/installers/oc.sh",
                         "${path.root}/scripts/installers/leiningen.sh",
                         "${path.root}/scripts/installers/miniconda.sh",
+                        "${path.root}/scripts/installers/mono.sh",
                         "${path.root}/scripts/installers/kotlin.sh",
                         "${path.root}/scripts/installers/mysql.sh",
                         "${path.root}/scripts/installers/sqlpackage.sh",


### PR DESCRIPTION
# Description
Mono maintainers confirmed that Ubuntu 20 packages will work for Ubuntu 22 and there is no ETA for native Ubuntu 22 packages so let's stick to those ones.
Also, this PR adds Nuget to the software readme as we somehow missed it before.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/4066

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
