### PR TITLE
[macOS] Delete DOTNET_ROOT environment variable

### DIFF
--- a/images/macos/assets/bashrc
+++ b/images/macos/assets/bashrc
@@ -22,8 +22,9 @@ export PATH="/usr/local/opt/curl/bin:$PATH"
 export PATH=$HOME/.cargo/bin:$PATH
 
 export RCT_NO_LAUNCH_PACKAGER=1
-export DOTNET_ROOT=$HOME/.dotnet
 export DOTNET_MULTILEVEL_LOOKUP=0
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_NOLOGO=1
 
 export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_INSTALL_CLEANUP=1


### PR DESCRIPTION
# Description

- .NET is installed in the default location, meaning the latest installed version is automatically available. Anyone wishing to use a different version in a different instance must set the variable manually or use a suitable automation tool ([setup-dotnet](https://github.com/actions/setup-dotnet) for GitHub Actions, [UseDotNet@2](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/use-dotnet-v2?view=azure-pipelines) for Azure DevOps).
- Setting DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 and DOTNET_NOLOGO=1

#### Related issue:

https://github.com/actions/runner-images/issues/13365
https://github.com/actions/runner-images/issues/13470

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
