### PR TITLE
[Ubuntu] Add android ndk r29 and cmake 4.1.2

### DIFF
--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -86,12 +86,13 @@
         "addon_list": [
         ],
         "additional_tools": [
-            "cmake;3.31.5"
+            "cmake;3.31.5",
+            "cmake;4.1.2"
         ],
         "ndk": {
             "default": "27",
             "versions": [
-                "26", "27", "28"
+                "26", "27", "28", "29"
             ]
         }
     },


### PR DESCRIPTION
# Description
Add Android NDK r29 and cmake 4.1.2 for ubuntu-24.04

#### Related issue:
https://github.com/actions/runner-images/issues/13229

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
