### PR TITLE
ghcup: use wget as default downloader

### DIFF
--- a/images/ubuntu/scripts/build/install-haskell.sh
+++ b/images/ubuntu/scripts/build/install-haskell.sh
@@ -28,7 +28,7 @@ major_minor_versions=$(echo "$available_versions" | cut -d"." -f 1,2 | uniq | ta
 for major_minor_version in $major_minor_versions; do
     full_version=$(echo "$available_versions" | grep "$major_minor_version." | tail -n1)
     echo "install ghc version $full_version..."
-    ghcup install ghc $full_version
+    ghcup --downloader wget install ghc $full_version
     ghcup set ghc $full_version
 done
 


### PR DESCRIPTION
# Description
I had a hard time creating custom images with the default downloader for haskell versions (curl).
Changing it to wget allows me to create templates for proxmox without build failures.

curl ended up returning error code 56 during the download of the first or second archive and broke the image generation process.

#### Related issue: #13353 

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [X] Changes are tested and related VM images are successfully generated

^ Atleast in my environment on Ubuntu 24.04.
