### PR TITLE
Prevent Install-WindowsUpdates.ps1 from failing

### DIFF
--- a/images/windows/scripts/build/Install-WindowsUpdates.ps1
+++ b/images/windows/scripts/build/Install-WindowsUpdates.ps1
@@ -35,4 +35,4 @@ function Install-WindowsUpdates {
 Install-WindowsUpdates
 
 # Create complete windows update file
-New-Item -Path $env:windir -Name WindowsUpdateDone.txt -ItemType File | Out-Null
+New-Item -Path $env:windir -Name WindowsUpdateDone.txt -ItemType File -Force | Out-Null


### PR DESCRIPTION
# Description
Prevent the script `Install-WindowsUpdates.ps1` from failing if there is already a `WindowsUpdateDone.txt` file create from a previous execution.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
