### PR TITLE
feat: change azcopy script to download directly from github releases

### DIFF
--- a/images/macos/scripts/build/install-azcopy.sh
+++ b/images/macos/scripts/build/install-azcopy.sh
@@ -6,14 +6,22 @@
 
 source ~/utils/utils.sh
 
-if is_Arm64; then
-    url="https://aka.ms/downloadazcopy-v10-mac-arm64"
+# Determine the architecture for azcopy download
+# azcopy uses "amd64" instead of "x64" in their release names
+# For reference check this specific release
+# https://github.com/Azure/azure-storage-azcopy/releases/tag/v10.30.1
+arch=$(get_arch)
+if [ "$arch" == "x64" ]; then
+    azcopy_arch="amd64"
 else
-    url="https://aka.ms/downloadazcopy-v10-mac"
+    azcopy_arch="arm64"
 fi
 
+# Download AzCopy from GitHub releases
+download_url=$(resolve_github_release_asset_url "Azure/azure-storage-azcopy" "contains(\"darwin_${azcopy_arch}\") and endswith(\".zip\")" "latest")
+
 # Install AzCopy
-archive_path=$(download_with_retry ${url})
+archive_path=$(download_with_retry ${download_url})
 unzip -qq $archive_path -d /tmp/azcopy
 extract_path=$(echo /tmp/azcopy/azcopy*)
 cp $extract_path/azcopy /usr/local/bin/azcopy

--- a/images/ubuntu/scripts/build/install-azcopy.sh
+++ b/images/ubuntu/scripts/build/install-azcopy.sh
@@ -7,8 +7,14 @@
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
 
+# Download AzCopy from GitHub releases
+# 
+# This doesn't do arch handling since this script is not
+# called via an arm64 instance.
+download_url=$(resolve_github_release_asset_url "Azure/azure-storage-azcopy" "contains(\"linux_amd64\") and endswith(\".tar.gz\")" "latest")
+
 # Install AzCopy10
-archive_path=$(download_with_retry "https://aka.ms/downloadazcopy-v10-linux")
+archive_path=$(download_with_retry "$download_url")
 tar xzf "$archive_path" --strip-components=1 -C /tmp
 install /tmp/azcopy /usr/local/bin/azcopy
 


### PR DESCRIPTION
# Description
The `azcopy` script currently uses a static URL for downloading. There seems to be a window during new releases of azcopy where the assets are available on github releases and a new release is also available but the static URL returns 404. I don't have full context of this static URL here, how it is patched to point to the releases, but this URL doesn't seem very robust. Switching to use the github releases assets would make for a more resilient script, adding the changes for that here.

Related issue: https://github.com/actions/runner-images/issues/13279

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
