### PR TITLE
Add ALSA (Advanced Linux Sound Architecture) to Ubuntu images

### DIFF
--- a/images/ubuntu/scripts/build/install-alsa.sh
+++ b/images/ubuntu/scripts/build/install-alsa.sh
@@ -1,0 +1,60 @@
+#!/bin/bash -e
+################################################################################
+##  File:  install-alsa.sh
+##  Desc:  Install ALSA (Advanced Linux Sound Architecture) libraries and tools
+##         Provides audio development API for MIDI and sound applications
+################################################################################
+
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/install.sh
+
+echo "Installing ALSA libraries and development tools..."
+
+# Install ALSA packages from apt
+# - alsa-base: Base ALSA configuration files
+# - alsa-utils: ALSA utilities (aplay, arecord, amixer, etc.)
+# - libasound2: ALSA shared library
+# - libasound2-dev: ALSA development files (headers, pkgconfig)
+# - libasound2-plugins: ALSA plugins for additional functionality
+
+apt-get install -y --no-install-recommends \
+    alsa-base \
+    alsa-utils \
+    libasound2 \
+    libasound2-dev \
+    libasound2-plugins
+
+# Create a virtual sound card using snd-dummy for environments without hardware sound
+# This enables ALSA API testing even on headless CI/CD runners
+echo "Loading snd-dummy kernel module for virtual sound card support..."
+if modprobe snd-dummy 2>/dev/null; then
+    echo "snd-dummy module loaded successfully"
+else
+    echo "Warning: Could not load snd-dummy module (may require kernel support)"
+fi
+
+# Ensure snd-dummy loads on boot by adding to modules
+if [ -d /etc/modules-load.d ]; then
+    echo "snd-dummy" > /etc/modules-load.d/alsa-dummy.conf
+    echo "Configured snd-dummy to load on boot"
+fi
+
+# Configure ALSA to use the dummy device as default when no hardware is present
+mkdir -p /etc/alsa/conf.d
+cat > /etc/alsa/conf.d/99-dummy.conf << 'EOF'
+# Default to dummy sound card when no hardware is available
+# This allows ALSA API to function in CI/CD environments
+pcm.!default {
+    type plug
+    slave.pcm "null"
+}
+
+ctl.!default {
+    type hw
+    card 0
+}
+EOF
+
+echo "ALSA installation completed successfully"
+
+invoke_tests "ALSA"

