### PR TITLE
[Ubuntu] Set sticky bit for Ruby hosted toolcache directory

### DIFF
--- a/images/ubuntu/scripts/build/configure-system.sh
+++ b/images/ubuntu/scripts/build/configure-system.sh
@@ -14,7 +14,7 @@ chmod -R 777 /usr/share
 echo "chmod -R 777 /opt"
 chmod -R 777 /opt
 echo "Setting sticky bit on hostedtoolcache Ruby directories due to the changes in Ruby 4.0; see issue: https://github.com/actions/runner-images/issues/13647"
-chmod -R +t /opt/hostedtoolcache/Ruby
+find /opt/hostedtoolcache/Ruby -type d -exec chmod +t {} +
 
 chmod 755 $IMAGE_FOLDER
 


### PR DESCRIPTION
# Description

Ruby 4.0 has ACL check for some purpose.

#### Related issue:

#13647

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
