### PR TITLE
Add provisioner shell to list installed apt packages

### DIFF
--- a/images/ubuntu/scripts/build/list-dpkg.sh
+++ b/images/ubuntu/scripts/build/list-dpkg.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+################################################################################
+##  File:  list-dpkg.sh
+##  Desc:  List all installed dpkg packages
+################################################################################
+
+echo "Listing all installed dpkg packages..."
+dpkg-query -W -f='${Package} ${Version}\n' | sort

--- a/images/ubuntu/templates/build.ubuntu-22_04.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-22_04.pkr.hcl
@@ -194,7 +194,7 @@ build {
 
   provisioner "shell" {
     execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-    inline          = ["dpkg-query -W -f='$${Package} $${Version}\\n' | sort"]
+    script          = "${path.root}/../scripts/build/list-dpkg.sh"
   }
 
   provisioner "shell" {

--- a/images/ubuntu/templates/build.ubuntu-24_04.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-24_04.pkr.hcl
@@ -183,7 +183,7 @@ provisioner "shell" {
 
   provisioner "shell" {
     execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-    inline          = ["dpkg-query -W -f='$${Package} $${Version}\\n' | sort"]
+    script          = "${path.root}/../scripts/build/list-dpkg.sh"
   }
 
   provisioner "shell" {


### PR DESCRIPTION
# Description

This PR adds a new step to the Ubuntu 22.04 and 24.04 image build pipelines to output a sorted list of installed apt packages and their versions.

#### Related issue: N/A

## Check list
- [x] Related issue / work item is attached
- [x] Documentation is updated (if applicable)