### PR TITLE
Typo in integration test for fwupd 

### DIFF
--- a/images/ubuntu/scripts/tests/System.Tests.ps1
+++ b/images/ubuntu/scripts/tests/System.Tests.ps1
@@ -9,7 +9,7 @@ Describe "Disk free space" -Skip:(-not [String]::IsNullOrEmpty($env:AGENT_NAME) 
 
 Describe "fwupd removed" {
     It "Is not present on box" {
-        $systemctlOutput = & systemctl list-unit fwupd-refresh.timer --no-legend
+        $systemctlOutput = & systemctl list-units fwupd-refresh.timer --no-legend
         # When disabled the output looks like this:
         #❯ systemctl list-units fwupd-refresh.timer --no-legend
         #● fwupd-refresh.timer masked failed failed fwupd-refresh.timer


### PR DESCRIPTION
# Description

The command should be using `list-units` 

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:https://github.com/actions/runner-images/issues/12710

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
