### PR TITLE
Fix ip address whiltelist value for hcl2 templates

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -264,7 +264,7 @@ Function GenerateResourcesAndImage {
         
         if ($builderScriptPath.Contains("pkr.hcl")) {
             if ($AgentIp) {
-                $AgentIp = '[ \"{0}\" ]' -f $AgentIp
+                $AgentIp = '[ "{0}" ]' -f $AgentIp
             } else {
                 $AgentIp = "[]"
             }


### PR DESCRIPTION
# Description
The value that is used for allowed_inbound_ip_addresses argument with HCL2 template is wrong so GenerateResourcesAndImage function fails when RestrictToAgentIpAddress switch is on and ImageType is Ubuntu2204. This request is to fix the value.

#### Related issue: https://github.com/actions/runner-images/issues/7143

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
