### PR TITLE
Update URL for Windows 11 SDK installation

### DIFF
--- a/images/windows/scripts/build/Install-VisualStudio.ps1
+++ b/images/windows/scripts/build/Install-VisualStudio.ps1
@@ -37,7 +37,7 @@ if (Test-IsWin22) {
 
 # Install Windows 11 SDK version 10.0.26100
 Install-Binary -Type EXE `
-    -Url 'https://go.microsoft.com/fwlink/?linkid=2286561' `
+    -Url 'https://go.microsoft.com/fwlink/?linkid=2349110' `
     -InstallArgs @("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64") `
     -ExpectedSubject $(Get-MicrosoftPublisher)
 


### PR DESCRIPTION
# Description
Update Windows 11 SDK version to the latest 10.0.26100.7705 (Feb 2026)

Related issue:
https://github.com/actions/runner-images/issues/13626

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
