### PR TITLE
Fix typo: Github -> GitHub in BasicTools test description

### DIFF
--- a/images/macos/scripts/tests/BasicTools.Tests.ps1
+++ b/images/macos/scripts/tests/BasicTools.Tests.ps1
@@ -69,7 +69,7 @@ Describe "bazelisk" {
     }
 }
 
-Describe "Github CLI" {
+Describe "GitHub CLI" {
     It "GitHub CLI" {
         "gh --version" | Should -ReturnZeroExitCode
     }


### PR DESCRIPTION
Fixed a simple typo in the macOS BasicTools test file where 'Github' should be 'GitHub' (with capital H) to match the official brand name.

**Changes:**
- Changed `Describe "Github CLI"` to `Describe "GitHub CLI"` in `images/macos/scripts/tests/BasicTools.Tests.ps1`

This is a minor documentation/consistency fix to ensure proper branding throughout the codebase.