### PR TITLE
[macOS-26] Update Xcode 26.2, add runtimes

### DIFF
--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -7,7 +7,7 @@
                     "link": "26.2",
                     "filename": "Xcode_26.2_Universal",
                     "version": "26.2+17C52",
-                    "sha256": "63743df751791508ac8e4f01a33e3f28f3a59a86ff3f33c8c155c3046daedf42",
+                    "sha256": "8f29ab6a9ac6670d3cf53545ffdb1c317d11607fa8db38fc56d3391df7783fbd",
                     "install_runtimes": "default"
                 },
                 {


### PR DESCRIPTION
# Description

Latest version is available as well as related runtimes.

#### Related issue:

https://github.com/actions/runner-images/issues/13424

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
