### PR TITLE
[macOS] Create symlink for mongodb@5.0

### DIFF
--- a/images/macos/provision/core/mongodb.sh
+++ b/images/macos/provision/core/mongodb.sh
@@ -11,4 +11,8 @@ versionToInstall=$(brew search --formulae /mongodb-community@$toolsetVersion/ | 
 echo "Installing mongodb $versionToInstall"
 brew_smart_install "$versionToInstall"
 
+if ! which mongo ; then
+    brew link "$versionToInstall"
+fi
+
 invoke_tests "Databases" "MongoDB"


### PR DESCRIPTION
# Description

mongodb-community@5.0 is keg-only, which means it was not symlinked into /usr/local:
```
vsphere-clone:   [-] mongo 207ms (170ms|37ms)
vsphere-clone:    CommandNotFoundException: The term 'mongo' is not recognized as a name of a cmdlet, function, script file, or executable program.
vsphere-clone:    Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
vsphere-clone:    at <ScriptBlock>, /Users/runner/image-generation/tests/Databases.Tests.ps1:7
```


#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/4089

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
