### PR TITLE
[macos] Update Software Report for XCode Simulators

### DIFF
--- a/images/macos/scripts/docs-gen/SoftwareReport.Xcode.psm1
+++ b/images/macos/scripts/docs-gen/SoftwareReport.Xcode.psm1
@@ -225,17 +225,18 @@ function Build-XcodeSimulatorsTable {
             }
         }
         return [PSCustomObject] @{
-            "OS" = $runtime.name
+            "Name"       = $runtime.name
+            "OS"         = $runtime.version
             "Simulators" = [String]::Join("<br>", $sortedRuntimeDevices)
         }
     } | Sort-Object {
         # Sort rule 1
-        $sdkNameParts = $_."OS".Split(" ")
+        $sdkNameParts = $_."Name".Split(" ")
         $platformName = [String]::Join(" ", $sdkNameParts[0..($sdkNameParts.Length - 2)])
         return Get-XcodePlatformOrder $platformName
     }, {
         # Sort rule 2
-        $sdkNameParts = $_."OS".Split(" ")
+        $sdkNameParts = $_."Name".Split(" ")
         return [System.Version]::Parse($sdkNameParts[-1])
     }
 }


### PR DESCRIPTION
# Description
This PR adds a new column with simulator version info to the `Installed Simulators` software report table

#### Related issue: https://github.com/actions/runner-images/issues/13220

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
