### PR TITLE
[Windows] Wait for mongodb service running

### DIFF
--- a/images/win/scripts/Installers/Install-MongoDB.ps1
+++ b/images/win/scripts/Installers/Install-MongoDB.ps1
@@ -14,6 +14,10 @@ $mongoPath = (Get-CimInstance Win32_Service -Filter "Name LIKE '$mongodbService'
 $mongoBin = Split-Path -Path $mongoPath.split('"')[1]
 Add-MachinePathItem "$mongoBin"
 
+# Wait for mongodb service running
+$svc = Get-Service $mongodbService
+$svc.WaitForStatus('Running','00:01:00')
+
 # Stop and disable mongodb service
 Stop-Service -Name $mongodbService
 Set-Service $mongodbService -StartupType Disabled


### PR DESCRIPTION
# Description
In slow environments we can get an error "Service 'MongoDB Server (MongoDB) (MongoDB)' cannot be stopped due to the following error: Cannot stop MongoDB service on computer '.'" due to delay start.

#### Related issue:
https://github.com/actions/virtual-environments-internal/issues/4159

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
