### PR TITLE
Add support for any version of Powershell Core on Windows images.

### DIFF
--- a/images/windows/scripts/build/Install-PowershellCore.ps1
+++ b/images/windows/scripts/build/Install-PowershellCore.ps1
@@ -21,10 +21,16 @@ try {
     } else {
         # Major.minor only, search release tags for latest matching version, from most to least stable.
         $releases = @($metadata.LTSReleaseTag) + @($metadata.StableReleaseTag) + @($metadata.ReleaseTag) + @($metadata.ServicingReleaseTag) + @($metadata.PreviewReleaseTag) + @($metadata.NextReleaseTag) | ForEach-Object { $_ -replace '^v' }
-        foreach ($release in $releases) {
-            if ($release -like "${pwshVersion}*") {
+        $release = $null
+        foreach ($r in $releases) {
+            if (-not [string]::IsNullOrEmpty($r) -and $r.StartsWith($pwshVersion, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $release = $r
                 break
             }
+        }
+        
+        if ([string]::IsNullOrEmpty($release)) {
+            throw "Could not find a matching PowerShell release for version ${pwshVersion}"
         }
     }
 


### PR DESCRIPTION
# Description
Allow the request of any version of PWSH on windows images.
The previous install script only supported LTS releases.
This change allows for major, minor or patch versioning. (7, 7.5, 7.5.4)
This change matches the Ubuntu behavior.
If a partial version is provided, the complete version is match from the most stable tag to the least stable tag.

#### Related issue: https://github.com/actions/runner-images/issues/13660

## Check list
- [x ] Related issue / work item is attached
- [x ] Tests are written (if applicable)
- [x ] Documentation is updated (if applicable)
- [x ] Changes are tested and related VM images are successfully generated
