### PR TITLE
Update README table to add architecture and label scheme note

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ To build a VM machine from this repo's source, see the [instructions](docs/creat
 
 ### Label scheme
 
-- In general the `-latest` label is used for the latest OS image version that is GA
-- Before moving the`-latest` label to a new OS version we will announce the change and give sufficient lead time for users to update their workflows
+- In general the `-latest` label is used for the latest OS image version that is GA.
+- Before moving the `-latest` label to a new OS version we will announce the change and give sufficient lead time for users to update their workflows.
 - The `-xlarge` and `-large` suffixes are unique to macOS images and are only available for GitHub Actions. Learn more about [GitHub Actions larger runners](https://docs.github.com/en/actions/reference/runners/larger-runners#available-macos-larger-runners-and-labels).
 
 [ubuntu-24.04]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
@@ -84,12 +84,12 @@ The `-latest` migration process is gradual and happens over 1-2 months in order 
 
 *How to best follow along with changes*
 
-1. Find the latest releases for this repository [here.](https://github.com/actions/runner-images/releases)
-2. Subscribe to the releases coming out of this repository, instructions [here.](https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications#configuring-your-watch-settings-for-an-individual-repository)
+1. Find the latest releases for this repository [here](https://github.com/actions/runner-images/releases).
+2. Subscribe to the releases coming out of this repository, instructions [here](https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications#configuring-your-watch-settings-for-an-individual-repository).
 3. Upcoming changes: A pre-release is created when the deployment of an image has started. As soon as the deployment is finished, the pre-release is converted to a release. If you have subscribed to releases, you will get notified of pre-releases as well.
 
    - You can also track upcoming changes using the [awaiting-deployment](https://github.com/actions/runner-images/labels/awaiting-deployment) label.
-4. For high impact changes, we will post these in advance to the GitHub Changelog on our [blog](https://github.blog/changelog/) and on [twitter](https://twitter.com/GHchangelog).
+4. For high impact changes, we will post these in advance to the GitHub Changelog on our [blog](https://github.blog/changelog/) and on [X](https://x.com/GHchangelog).
    - Ex: breaking changes, GA or deprecation of images
 
 *Cadence*
@@ -137,10 +137,10 @@ We use third-party package managers to install software during the image generat
 ### Image Deprecation Policy
 
 - Images begin the deprecation process of the oldest image label once a new GA OS version has been released.
-- Deprecation process begins with an announcement that sets a date for deprecation
-- As it gets closer to the date, GitHub begins doing scheduled brownouts of the image
+- Deprecation process begins with an announcement that sets a date for deprecation.
+- As it gets closer to the date, GitHub begins doing scheduled brownouts of the image.
 - During this time there will be an Announcement pinned in the repo to remind users of the deprecation.
-- Finally GitHub will deprecate the image and it will no longer be available
+- Finally, GitHub will deprecate the image and it will no longer be available.
 
 ### Preinstallation Policy
 


### PR DESCRIPTION
# Description

This PR updates the documentation in `README.md` to clarify architecture and provides additional information about macOS runner labels.

Also fixed typos, etc.

#### Related issues: https://github.com/actions/runner-images/issues/13545

## Check list
- [x] Related issue / work item is attached
~~- [ ] Tests are written (if applicable)~~
- [x] Documentation is updated (if applicable)
~~- [ ] Changes are tested and related VM images are successfully generated~~
