### PR TITLE
[MacOS] Updated XCode26.4 to Beta3

### DIFF
--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -8,7 +8,7 @@
                     "filename": "Xcode_26.4_beta_3_Universal",
                     "version": "26.4+17E5179g",
                     "symlinks": ["26.4"],
-                    "sha256": "962d6bf68816f0328a6cc632153110943be4b2f59b6e0ce05ce6c07ce3edad95",
+                    "sha256": "dc55afeb7cdbfed3547996ce273058b46a8922c78005ab371da7f4bcdddfa53a",
                     "install_runtimes": "none"
                 },
                 {
@@ -54,7 +54,7 @@
                     "filename": "Xcode_26.4_beta_3_Universal",
                     "version": "26.4+17E5179g",
                     "symlinks": ["26.4"],
-                    "sha256": "962d6bf68816f0328a6cc632153110943be4b2f59b6e0ce05ce6c07ce3edad95",
+                    "sha256": "dc55afeb7cdbfed3547996ce273058b46a8922c78005ab371da7f4bcdddfa53a",
                     "install_runtimes": "none"
                 },
                 {


### PR DESCRIPTION
# Description
- Updated XCode26.4 to Beta3 for MacOS 26 Intel and ARM

#### Related issue:
- https://github.com/actions/runner-images/issues/13778

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
