### PR TITLE
Update maven download location for Ubuntu

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -73,7 +73,7 @@
     "java": {
         "default": "11",
         "versions": [ "8", "11", "17", "21", "25"],
-        "maven": "3.9.11"
+        "maven": "3.9.12"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -71,7 +71,7 @@
     "java": {
         "default": "17",
         "versions": [ "8", "11", "17", "21", "25"],
-        "maven": "3.9.11"
+        "maven": "3.9.12"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",


### PR DESCRIPTION
# Description

BugFix: Update Maven download location for Ubuntu images.

# Context

It is a proposal, feel free to comment or decline if it does not fit the java environment, I'm not an expert on it.

#13454 

