### PR TITLE
Do not remove release doc refs manually

### DIFF
--- a/.github/workflows/merge_pull_request.yml
+++ b/.github/workflows/merge_pull_request.yml
@@ -46,14 +46,3 @@ jobs:
             pull_number: ${{ github.event.client_payload.PullRequestNumber }},
             merge_method: "squash"
           })
-
-    - name: Delete docs branch ${{ github.event.client_payload.ReleaseBranchName }}-docs
-      uses: actions/github-script@v2
-      with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          github.git.deleteRef({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            ref: "heads/${{ github.event.client_payload.ReleaseBranchName }}-docs"
-          })


### PR DESCRIPTION
# Description

Given that now it is handled by the repository settings we should not do it via a workflow file, otherwise we experience an error.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
