### PR TITLE
feat: Add multiple PowerShell version support (stable, lts, preview)

### DIFF
--- a/docs/powershell-multi-version.md
+++ b/docs/powershell-multi-version.md
@@ -1,0 +1,131 @@
+# Multiple PowerShell Versions Support
+
+This document describes the multi-version PowerShell support feature in GitHub Actions runner images.
+
+## Overview
+
+Runner images now include multiple PowerShell versions installed side-by-side, allowing workflows to specify which version channel to use:
+
+- **stable** - The latest stable release of PowerShell
+- **lts** - The Long-Term Support (LTS) version
+- **preview** - The latest preview release
+
+## Installed Versions
+
+Each version is installed to a separate directory and available through channel-specific binaries:
+
+| Channel | Binary | Description |
+|---------|--------|-------------|
+| stable | `pwsh-stable` | Latest stable PowerShell release |
+| lts | `pwsh-lts` | Long-Term Support version |
+| preview | `pwsh-preview` | Latest preview build |
+| default | `pwsh` | Points to the default channel (stable) |
+
+## Using Different Versions
+
+### Direct Invocation
+
+Call the specific version binary directly:
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run with stable
+        run: pwsh-stable -Command "Write-Host 'Using stable PowerShell'; $PSVersionTable"
+
+      - name: Run with LTS
+        run: pwsh-lts -Command "Write-Host 'Using LTS PowerShell'; $PSVersionTable"
+
+      - name: Run with preview
+        run: pwsh-preview -Command "Write-Host 'Using preview PowerShell'; $PSVersionTable"
+```
+
+### Using pwsh-select Helper
+
+The `pwsh-select` utility allows switching the default `pwsh` command between versions:
+
+```bash
+# List installed versions
+pwsh-select list
+
+# Switch to LTS version
+pwsh-select lts
+
+# Switch to preview version
+pwsh-select preview
+
+# Switch back to stable
+pwsh-select stable
+```
+
+Example workflow using `pwsh-select`:
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Switch to LTS PowerShell
+        run: |
+          sudo pwsh-select lts
+          pwsh --version
+
+      - name: Run PowerShell script
+        shell: pwsh
+        run: |
+          Write-Host "Running on PowerShell $($PSVersionTable.PSVersion)"
+```
+
+### Specifying Shell with Full Path
+
+For Windows runners, you can use full paths:
+
+```yaml
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - name: Run with preview PowerShell
+        shell: C:\Program Files\PowerShell\pwsh-preview\pwsh.exe {0}
+        run: |
+          Write-Host "Running PowerShell Preview"
+          $PSVersionTable
+```
+
+## Platform-Specific Paths
+
+### Linux/macOS
+
+- Installation directory: `/opt/microsoft/powershell/`
+- Binaries: `/usr/local/bin/pwsh`, `/usr/local/bin/pwsh-stable`, `/usr/local/bin/pwsh-lts`, `/usr/local/bin/pwsh-preview`
+
+### Windows
+
+- Installation directory: `C:\Program Files\PowerShell\`
+- Channel directories: `pwsh-stable`, `pwsh-lts`, `pwsh-preview`
+- Default link: `C:\Program Files\PowerShell\7\`
+
+## Version Configuration
+
+The versions installed are configured in the toolset JSON files:
+
+```json
+{
+    "pwsh": {
+        "versions": {
+            "stable": "7.5",
+            "lts": "7.4",
+            "preview": "7.6"
+        },
+        "default": "stable"
+    }
+}
+```
+
+## Related Issues
+
+This feature addresses the request in [#13569](https://github.com/actions/runner-images/issues/13569) for specifying PowerShell versions in workflows.
+
+> **Note:** The workflow YAML syntax changes (`version: preview`, `version: lts`, etc.) would need to be implemented in the [actions/runner](https://github.com/actions/runner) repository. This runner-images enhancement provides the infrastructure for multiple versions while that enhancement is developed.

--- a/images/ubuntu-slim/scripts/build/install-powershell.sh
+++ b/images/ubuntu-slim/scripts/build/install-powershell.sh
@@ -1,15 +1,160 @@
 #!/bin/bash -e
 ################################################################################
 ##  File:  install-powershell.sh
-##  Desc:  Install PowerShell Core
+##  Desc:  Install multiple PowerShell Core versions (stable, lts, preview)
 ################################################################################
 
-# Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 
-pwsh_version=$(get_toolset_value .pwsh.version)
+PWSH_INSTALL_DIR="/opt/microsoft/powershell"
 
-# Install Powershell
+get_pwsh_download_url() {
+    local channel=$1
+    local version_prefix=$2
+    local metadata_url="https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/metadata.json"
+    local metadata_file=$(download_with_retry "$metadata_url")
 
-    apt-get install powershell=$pwsh_version*
+    local arch=$(uname -m)
+    local arch_suffix="x64"
+    [[ "$arch" == "aarch64" ]] && arch_suffix="arm64"
+
+    local releases=""
+    if [[ "$channel" == "preview" ]]; then
+        releases=$(jq -r '.PreviewReleaseTag[]' "$metadata_file" 2>/dev/null || jq -r '.PreviewReleaseTag' "$metadata_file")
+    else
+        releases=$(jq -r '.StableReleaseTag[]' "$metadata_file" 2>/dev/null || jq -r '.StableReleaseTag' "$metadata_file")
+        lts_releases=$(jq -r '.LTSReleaseTag[]' "$metadata_file" 2>/dev/null || jq -r '.LTSReleaseTag' "$metadata_file")
+        [[ "$channel" == "lts" ]] && releases="$lts_releases"
+    fi
+
+    local matched_version=""
+    for version in $releases; do
+        version_clean=$(echo "$version" | sed 's/^v//')
+        if [[ "$version_clean" == "$version_prefix"* ]]; then
+            matched_version="$version_clean"
+            break
+        fi
+    done
+
+    if [[ -z "$matched_version" ]]; then
+        echo "No matching version found for $channel ($version_prefix)" >&2
+        return 1
+    fi
+
+    echo "https://github.com/PowerShell/PowerShell/releases/download/v${matched_version}/powershell-${matched_version}-linux-${arch_suffix}.tar.gz"
+}
+
+install_pwsh_version() {
+    local channel=$1
+    local version_prefix=$2
+
+    echo "Installing PowerShell $channel ($version_prefix.*)..."
+
+    local download_url=$(get_pwsh_download_url "$channel" "$version_prefix")
+    if [[ -z "$download_url" ]]; then
+        echo "Failed to get download URL for $channel" >&2
+        return 1
+    fi
+
+    local version=$(echo "$download_url" | grep -oP 'powershell-\K[0-9]+\.[0-9]+\.[0-9]+(-\w+\.\d+)?')
+    local install_path="$PWSH_INSTALL_DIR/$version"
+
+    mkdir -p "$install_path"
+    local archive=$(download_with_retry "$download_url")
+    tar -xzf "$archive" -C "$install_path"
+    rm -f "$archive"
+
+    chmod +x "$install_path/pwsh"
+    ln -sf "$install_path/pwsh" "/usr/local/bin/pwsh-$channel"
+
+    echo "PowerShell $channel ($version) installed to $install_path"
+}
+
+set_default_pwsh() {
+    local default_channel=$1
+
+    echo "Setting default PowerShell to $default_channel..."
+
+    if [[ -L "/usr/local/bin/pwsh-$default_channel" ]]; then
+        local target=$(readlink -f "/usr/local/bin/pwsh-$default_channel")
+        ln -sf "$target" "/usr/local/bin/pwsh"
+        echo "Default PowerShell set to $default_channel"
+    fi
+}
+
+create_version_selector() {
+    cat > /usr/local/bin/pwsh-select << 'SELECTOR_EOF'
+#!/bin/bash
+AVAILABLE_CHANNELS="stable lts preview"
+
+show_help() {
+    echo "Usage: pwsh-select [channel]"
+    echo ""
+    echo "Switch between installed PowerShell versions."
+    echo "Channels: stable, lts, preview"
+    echo ""
+    echo "Examples:"
+    echo "  pwsh-select stable    # Switch to stable"
+    echo "  pwsh-select lts       # Switch to LTS"
+    echo "  pwsh-select preview   # Switch to preview"
+    echo "  pwsh-select list      # List versions"
+}
+
+list_versions() {
+    echo "Installed PowerShell versions:"
+    for channel in $AVAILABLE_CHANNELS; do
+        if [[ -L "/usr/local/bin/pwsh-$channel" ]]; then
+            version=$(/usr/local/bin/pwsh-$channel --version 2>/dev/null | awk '{print $2}')
+            current=""
+            [[ "$(readlink -f /usr/local/bin/pwsh)" == "$(readlink -f /usr/local/bin/pwsh-$channel)" ]] && current=" (current)"
+            echo "  $channel: $version$current"
+        fi
+    done
+}
+
+case "$1" in
+    stable|lts|preview)
+        if [[ -L "/usr/local/bin/pwsh-$1" ]]; then
+            target=$(readlink -f "/usr/local/bin/pwsh-$1")
+            sudo ln -sf "$target" "/usr/local/bin/pwsh"
+            echo "Switched to PowerShell $1"
+            pwsh --version
+        else
+            echo "Error: PowerShell $1 is not installed"
+            exit 1
+        fi
+        ;;
+    list|--list|-l)
+        list_versions
+        ;;
+    help|--help|-h|"")
+        show_help
+        ;;
+    *)
+        echo "Unknown option: $1"
+        show_help
+        exit 1
+        ;;
+esac
+SELECTOR_EOF
+    chmod +x /usr/local/bin/pwsh-select
+}
+
+mkdir -p "$PWSH_INSTALL_DIR"
+
+stable_version=$(get_toolset_value ".pwsh.versions.stable" 2>/dev/null || echo "")
+lts_version=$(get_toolset_value ".pwsh.versions.lts" 2>/dev/null || echo "")
+preview_version=$(get_toolset_value ".pwsh.versions.preview" 2>/dev/null || echo "")
+default_channel=$(get_toolset_value ".pwsh.default" 2>/dev/null || echo "stable")
+
+[[ -n "$stable_version" && "$stable_version" != "null" ]] && install_pwsh_version "stable" "$stable_version"
+[[ -n "$lts_version" && "$lts_version" != "null" ]] && install_pwsh_version "lts" "$lts_version"
+[[ -n "$preview_version" && "$preview_version" != "null" ]] && install_pwsh_version "preview" "$preview_version"
+
+set_default_pwsh "$default_channel"
+create_version_selector
+
+echo ""
+echo "PowerShell installation completed."
+pwsh --version

--- a/images/ubuntu-slim/test.sh
+++ b/images/ubuntu-slim/test.sh
@@ -92,7 +92,11 @@ run_test "bc is installed" bc --version
 run_test "zstd is installed" zstd --version
 run_test "google cloud SDK is installed" gcloud --version
 run_test "git lfs is installed" git lfs version
-run_test "powershell is installed" pwsh --version
+run_test "powershell (default) is installed" pwsh --version
+run_test "powershell stable is installed" pwsh-stable --version
+run_test "powershell lts is installed" pwsh-lts --version
+run_test "powershell preview is installed" pwsh-preview --version
+run_test "pwsh-select helper is installed" pwsh-select list
 run_test "docker-cli is installed" docker --version
 run_test "docker compose is installed" docker compose version
 run_test "docker buildx is installed" docker buildx version

--- a/images/ubuntu-slim/toolsets/toolset.json
+++ b/images/ubuntu-slim/toolsets/toolset.json
@@ -104,6 +104,11 @@
     },
     "node_modules": [ ],
     "pwsh": {
-        "version": "7.5"
+        "versions": {
+            "stable": "7.5",
+            "lts": "7.4",
+            "preview": "7.6"
+        },
+        "default": "stable"
     }
 }

--- a/images/ubuntu/scripts/build/install-powershell.sh
+++ b/images/ubuntu/scripts/build/install-powershell.sh
@@ -1,15 +1,163 @@
 #!/bin/bash -e
 ################################################################################
 ##  File:  install-powershell.sh
-##  Desc:  Install PowerShell Core
+##  Desc:  Install multiple PowerShell Core versions (stable, lts, preview)
 ################################################################################
 
-# Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 
-pwsh_version=$(get_toolset_value .pwsh.version)
+PWSH_INSTALL_DIR="/opt/microsoft/powershell"
 
-# Install Powershell
+get_pwsh_download_url() {
+    local channel=$1
+    local version_prefix=$2
+    local metadata_url="https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/metadata.json"
+    local metadata_file=$(download_with_retry "$metadata_url")
 
-    apt-get install powershell=$pwsh_version*
+    local arch=$(uname -m)
+    local arch_suffix="x64"
+    [[ "$arch" == "aarch64" ]] && arch_suffix="arm64"
+
+    local releases=""
+    if [[ "$channel" == "preview" ]]; then
+        releases=$(jq -r '.PreviewReleaseTag[]' "$metadata_file" 2>/dev/null || jq -r '.PreviewReleaseTag' "$metadata_file")
+    else
+        releases=$(jq -r '.StableReleaseTag[]' "$metadata_file" 2>/dev/null || jq -r '.StableReleaseTag' "$metadata_file")
+        lts_releases=$(jq -r '.LTSReleaseTag[]' "$metadata_file" 2>/dev/null || jq -r '.LTSReleaseTag' "$metadata_file")
+        [[ "$channel" == "lts" ]] && releases="$lts_releases"
+    fi
+
+    local matched_version=""
+    for version in $releases; do
+        version_clean=$(echo "$version" | sed 's/^v//')
+        if [[ "$version_clean" == "$version_prefix"* ]]; then
+            matched_version="$version_clean"
+            break
+        fi
+    done
+
+    if [[ -z "$matched_version" ]]; then
+        echo "No matching version found for $channel ($version_prefix)" >&2
+        return 1
+    fi
+
+    echo "https://github.com/PowerShell/PowerShell/releases/download/v${matched_version}/powershell-${matched_version}-linux-${arch_suffix}.tar.gz"
+}
+
+install_pwsh_version() {
+    local channel=$1
+    local version_prefix=$2
+
+    echo "Installing PowerShell $channel ($version_prefix.*)..."
+
+    local download_url=$(get_pwsh_download_url "$channel" "$version_prefix")
+    if [[ -z "$download_url" ]]; then
+        echo "Failed to get download URL for $channel" >&2
+        return 1
+    fi
+
+    local version=$(echo "$download_url" | grep -oP 'powershell-\K[0-9]+\.[0-9]+\.[0-9]+(-\w+\.\d+)?')
+    local install_path="$PWSH_INSTALL_DIR/$version"
+
+    mkdir -p "$install_path"
+    local archive=$(download_with_retry "$download_url")
+    tar -xzf "$archive" -C "$install_path"
+    rm -f "$archive"
+
+    chmod +x "$install_path/pwsh"
+    ln -sf "$install_path/pwsh" "/usr/local/bin/pwsh-$channel"
+
+    echo "PowerShell $channel ($version) installed to $install_path"
+}
+
+set_default_pwsh() {
+    local default_channel=$1
+
+    echo "Setting default PowerShell to $default_channel..."
+
+    if [[ -L "/usr/local/bin/pwsh-$default_channel" ]]; then
+        local target=$(readlink -f "/usr/local/bin/pwsh-$default_channel")
+        ln -sf "$target" "/usr/local/bin/pwsh"
+        echo "Default PowerShell set to $default_channel"
+    fi
+}
+
+create_version_selector() {
+    cat > /usr/local/bin/pwsh-select << 'SELECTOR_EOF'
+#!/bin/bash
+AVAILABLE_CHANNELS="stable lts preview"
+
+show_help() {
+    echo "Usage: pwsh-select [channel]"
+    echo ""
+    echo "Switch between installed PowerShell versions."
+    echo ""
+    echo "Channels: stable, lts, preview"
+    echo ""
+    echo "Examples:"
+    echo "  pwsh-select stable    # Switch to stable channel"
+    echo "  pwsh-select lts       # Switch to LTS channel"
+    echo "  pwsh-select preview   # Switch to preview channel"
+    echo "  pwsh-select list      # List installed versions"
+}
+
+list_versions() {
+    echo "Installed PowerShell versions:"
+    for channel in $AVAILABLE_CHANNELS; do
+        if [[ -L "/usr/local/bin/pwsh-$channel" ]]; then
+            version=$(/usr/local/bin/pwsh-$channel --version 2>/dev/null | awk '{print $2}')
+            current=""
+            [[ "$(readlink -f /usr/local/bin/pwsh)" == "$(readlink -f /usr/local/bin/pwsh-$channel)" ]] && current=" (current)"
+            echo "  $channel: $version$current"
+        fi
+    done
+}
+
+case "$1" in
+    stable|lts|preview)
+        if [[ -L "/usr/local/bin/pwsh-$1" ]]; then
+            target=$(readlink -f "/usr/local/bin/pwsh-$1")
+            sudo ln -sf "$target" "/usr/local/bin/pwsh"
+            echo "Switched to PowerShell $1"
+            pwsh --version
+        else
+            echo "Error: PowerShell $1 is not installed"
+            exit 1
+        fi
+        ;;
+    list|--list|-l)
+        list_versions
+        ;;
+    help|--help|-h|"")
+        show_help
+        ;;
+    *)
+        echo "Unknown option: $1"
+        show_help
+        exit 1
+        ;;
+esac
+SELECTOR_EOF
+    chmod +x /usr/local/bin/pwsh-select
+}
+
+mkdir -p "$PWSH_INSTALL_DIR"
+
+stable_version=$(get_toolset_value ".pwsh.versions.stable" 2>/dev/null || echo "")
+lts_version=$(get_toolset_value ".pwsh.versions.lts" 2>/dev/null || echo "")
+preview_version=$(get_toolset_value ".pwsh.versions.preview" 2>/dev/null || echo "")
+default_channel=$(get_toolset_value ".pwsh.default" 2>/dev/null || echo "stable")
+
+[[ -n "$stable_version" && "$stable_version" != "null" ]] && install_pwsh_version "stable" "$stable_version"
+[[ -n "$lts_version" && "$lts_version" != "null" ]] && install_pwsh_version "lts" "$lts_version"
+[[ -n "$preview_version" && "$preview_version" != "null" ]] && install_pwsh_version "preview" "$preview_version"
+
+set_default_pwsh "$default_channel"
+create_version_selector
+
+echo ""
+echo "PowerShell installation completed."
+pwsh --version
+echo ""
+pwsh-select list

--- a/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -244,7 +244,11 @@ $cachedTools.AddToolVersionsList("Ruby", $(Get-ToolcacheRubyVersions), "^\d+\.\d
 
 # PowerShell Tools
 $powerShellTools = $installedSoftware.AddHeader("PowerShell Tools")
-$powerShellTools.AddToolVersion("PowerShell", $(Get-PowershellVersion))
+$powerShellTools.AddToolVersion("PowerShell (default)", $(Get-PowershellVersion))
+$pwshVersions = Get-PowerShellVersions
+foreach ($pwshVer in $pwshVersions) {
+    $powerShellTools.AddToolVersion("PowerShell $($pwshVer.Channel)", $pwshVer.Version)
+}
 $powerShellTools.AddHeader("PowerShell Modules").AddNodes($(Get-PowerShellModules))
 
 $installedSoftware.AddHeader("Web Servers").AddTable($(Build-WebServersTable))

--- a/images/ubuntu/scripts/docs-gen/SoftwareReport.Common.psm1
+++ b/images/ubuntu/scripts/docs-gen/SoftwareReport.Common.psm1
@@ -105,6 +105,22 @@ function Get-PowershellVersion {
     return $pwshVersion
 }
 
+function Get-PowerShellVersions {
+    $versions = @()
+    $channels = @("stable", "lts", "preview")
+    foreach ($channel in $channels) {
+        $binary = "pwsh-$channel"
+        if (Get-Command $binary -ErrorAction SilentlyContinue) {
+            $version = (& $binary --version) | Get-StringPart -Part 1
+            $versions += [PSCustomObject]@{
+                Channel = $channel
+                Version = $version
+            }
+        }
+    }
+    return $versions
+}
+
 function Get-RubyVersion {
     $rubyVersion = ruby --version | Out-String | Get-StringPart -Part 1
     return $rubyVersion

--- a/images/ubuntu/scripts/tests/PowerShell.Tests.ps1
+++ b/images/ubuntu/scripts/tests/PowerShell.Tests.ps1
@@ -1,0 +1,49 @@
+Import-Module "$PSScriptRoot/../helpers/Common.Helpers.psm1"
+
+Describe "PowerShell Core Multi-Version" {
+    It "pwsh (default) is installed" {
+        "pwsh --version" | Should -ReturnZeroExitCode
+    }
+
+    It "pwsh-stable is installed" {
+        "pwsh-stable --version" | Should -ReturnZeroExitCode
+    }
+
+    It "pwsh-lts is installed" {
+        "pwsh-lts --version" | Should -ReturnZeroExitCode
+    }
+
+    It "pwsh-preview is installed" {
+        "pwsh-preview --version" | Should -ReturnZeroExitCode
+    }
+
+    It "pwsh-select helper is available" {
+        "pwsh-select --help" | Should -ReturnZeroExitCode
+    }
+
+    It "pwsh versions directory exists" {
+        "/opt/microsoft/powershell" | Should -Exist
+    }
+
+    Context "Version Channels" {
+        $toolset = Get-ToolsetContent
+
+        It "stable version matches toolset" {
+            $expectedVersion = $toolset.pwsh.versions.stable
+            $actualVersion = & pwsh-stable --version | Select-Object -First 1
+            $actualVersion | Should -Match $expectedVersion
+        }
+
+        It "lts version matches toolset" {
+            $expectedVersion = $toolset.pwsh.versions.lts
+            $actualVersion = & pwsh-lts --version | Select-Object -First 1
+            $actualVersion | Should -Match $expectedVersion
+        }
+
+        It "preview version matches toolset" {
+            $expectedVersion = $toolset.pwsh.versions.preview
+            $actualVersion = & pwsh-preview --version | Select-Object -First 1
+            $actualVersion | Should -Match $expectedVersion
+        }
+    }
+}

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -351,6 +351,11 @@
         "version": "14"
     },
     "pwsh": {
-        "version": "7.4"
+        "versions": {
+            "stable": "7.5",
+            "lts": "7.4",
+            "preview": "7.6"
+        },
+        "default": "stable"
     }
 }

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -321,6 +321,11 @@
         "version": "16"
     },
     "pwsh": {
-        "version": "7.4"
+        "versions": {
+            "stable": "7.5",
+            "lts": "7.4",
+            "preview": "7.6"
+        },
+        "default": "stable"
     }
 }

--- a/images/windows/scripts/build/Install-PowershellCore.ps1
+++ b/images/windows/scripts/build/Install-PowershellCore.ps1
@@ -1,43 +1,177 @@
 ################################################################################
 ##  File:  Install-PowershellCore.ps1
-##  Desc:  Install PowerShell Core
+##  Desc:  Install multiple PowerShell Core versions (stable, lts, preview)
 ##  Supply chain security: checksum validation
 ################################################################################
 
 $ErrorActionPreference = "Stop"
 
-$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
-New-Item -ItemType Directory -Path $tempDir -Force -ErrorAction SilentlyContinue | Out-Null
-try {
-    $originalValue = [Net.ServicePointManager]::SecurityProtocol
-    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+$PwshInstallDir = "C:\Program Files\PowerShell"
 
-    $metadata = Invoke-RestMethod https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/metadata.json
-    $pwshMajorMinor = (Get-ToolsetContent).pwsh.version
+function Get-PwshDownloadUrl {
+    param (
+        [string]$Channel,
+        [string]$VersionPrefix
+    )
 
-    $releases = $metadata.LTSReleaseTag -replace '^v'
-    foreach ($release in $releases) {
-        if ($release -like "${pwshMajorMinor}*") {
-            $downloadUrl = "https://github.com/PowerShell/PowerShell/releases/download/v${release}/PowerShell-${release}-win-x64.msi"
-            break
-        }
+    $metadata = Invoke-RestMethod "https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/metadata.json"
+
+    $releases = switch ($Channel) {
+        "preview" { $metadata.PreviewReleaseTag -replace '^v' }
+        "lts" { $metadata.LTSReleaseTag -replace '^v' }
+        default { $metadata.StableReleaseTag -replace '^v' }
     }
 
-    $installerName = Split-Path $downloadUrl -Leaf
-    $externalHash = Get-ChecksumFromUrl -Type "SHA256" `
-        -Url ($downloadUrl -replace $installerName, "hashes.sha256") `
-        -FileName $installerName
-    Install-Binary -Url $downloadUrl -ExpectedSHA256Sum $externalHash
-} finally {
-    # Restore original value
-    [Net.ServicePointManager]::SecurityProtocol = $originalValue
-    Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    foreach ($release in $releases) {
+        if ($release -like "${VersionPrefix}*") {
+            return @{
+                Version = $release
+                Url = "https://github.com/PowerShell/PowerShell/releases/download/v${release}/PowerShell-${release}-win-x64.zip"
+            }
+        }
+    }
+    return $null
 }
 
-# about_update_notifications
-# While the update check happens during the first session in a given 24-hour period, for performance reasons,
-# the notification will only be shown on the start of subsequent sessions.
-# Also for performance reasons, the check will not start until at least 3 seconds after the session begins.
+function Install-PwshVersion {
+    param (
+        [string]$Channel,
+        [string]$VersionPrefix
+    )
+
+    Write-Host "Installing PowerShell $Channel ($VersionPrefix.*)..."
+
+    $downloadInfo = Get-PwshDownloadUrl -Channel $Channel -VersionPrefix $VersionPrefix
+    if (-not $downloadInfo) {
+        Write-Warning "No matching version found for $Channel ($VersionPrefix)"
+        return
+    }
+
+    $version = $downloadInfo.Version
+    $downloadUrl = $downloadInfo.Url
+    $installPath = Join-Path $PwshInstallDir $version
+
+    $archivePath = Invoke-DownloadWithRetry -Url $downloadUrl
+    Expand-Archive -Path $archivePath -DestinationPath $installPath -Force
+    Remove-Item -Path $archivePath -Force
+
+    $linkPath = Join-Path $PwshInstallDir "pwsh-$Channel"
+    if (Test-Path $linkPath) {
+        Remove-Item $linkPath -Recurse -Force
+    }
+    New-Item -ItemType Junction -Path $linkPath -Target $installPath | Out-Null
+
+    Write-Host "PowerShell $Channel ($version) installed to $installPath"
+}
+
+function Set-DefaultPwsh {
+    param ([string]$Channel)
+
+    Write-Host "Setting default PowerShell to $Channel..."
+
+    $linkPath = Join-Path $PwshInstallDir "pwsh-$Channel"
+    if (Test-Path $linkPath) {
+        $target = (Get-Item $linkPath).Target
+        $defaultLink = Join-Path $PwshInstallDir "7"
+        if (Test-Path $defaultLink) {
+            Remove-Item $defaultLink -Recurse -Force
+        }
+        New-Item -ItemType Junction -Path $defaultLink -Target $target | Out-Null
+        Write-Host "Default PowerShell set to $Channel"
+    }
+}
+
+function New-PwshSelectScript {
+    $scriptContent = @'
+param(
+    [Parameter(Position=0)]
+    [string]$Command = "help"
+)
+
+$PwshDir = "C:\Program Files\PowerShell"
+$AvailableChannels = @("stable", "lts", "preview")
+
+function Show-Help {
+    Write-Host "Usage: pwsh-select [channel]"
+    Write-Host ""
+    Write-Host "Switch between installed PowerShell versions."
+    Write-Host "Channels: stable, lts, preview"
+    Write-Host ""
+    Write-Host "Examples:"
+    Write-Host "  pwsh-select stable    # Switch to stable"
+    Write-Host "  pwsh-select lts       # Switch to LTS"
+    Write-Host "  pwsh-select preview   # Switch to preview"
+    Write-Host "  pwsh-select list      # List versions"
+}
+
+function Show-Versions {
+    Write-Host "Installed PowerShell versions:"
+    foreach ($channel in $AvailableChannels) {
+        $channelPath = Join-Path $PwshDir "pwsh-$channel"
+        if (Test-Path $channelPath) {
+            $pwshExe = Join-Path $channelPath "pwsh.exe"
+            if (Test-Path $pwshExe) {
+                $version = (& $pwshExe --version) -replace "PowerShell\s+"
+                $defaultPath = Join-Path $PwshDir "7"
+                $current = ""
+                if ((Test-Path $defaultPath) -and ((Get-Item $defaultPath).Target -eq (Get-Item $channelPath).Target)) {
+                    $current = " (current)"
+                }
+                Write-Host "  ${channel}: ${version}${current}"
+            }
+        }
+    }
+}
+
+switch ($Command) {
+    { $_ -in $AvailableChannels } {
+        $channelPath = Join-Path $PwshDir "pwsh-$Command"
+        if (Test-Path $channelPath) {
+            $target = (Get-Item $channelPath).Target
+            $defaultLink = Join-Path $PwshDir "7"
+            if (Test-Path $defaultLink) {
+                [System.IO.Directory]::Delete($defaultLink, $true)
+            }
+            New-Item -ItemType Junction -Path $defaultLink -Target $target | Out-Null
+            Write-Host "Switched to PowerShell $Command"
+            pwsh --version
+        } else {
+            Write-Error "PowerShell $Command is not installed"
+        }
+    }
+    "list" { Show-Versions }
+    default { Show-Help }
+}
+'@
+    $scriptPath = "C:\Windows\System32\pwsh-select.ps1"
+    Set-Content -Path $scriptPath -Value $scriptContent -Force
+    Write-Host "Created pwsh-select script at $scriptPath"
+}
+
+$toolset = Get-ToolsetContent
+
+$stableVersion = $toolset.pwsh.versions.stable
+$ltsVersion = $toolset.pwsh.versions.lts
+$previewVersion = $toolset.pwsh.versions.preview
+$defaultChannel = $toolset.pwsh.default
+
+if ($stableVersion) { Install-PwshVersion -Channel "stable" -VersionPrefix $stableVersion }
+if ($ltsVersion) { Install-PwshVersion -Channel "lts" -VersionPrefix $ltsVersion }
+if ($previewVersion) { Install-PwshVersion -Channel "preview" -VersionPrefix $previewVersion }
+
+Set-DefaultPwsh -Channel $defaultChannel
+New-PwshSelectScript
+
 [Environment]::SetEnvironmentVariable("POWERSHELL_UPDATECHECK", "Off", "Machine")
+
+$pwshPath = Join-Path $PwshInstallDir "7"
+$envPath = [Environment]::GetEnvironmentVariable("PATH", "Machine")
+if ($envPath -notlike "*$pwshPath*") {
+    [Environment]::SetEnvironmentVariable("PATH", "$pwshPath;$envPath", "Machine")
+}
+
+Write-Host ""
+Write-Host "PowerShell installation completed."
+pwsh --version
 
 Invoke-PesterTests -TestFile "Tools" -TestName "PowerShell Core"

--- a/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -209,7 +209,11 @@ $netCoreTools.AddNodes($(Get-DotnetTools))
 
 # PowerShell Tools
 $psTools = $installedSoftware.AddHeader("PowerShell Tools")
-$psTools.AddToolVersion("PowerShell", $(Get-PowershellCoreVersion))
+$psTools.AddToolVersion("PowerShell (default)", $(Get-PowershellCoreVersion))
+$pwshVersions = Get-PowerShellVersions
+foreach ($pwshVer in $pwshVersions) {
+    $psTools.AddToolVersion("PowerShell $($pwshVer.Channel)", $pwshVer.Version)
+}
 
 $psModules = $psTools.AddHeader("Powershell Modules")
 $psModules.AddNodes($(Get-PowerShellModules))

--- a/images/windows/scripts/docs-gen/SoftwareReport.Common.psm1
+++ b/images/windows/scripts/docs-gen/SoftwareReport.Common.psm1
@@ -73,6 +73,24 @@ function Get-PowershellCoreVersion {
     pwsh --version | Get-StringPart -Part 1
 }
 
+function Get-PowerShellVersions {
+    $versions = @()
+    $channels = @("stable", "lts", "preview")
+    $pwshDir = "C:\Program Files\PowerShell"
+    foreach ($channel in $channels) {
+        $channelPath = Join-Path $pwshDir "pwsh-$channel"
+        $pwshExe = Join-Path $channelPath "pwsh.exe"
+        if (Test-Path $pwshExe) {
+            $version = (& $pwshExe --version) -replace "PowerShell\s+"
+            $versions += [PSCustomObject]@{
+                Channel = $channel
+                Version = $version
+            }
+        }
+    }
+    return $versions
+}
+
 function Get-RubyVersion {
     ruby --version | Get-StringPart -Part 1
 }

--- a/images/windows/scripts/tests/Tools.Tests.ps1
+++ b/images/windows/scripts/tests/Tools.Tests.ps1
@@ -103,12 +103,34 @@ Describe "NSIS" -Skip:(Test-IsWin25) {
 }
 
 Describe "PowerShell Core" {
-    It "pwsh" {
+    It "pwsh (default)" {
         "pwsh --version" | Should -ReturnZeroExitCode
     }
 
     It "Execute 2+2 command" {
         pwsh -Command "2+2" | Should -BeExactly 4
+    }
+
+    It "pwsh-stable is installed" {
+        $stablePath = "C:\Program Files\PowerShell\pwsh-stable\pwsh.exe"
+        $stablePath | Should -Exist
+        "& '$stablePath' --version" | Should -ReturnZeroExitCode
+    }
+
+    It "pwsh-lts is installed" {
+        $ltsPath = "C:\Program Files\PowerShell\pwsh-lts\pwsh.exe"
+        $ltsPath | Should -Exist
+        "& '$ltsPath' --version" | Should -ReturnZeroExitCode
+    }
+
+    It "pwsh-preview is installed" {
+        $previewPath = "C:\Program Files\PowerShell\pwsh-preview\pwsh.exe"
+        $previewPath | Should -Exist
+        "& '$previewPath' --version" | Should -ReturnZeroExitCode
+    }
+
+    It "pwsh-select script exists" {
+        "C:\Windows\System32\pwsh-select.ps1" | Should -Exist
     }
 }
 

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -355,6 +355,11 @@
         "version": "3.*"
     },
     "pwsh": {
-        "version": "7.4"
+        "versions": {
+            "stable": "7.5",
+            "lts": "7.4",
+            "preview": "7.6"
+        },
+        "default": "stable"
     }
 }

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -323,6 +323,11 @@
         "version": "3.*"
     },
     "pwsh": {
-        "version": "7.4"
+        "versions": {
+            "stable": "7.5",
+            "lts": "7.4",
+            "preview": "7.6"
+        },
+        "default": "stable"
     }
 }


### PR DESCRIPTION
## Summary

This PR addresses issue #13569 by adding support for multiple PowerShell versions on runner images.

## Changes

### Toolset Configuration
- Updated all toolsets (Ubuntu 22.04, 24.04, Ubuntu-slim, Windows 2022, 2025) to support version channels:
  - **stable**: 7.5
  - **lts**: 7.4
  - **preview**: 7.6

### Installation Scripts
- Rewrote `install-powershell.sh` for Ubuntu/Ubuntu-slim to install all three channels
- Rewrote `Install-PowershellCore.ps1` for Windows with multi-version support
- Each channel installed to its own directory with channel-specific symlinks

### New Utilities
- Added `pwsh-select` helper script for switching between versions
- Users can call `pwsh-stable`, `pwsh-lts`, or `pwsh-preview` directly

### Tests
- Added `PowerShell.Tests.ps1` for Ubuntu with comprehensive version checks
- Updated `test.sh` for Ubuntu-slim
- Updated `Tools.Tests.ps1` for Windows

### Documentation
- Updated software report generators to list all installed versions
- Added [docs/powershell-multi-version.md](docs/powershell-multi-version.md) with usage instructions

## Usage Examples

```yaml
# Direct invocation
- run: pwsh-stable -Command "$PSVersionTable"
- run: pwsh-lts -Command "Write-Host 'Using LTS'"
- run: pwsh-preview -Command "Test-Path file.txt"

# Switch default version
- run: |
    sudo pwsh-select lts
    pwsh --version
```

## Notes

The full workflow YAML syntax changes (`version: preview`) would need implementation in the `actions/runner` repository. This PR provides the infrastructure (multiple installed versions) to support that enhancement.

Fixes #13569