### PR TITLE
[MacOS] Update XCode 26.4 to Beta 2

### DIFF
--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -8,7 +8,7 @@
                     "filename": "Xcode_26.4_beta_2_Universal",
                     "version": "26.4+17E5170d",
                     "symlinks": ["26.4"],
-                    "sha256": "c3b9ae14b208909bfb369b3c4bdd23993579afcba10c40bb6825ad7c29f0291e",
+                    "sha256": "962d6bf68816f0328a6cc632153110943be4b2f59b6e0ce05ce6c07ce3edad95",
                     "install_runtimes": "none"
                 },
                 {
@@ -47,11 +47,11 @@
         "arm64": {
             "versions": [
                 {
-                    "link": "26.4_beta",
-                    "filename": "Xcode_26.4_beta_Universal",
-                    "version": "26.4+17E5159k",
+                    "link": "26.4_beta_2",
+                    "filename": "Xcode_26.4_beta_2_Universal",
+                    "version": "26.4+17E5170d",
                     "symlinks": ["26.4"],
-                    "sha256": "c3b9ae14b208909bfb369b3c4bdd23993579afcba10c40bb6825ad7c29f0291e",
+                    "sha256": "962d6bf68816f0328a6cc632153110943be4b2f59b6e0ce05ce6c07ce3edad95",
                     "install_runtimes": "none"
                 },
                 {


### PR DESCRIPTION
# Description
- Updated XCode 26.4 to Beta 2

#### Related issue:
https://github.com/actions/runner-images/issues/13720

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
