### PR TITLE
[Windows] Fix PowerShell parameter binding error by splitting New-Item commands

### DIFF
--- a/images/windows/templates/windows-2019.pkr.hcl
+++ b/images/windows/templates/windows-2019.pkr.hcl
@@ -261,8 +261,7 @@ build {
 
   provisioner "powershell" {
     inline = [
-      "New-Item -Path '${var.image_folder}' -ItemType Directory -Force",
-      "New-Item -Path '${var.temp_dir}' -ItemType Directory -Force"
+      "New-Item -Path @('${var.image_folder}', '${var.temp_dir}') -ItemType Directory -Force"
     ]
   }
 

--- a/images/windows/templates/windows-2022.pkr.hcl
+++ b/images/windows/templates/windows-2022.pkr.hcl
@@ -261,8 +261,7 @@ build {
 
   provisioner "powershell" {
     inline = [
-      "New-Item -Path '${var.image_folder}' -ItemType Directory -Force",
-      "New-Item -Path '${var.temp_dir}' -ItemType Directory -Force"
+      "New-Item -Path @('${var.image_folder}', '${var.temp_dir}') -ItemType Directory -Force"
     ]
   }
 

--- a/images/windows/templates/windows-2025.pkr.hcl
+++ b/images/windows/templates/windows-2025.pkr.hcl
@@ -261,8 +261,7 @@ build {
 
   provisioner "powershell" {
     inline = [
-      "New-Item -Path '${var.image_folder}' -ItemType Directory -Force",
-      "New-Item -Path '${var.temp_dir}' -ItemType Directory -Force"
+      "New-Item -Path @('${var.image_folder}', '${var.temp_dir}') -ItemType Directory -Force"
     ]
   }
 


### PR DESCRIPTION
# Description

Split the New-Item commands to avoid specifying the -Path parameter multiple times. This resolves the PowerShell parameter binding error encountered during provisioning.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
