### PR TITLE
[windows-2022, ubuntu-22.04] Change to Generation 2 VM

### DIFF
--- a/images/ubuntu/templates/locals.ubuntu.pkr.hcl
+++ b/images/ubuntu/templates/locals.ubuntu.pkr.hcl
@@ -1,7 +1,7 @@
 locals {
   image_properties_map = {
       "ubuntu22" = {
-            source_image_marketplace_sku = "canonical:0001-com-ubuntu-server-jammy:22_04-lts"
+            source_image_marketplace_sku = "canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2"
             os_disk_size_gb = 75
       },
       "ubuntu24" = {

--- a/images/windows/templates/locals.windows.pkr.hcl
+++ b/images/windows/templates/locals.windows.pkr.hcl
@@ -5,7 +5,7 @@ locals {
             os_disk_size_gb = 256
       },
       "win22" = {
-            source_image_marketplace_sku = "MicrosoftWindowsServer:WindowsServer:2022-Datacenter"
+            source_image_marketplace_sku = "MicrosoftWindowsServer:WindowsServer:2022-Datacenter-g2"
             os_disk_size_gb = 256
       },
       "win25" = {


### PR DESCRIPTION
# Description
This PR changes `windows-2022` and `ubuntu-22.04` to produce Generation 2 VMs

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
