### PR TITLE
[macOS-26] Switch default Xcode to 26.2

### DIFF
--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -1,6 +1,6 @@
 {
     "xcode": {
-        "default": "26.0.1",
+        "default": "26.2",
         "arm64":{
             "versions": [
                 {


### PR DESCRIPTION
# Description

Let's use latest!

#### Related issue:

https://github.com/actions/runner-images/issues/13519

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
