### PR TITLE
[Ubuntu] Update Maven to 3.9.12

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -73,7 +73,7 @@
     "java": {
         "default": "11",
         "versions": [ "8", "11", "17", "21", "25"],
-        "maven": "3.9.11"
+        "maven": "3.9.12"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -71,7 +71,7 @@
     "java": {
         "default": "17",
         "versions": [ "8", "11", "17", "21", "25"],
-        "maven": "3.9.11"
+        "maven": "3.9.12"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",


### PR DESCRIPTION
# Description

Version 3.9.11 was removed from the Maven repository.

#### Related issue:

https://github.com/actions/runner-images/issues/13454

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
