### PR TITLE
[Windows] Fix Maven 406 error. Add filters to assets request

### DIFF
--- a/images/windows/scripts/build/Install-JavaTools.ps1
+++ b/images/windows/scripts/build/Install-JavaTools.ps1
@@ -53,7 +53,7 @@ function Install-JavaJDK {
     )
 
     # Get Java version from api
-    $assetUrl = Invoke-RestMethod -Uri "https://api.adoptium.net/v3/assets/latest/${JDKVersion}/hotspot" -Headers @{"Accept" = "application/json"}
+    $assetUrl = Invoke-RestMethod -Uri "https://api.adoptium.net/v3/assets/latest/${JDKVersion}/hotspot?architecture=${Architecture}&os=windows" -Headers @{"Accept" = "application/json"}
 
     $asset = $assetUrl | Where-Object {
         $_.binary.os -eq "windows" `


### PR DESCRIPTION
# Description
Fix Maven 406 error. Add filters to assets request

#### Related issue:
https://github.com/actions/runner-images/issues/13781

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
