### PR TITLE
[Windows] Change VS extensions order for windows-2019 image

### DIFF
--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -314,12 +314,12 @@
             "Component.MDD.Linux.GCC.arm"
         ],
         "vsix": [
-            "ProBITools.MicrosoftAnalysisServicesModelingProjects",
-            "SSIS.SqlServerIntegrationServicesProjects",
             "ProBITools.MicrosoftReportProjectsforVisualStudio",
             "VisualStudioClient.MicrosoftVisualStudio2017InstallerProjects",
             "ms-biztalk.BizTalk",
-            "WixToolset.WixToolsetVisualStudio2019Extension"
+            "WixToolset.WixToolsetVisualStudio2019Extension",
+            "ProBITools.MicrosoftAnalysisServicesModelingProjects",
+            "SSIS.SqlServerIntegrationServicesProjects"
         ]
     },
     "docker": {


### PR DESCRIPTION
# Description
This pull request makes a minor adjustment to the order of Visual Studio extension identifiers in the `vsix` array within the `toolset-2019.json` file. The change does not affect functionality, but changes the list order to unlock image generation.

#### Related issue:
https://github.com/github/hosted-runners-images/issues/383

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
