### PR TITLE
Add certutil to Ubuntu

### DIFF
--- a/images/ubuntu/scripts/tests/Apt.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Apt.Tests.ps1
@@ -8,6 +8,7 @@ Describe "Apt" {
         switch ($toolName) {
             "acl"               { $toolName = "getfacl"; break }
             "aria2"             { $toolName = "aria2c"; break }
+            "libnss3-tools"     { $toolName = "certutil"; break }
             "p7zip-full"        { $toolName = "p7zip"; break }
             "subversion"        { $toolName = "svn"; break }
             "sphinxsearch"      { $toolName = "searchd"; break }

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -180,6 +180,7 @@
             "binutils",
             "bison",
             "brotli",
+            "libnss3-tools",
             "coreutils",
             "file",
             "findutils",

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -157,6 +157,7 @@
             "binutils",
             "bison",
             "brotli",
+            "libnss3-tools",
             "coreutils",
             "file",
             "findutils",


### PR DESCRIPTION
# Description
New tool

Adds `certutil` via `libnss3-tools` from `apt`

This significantly simplifies certificate handling when working with playwright in CCA

- https://launchpad.net/ubuntu/focal/+package/libnss3-tools. 

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
