### PR TITLE
Change CodeQL bundle download format to .tar.zst

### DIFF
--- a/images/ubuntu/scripts/build/install-codeql-bundle.sh
+++ b/images/ubuntu/scripts/build/install-codeql-bundle.sh
@@ -30,7 +30,7 @@ bundle_tag_name="codeql-bundle-v$bundle_version"
 echo "Downloading CodeQL bundle $bundle_version..."
 # Note that this is the all-platforms CodeQL bundle, to support scenarios where customers run
 # different operating systems within containers.
-codeql_archive=$(download_with_retry "https://github.com/github/codeql-action/releases/download/$bundle_tag_name/codeql-bundle-linux64.tar.gz")
+codeql_archive=$(download_with_retry "https://github.com/github/codeql-action/releases/download/$bundle_tag_name/codeql-bundle-linux64.tar.zst")
 
 codeql_toolcache_path="$AGENT_TOOLSDIRECTORY/CodeQL/$bundle_version/x64"
 mkdir -p "$codeql_toolcache_path"


### PR DESCRIPTION
Updated download link for CodeQL bundle to use `.tar.zst` format. 
[We are seeing](https://github.com/github/codeql-team/issues/4544#issuecomment-4069510455) toolcache miss and requests to donwload CodeQL latest version despite the fact that the version requested is the same as the version installed. Checking the codeql-action download we see that the action tries to download a `.tar.zst` in all platform (but windows), so this change is needed to install the proper version (`.tar.zst`) in Ubuntu.
This is the codeql-action code that checks the existence of the pre-installed bundle:
``` 
        const expectedExtension = process.env['RUNNER_OS'] === 'Windows' ? '.tar.gz' : '.tar.zst';
        if (!toolsUrl.endsWith(expectedExtension)) {
          core.setFailed(
            `Expected the tools URL to be a ${expectedExtension} file, but found ${toolsUrl}.`
          );
        }
```

# Description
Bug fixing

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
