### PR TITLE
[ubuntu] Fix .Net SDK sorting

### DIFF
--- a/images/ubuntu/scripts/build/install-dotnetcore-sdk.sh
+++ b/images/ubuntu/scripts/build/install-dotnetcore-sdk.sh
@@ -47,7 +47,7 @@ for version in ${dotnet_versions[@]}; do
     sdks=("${sdks[@]}" $(echo "${releases}" | jq -r '.releases[].sdks[]?.version | select(contains("preview") or contains("rc") | not)'))
 done
 
-sorted_sdks=$(echo ${sdks[@]} | tr ' ' '\n' | sort -r | uniq -w 5)
+sorted_sdks=$(echo ${sdks[@]} | tr ' ' '\n' | sort -rV | awk -F'.' '!seen[$1"."$2"."int($3/100)]++' )
 
 # Issue https://github.com/actions/runner-images/issues/13705
 # Workaround for broken .NET SDK 10.0.103 - replace it with .NET SDK 10.0.102


### PR DESCRIPTION
# Description
This PR fixes .NET SDK sorting in [install-dotnetcore-sdk.sh](https://github.com/actions/runner-images/compare/main...shamil-mubarakshin:ubuntu-patch-dotnet-sdk-sort?expand=1#diff-3a7280bfc10eff7fe7baa1354e44e343e7539ce5aab4ee5e3d115c2099c5eba2) script for ubuntu images

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
