### PR TITLE
[Windows] Add android ndk r29 and cmake 4.1.2

### DIFF
--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -115,14 +115,14 @@
         ],
         "addons": [],
         "additional_tools": [
-            "cmake;3.18.1",
             "cmake;3.22.1",
-            "cmake;3.31.5"
+            "cmake;3.31.5",
+            "cmake;4.1.2"
         ],
         "ndk": {
             "default": "27",
             "versions": [
-                "26", "27", "28"
+                "26", "27", "28", "29"
             ]
         }
     },

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -97,14 +97,14 @@
         ],
         "addons": [],
         "additional_tools": [
-            "cmake;3.22.1",
             "cmake;3.30.5",
-            "cmake;3.31.5"
+            "cmake;3.31.5",
+            "cmake;4.1.2"
         ],
         "ndk": {
             "default": "27",
             "versions": [
-                "26", "27", "28"
+                "26", "27", "28", "29"
             ]
         }
     },


### PR DESCRIPTION
# Description
Add android ndk r29 and cmake 4.1.2 for Windows images

#### Related issue:
https://github.com/actions/runner-images/issues/13229

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
