### PR TITLE
Add links to Deprecated badges on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ To build a VM machine from this repo's source, see the [instructions](docs/creat
 | macOS 15 Arm64 | `macos-latest`, `macos-15`, or `macos-15-xlarge` | [macOS-15-arm64] |
 | macOS 14 | `macos-14-large`| [macOS-14] |
 | macOS 14 Arm64 | `macos-14` or `macos-14-xlarge`| [macOS-14-arm64] |
-| macOS 13 [![Retired badge](https://img.shields.io/badge/-Retired-red)](https://github.com/actions/runner-images/issues/13046) | `macos-13` or `macos-13-large` | [macOS-13] |
-| macOS 13 Arm64 [![Retired badge](https://img.shields.io/badge/-Retired-red)](https://github.com/actions/runner-images/issues/13046) | `macos-13-xlarge` | [macOS-13-arm64] |
+| macOS 13 [![Deprecated badge](https://img.shields.io/badge/-Deprecated-red)](https://github.com/actions/runner-images/issues/13046) | `macos-13` or `macos-13-large` | [macOS-13] |
+| macOS 13 Arm64 [![Deprecated badge](https://img.shields.io/badge/-Deprecated-red)](https://github.com/actions/runner-images/issues/13046) | `macos-13-xlarge` | [macOS-13-arm64] |
 | Windows Server 2025 | `windows-latest` or `windows-2025` | [windows-2025] |
 | Windows Server 2022 | `windows-2022` | [windows-2022] |
 | Windows Server 2019 [![Deprecated badge](https://img.shields.io/badge/-Deprecated-red)](https://github.com/actions/runner-images/issues/12045) | `windows-2019` | [windows-2019] |


### PR DESCRIPTION
# Description
Currently there is no link in the README, which means you have to manually search the corresponding GitHub issue.

#### Related issue:
- #12045
- #13046
- #12955
  (which is why I did not change Windows Server 2019 from "Deprecated" to "Retired" because apparently on Azure it is still available?)
- #13413
  (this might be a general issue, that those image READMEs for some reason don't link to the deprecation issues)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
