### PR TITLE
[macOS] Update Xcode 26.1 to patch 1; without runtimes

### DIFF
--- a/images/macos/scripts/build/Install-Xcode.ps1
+++ b/images/macos/scripts/build/Install-Xcode.ps1
@@ -35,14 +35,10 @@ $xcodeVersions | ForEach-Object {
     Write-Host "Configuring Xcode $($_.link) ..."
     Invoke-XcodeRunFirstLaunch -Version $_.link
     Install-XcodeAdditionalSimulatorRuntimes -Version $_.link -Arch $arch -Runtimes $_.install_runtimes
-    if (($_.link -match '^(\d+)\.(\d+)$') -and ([int]$matches[1] -ge 26)) {
+    if (($_.link -eq "26.0.1")) {
         Install-XcodeAdditionalComponents -Version $_.link
+        Update-DyldCache -Version $_.link
     }
-}
-
-# Update dyld shared cache for the latest stable Xcode version
-if ((-not $os.IsSonoma)) {
-    Update-DyldCache -XcodeVersions $xcodeVersions
 }
 
 Invoke-XcodeRunFirstLaunch -Version $defaultXcode

--- a/images/macos/scripts/helpers/Xcode.Installer.psm1
+++ b/images/macos/scripts/helpers/Xcode.Installer.psm1
@@ -320,19 +320,10 @@ function Invoke-ValidateCommand {
 function Update-DyldCache {
     param (
         [Parameter(Mandatory)]
-        [array] $XcodeVersions
+        [string] $Version
     )
 
-    # Find the latest stable Xcode version (excluding beta and RC versions)
-    $latestStableXcode = $XcodeVersions | Where-Object { 
-        -not ($_.link.Contains("beta") -or $_.link.Contains("Release_Candidate") -or $_.link.Contains("_RC"))
-    } | Sort-Object { [version]($_.version -split '\+')[0] } -Descending | Select-Object -First 1
-
-    if ($latestStableXcode) {
-        Write-Host "Updating dyld shared cache for Xcode $($latestStableXcode.link)..."
-        Switch-Xcode -Version $latestStableXcode.link
-        Invoke-ValidateCommand "xcrun simctl runtime dyld_shared_cache update --all"
-    } else {
-        Write-Host "No stable Xcode version found for dyld cache update."
-    }
+    Write-Host "Updating dyld shared cache for Xcode $Version ..."
+    Switch-Xcode -Version $Version
+    Invoke-ValidateCommand "xcrun simctl runtime dyld_shared_cache update --all"
 }

--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -3,22 +3,22 @@
         "default": "15.2",
         "x64": {
             "versions": [
-                { "link": "15.2", "filename": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "default", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},
-                { "link": "15.1", "filename": "15.1", "version": "15.1.0+15C65", "install_runtimes": "default", "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05"},
-                { "link": "15.0.1", "filename": "15.0.1", "version": "15.0.1+15A507", "symlinks": ["15.0"], "install_runtimes": "default", "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8"},
-                { "link": "14.3.1", "filename": "14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"], "install_runtimes": "default", "sha256": "B5CC7BF37447C32A971B37D71C7DA1AF7ABB45CEE4B96FE126A1D3B0D2C260AF"},
-                { "link": "14.2", "filename": "14.2", "version": "14.2.0+14C18", "install_runtimes": "default", "sha256": "686B9D53CA49E50D563BC0104B1E8B4F7CCFE80064A6D689965FB819BF8EFE72"},
-                { "link": "14.1", "filename": "14.1", "version": "14.1.0+14B47b", "install_runtimes": "default", "sha256": "12F8A3AEF78BF354470AD8B351ADDD925C8EDAD888137D138CA50A8130EB9F2F"}
+                { "link": "15.2", "filename": "Xcode_15.2", "version": "15.2.0+15C500b", "install_runtimes": "default", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},
+                { "link": "15.1", "filename": "Xcode_15.1", "version": "15.1.0+15C65", "install_runtimes": "default", "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05"},
+                { "link": "15.0.1", "filename": "Xcode_15.0.1", "version": "15.0.1+15A507", "symlinks": ["15.0"], "install_runtimes": "default", "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8"},
+                { "link": "14.3.1", "filename": "Xcode_14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"], "install_runtimes": "default", "sha256": "B5CC7BF37447C32A971B37D71C7DA1AF7ABB45CEE4B96FE126A1D3B0D2C260AF"},
+                { "link": "14.2", "filename": "Xcode_14.2", "version": "14.2.0+14C18", "install_runtimes": "default", "sha256": "686B9D53CA49E50D563BC0104B1E8B4F7CCFE80064A6D689965FB819BF8EFE72"},
+                { "link": "14.1", "filename": "Xcode_14.1", "version": "14.1.0+14B47b", "install_runtimes": "default", "sha256": "12F8A3AEF78BF354470AD8B351ADDD925C8EDAD888137D138CA50A8130EB9F2F"}
                 ]
         },
         "arm64":{
             "versions": [
-                { "link": "15.2", "filename": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "default", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},
-                { "link": "15.1", "filename": "15.1", "version": "15.1.0+15C65", "install_runtimes": "default", "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05"},
-                { "link": "15.0.1", "filename": "15.0.1", "version": "15.0.1+15A507", "symlinks": ["15.0"], "install_runtimes": "default", "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8"},
-                { "link": "14.3.1", "filename": "14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"], "install_runtimes": "default", "sha256": "B5CC7BF37447C32A971B37D71C7DA1AF7ABB45CEE4B96FE126A1D3B0D2C260AF"},
-                { "link": "14.2", "filename": "14.2", "version": "14.2.0+14C18", "install_runtimes": "default", "sha256": "686B9D53CA49E50D563BC0104B1E8B4F7CCFE80064A6D689965FB819BF8EFE72"},
-                { "link": "14.1", "filename": "14.1", "version": "14.1.0+14B47b", "install_runtimes": "default", "sha256": "12F8A3AEF78BF354470AD8B351ADDD925C8EDAD888137D138CA50A8130EB9F2F"}
+                { "link": "15.2", "filename": "Xcode_15.2", "version": "15.2.0+15C500b", "install_runtimes": "default", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},
+                { "link": "15.1", "filename": "Xcode_15.1", "version": "15.1.0+15C65", "install_runtimes": "default", "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05"},
+                { "link": "15.0.1", "filename": "Xcode_15.0.1", "version": "15.0.1+15A507", "symlinks": ["15.0"], "install_runtimes": "default", "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8"},
+                { "link": "14.3.1", "filename": "Xcode_14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"], "install_runtimes": "default", "sha256": "B5CC7BF37447C32A971B37D71C7DA1AF7ABB45CEE4B96FE126A1D3B0D2C260AF"},
+                { "link": "14.2", "filename": "Xcode_14.2", "version": "14.2.0+14C18", "install_runtimes": "default", "sha256": "686B9D53CA49E50D563BC0104B1E8B4F7CCFE80064A6D689965FB819BF8EFE72"},
+                { "link": "14.1", "filename": "Xcode_14.1", "version": "14.1.0+14B47b", "install_runtimes": "default", "sha256": "12F8A3AEF78BF354470AD8B351ADDD925C8EDAD888137D138CA50A8130EB9F2F"}
             ]
         }
     },

