### PR TITLE
[Windows] Fix 406 when installing java tools

### DIFF
--- a/images/windows/scripts/build/Install-JavaTools.ps1
+++ b/images/windows/scripts/build/Install-JavaTools.ps1
@@ -53,7 +53,7 @@ function Install-JavaJDK {
     )
 
     # Get Java version from api
-    $assetUrl = Invoke-RestMethod -Uri "https://api.adoptium.net/v3/assets/latest/${JDKVersion}/hotspot"
+    $assetUrl = Invoke-RestMethod -Uri "https://api.adoptium.net/v3/assets/latest/${JDKVersion}/hotspot" -Headers @{"Accept" = "application/json"}
 
     $asset = $assetUrl | Where-Object {
         $_.binary.os -eq "windows" `


### PR DESCRIPTION
# Description
Fix error during java tool installation on Windows images
 
>Invoke-RestMethod : The remote server returned an error: (406) Not Acceptable


Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.

Added accept header when calling to Adoptium api in `images/windows/scripts/build/Install-JavaTools.ps1`. When I was attempting to create Windows images it was failing during java install with 406 from Adoptium.

- Fixes actions/runner-images#13781

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
