### PR TITLE
[macos-15] Update Xcodes and Xcode's runtimes set

### DIFF
--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -4,6 +4,13 @@
         "x64": {
             "versions": [
                 {
+                    "link": "26.2",
+                    "filename": "Xcode_26.2_Universal",
+                    "version": "26.2+17C52",
+                    "sha256": "8f29ab6a9ac6670d3cf53545ffdb1c317d11607fa8db38fc56d3391df7783fbd",
+                    "install_runtimes": "default"
+                },
+                {
                     "link": "26.1.1",
                     "filename": "Xcode_26.1.1_Universal",
                     "version": "26.1.1+17B100",
@@ -25,9 +32,9 @@
                     "version": "16.4.0+16F6",
                     "sha256": "2dbf65ba28fb85b34e72c14c529a42d5c3189ab0f11fb29fdebd5f4ee6c87900",
                     "install_runtimes": [
-                        { "iOS": ["18.4", "18.5", "18.6"] },
-                        { "watchOS": ["11.2", "11.4", "11.5"] },
-                        { "tvOS": ["18.2", "18.4", "18.5"] }
+                        { "iOS": ["18.5", "18.6"] },
+                        { "watchOS": ["11.5"] },
+                        { "tvOS": ["18.5"] }
                     ] 
                 },
                 {
@@ -64,6 +71,13 @@
         "arm64":{
             "versions": [
                 {
+                    "link": "26.2",
+                    "filename": "Xcode_26.2_Universal",
+                    "version": "26.2+17C52",
+                    "sha256": "8f29ab6a9ac6670d3cf53545ffdb1c317d11607fa8db38fc56d3391df7783fbd",
+                    "install_runtimes": "default"
+                },
+                {
                     "link": "26.1.1",
                     "filename": "Xcode_26.1.1_Universal",
                     "version": "26.1.1+17B100",
@@ -85,9 +99,9 @@
                     "version": "16.4.0+16F6",
                     "sha256": "2dbf65ba28fb85b34e72c14c529a42d5c3189ab0f11fb29fdebd5f4ee6c87900",
                     "install_runtimes": [
-                        { "iOS": ["18.4", "18.5", "18.6"] },
-                        { "watchOS": ["11.2", "11.4", "11.5"] },
-                        { "tvOS": ["18.2", "18.4", "18.5"] },
+                        { "iOS": ["18.5", "18.6"] },
+                        { "watchOS": ["11.5"] },
+                        { "tvOS": ["18.5"] },
                         { "visionOS": ["2.3", "2.4", "2.5"] }
                     ]
                 },


### PR DESCRIPTION
# Description

- Deprecating Xcode's runtimes as per announcement
- Adding Xcode 26.2 to macOS-15 using free disk space

#### Related issue:

https://github.com/actions/runner-images/issues/13392

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
