### PR TITLE
Fix inaccurate comment in ubuntu-slim scripts

### DIFF
--- a/images/ubuntu-slim/scripts/build/install-docker-cli.sh
+++ b/images/ubuntu-slim/scripts/build/install-docker-cli.sh
@@ -4,6 +4,7 @@
 ##  Desc:  Install Docker CLI and plugins (Compose, Buildx) but not the engine.
 ##         The Docker daemon is not included since ubuntu-slim runs as a container.
 ##         ubuntu-slim does not run in Privileged mode, so functionality from these tools is limited.
+##         It cannot build or run containers locally.
 ################################################################################
 
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg


### PR DESCRIPTION
Clarify limitations of Docker CLI in ubuntu-slim container.

# Description
We don't currently support docker-in-docker, so I'm adjusting this comment to call that out.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

https://github.com/actions/runner-images/issues/13583

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
