### PR TITLE
[Windows] Bypass Windows Defender false alarm

### DIFF
--- a/images/win/scripts/Installers/Configure-Antivirus.ps1
+++ b/images/win/scripts/Installers/Configure-Antivirus.ps1
@@ -1,25 +1,34 @@
 Write-Host "Disable Windows Defender..."
-Set-MpPreference -DisableArchiveScanning $true
-Set-MpPreference -DisableAutoExclusions  $true
-Set-MpPreference -DisableBehaviorMonitoring $true
-Set-MpPreference -DisableBlockAtFirstSeen $true
-Set-MpPreference -DisableCatchupFullScan $true
-Set-MpPreference -DisableCatchupQuickScan $true
-Set-MpPreference -DisableIntrusionPreventionSystem $true
-Set-MpPreference -DisableIOAVProtection $true
-Set-MpPreference -DisablePrivacyMode $true
-Set-MpPreference -DisableScanningNetworkFiles $true
-Set-MpPreference -DisableScriptScanning $true
-Set-MpPreference -MAPSReporting 0
-Set-MpPreference -PUAProtection 0
-Set-MpPreference -SignatureDisableUpdateOnStartupWithoutEngine $true
-Set-MpPreference -SubmitSamplesConsent 2
-Set-MpPreference -ScanAvgCPULoadFactor 5 -ExclusionPath "D:\", "C:\"
-Set-MpPreference -DisableRealtimeMonitoring $true
+$avPreference = @(
+    @{DisableArchiveScanning = $true}
+    @{DisableAutoExclusions = $true}
+    @{DisableBehaviorMonitoring = $true}
+    @{DisableBlockAtFirstSeen = $true}
+    @{DisableCatchupFullScan = $true}
+    @{DisableCatchupQuickScan = $true}
+    @{DisableIntrusionPreventionSystem = $true}
+    @{DisableIOAVProtection = $true}
+    @{DisablePrivacyMode = $true}
+    @{DisableScanningNetworkFiles = $true}
+    @{DisableScriptScanning = $true}
+    @{MAPSReporting = 0}
+    @{PUAProtection = 0}
+    @{SignatureDisableUpdateOnStartupWithoutEngine = $true}
+    @{SubmitSamplesConsent = 2}
+    @{ScanAvgCPULoadFactor = 5; ExclusionPath = @("D:\", "C:\")}
+    @{DisableRealtimeMonitoring = $true}
+)
 
 if (-not (Test-IsWin16)) {
-    Set-MpPreference -EnableControlledFolderAccess Disable
-    Set-MpPreference -EnableNetworkProtection Disabled
+    $avPreference += @(
+        @{EnableControlledFolderAccess = "Disable"}
+        @{EnableNetworkProtection = "Disabled"}
+    )
+}
+
+$avPreference | Foreach-Object {
+    $avParams = $_
+    Set-MpPreference @avParams
 }
 
 Write-Host "Disable Windows Defender scheduled tasks"


### PR DESCRIPTION
# Description
Windows Defender marks the Configure-Antivirus.ps1 script as a virus.
![image](https://user-images.githubusercontent.com/47745270/180845712-399abf18-804a-4b22-b9db-12453e008750.png)

#### Related issue:
https://github.com/actions/virtual-environments/discussions/5964

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
