### PR TITLE
Preinstall docker images for the Agentic Worfklows

### DIFF
--- a/images/ubuntu/scripts/build/install-docker.sh
+++ b/images/ubuntu/scripts/build/install-docker.sh
@@ -65,9 +65,16 @@ systemctl is-enabled --quiet docker.service || systemctl enable docker.service
 sleep 10
 docker info
 
-# Pull Dependabot docker image
 if ! is_ubuntu22; then
+    # Pull Dependabot docker image
     docker pull ghcr.io/dependabot/dependabot-updater-core:latest
+
+    # Pull AW docker images
+    docker pull ghcr.io/github/gh-aw-mcpg:latest
+    docker pull ghcr.io/github/gh-aw-firewall/agent:latest
+    docker pull ghcr.io/github/gh-aw-firewall/api-proxy:latest
+    docker pull ghcr.io/github/gh-aw-firewall/squid:latest
+    docker pull ghcr.io/github/github-mcp-server:latest
 fi
 
 # Download amazon-ecr-credential-helper


### PR DESCRIPTION
# Description

This PR pre-installs Docker images used by the [Agentic Workflows](https://github.github.com/gh-aw/) 

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
