### PR TITLE
Add required plugin section for ubuntu22 and ubuntu-minimal

### DIFF
--- a/images/ubuntu/templates/ubuntu-22.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-22.04.pkr.hcl
@@ -1,3 +1,12 @@
+packer {
+  required_plugins {
+    azure = {
+      source  = "github.com/hashicorp/azure"
+      version = "~> 2"
+    }
+  }
+}
+
 locals {
   managed_image_name = var.managed_image_name != "" ? var.managed_image_name : "packer-${var.image_os}-${var.image_version}"
 }

--- a/images/ubuntu/templates/ubuntu-minimal.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-minimal.pkr.hcl
@@ -1,3 +1,12 @@
+packer {
+  required_plugins {
+    azure = {
+      source  = "github.com/hashicorp/azure"
+      version = "~> 2"
+    }
+  }
+}
+
 locals {
   image_os = "ubuntu22"
 


### PR DESCRIPTION
# Description
Adds the required plugin block for ubuntu22 and ubuntu-minimal so the azure plugin is installed on `packer init`. I'm not 100% sure the version constraint is the right one for you folks, but that can easily be changed.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: #8989 

## Check list
- [x] Related issue / work item is attached
- [x] Changes are tested and related VM images are successfully generated
