### PR TITLE
[macOS] Install MetalToolchain for Xcode Releases only

### DIFF
--- a/images/macos/scripts/build/Install-Xcode.ps1
+++ b/images/macos/scripts/build/Install-Xcode.ps1
@@ -35,7 +35,7 @@ $xcodeVersions | ForEach-Object {
     Write-Host "Configuring Xcode $($_.link) ..."
     Invoke-XcodeRunFirstLaunch -Version $_.link
     Install-XcodeAdditionalSimulatorRuntimes -Version $_.link -Arch $arch -Runtimes $_.install_runtimes
-    if (($_.link -match '^(\d+)\.(\d+)$') -and ([int]$matches[0] -ge 26)) {
+    if (($_.link -match '^(\d+)\.(\d+)$') -and ([int]$matches[1] -ge 26)) {
         Install-XcodeAdditionalComponents -Version $_.link
     }
 }


### PR DESCRIPTION
# Description

Xcode 26.2 beta breaks Simulators due to a CoreSim update

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
