### PR TITLE
[ubuntu] Modify installation and add .NET 9

### DIFF
--- a/images/ubuntu/scripts/build/install-dotnetcore-sdk.sh
+++ b/images/ubuntu/scripts/build/install-dotnetcore-sdk.sh
@@ -9,83 +9,59 @@ source $HELPER_SCRIPTS/etc-environment.sh
 source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 
-extract_dotnet_sdk() {
-    local archive_name=$1
-
-    set -e
-    destination="./tmp-$(basename -s .tar.gz $archive_name)"
-
-    echo "Extracting $archive_name to $destination"
-    mkdir "$destination" && tar -C "$destination" -xzf "$archive_name"
-    rsync -qav --remove-source-files "$destination/shared/" /usr/share/dotnet/shared/
-    rsync -qav --remove-source-files "$destination/host/" /usr/share/dotnet/host/
-    rsync -qav --remove-source-files "$destination/sdk/" /usr/share/dotnet/sdk/
-    rm -rf "$destination" "$archive_name"
-}
-
-# Ubuntu 20 doesn't support EOL versions
-latest_dotnet_packages=$(get_toolset_value '.dotnet.aptPackages[]')
 dotnet_versions=$(get_toolset_value '.dotnet.versions[]')
 dotnet_tools=$(get_toolset_value '.dotnet.tools[].name')
 
 # Disable telemetry
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 
-# Install .NET SDK from apt
-# There is a versions conflict, that leads to
-# Microsoft <-> Canonical repos dependencies mix up.
-# Give Microsoft's repo higher priority to avoid collisions.
-# See: https://github.com/dotnet/core/issues/7699
-cat << EOF > /etc/apt/preferences.d/dotnet
-Package: *net*
-Pin: origin packages.microsoft.com
-Pin-Priority: 1001
-EOF
-
+# Install dotnet dependencies
+# https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-decision#dependencies
 apt-get update
+apt-get install --no-install-recommends \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    liblttng-ust1 \
+    libssl3 \
+    libstdc++6 \
+    zlib1g
 
-for latest_package in ${latest_dotnet_packages[@]}; do
-    echo "Determining if .NET Core ($latest_package) is installed"
-    if ! dpkg -S $latest_package &> /dev/null; then
-        echo "Could not find .NET Core ($latest_package), installing..."
-        apt-get install $latest_package
-    else
-        echo ".NET Core ($latest_package) is already installed"
-    fi
-done
+if is_ubuntu22; then
+    apt-get install --no-install-recommends libicu70
+fi
 
-rm /etc/apt/preferences.d/dotnet
+if is_ubuntu24; then
+    apt-get install --no-install-recommends libicu74
+fi
 
-apt-get update
+# Install .NET SDKs and Runtimes
+mkdir -p /usr/share/dotnet
 
-# Install .NET SDK from home repository
-# Get list of all released SDKs from channels which are not end-of-life or preview
 sdks=()
 for version in ${dotnet_versions[@]}; do
     release_url="https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/${version}/releases.json"
     releases=$(cat "$(download_with_retry "$release_url")")
-    if [[ $version == "6.0" ]]; then
-        sdks=("${sdks[@]}" $(echo "${releases}" | jq -r 'first(.releases[].sdks[]?.version | select(contains("preview") or contains("rc") | not))'))
-    else
-        sdks=("${sdks[@]}" $(echo "${releases}" | jq -r '.releases[].sdk.version | select(contains("preview") or contains("rc") | not)'))
-        sdks=("${sdks[@]}" $(echo "${releases}" | jq -r '.releases[].sdks[]?.version | select(contains("preview") or contains("rc") | not)'))
-    fi
+    sdks=("${sdks[@]}" $(echo "${releases}" | jq -r '.releases[].sdk.version | select(contains("preview") or contains("rc") | not)'))
+    sdks=("${sdks[@]}" $(echo "${releases}" | jq -r '.releases[].sdks[]?.version | select(contains("preview") or contains("rc") | not)'))
 done
 
 sorted_sdks=$(echo ${sdks[@]} | tr ' ' '\n' | sort -r | uniq -w 5)
 
