### PR TITLE
[windows-2025, ubuntu-24.04] Change to Generation 2 VM

### DIFF
--- a/images/ubuntu/templates/locals.ubuntu.pkr.hcl
+++ b/images/ubuntu/templates/locals.ubuntu.pkr.hcl
@@ -5,7 +5,7 @@ locals {
             os_disk_size_gb = 75
       },
       "ubuntu24" = {
-            source_image_marketplace_sku = "canonical:ubuntu-24_04-lts:server-gen1"
+            source_image_marketplace_sku = "canonical:ubuntu-24_04-lts:server"
             os_disk_size_gb = 75
       }
   }

--- a/images/windows/templates/locals.windows.pkr.hcl
+++ b/images/windows/templates/locals.windows.pkr.hcl
@@ -9,7 +9,7 @@ locals {
             os_disk_size_gb = 256
       },
       "win25" = {
-            source_image_marketplace_sku = "MicrosoftWindowsServer:WindowsServer:2025-Datacenter"
+            source_image_marketplace_sku = "MicrosoftWindowsServer:WindowsServer:2025-Datacenter-g2"
             os_disk_size_gb = 150
       }
   }


### PR DESCRIPTION
# Description
This PR changes `windows-2025` and `ubuntu-24.04` to produce Generation 2 VMs

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
