### PR TITLE
Remove Deprecated Workload Component.MDD.Linux.GCC.arm

### DIFF
--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -229,7 +229,6 @@
             "Microsoft.VisualStudio.Workload.Universal",
             "Microsoft.VisualStudio.Workload.VisualStudioExtension",
             "Component.MDD.Linux",
-            "Component.MDD.Linux.GCC.arm",
             "Component.Microsoft.Windows.DriverKit",
             "wasm.tools",
             "Microsoft.Component.MSBuild"

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -207,7 +207,6 @@
             "Microsoft.VisualStudio.Workload.Universal",
             "Microsoft.VisualStudio.Workload.VisualStudioExtension",
             "Component.MDD.Linux",
-            "Component.MDD.Linux.GCC.arm",
             "Component.Microsoft.Windows.DriverKit",
             "wasm.tools",
             "Microsoft.Component.MSBuild"


### PR DESCRIPTION
# Description
Removes from windows Toolsets.
The workload is deprecated and no longer seems to be installable preventing both windows 2022 and 2025 from building correctly.
Deprecation Mention Source: https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-community?view=visualstudio

#### Related issue: https://github.com/actions/runner-images/issues/13562

## Check list
- [ YES ] Related issue / work item is attached
- [ N/A ] Tests are written (if applicable)
- [ N/A ] Documentation is updated (if applicable)
- [ YES ] Changes are tested and related VM images are successfully generated