--- a/images/macos/toolsets/toolset-14.json
+++ b/images/macos/toolsets/toolset-14.json
@@ -5,7 +5,7 @@
             "versions": [
                 {
                     "link": "16.2",
-                    "filename": "16.2",
+                    "filename": "Xcode_16.2",
                     "version": "16.2+16C5032a",
                     "sha256": "0e367d06eb7c334ea143bada5e4422f56688aabff571bedf0d2ad9434b7290de",
                     "install_runtimes": [
@@ -16,42 +16,42 @@
                 },
                 {
                     "link": "16.1",
-                    "filename": "16.1",
+                    "filename": "Xcode_16.1",
                     "version": "16.1+16B40",
                     "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720",
                     "install_runtimes": "default"
                 },
                 {
                     "link": "15.4",
-                    "filename": "15.4",
+                    "filename": "Xcode_15.4",
                     "version": "15.4.0+15F31d",
                     "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a",
                     "install_runtimes": "default"
                 },
                 {
                     "link": "15.3",
-                    "filename": "15.3",
+                    "filename": "Xcode_15.3",
                     "version": "15.3.0+15E204a",
                     "sha256": "f13f6a2e2df432c3008e394640b8549a18c285acd7fd148d6c4bac8c3a5af234",
                     "install_runtimes": "default"
                 },
                 {
                     "link": "15.2",
-                    "filename": "15.2",
+                    "filename": "Xcode_15.2",
                     "version": "15.2.0+15C500b",
                     "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B",
                     "install_runtimes": "default"
                 },
                 {
                     "link": "15.1",
-                    "filename": "15.1",
+                    "filename": "Xcode_15.1",
                     "version": "15.1.0+15C65",
                     "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05",
                     "install_runtimes": "default"
                 },
                 {
                     "link": "15.0.1",
-                    "filename": "15.0.1",
+                    "filename": "Xcode_15.0.1",
                     "version": "15.0.1+15A507",
                     "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8",
                     "symlinks": ["15.0"],
@@ -63,7 +63,7 @@
             "versions": [
                 {
                     "link": "16.2",
-                    "filename": "16.2",
+                    "filename": "Xcode_16.2",
                     "version": "16.2+16C5032a",
                     "sha256": "0e367d06eb7c334ea143bada5e4422f56688aabff571bedf0d2ad9434b7290de",
                     "install_runtimes": [
@@ -75,42 +75,42 @@
                 },
                 {
                     "link": "16.1",
-                    "filename": "16.1",
+                    "filename": "Xcode_16.1",
                     "version": "16.1+16B40",
                     "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720",
                     "install_runtimes": "default"
                 },
                 {
                     "link": "15.4",
-                    "filename": "15.4",
+                    "filename": "Xcode_15.4",
                     "version": "15.4.0+15F31d",
                     "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a",
                     "install_runtimes": "default"
                 },
                 {
                     "link": "15.3",
-                    "filename": "15.3",
+                    "filename": "Xcode_15.3",
                     "version": "15.3.0+15E204a",
                     "sha256": "f13f6a2e2df432c3008e394640b8549a18c285acd7fd148d6c4bac8c3a5af234",
                     "install_runtimes": "default"
                 },
                 {
                     "link": "15.2",
-                    "filename": "15.2",
+                    "filename": "Xcode_15.2",
                     "version": "15.2.0+15C500b",
                     "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B",
                     "install_runtimes": "default"
                 },
                 {
                     "link": "15.1",
-                    "filename": "15.1",
+                    "filename": "Xcode_15.1",
                     "version": "15.1.0+15C65",
                     "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05",
                     "install_runtimes": "default"
                 },
                 {
                     "link": "15.0.1",
-                    "filename": "15.0.1",
+                    "filename": "Xcode_15.0.1",
                     "version": "15.0.1+15A507",
                     "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8",
                     "symlinks": ["15.0"],

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -4,16 +4,16 @@
         "x64": {
             "versions": [
                 {
-                    "link": "26.1_Release_Candidate",
-                    "filename": "26.1_Release_Candidate_Universal",
-                    "version": "26.1_Release_Candidate_Universal+17B54",
+                    "link": "26.1.1",
+                    "filename": "Xcode_26.1.1_Universal",
+                    "version": "26.1.1+17B100",
                     "symlinks": ["26.1"],
-                    "sha256": "6504F2527444D295585515C7E41A862FFD701E3255D6634A40A714C4895E6CCD",
+                    "sha256": "ed55d55fa28455c11a65e0809ba8fdf7d83fdeb268aabf9af7fcc1ee911543eb",
                     "install_runtimes": "none"
                 },
                 {
                     "link": "26.0.1",
-                    "filename": "26.0.1_Universal",
+                    "filename": "Xcode_26.0.1_Universal",
                     "version": "26.0.1+17A400",
                     "symlinks": ["26.0"],
                     "sha256": "9881c457068c86ac91e94cca2d7116dfd01cb7179c22b0863b63c7f3bb7e7695",
@@ -21,7 +21,7 @@
                 },
                 {
                     "link": "16.4",
-                    "filename": "16.4",
+                    "filename": "Xcode_16.4",
                     "version": "16.4.0+16F6",
                     "sha256": "2dbf65ba28fb85b34e72c14c529a42d5c3189ab0f11fb29fdebd5f4ee6c87900",
                     "install_runtimes": [
@@ -32,28 +32,28 @@
                 },
                 {
                     "link": "16.3",
-                    "filename": "16.3",
+                    "filename": "Xcode_16.3",
                     "version": "16.3+16E140",
                     "sha256": "c593177b73e45f31e1cf7ced131760d8aa8e1532f5bbf8ba11a4ded01da14fbb",
                     "install_runtimes": "none"
                 },
                 {
                     "link": "16.2",
-                    "filename": "16.2",
+                    "filename": "Xcode_16.2",
                     "version": "16.2+16C5032a",
                     "sha256": "0e367d06eb7c334ea143bada5e4422f56688aabff571bedf0d2ad9434b7290de",
                     "install_runtimes": "none"
                 },
                 {
                     "link": "16.1",
-                    "filename": "16.1",
+                    "filename": "Xcode_16.1",
                     "version": "16.1+16B40",
                     "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720",
                     "install_runtimes": "none"
                 },
                 {
                     "link": "16",
-                    "filename": "16",
+                    "filename": "Xcode_16",
                     "version": "16.0.0+16A242d",
                     "sha256": "4a26c3d102a55c7222fb145e0ee1503249c9c26c6e02dc64d783c8810b37b1e3",
                     "symlinks": ["16.0"],
@@ -64,16 +64,16 @@
         "arm64":{
             "versions": [
                 {
-                    "link": "26.1_Release_Candidate",
-                    "filename": "26.1_Release_Candidate_Universal",
-                    "version": "26.1_Release_Candidate_Universal+17B54",
+                    "link": "26.1.1",
+                    "filename": "Xcode_26.1.1_Universal",
+                    "version": "26.1.1+17B100",
                     "symlinks": ["26.1"],
-                    "sha256": "6504F2527444D295585515C7E41A862FFD701E3255D6634A40A714C4895E6CCD",
+                    "sha256": "ed55d55fa28455c11a65e0809ba8fdf7d83fdeb268aabf9af7fcc1ee911543eb",
                     "install_runtimes": "none"
                 },
                 {
                     "link": "26.0.1",
-                    "filename": "26.0.1_Universal",
+                    "filename": "Xcode_26.0.1_Universal",
                     "version": "26.0.1+17A400",
                     "symlinks": ["26.0"],
                     "sha256": "9881c457068c86ac91e94cca2d7116dfd01cb7179c22b0863b63c7f3bb7e7695",
@@ -81,7 +81,7 @@
                 },
                 {
                     "link": "16.4",
-                    "filename": "16.4",
+                    "filename": "Xcode_16.4",
                     "version": "16.4.0+16F6",
                     "sha256": "2dbf65ba28fb85b34e72c14c529a42d5c3189ab0f11fb29fdebd5f4ee6c87900",
                     "install_runtimes": [
@@ -93,28 +93,28 @@
                 },
                 {
                     "link": "16.3",
-                    "filename": "16.3",
+                    "filename": "Xcode_16.3",
                     "version": "16.3+16E140",
                     "sha256": "c593177b73e45f31e1cf7ced131760d8aa8e1532f5bbf8ba11a4ded01da14fbb",
                     "install_runtimes": "none"
                 },
                 {
                     "link": "16.2",
-                    "filename": "16.2",
+                    "filename": "Xcode_16.2",
                     "version": "16.2+16C5032a",
                     "sha256": "0e367d06eb7c334ea143bada5e4422f56688aabff571bedf0d2ad9434b7290de",
                     "install_runtimes": "none"
                 },
                 {
                     "link": "16.1",
-                    "filename": "16.1",
+                    "filename": "Xcode_16.1",
                     "version": "16.1+16B40",
                     "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720",
                     "install_runtimes": "none"
                 },
                 {
                     "link": "16",
-                    "filename": "16",
+                    "filename": "Xcode_16",
                     "version": "16.0.0+16A242d",
                     "sha256": "4a26c3d102a55c7222fb145e0ee1503249c9c26c6e02dc64d783c8810b37b1e3",
                     "symlinks": ["16.0"],

--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -4,16 +4,16 @@
         "arm64":{
             "versions": [
                 {
-                    "link": "26.1_Release_Candidate",
-                    "filename": "26.1_Release_Candidate_Universal",
-                    "version": "26.1_Release_Candidate_Universal+17B54",
+                    "link": "26.1.1",
+                    "filename": "Xcode_26.1.1_Universal",
+                    "version": "26.1.1+17B100",
                     "symlinks": ["26.1"],
-                    "sha256": "6504F2527444D295585515C7E41A862FFD701E3255D6634A40A714C4895E6CCD",
-                    "install_runtimes": "default"
+                    "sha256": "ed55d55fa28455c11a65e0809ba8fdf7d83fdeb268aabf9af7fcc1ee911543eb",
+                    "install_runtimes": "none"
                 },
                 {
                     "link": "26.0.1",
-                    "filename": "26.0.1_Universal",
+                    "filename": "Xcode_26.0.1_Universal",
                     "version": "26.0.1+17A400",
                     "symlinks": ["26.0"],
                     "sha256": "9881c457068c86ac91e94cca2d7116dfd01cb7179c22b0863b63c7f3bb7e7695",
@@ -21,7 +21,7 @@
                 },
                 {
                     "link": "16.4",
-                    "filename": "16.4",
+                    "filename": "Xcode_16.4",
                     "version": "16.4.0+16F6",
                     "sha256": "2dbf65ba28fb85b34e72c14c529a42d5c3189ab0f11fb29fdebd5f4ee6c87900",
                     "install_runtimes": [


### PR DESCRIPTION
# Description

The changes add a new version of Xcode 26.1 to replace the previous one, and also lead to the fact that during the build process we avoid any use of Xcode version newer than 26.0.1 due to complete incompatibility with runtimes from lower versions of Xcode 16.

#### Related issue:

https://github.com/actions/runner-images/issues/13292

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
