### PR TITLE
Preinstall latest dependabot-updater-core docker image into ubuntu-2404

### DIFF
--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -193,6 +193,7 @@
     ],
     "docker": {
         "images": [
+            "ghcr.io/dependabot/dependabot-updater-core:latest"
         ],
         "components": [
             {


### PR DESCRIPTION
# Description
New tool, Bug fixing, or Improvement?
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.

This adds the [dependabot-updater-core:latest image](https://github.com/dependabot/dependabot-core/pkgs/container/dependabot-updater-core) as a preinstalled docker image.  Dependabot pulls this image on every single Dependabot actions job which can cause disruptive behavior to GitHub services, but many of the layers of the image don't frequently change.  

For recurring jobs, on average we enqueue 8-10 jobs/s, peaking weekly on Sunday morning through Monday evening up to 40 jobs/s.   We also deal with bursty usage patterns when large-scale vulnerabilities are disclosed and Dependabot works to open remediation PRs.  The combination of the sustained rate + additional busty behavior can cause Dependabot to run slowly and encounter elevated error rates while pulilng images from GHCR

Preinstalling the image can save up to 12s and 11 layer pulls per job, reducing impact on the systems Dependabot relies on.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

<details><summary>Timing: docker pull on my local machine took ~12s</summary>

The 15s timing below includes ~3s of me filling out a popup prompting me to give docker access to my stored credentials to ghcr.io

```
➜  ~ time docker pull ghcr.io/dependabot/dependabot-updater-core:latest
latest: Pulling from dependabot/dependabot-updater-core
02de03a7213b: Pull complete
22ffc31ce5ef: Pull complete
9633d5c66cb7: Pull complete
493aa06a4db2: Pull complete
4f4fb700ef54: Pull complete
919cf6e8ec76: Pull complete
d6281cdd15ae: Pull complete
1e0f76a1b41f: Pull complete
08ee8b28aab9: Pull complete
b868c62be690: Pull complete
e24f6944b21e: Pull complete
Digest: sha256:e4f859809c0866f0936182fb2f2b30f7384a17b622246537ab42e7e9f006940c
Status: Downloaded newer image for ghcr.io/dependabot/dependabot-updater-core:latest
ghcr.io/dependabot/dependabot-updater-core:latest

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview ghcr.io/dependabot/dependabot-updater-core:latest
docker pull ghcr.io/dependabot/dependabot-updater-core:latest  0.10s user 0.06s system 1% cpu 15.532 total
```

</details>

<details><summary>Size: 775MB</summary>

```
➜  ~ docker image ls
REPOSITORY                                                               TAG       IMAGE ID       CREATED         SIZE
ghcr.io/dependabot/dependabot-updater-core                               latest    c036b208800d   3 days ago      775MB
```

</details>

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
