### PR TITLE
[Ubuntu] dearmor gpg key for google-cloud-sdk

### DIFF
--- a/images/linux/scripts/installers/google-cloud-sdk.sh
+++ b/images/linux/scripts/installers/google-cloud-sdk.sh
@@ -8,7 +8,7 @@ REPO_URL="https://packages.cloud.google.com/apt"
 
 # Install the Google Cloud SDK
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] $REPO_URL cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list
-wget -q https://packages.cloud.google.com/apt/doc/apt-key.gpg -O /usr/share/keyrings/cloud.google.gpg
+wget -qO- https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor > /usr/share/keyrings/cloud.google.gpg
 apt-get update -y
 apt-get install -y google-cloud-sdk
 


### PR DESCRIPTION
# Description
Change the way of setting up gpg key from packages.cloud.google.com
It looks like the key needs to be de-armored now.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
