### PR TITLE
Fix disk space issue

### DIFF
--- a/images/ubuntu/templates/variable.ubuntu.pkr.hcl
+++ b/images/ubuntu/templates/variable.ubuntu.pkr.hcl
@@ -96,7 +96,7 @@ variable "private_virtual_network_with_public_ip" {
 }
 variable "os_disk_size_gb" {
   type    = number
-  default = 0
+  default = null
 }
 variable "source_image_version" {
   type    = string

--- a/images/windows/templates/variable.windows.pkr.hcl
+++ b/images/windows/templates/variable.windows.pkr.hcl
@@ -104,7 +104,7 @@ variable "private_virtual_network_with_public_ip" {
 }
 variable "os_disk_size_gb" {
   type    = number
-  default = 0
+  default = null
 }
 variable "source_image_version" {
   type    = string


### PR DESCRIPTION
# Description
This PR updates the default value of `os_disk_size_gb` variable. 
`default=0` here does not mean "empty", it means the Azure default value for the VM disk size.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
