### PR TITLE
openssl: do not install DLLs globally to system32 on Windows

### DIFF
--- a/images/windows/scripts/build/Install-OpenSSL.ps1
+++ b/images/windows/scripts/build/Install-OpenSSL.ps1
@@ -34,7 +34,7 @@ if ($null -eq $installerUrl) {
 
 Install-Binary `
     -Url $installerUrl `
-    -InstallArgs @('/silent', '/sp-', '/suppressmsgboxes', "/DIR=`"$installDir`"") `
+    -InstallArgs @('/silent', '/sp-', '/suppressmsgboxes','/tasks="copytobin"', "/DIR=`"$installDir`"") `
     -ExpectedSHA512Sum $installerHash
 
 # Update PATH

--- a/images/windows/scripts/tests/Tools.Tests.ps1
+++ b/images/windows/scripts/tests/Tools.Tests.ps1
@@ -235,4 +235,9 @@ Describe "OpenSSL" {
     It "OpenSSL Full package" {
         Join-Path ${env:ProgramFiles} 'OpenSSL\include' | Should -Exist
     }
+
+    It "OpenSSL DLLs not in System32" {
+        Get-ChildItem -Path "$env:SystemRoot\System32" -Filter "libcrypto-*.dll" -File -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+	    Get-ChildItem -Path "$env:SystemRoot\System32" -Filter "libssl-*.dll" -File -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+    }
 }


### PR DESCRIPTION
# Description
Pass `/tasks="copytobin"` to the OpenSSL installer on Windows so that the DLLs required to run `openssl.exe` are only local to `openssl.exe` and not globally exposed to all processes in `C:/Windows/system32`.

There are other copies of the same DLLs `libssl-3-x64.dll` and `libcrypto-3-x64.dll` across the system, used by different tools, and being in `C:/Windows/system32` gives them a higher priority, which can result in runtime incompatibilities or unexpected results in some scenarios (e.g. if user expects them to be found in `PATH` environment variable, or if the expected version is newer than the one installed at the system level).

This change should **NOT** impact the ability to run and invoke the `openssl.exe` tool, which is what the existing test already covered.

#### Related issue:
https://github.com/actions/runner-images/issues/13198
## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
