### PR TITLE
[Windows] Add ndk-related environment variables

### DIFF
--- a/images/win/scripts/Installers/Install-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Install-AndroidSDK.ps1
@@ -109,6 +109,7 @@ Install-AndroidSDKPackages -AndroidSDKManagerPath $sdkManager `
 
 # NDKs
 $ndkMajorVersions = $androidToolset.ndk.versions
+$ndkDefaultMajorVersion = $androidToolset.ndk.default
 $ndkLatestMajorVersion = $ndkMajorVersions | Select-Object -Last 1
 
 $androidNDKs = $ndkMajorVersions | Foreach-Object {
@@ -120,10 +121,16 @@ Install-AndroidSDKPackages -AndroidSDKManagerPath $sdkManager `
                 -AndroidPackages $androidNDKs
 
 $ndkLatestVersion = ($androidNDKs | Where-Object { $_ -match "ndk;$ndkLatestMajorVersion" }).Split(';')[1]
+$ndkDefaultVersion = ($androidNDKs | Where-Object { $_ -match "ndk;$ndkDefaultMajorVersion" }).Split(';')[1]
+$ndkRoot = "$sdkRoot\ndk\$ndkDefaultVersion"
 
 # Create env variables
 setx ANDROID_HOME $sdkRoot /M
 setx ANDROID_SDK_ROOT $sdkRoot /M
+# ANDROID_NDK, ANDROID_NDK_HOME, and ANDROID_NDK_LATEST_HOME variables should be set as many customer builds depend on them https://github.com/actions/virtual-environments/issues/5879
+setx ANDROID_NDK $ndkRoot /M
+setx ANDROID_NDK_HOME $ndkRoot /M
+setx ANDROID_NDK_ROOT $ndkRoot /M
 
 $ndkLatestPath = "$sdkRoot\ndk\$ndkLatestVersion"
 if (Test-Path $ndkLatestPath) {

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Android.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Android.psm1
@@ -164,8 +164,14 @@ function Get-AndroidNdkVersions {
         [object] $PackageInfo
     )
 
+    $ndkDefaultFullVersion = Get-ChildItem $env:ANDROID_NDK_HOME -Name
+
     $versions = $packageInfo | Where-Object { $_ -Match "ndk;" } | ForEach-Object {
-        (Split-TableRowByColumns $_)[1]
+        $version = (Split-TableRowByColumns $_)[1]
+        if ($version -eq $ndkDefaultFullVersion) {
+            $version += " (default)"
+        }
+        $version
     }
     return ($versions -Join "<br>")
 }
@@ -173,7 +179,7 @@ function Get-AndroidNdkVersions {
 function Build-AndroidEnvironmentTable {
     $androidVersions = Get-Item env:ANDROID_*
 
-    $shoulddResolveLink = 'ANDROID_NDK_LATEST_HOME'
+    $shoulddResolveLink = 'ANDROID_NDK', 'ANDROID_NDK_HOME', 'ANDROID_NDK_ROOT', 'ANDROID_NDK_LATEST_HOME'
     return $androidVersions | Sort-Object -Property Name | ForEach-Object {
         [PSCustomObject] @{
             "Name" = $_.Name

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -184,6 +184,7 @@
             "patcher;v4"
         ],
         "ndk": {
+            "default": "25",
             "versions": [
                 "23", "24", "25"
             ]

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -154,6 +154,7 @@
             "patcher;v4"
         ],
         "ndk": {
+            "default": "25",
             "versions": [
                 "23", "24", "25"
             ]


### PR DESCRIPTION
# Description
It turned out some of the NDK-related variables are required by customers' projects ([like openssl](https://github.com/openssl/openssl/blob/master/Configurations/15-android.conf#L27)). We need to define all three variables pointed to the latest LTS NDK (default one) to stay on the safe side — ` 'ANDROID_NDK', 'ANDROID_NDK_HOME', 'ANDROID_NDK_ROOT'`

#### Related issue:
https://github.com/actions/virtual-environments/issues/5879

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
