### PR TITLE
[macOS] Update Xcode 26 to beta 7

### DIFF
--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -4,11 +4,11 @@
         "x64": {
             "versions": [
                 {
-                    "link": "26_beta_6",
-                    "filename": "26_beta_6_Universal",
-                    "version": "26.0.0-Beta.6+17A5305f",
+                    "link": "26_beta_7",
+                    "filename": "26_beta_7_Universal",
+                    "version": "26.0.0-Beta.7+17A5305k",
                     "symlinks": ["26.0"],
-                    "sha256": "969b8dfe04c366a1900db6052aae7e711f3ecd34b1cfd08f51b5f98c031c2abd",
+                    "sha256": "d711e1d6774647d38daac112ebb6d085af863ecc541f8de2360eaf44e638e8a6",
                     "install_runtimes": "none"
                 },
                 {
@@ -56,11 +56,11 @@
         "arm64":{
             "versions": [
                 {
-                    "link": "26_beta_6",
-                    "filename": "26_beta_6_Universal",
-                    "version": "26.0.0-Beta.6+17A5305f",
+                    "link": "26_beta_7",
+                    "filename": "26_beta_7_Universal",
+                    "version": "26.0.0-Beta.7+17A5305k",
                     "symlinks": ["26.0"],
-                    "sha256": "969b8dfe04c366a1900db6052aae7e711f3ecd34b1cfd08f51b5f98c031c2abd",
+                    "sha256": "d711e1d6774647d38daac112ebb6d085af863ecc541f8de2360eaf44e638e8a6",
                     "install_runtimes": "none"
                 },
                 {


### PR DESCRIPTION
# Description

Update Xcode 26 to the newly released beta 7 version.

#### Related issue:

https://github.com/actions/runner-images/issues/12904

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
