### PR TITLE
[Windows] Update PowerShell Az Module to 9.0.1

### DIFF
--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -127,7 +127,7 @@
             "name": "az",
             "url" : "https://raw.githubusercontent.com/Azure/az-ps-module-versions/main/versions-manifest.json",
             "versions": [
-                "7.5.0"
+                "9.0.1"
             ],
             "zip_versions": [
                 "1.0.0",

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -119,7 +119,7 @@
             "name": "az",
             "url" : "https://raw.githubusercontent.com/Azure/az-ps-module-versions/main/versions-manifest.json",
             "versions": [
-                "7.5.0"
+                "9.0.1"
             ],
             "zip_versions": [
                 "6.6.0"


### PR DESCRIPTION
# Description
Update installed Powershell Az Module, from 7.5.0 to 9.0.1.
The 7.5.0 is seven months old, and version 9.x is out (1 month ago).
At the moment 9.1.1 is available, but because it's less than 1 day old (at the moment of writing) I prefer to pin to 9.0.1 which has been released one month ago.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
