### PR TITLE
[windows] Add exe installation of MicrosoftAnalysisServices Visual Studio extension

### DIFF
--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -249,6 +249,11 @@ function Get-VsixExtenstionFromMarketplace {
             $fileName = "Microsoft.DataTools.AnalysisServices.vsix"
             $downloadUri = "https://download.microsoft.com/download/c/8/9/c896a7f2-d0fd-45ac-90e6-ff61f67523cb/Microsoft.DataTools.AnalysisServices.vsix"
         }
+        # Starting from version 4.1 SqlServerIntegrationServicesProjects extension is distributed as exe file
+        "SSIS.SqlServerIntegrationServicesProjects" {
+            $fileName = "Microsoft.DataTools.IntegrationServices.exe"
+            $downloadUri = $assetUri + "/" + $fileName
+        }
     }
 
     return [PSCustomObject] @{

--- a/images/win/scripts/Installers/Install-Vsix.ps1
+++ b/images/win/scripts/Installers/Install-Vsix.ps1
@@ -14,7 +14,7 @@ $vsVersion = $toolset.visualStudio.Version
 $vsixPackagesList | ForEach-Object {
     # Retrieve cdn endpoint to avoid HTTP error 429 https://github.com/actions/virtual-environments/issues/3074
     $vsixPackage = Get-VsixExtenstionFromMarketplace -ExtensionMarketPlaceName $_
-    if ($vsixPackage.FileName -match ".*\.vsix") {
+    if ($vsixPackage.FileName.EndsWith(".vsix")) {
         Install-VsixExtension -Url $vsixPackage.DownloadUri -Name $vsixPackage.FileName -VSversion $vsVersion
     } else {
         $argumentList = ('/install', '/quiet', '/norestart')

--- a/images/win/scripts/Installers/Install-Vsix.ps1
+++ b/images/win/scripts/Installers/Install-Vsix.ps1
@@ -14,7 +14,12 @@ $vsVersion = $toolset.visualStudio.Version
 $vsixPackagesList | ForEach-Object {
     # Retrieve cdn endpoint to avoid HTTP error 429 https://github.com/actions/virtual-environments/issues/3074
     $vsixPackage = Get-VsixExtenstionFromMarketplace -ExtensionMarketPlaceName $_
-    Install-VsixExtension -Url $vsixPackage.DownloadUri -Name $vsixPackage.FileName -VSversion $vsVersion
+    if ($vsixPackage.FileName -match ".*\.vsix") {
+        Install-VsixExtension -Url $vsixPackage.DownloadUri -Name $vsixPackage.FileName -VSversion $vsVersion
+    } else {
+        $argumentList = ('/install', '/quiet', '/norestart')
+        Install-Binary -Url $vsixPackage.DownloadUri -Name $vsixPackage.FileName -ArgumentList $argumentList
+    }
 }
 
 Invoke-PesterTests -TestFile "Vsix"


### PR DESCRIPTION
# Description
Starting from version 4.1.2 [SSIS.SqlServerIntegrationServicesProjects Visual studio extenstion](https://marketplace.visualstudio.com/items?itemName=SSIS.SqlServerIntegrationServicesProjects) is distributed via executable file rather than vsix one. This PR adds the ability to install the new extension version.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/4104

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
