### PR TITLE
fix typo

### DIFF
--- a/images/ubuntu/scripts/tests/System.Tests.ps1
+++ b/images/ubuntu/scripts/tests/System.Tests.ps1
@@ -9,7 +9,7 @@ Describe "Disk free space" -Skip:(-not [String]::IsNullOrEmpty($env:AGENT_NAME) 
 
 Describe "fwupd removed" {
     It "Is not present on box" {
-        $systemctlOutput = & systemctl list-unit fwupd-refresh.timer --no-legend
+        $systemctlOutput = & systemctl list-units fwupd-refresh.timer --no-legend
         # When disabled the output looks like this:
         #❯ systemctl list-units fwupd-refresh.timer --no-legend
         #● fwupd-refresh.timer masked failed failed fwupd-refresh.timer


### PR DESCRIPTION
# Description

Fix typo. 'list-unit' is not valid systemctl subcommand, should be 'list-units'.

#### Related issue:

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
