### PR TITLE
images/windows/toolsets: add NFS-Client optional feature

### DIFF
--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -213,6 +213,7 @@
         { "name": "Containers" },
         { "name": "Microsoft-Windows-Subsystem-Linux", "optionalFeature": true },
         { "name": "VirtualMachinePlatform", "optionalFeature": true },
+        { "name": "NFS-Client", "includeAllSubFeatures": true },
         { "name": "Wireless-Networking" }
     ],
     "visualStudio": {

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -141,6 +141,7 @@
         { "name": "NET-Framework-45-Features", "includeAllSubFeatures": true },
         { "name": "Client-ProjFS", "optionalFeature": true },
         { "name": "NET-Framework-Features", "includeAllSubFeatures": true },
+        { "name": "NFS-Client", "includeAllSubFeatures": true },
         { "name": "Hyper-V", "includeAllSubFeatures": true },
         { "name": "HypervisorPlatform", "optionalFeature": true },
         { "name": "Hyper-V-PowerShell" },

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -123,6 +123,7 @@
         { "name": "NET-Framework-45-Features", "includeAllSubFeatures": true },
         { "name": "Client-ProjFS", "optionalFeature": true },
         { "name": "NET-Framework-Features", "includeAllSubFeatures": true },
+        { "name": "NFS-Client", "includeAllSubFeatures": true },
         { "name": "Hyper-V", "includeAllSubFeatures": true },
         { "name": "HypervisorPlatform", "optionalFeature": true },
         { "name": "Hyper-V-PowerShell" },


### PR DESCRIPTION
# Description

People wanting to use GitHub-hosted Windows runners with a [gomodfs](https://github.com/tailscale/gomodfs/) NFS server need the Windows NFS client, but that takes 3 minutes to install in every run.

This pre-installs it, to save each build 3 minutes later.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
