### PR TITLE
[ubuntu] Fix fwupd removal test by correctly handling systemctl output

### DIFF
--- a/images/ubuntu/scripts/tests/System.Tests.ps1
+++ b/images/ubuntu/scripts/tests/System.Tests.ps1
@@ -9,7 +9,12 @@ Describe "Disk free space" -Skip:(-not [String]::IsNullOrEmpty($env:AGENT_NAME) 
 
 Describe "fwupd removed" {
     It "Is not present on box" {
-        $systemctlOutput = & systemctl list-unit-files fwupd-refresh.timer
-        $systemctlOutput | Should -Match "masked"
+        $systemctlOutput = & systemctl list-unit-files fwupd-refresh.timer --no-legend
+            if ($systemctlOutput) {
+                $systemctlOutput | Should -Match "masked"
+            } else {
+                $true | Should -Be $true
+            }
+
     }
 }


### PR DESCRIPTION
# Description
Fixed the fwupd removal test by correctly handling systemctl output formatting issues. Ensured reliability by addressing mismatches and improving verification for fwupd-refresh.timer.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
