### PR TITLE
[macOS] Add android ndk r29 and cmake 4.1.2

### DIFF
--- a/images/macos/toolsets/toolset-14.json
+++ b/images/macos/toolsets/toolset-14.json
@@ -139,12 +139,13 @@
         ],
         "addons": [],
         "additional_tools": [
-            "cmake;3.31.5"
+            "cmake;3.31.5",
+            "cmake;4.1.2"
         ],
         "ndk": {
             "default": "26",
             "versions": [
-                "26", "27", "28"
+                "26", "27", "28", "29"
             ]
         }
     },

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -143,12 +143,13 @@
         ],
         "addons": [],
         "additional_tools": [
-            "cmake;3.31.5"
+            "cmake;3.31.5",
+            "cmake;4.1.2"
         ],
         "ndk": {
             "default": "27",
             "versions": [
-                "26", "27","28"
+                "26", "27","28", "29"
             ]
         }
     },

--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -54,12 +54,13 @@
         ],
         "addons": [],
         "additional_tools": [
-            "cmake;3.31.5"
+            "cmake;3.31.5",
+            "cmake;4.1.2"
         ],
         "ndk": {
             "default": "27",
             "versions": [
-                "27","28"
+                "27","28", "29"
             ]
         }
     },


### PR DESCRIPTION
# Description
Add android ndk r29 and cmake 4.1.2 for macOS images

#### Related issue:
https://github.com/actions/runner-images/issues/13229

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