--- a/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -92,6 +92,7 @@ if (Test-IsUbuntu22) {
 
 # Tools
 $tools = $installedSoftware.AddHeader("Tools")
+$tools.AddToolVersion("ALSA", $(Get-AlsaVersion))
 $tools.AddToolVersion("Ansible", $(Get-AnsibleVersion))
 if (Test-IsUbuntu22) {
     $tools.AddToolVersion("apt-fast", $(Get-AptFastVersion))

--- a/images/ubuntu/scripts/docs-gen/SoftwareReport.Tools.psm1
+++ b/images/ubuntu/scripts/docs-gen/SoftwareReport.Tools.psm1
@@ -283,3 +283,8 @@ function Get-YqVersion {
     $yqVersion = $(yq -V) | Get-StringPart -Part 3
     return $yqVersion.TrimStart("v").Trim()
 }
+
+function Get-AlsaVersion {
+    $alsaVersion = dpkg-query -W -f '${Version}' libasound2 | Get-StringPart -Part 0 -Delimiter "-"
+    return $alsaVersion
+}

--- a/images/ubuntu/scripts/tests/ALSA.Tests.ps1
+++ b/images/ubuntu/scripts/tests/ALSA.Tests.ps1
@@ -1,0 +1,39 @@
+Import-Module "$PSScriptRoot/../helpers/Common.Helpers.psm1"
+
+Describe "ALSA" {
+    It "libasound2 is installed" {
+        $result = Get-CommandResult "dpkg -s libasound2"
+        $result.ExitCode | Should -Be 0
+        $result.Output | Should -Match "Status: install ok installed"
+    }
+
+    It "libasound2-dev is installed" {
+        $result = Get-CommandResult "dpkg -s libasound2-dev"
+        $result.ExitCode | Should -Be 0
+        $result.Output | Should -Match "Status: install ok installed"
+    }
+
+    It "alsa-utils is installed" {
+        $result = Get-CommandResult "dpkg -s alsa-utils"
+        $result.ExitCode | Should -Be 0
+        $result.Output | Should -Match "Status: install ok installed"
+    }
+
+    It "ALSA development headers exist" {
+        "/usr/include/alsa/asoundlib.h" | Should -Exist
+    }
+
+    It "ALSA pkgconfig file exists" {
+        "/usr/lib/x86_64-linux-gnu/pkgconfig/alsa.pc" | Should -Exist
+    }
+
+    It "aplay command is available" {
+        $result = Get-Command "aplay" -ErrorAction SilentlyContinue
+        $result | Should -Not -BeNullOrEmpty
+    }
+
+    It "amixer command is available" {
+        $result = Get-Command "amixer" -ErrorAction SilentlyContinue
+        $result | Should -Not -BeNullOrEmpty
+    }
+}

--- a/images/ubuntu/templates/build.ubuntu-22_04.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-22_04.pkr.hcl
@@ -99,6 +99,7 @@ build {
     execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
+      "${path.root}/../scripts/build/install-alsa.sh",
       "${path.root}/../scripts/build/install-apt-common.sh",
       "${path.root}/../scripts/build/install-azcopy.sh",
       "${path.root}/../scripts/build/install-azure-cli.sh",

--- a/images/ubuntu/templates/build.ubuntu-24_04.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-24_04.pkr.hcl
@@ -99,6 +99,7 @@ provisioner "shell" {
     execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
+      "${path.root}/../scripts/build/install-alsa.sh",
       "${path.root}/../scripts/build/install-apt-common.sh",
       "${path.root}/../scripts/build/install-azcopy.sh",
       "${path.root}/../scripts/build/install-azure-cli.sh",


### PR DESCRIPTION
## Description

This PR adds ALSA (Advanced Linux Sound Architecture) libraries and development tools to Ubuntu 22.04 and 24.04 runner images to enable audio/MIDI application development and testing in CI/CD workflows.

## Changes

### New Files
- `images/ubuntu/scripts/build/install-alsa.sh` - Installation script
- `images/ubuntu/scripts/tests/ALSA.Tests.ps1` - Pester tests

### Modified Files
- `images/ubuntu/templates/build.ubuntu-22_04.pkr.hcl` - Added ALSA to build
- `images/ubuntu/templates/build.ubuntu-24_04.pkr.hcl` - Added ALSA to build
- `images/ubuntu/scripts/docs-gen/SoftwareReport.Tools.psm1` - Version reporting
- `images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1` - Documentation

## Packages Installed

| Package | Description |
|---------|-------------|
| `alsa-base` | Base ALSA configuration files |
| `alsa-utils` | ALSA utilities (aplay, arecord, amixer, etc.) |
| `libasound2` | ALSA shared library |
| `libasound2-dev` | ALSA development files (headers, pkgconfig) |
| `libasound2-plugins` | ALSA plugins for additional functionality |

## Additional Configuration

- Configures `snd-dummy` kernel module for virtual sound card support
- Sets up ALSA to work in headless CI/CD environments without hardware audio
- Creates default configuration for null PCM device

## Testing

The Pester tests validate:
- Package installation status
- Development headers existence (`/usr/include/alsa/asoundlib.h`)
- pkgconfig file presence
- CLI tools availability (`aplay`, `amixer`)

## Use Case

This enables developers working with audio/MIDI libraries (like DryWetMIDI) to run their test suites on GitHub Actions and Azure DevOps hosted agents.

Fixes #13610