### PR TITLE
fix of insalling haskell stack

### DIFF
--- a/images/ubuntu/scripts/build/install-haskell.sh
+++ b/images/ubuntu/scripts/build/install-haskell.sh
@@ -39,6 +39,6 @@ chmod -R 777 $GHCUP_INSTALL_BASE_PREFIX/.ghcup
 ln -s $GHCUP_INSTALL_BASE_PREFIX/.ghcup /etc/skel/.ghcup
 
 # Install the latest stable release of haskell stack
-curl -fsSL https://get.haskellstack.org/ | bash
+ghcup install stack latest
 
 invoke_tests "Haskell"


### PR DESCRIPTION
# Description
Bug fixing.
Fix installing of haskell stack. (error is: get.haskellstack.org: Name or service not known)
First  reason is : get.haskellstack.org now is inaccesible.
Second reason it is better to use previously installed specialized package manager for haskell ghcup.


