### PR TITLE
Add image deploy state badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ To build a VM machine from this repo's source, see the [instructions](docs/creat
 
 | Image | Architecture | YAML Label | Included Software |
 | --------------------|--------------|---------------------|------------------|
-| Ubuntu 24.04 | x64 | `ubuntu-latest` or `ubuntu-24.04` | [ubuntu-24.04] |
-| Ubuntu 22.04 | x64 | `ubuntu-22.04` | [ubuntu-22.04] |
-| Ubuntu Slim | x64 | `ubuntu-slim` | [ubuntu-slim] |
-| macOS 26 Arm64 ![beta](https://img.shields.io/badge/beta-yellow) | arm64 | `macos-26` or `macos-26-xlarge` | [macOS-26-arm64] |
-| macOS 15 | x64 | `macos-latest-large`, `macos-15-large`, or `macos-15-intel` | [macOS-15] |
-| macOS 15 Arm64 | arm64 | `macos-latest`, `macos-15`, or `macos-15-xlarge` | [macOS-15-arm64] |
-| macOS 14 | x64 | `macos-14-large`| [macOS-14] |
-| macOS 14 Arm64 | arm64 | `macos-14` or `macos-14-xlarge`| [macOS-14-arm64] |
-| Windows Server 2025 | x64 | `windows-latest` or `windows-2025` | [windows-2025] |
-| Windows Server 2022 | x64 | `windows-2022` | [windows-2022] |
+| Ubuntu 24.04<br>![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fhosted-runners-images-bot%2F79267492faab096d04cdd25ce7014cec%2Fraw%2Fubuntu24.json) | x64 | `ubuntu-latest` or `ubuntu-24.04` | [ubuntu-24.04] |
+| Ubuntu 22.04<br>![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fhosted-runners-images-bot%2F79267492faab096d04cdd25ce7014cec%2Fraw%2Fubuntu22.json) | x64 | `ubuntu-22.04` | [ubuntu-22.04] |
+| Ubuntu Slim<br>![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fhosted-runners-images-bot%2F79267492faab096d04cdd25ce7014cec%2Fraw%2Fubuntu-slim.json) | x64 | `ubuntu-slim` | [ubuntu-slim] |
+| macOS 26 Arm64 ![beta](https://img.shields.io/badge/beta-yellow)<br>![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fhosted-runners-images-bot%2F79267492faab096d04cdd25ce7014cec%2Fraw%2Fmacos-26-arm64.json) | arm64 | `macos-26` or `macos-26-xlarge` | [macOS-26-arm64] |
+| macOS 15<br>![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fhosted-runners-images-bot%2F79267492faab096d04cdd25ce7014cec%2Fraw%2Fmacos-15.json) | x64 | `macos-latest-large`, `macos-15-large`, or `macos-15-intel` | [macOS-15] |
+| macOS 15 Arm64<br>![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fhosted-runners-images-bot%2F79267492faab096d04cdd25ce7014cec%2Fraw%2Fmacos-15-arm64.json) | arm64 | `macos-latest`, `macos-15`, or `macos-15-xlarge` | [macOS-15-arm64] |
+| macOS 14<br>![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fhosted-runners-images-bot%2F79267492faab096d04cdd25ce7014cec%2Fraw%2Fmacos-14.json) | x64 | `macos-14-large`| [macOS-14] |
+| macOS 14 Arm64<br>![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fhosted-runners-images-bot%2F79267492faab096d04cdd25ce7014cec%2Fraw%2Fmacos-14-arm64.json) | arm64 | `macos-14` or `macos-14-xlarge`| [macOS-14-arm64] |
+| Windows Server 2025<br>![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fhosted-runners-images-bot%2F79267492faab096d04cdd25ce7014cec%2Fraw%2Fwin25.json) | x64 | `windows-latest` or `windows-2025` | [windows-2025] |
+| Windows Server 2022<br>![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fhosted-runners-images-bot%2F79267492faab096d04cdd25ce7014cec%2Fraw%2Fwin22.json) | x64 | `windows-2022` | [windows-2022] |
 
 ### Label scheme
 


### PR DESCRIPTION
# Description

This PR updates the virtual machine images table in the `README.md` file to display status badges for each image.

These badges are generated off gist files owned by our bot.

#### Related issue: https://github.com/github/hosted-runners-images/issues/336

## Check list
- [x] Related issue / work item is attached
~~- [ ] Tests are written (if applicable)~~
~~- [ ] Documentation is updated (if applicable)~~
~~- [ ] Changes are tested and related VM images are successfully generated~~
