### PR TITLE
[docs] Remove macOS 13 from docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/announcement.yml
+++ b/.github/ISSUE_TEMPLATE/announcement.yml
@@ -39,8 +39,6 @@ body:
         - label: Ubuntu 22.04
         - label: Ubuntu 24.04
         - label: Ubuntu Slim
-        - label: macOS 13
-        - label: macOS 13 Arm64
         - label: macOS 14
         - label: macOS 14 Arm64
         - label: macOS 15

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -22,8 +22,6 @@ body:
         - label: Ubuntu 22.04
         - label: Ubuntu 24.04
         - label: Ubuntu Slim
-        - label: macOS 13
-        - label: macOS 13 Arm64
         - label: macOS 14
         - label: macOS 14 Arm64
         - label: macOS 15

--- a/.github/ISSUE_TEMPLATE/tool-request.yml
+++ b/.github/ISSUE_TEMPLATE/tool-request.yml
@@ -60,8 +60,6 @@ body:
         - label: Ubuntu 22.04
         - label: Ubuntu 24.04
         - label: Ubuntu Slim
-        - label: macOS 13
-        - label: macOS 13 Arm64
         - label: macOS 14
         - label: macOS 14 Arm64
         - label: macOS 15

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ To build a VM machine from this repo's source, see the [instructions](docs/creat
 | macOS 15 Arm64 | `macos-latest`, `macos-15`, or `macos-15-xlarge` | [macOS-15-arm64] |
 | macOS 14 | `macos-14-large`| [macOS-14] |
 | macOS 14 Arm64 | `macos-14` or `macos-14-xlarge`| [macOS-14-arm64] |
-| macOS 13 [![Deprecated badge](https://img.shields.io/badge/-Deprecated-red)](https://github.com/actions/runner-images/issues/13046) | `macos-13` or `macos-13-large` | [macOS-13] |
-| macOS 13 Arm64 [![Deprecated badge](https://img.shields.io/badge/-Deprecated-red)](https://github.com/actions/runner-images/issues/13046) | `macos-13-xlarge` | [macOS-13-arm64] |
 | Windows Server 2025 | `windows-latest` or `windows-2025` | [windows-2025] |
 | Windows Server 2022 | `windows-2022` | [windows-2022] |
 | Windows Server 2019 [![Deprecated badge](https://img.shields.io/badge/-Deprecated-red)](https://github.com/actions/runner-images/issues/12045) | `windows-2019` | [windows-2019] |
@@ -43,8 +41,6 @@ To build a VM machine from this repo's source, see the [instructions](docs/creat
 [windows-2019]: https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md
 [windows-2025]: https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
 [windows-2022]: https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
-[macOS-13]: https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
-[macOS-13-arm64]: https://github.com/actions/runner-images/blob/main/images/macos/macos-13-arm64-Readme.md
 [macOS-14]: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
 [macOS-14-arm64]: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
 [macOS-15]: https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md


### PR DESCRIPTION
# Description

Images were retired.

#### Related issue:

https://github.com/actions/runner-images/issues/13046

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
