### PR TITLE
[Windows] Git installation tests for SSH hostkeys

### DIFF
--- a/images/windows/scripts/tests/Git.Tests.ps1
+++ b/images/windows/scripts/tests/Git.Tests.ps1
@@ -23,3 +23,39 @@ Describe "Git" {
         $env:GCM_INTERACTIVE | Should -BeExactly Never
     }
 }
+
+Describe "SshHostkeys" {
+    $sshHosts = 'github.com', 'ssh.dev.azure.com'
+    $sshTestCases = $sshHosts | ForEach-Object {
+        @{
+            hostName = $_
+        }
+    }
+
+    Context "OpenSSH" {
+        It "KnownHosts for <hostname>" -TestCases $sshTestCases {
+            $KnownHosts = "$env:ProgramData\ssh\ssh_known_hosts"
+            $SshKeyGen = "$env:SystemRoot\System32\OpenSSH\ssh-keygen.exe"
+            & $SshKeyGen -F $hostName -f $KnownHosts | Out-String | Should -Match "Host $hostname found"
+        }
+
+        It "SSH accepts <hostname> keys" -TestCases $sshTestCases {
+            $SSHOptions='-o BatchMode=yes'
+            $SshCmd = "$env:SystemRoot\System32\OpenSSH\ssh.exe"
+            & $SshCmd $SSHOptions -T git@$hostName 2>&1 | Out-String | Should -Not -Match "Host key verification failed."
+        }
+    }
+    Context "Git for Windows" {
+        It "KnownHosts for <hostname>" -TestCases $sshTestCases {
+            $KnownHosts = "$env:ProgramFiles\Git\etc\ssh\ssh_known_hosts"
+            $SshKeyGen = "$env:ProgramFiles\Git\usr\bin\ssh-keygen.exe"
+            & $SshKeyGen -F $hostName -f $KnownHosts | Out-String | Should -Match "Host $hostname found"
+        }
+
+        It "SSH accepts <hostname> keys" -TestCases $sshTestCases {
+            $SSHOptions='-o BatchMode=yes'
+            $SshCmd = "$env:ProgramFiles\git\usr\bin\ssh.exe"
+            & $SshCmd $SSHOptions -T git@$hostName 2>&1 | Out-String | Should -Not -Match "Host key verification failed."
+        }
+    }
+}


### PR DESCRIPTION
# Description

This is a follow-up to the comment in #13154 requesting tests be provided. While they did pass my meager testing, the tests aren't the most elegant and I will not be offended in the least should this PR be deemed a worthless addition.

Tests provisioned SSH hostkeys for github.com and ssh.dev.azure.com
* ssh-keygen is able to parse the ssh_known_hosts files
* Hostkeys for github.com and ssh.dev.azure.com are verified

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
