### PR TITLE
[Ubuntu] fix dotnet installation & scripts sorcing on 24.04

### DIFF
--- a/images/ubuntu/scripts/build/configure-apt.sh
+++ b/images/ubuntu/scripts/build/configure-apt.sh
@@ -4,6 +4,8 @@
 ##  Desc:  Configure apt, install jq and apt-fast packages.
 ################################################################################
 
+source $HELPER_SCRIPTS/os.sh
+
 # Stop and disable apt-daily upgrade services;
 systemctl stop apt-daily.timer
 systemctl disable apt-daily.timer

--- a/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
@@ -183,13 +183,18 @@ build {
     inline          = ["mkdir ${var.image_folder}", "chmod 777 ${var.image_folder}"]
   }
 
+  provisioner "file" {
+    destination = "${var.helper_script_folder}"
+    source      = "${path.root}/../scripts/helpers"
+  }
+
   provisioner "shell" {
     execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     script          = "${path.root}/../scripts/build/configure-apt-mock.sh"
   }
 
   provisioner "shell" {
-    environment_vars = ["DEBIAN_FRONTEND=noninteractive"]
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}","DEBIAN_FRONTEND=noninteractive"]
     execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts          = [
       "${path.root}/../scripts/build/install-ms-repos.sh",
@@ -201,11 +206,6 @@ build {
   provisioner "shell" {
     execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     script          = "${path.root}/../scripts/build/configure-limits.sh"
-  }
-
-  provisioner "file" {
-    destination = "${var.helper_script_folder}"
-    source      = "${path.root}/../scripts/helpers"
   }
 
   provisioner "file" {

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -219,13 +219,9 @@
     ],
     "dotnet": {
         "aptPackages": [
-            "dotnet-sdk-6.0",
-            "dotnet-sdk-7.0",
             "dotnet-sdk-8.0"
         ],
         "versions": [
-            "6.0",
-            "7.0",
             "8.0"
         ],
         "tools": [


### PR DESCRIPTION
# Description


There seems to be dependency hell from the Microsoft <-> Canonical repos which prevents us from installing non-canonical versions of dotnet-sdk (literally .NET 7 & .NET 8), once you put both of them at hold with `apt-mark` you can see the mismatch as shown in the screenshot below:

![image](https://github.com/actions/runner-images/assets/88318005/99772d18-35af-43e3-8c7d-7074f1b0419e)

We are unable to resolve this on our end, but might be Microsoft will ever add .NET 8 to their repo and all the dependencies will eventually become consistent.

Apart from that we should fix the sorting issue so we could use the `is_UbuntuXX` from the start of the packer template (previously it has never been used so early in the build process so some modifications were needed).


#### Related issue: https://github.com/actions/runner-images/issues/9902

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
