### PR TITLE
[windows] Remove Msys2 checksum verification

### DIFF
--- a/images/windows/scripts/build/Install-Msys2.ps1
+++ b/images/windows/scripts/build/Install-Msys2.ps1
@@ -22,13 +22,6 @@ function Install-Msys2 {
     Write-Host "Download msys2 installer $installerName"
     $installerPath = Invoke-DownloadWithRetry $downloadUri
 
-    #region Supply chain security - MSYS2
-    $externalHash = Get-ChecksumFromUrl -Type "SHA256" `
-        -Url ($downloadUri -replace $installerName, "msys2-checksums.txt") `
-        -FileName $installerName
-    Test-FileChecksum $installerPath -ExpectedSHA256Sum $externalHash
-    #endregion
-
     Write-Host "Starting msys2 installation"
     & $installerPath in --confirm-command --accept-messages --root C:/msys64
     if ($LastExitCode -ne 0) {


### PR DESCRIPTION
# Description
This PR removes Msys2 checksum validation for windows

#### Related issue: https://github.com/actions/runner-images-internal/issues/7297

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
