### PR TITLE
[WIndows] Update OpenSSL to 3.* on windows-2022 and script itself

### DIFF
--- a/images/windows/scripts/build/Install-OpenSSL.ps1
+++ b/images/windows/scripts/build/Install-OpenSSL.ps1
@@ -22,7 +22,7 @@ $installerHash = $null
 
 foreach ($key in $installerNames) {
     $installer = $installersAvailable.$key
-    if (($installer.light -eq $light) -and ($installer.arch -eq $arch) -and ($installer.bits -eq $bits) -and ($installer.installer -eq $installerType) -and ($installer.basever -eq $version)) {
+    if (($installer.light -eq $light) -and ($installer.arch -eq $arch) -and ($installer.bits -eq $bits) -and ($installer.installer -eq $installerType) -and ($installer.basever -like $version)) {
         $installerUrl = $installer.url
         $installerHash = $installer.sha512
     }

--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -445,9 +445,9 @@
     "openssl": {
         "version": "1.1.1",
         "pinnedDetails": {
-            "link": "https://github.com/somelink",
-            "reason": "this was pinned due to a downstream issue with the installer",
-            "review-at": "2025-01-30"
+            "link": "https://github.com/actions/runner-images/issues/12045",
+            "reason": "Image is deprecated and will be removed soon",
+            "review-at": "2027-01-01"
         }
     },
     "pwsh": {

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -362,13 +362,7 @@
         "version": "latest"
     },
     "openssl": {
-        "version": "1.1.1",
-        "pinnedDetails": {
-            "link": "https://github.com/actions/runner-images-internal/pull/6702",
-            "reason": "Meaningful reason must be added at next update.",
-            "review-at": "2024-06-01",
-            "type": "preexisting-pinned-version-without-reason"
-        }
+        "version": "3.*"
     },
     "pwsh": {
         "version": "7.4"

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -327,13 +327,7 @@
         "version": "latest"
     },
     "openssl": {
-        "version": "3.5.3",
-        "pinnedDetails": {
-            "link": "https://github.com/openssl/openssl/releases/tag/openssl-3.5.3",
-            "reason": "Installer not found for version 3.5.2",
-            "review-at": "2025-10-10",
-            "type": "preexisting-pinned-version-without-reason"
-        }
+        "version": "3.*"
     },
     "pwsh": {
         "version": "7.4"


### PR DESCRIPTION
# Description

- The installer can now work with version patterns
- Updated the Windows 2022 OpenSSL version from 1.1.1 to 3.*
- Disabled notifications

#### Related issue:

https://github.com/actions/runner-images/issues/12676
https://github.com/actions/runner-images/issues/13097

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
