### PR TITLE
[Ubuntu, Windows] Add new android NDK and CMake

### DIFF
--- a/images/ubuntu/toolsets/toolset-2004.json
+++ b/images/ubuntu/toolsets/toolset-2004.json
@@ -88,9 +88,9 @@
         "addon_list": [
         ],
         "additional_tools": [
-            "cmake;3.10.2.4988404",
             "cmake;3.18.1",
-            "cmake;3.22.1"
+            "cmake;3.22.1",
+            "cmake;3.31.5"
         ],
         "ndk": {
             "default": "27",

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -85,9 +85,9 @@
         "addon_list": [
         ],
         "additional_tools": [
-            "cmake;3.10.2.4988404",
             "cmake;3.18.1",
-            "cmake;3.22.1"
+            "cmake;3.22.1",
+            "cmake;3.31.5"
         ],
         "ndk": {
             "default": "27",

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -81,11 +81,12 @@
         "addon_list": [
         ],
         "additional_tools": [
+            "cmake;3.31.5"
         ],
         "ndk": {
             "default": "27",
             "versions": [
-                "26", "27"
+                "26", "27", "28"
             ]
         }
     },

--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -143,14 +143,14 @@
             "addon-google_apis-google-21"
         ],
         "additional_tools": [
-            "cmake;3.10.2.4988404",
             "cmake;3.18.1",
-            "cmake;3.22.1"
+            "cmake;3.22.1",
+            "cmake;3.31.5"
         ],
         "ndk": {
             "default": "27",
             "versions": [
-                "26" , "27"
+                "26" , "27", "28"
             ]
         }
     },

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -139,12 +139,13 @@
         "addons": [],
         "additional_tools": [
             "cmake;3.18.1",
-            "cmake;3.22.1"
+            "cmake;3.22.1",
+            "cmake;3.31.5"
         ],
         "ndk": {
             "default": "27",
             "versions": [
-                "26", "27"
+                "26", "27", "28"
             ]
         }
     },

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -96,12 +96,13 @@
         "addons": [],
         "additional_tools": [
             "cmake;3.22.1",
-            "cmake;3.30.5"
+            "cmake;3.30.5",
+            "cmake;3.31.5"
         ],
         "ndk": {
             "default": "27",
             "versions": [
-                "26", "27"
+                "26", "27", "28"
             ]
         }
     },


### PR DESCRIPTION
# Description
This pull request introduces the following changes:
- `cmake;3.10.2.4988404`  - will be deleted from the Ubuntu 20.04, Ubuntu 22.04 and Windows 2019 images.
- `cmake;3.31.5` - will be added to all Ubuntu and Windows images.
- `r28 android NDK` - will be added to all Windows and Ubuntu 24.04 images. Unfortunately we cannot add `r28 NDK` to Ubuntu 20.04 and Ubuntu 22.04 due to lack of disk space. 

#### Related issue:
- https://github.com/actions/runner-images/issues/11576
- https://github.com/actions/runner-images/issues/11111

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
