### PR TITLE
[Windows] Disable mongodb service by default

### DIFF
--- a/images/win/scripts/Installers/Install-MongoDB.ps1
+++ b/images/win/scripts/Installers/Install-MongoDB.ps1
@@ -3,11 +3,19 @@
 ##  Desc:  Install MongoDB
 ####################################################################################
 
+# Install mongodb package
 $toolsetVersion = (Get-ToolsetContent).mongodb.version
 $latestChocoPackage = Get-LatestChocoPackageVersion -TargetVersion $toolsetVersion -PackageName "mongodb"
 Choco-Install -PackageName mongodb -ArgumentList "--version=$latestChocoPackage"
-$mongoPath = (Get-CimInstance Win32_Service -Filter "Name LIKE 'mongodb'").PathName
+
+# Add mongodb to the PATH
+$mongodbService = "mongodb"
+$mongoPath = (Get-CimInstance Win32_Service -Filter "Name LIKE '$mongodbService'").PathName
 $mongoBin = Split-Path -Path $mongoPath.split('"')[1]
 Add-MachinePathItem "$mongoBin"
+
+# Stop and disable mongodb service
+Stop-Service -Name $mongodbService
+Set-Service $mongodbService -StartupType Disabled
 
 Invoke-PesterTests -TestFile "Databases" -TestName "MongoDB"

--- a/images/win/scripts/Tests/Databases.Tests.ps1
+++ b/images/win/scripts/Tests/Databases.Tests.ps1
@@ -10,7 +10,7 @@ Describe "MongoDB" {
     }
 
     Context "Service" {
-        $mongoService = Get-Service -Name mongodb
+        $mongoService = Get-Service -Name mongodb -ErrorAction Ignore
         $mongoServiceTests = @{
             Name = $mongoService.Name
             Status = $mongoService.Status

--- a/images/win/scripts/Tests/Databases.Tests.ps1
+++ b/images/win/scripts/Tests/Databases.Tests.ps1
@@ -1,10 +1,29 @@
 Describe "MongoDB" {
-    It "<ToolName>" -TestCases @(
-        @{ ToolName = "mongo" }
-        @{ ToolName = "mongod" }
-    ) {
-        $toolsetVersion = (Get-ToolsetContent).mongodb.version
-        (&$ToolName --version)[2].Split('"')[-2] | Should -BeLike "$toolsetVersion*"
+    Context "Version" {
+        It "<ToolName>" -TestCases @(
+            @{ ToolName = "mongo" }
+            @{ ToolName = "mongod" }
+        ) {
+            $toolsetVersion = (Get-ToolsetContent).mongodb.version
+            (&$ToolName --version)[2].Split('"')[-2] | Should -BeLike "$toolsetVersion*"
+        }
+    }
+
+    Context "Service" {
+        $mongoService = Get-Service -Name mongodb
+        $mongoServiceTests = @{
+            Name = $mongoService.Name
+            Status = $mongoService.Status
+            StartType = $mongoService.StartType
+        }
+
+        It "<Name> service is stopped" -TestCases $mongoServiceTests {
+            $Status | Should -Be "Stopped"
+        }
+
+        It "<Name> service is disabled" -TestCases $mongoServiceTests {
+            $StartType | Should -Be "Disabled"
+        }
     }
 }
 


### PR DESCRIPTION
# Description
Disable mongodb service by default on Windows Server 2019/2022.

#### Related issue:
https://github.com/actions/virtual-environments/issues/5949

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
