### PR TITLE
Revert "chore: Add ppa candidate repo to install 2.50.1 version of git"

### DIFF
--- a/images/ubuntu/scripts/build/install-git.sh
+++ b/images/ubuntu/scripts/build/install-git.sh
@@ -7,7 +7,7 @@
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
 
-GIT_REPO="ppa:git-core/candidate"
+GIT_REPO="ppa:git-core/ppa"
 
 ## Install git
 add-apt-repository $GIT_REPO -y


### PR DESCRIPTION
Reverts actions/runner-images#12563


As in https://launchpad.net/~git-core/+archive/ubuntu/ppa , have the latest version 2.50.1 released.