### PR TITLE
[Windows] Added workaround for broken .NET 10.0.103

### DIFF
--- a/images/windows/scripts/build/Install-DotnetSDK.ps1
+++ b/images/windows/scripts/build/Install-DotnetSDK.ps1
@@ -107,6 +107,11 @@ if ((Test-IsWin22) -or (Test-IsWin25)) {
 # Install and warm up dotnet
 foreach ($dotnetVersion in $dotnetToolset.versions) {
     $sdkVersionsToInstall = Get-SDKVersionsToInstall -DotnetVersion $dotnetVersion
+
+    # Issue https://github.com/actions/runner-images/issues/13705
+    # Workaround for broken .NET SDK 10.0.103 - replace it with .NET SDK 10.0.102
+    $sdkVersionsToInstall = $sdkVersionsToInstall | ForEach-Object { if ($_ -eq "10.0.103") { Write-Host ".NET 10.0.103 detected, replacing with 10.0.102"; "10.0.102" } else { $_ } }
+
     foreach ($sdkVersion in $sdkVersionsToInstall) {
         Install-DotnetSDK -InstallScriptPath $installScriptPath -SDKVersion $sdkVersion -DotnetVersion $dotnetVersion
         if ($dotnetToolset.warmup) {


### PR DESCRIPTION
# Description
- Added workaround which pins stable .NET version 10.0.102 instead of broken 10.0.103

#### Related issue:
https://github.com/actions/runner-images/issues/13705

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
