### PR TITLE
[windows] Workaround .NET SDK installation

### DIFF
--- a/images/windows/scripts/build/Install-DotnetSDK.ps1
+++ b/images/windows/scripts/build/Install-DotnetSDK.ps1
@@ -97,7 +97,7 @@ $dotnetToolset = (Get-ToolsetContent).dotnet
 # https://github.com/dotnet/install-scripts/pull/676 didn't make it to https://dot.net/v1/dotnet-install.ps1 yet.
 # Temporary change to use specific commit
 $installScriptUrl = "https://raw.githubusercontent.com/dotnet/install-scripts/bf2a23874784df29ff9fefcc50cc96dc41b08b4a/src/dotnet-install.ps1"
-$installScriptPath = Invoke-DownloadWithRetry -Url "$installScriptUrl"
+$installScriptPath = Invoke-DownloadWithRetry -Url $installScriptUrl
 
 # Visual Studio 2022 pre-creates sdk-manifests/8.0.100 folder, causing dotnet-install to skip manifests creation
 # https://github.com/actions/runner-images/issues/11402


### PR DESCRIPTION
# Description
Invoke-WebRequest in PowerShell 5.1 now triggers warning which halts `dotnet-install.ps1` execution. [MS ref](https://support.microsoft.com/en-us/topic/powershell-5-1-preventing-script-execution-from-web-content-7cb95559-655e-43fd-a8bd-ceef2406b705).
This PR updates `dotnet-install.ps1` download URL to workaround the issue

Closes #13418 

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