-# Download/install additional SDKs in parallel
-export -f download_with_retry
-export -f extract_dotnet_sdk
+## Download installer from dot.net
+DOTNET_INSTALL_SCRIPT="https://dot.net/v1/dotnet-install.sh"
+install_script_path=$(download_with_retry $DOTNET_INSTALL_SCRIPT)
+chmod +x $install_script_path
 
-parallel --jobs 0 --halt soon,fail=1 \
-    'url="https://dotnetcli.blob.core.windows.net/dotnet/Sdk/{}/dotnet-sdk-{}-linux-x64.tar.gz"; \
-    download_with_retry $url' ::: "${sorted_sdks[@]}"
+for sdk in ${sorted_sdks[@]}; do
+    echo "Installing .NET SDK $sdk"
+    $install_script_path --version $sdk --install-dir /usr/share/dotnet --no-path
+done
 
-find . -name "*.tar.gz" | parallel --halt soon,fail=1 'extract_dotnet_sdk {}'
+## Dotnet installer doesn't create symlinks to executable or modify PATH
+ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
-# NuGetFallbackFolder at /usr/share/dotnet/sdk/NuGetFallbackFolder is warmed up by smoke test
-# Additional FTE will just copy to ~/.dotnet/NuGet which provides no benefit on a fungible machine
 set_etc_environment_variable DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1
 set_etc_environment_variable DOTNET_NOLOGO 1
 set_etc_environment_variable DOTNET_MULTILEVEL_LOOKUP 0

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -268,10 +268,6 @@
         }
     ],
     "dotnet": {
-        "aptPackages": [
-            "dotnet-sdk-8.0",
-            "dotnet-sdk-9.0"
-        ],
         "versions": [
             "8.0",
             "9.0"

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -228,11 +228,9 @@
         }
     ],
     "dotnet": {
-        "aptPackages": [
-            "dotnet-sdk-8.0"
-        ],
         "versions": [
-            "8.0"
+            "8.0",
+            "9.0"
         ],
         "tools": [
             { "name": "nbgv", "test": "nbgv --version", "getversion" : "nbgv --version" }


### PR DESCRIPTION
# Description
This pull request updates the way .NET SDKs are installed on Ubuntu images by removing the use of Ubuntu package repositories and switching to direct installation from Microsoft's official installer script. This change ensures more consistent and up-to-date SDK installations across supported Ubuntu versions.

.NET SDK installation process overhaul:

* Removed installation of .NET SDKs via `apt` packages (`dotnet-sdk-8.0`, `dotnet-sdk-9.0`) and related repository pinning logic from `install-dotnetcore-sdk.sh` and `toolset-2204.json`/`toolset-2404.json`. (.[[1]](diffhunk://#diff-3a7280bfc10eff7fe7baa1354e44e343e7539ce5aab4ee5e3d115c2099c5eba2L12-L88) [[2]](diffhunk://#diff-be8309c2f1b885c28cd700b77c90b395634d4ce945ec801f23999d1f8aebc696L271-L274) [[3]](diffhunk://#diff-d971735ef1477edb458b92ea8b0bc7f771ac3c498e54be90acfc8be9d1f7aa3eL231-R233)
* Added direct installation of required dependencies for .NET, with conditional handling for `libicu` versions based on Ubuntu release (`libicu70` for 22.04, `libicu74` for 24.04).
* Updated the script to download and use the official `dotnet-install.sh` script to install all specified SDK versions directly to `/usr/share/dotnet`, and create a symlink to `/usr/bin/dotnet`.

Configuration and cleanup improvements:

* Removed legacy extraction logic and parallel downloading of tarballs, simplifying the install process.
* Updated environment variable configuration to support the new installation method.

Toolset versioning update:

* Added support for installing both .NET 8.0 and 9.0 SDKs for Ubuntu 24.04 in `toolset-2404.json`.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
