### PR TITLE
Use ubuntu-slim for lightweight workflows

### DIFF
--- a/.github/workflows/check-pinned-versions.yml
+++ b/.github/workflows/check-pinned-versions.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   check-pinning-dates:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/create_pull_request.yml
+++ b/.github/workflows/create_pull_request.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   Create_pull_request:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/merge_pull_request.yml
+++ b/.github/workflows/merge_pull_request.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   Merge_pull_request:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/update_github_release.yml
+++ b/.github/workflows/update_github_release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   Update_GitHub_release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
     - name: Update release for ${{ github.event.client_payload.ReleaseBranchName }}


### PR DESCRIPTION
# Description

This PR swaps `ubuntu-latest` with `ubuntu-slim` for lightweight workflows.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: https://github.com/github/hosted-runners-images/issues/418
