### PR TITLE
[macos] Fix preimage data

### DIFF
--- a/images/macos/scripts/build/configure-preimagedata.sh
+++ b/images/macos/scripts/build/configure-preimagedata.sh
@@ -9,6 +9,8 @@ source ~/utils/utils.sh
 arch=$(get_arch)
 imagedata_file="$HOME/imagedata.json"
 image_version=$(echo $IMAGE_VERSION | cut -d _ -f 2)
+image_version_major=${image_version/.*/}
+image_version_minor=$(echo $image_version | cut -d "." -f 2)
 os_name=$(sw_vers -productName)
 os_version=$(sw_vers -productVersion)
 os_build=$(sw_vers -buildVersion)
@@ -20,8 +22,8 @@ else
   image_label="macos-${label_version}"
 fi
 
-software_url="https://github.com/actions/runner-images/blob/${image_label}/${image_version}/images/macos/${image_label}-Readme.md"
-releaseUrl="https://github.com/actions/runner-images/releases/tag/${image_label}%2F${image_version}"
+software_url="https://github.com/actions/runner-images/blob/${image_label}/${image_version_major}.${image_version_minor}/images/macos/${image_label}-Readme.md"
+releaseUrl="https://github.com/actions/runner-images/releases/tag/${image_label}%2F${image_version_major}.${image_version_minor}"
 
 cat <<EOF > $imagedata_file
     [


### PR DESCRIPTION
# Description
This PR updates fixes software report and release links for macOS images

#### Related issue: https://github.com/actions/runner-images/issues/13394

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
