### PR TITLE
[macOS] Install only Universal simulator runtimes for Xcode 26+

### DIFF
--- a/images/macos/scripts/helpers/Xcode.Installer.psm1
+++ b/images/macos/scripts/helpers/Xcode.Installer.psm1
@@ -213,7 +213,7 @@ function Install-XcodeAdditionalSimulatorRuntimes {
                         Invoke-ValidateCommand "$xcodebuildPath -downloadPlatform $platform -buildVersion $platformVersion $archSuffix" | Out-Null
                         continue
                     }
-                    throw "$platformVersion is not a valid value for $platform version. Valid values are 'latest', or 'skip', or a semver from 0.0 to 99.9.(9), or a build number."
+                    throw "$platformVersion is not a valid value for $platform version. Valid values are 'default', or 'skip', or a semver from 0.0 to 99.9.(9), or a build number."
                 }
             }
         }


### PR DESCRIPTION
# Description

Fixing `xcodebuild` behaviour described here: https://github.com/actions/runner-images/issues/13519#issuecomment-3759635114

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
