### PR TITLE
[ubuntu] Update docker to 29.1.5, compose to 2.40.3

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -222,11 +222,11 @@
             },
             {
                 "package": "docker-ce-cli",
-                "version": "28.0.4"
+                "version": "29.1.5"
             },
             {
                 "package": "docker-ce",
-                "version": "28.0.4"
+                "version": "29.1.5"
             }
         ],
         "plugins": [
@@ -237,7 +237,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.38.2",
+                "version": "2.40.3",
                 "asset": "linux-x86_64"
             }
         ]

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -199,11 +199,11 @@
             },
             {
                 "package": "docker-ce-cli",
-                "version": "28.0.4"
+                "version": "29.1.5"
             },
             {
                 "package": "docker-ce",
-                "version": "28.0.4"
+                "version": "29.1.5"
             }
         ],
         "plugins": [
@@ -214,7 +214,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.38.2",
+                "version": "2.40.3",
                 "asset": "linux-x86_64"
             }
         ]


### PR DESCRIPTION
# Description
This PR updates `docker` and `docker compose` on ubuntu images:
- docker is updated to `29.1.5`
- docker compose is updated to `2.40.3`

#### Related issue: https://github.com/actions/runner-images/issues/13474

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
