### PR TITLE
fix: Configure-Xcode-Simulators duplicate removal logic

### DIFF
--- a/images/macos/scripts/build/Configure-Xcode-Simulators.ps1
+++ b/images/macos/scripts/build/Configure-Xcode-Simulators.ps1
@@ -41,30 +41,38 @@ foreach ($xcodeVersion in $xcodeVersions.link) {
             }
         }
         Write-Host "///////////////////////////////////////////////////////////////////"
-        for ($i = 0; $i -lt $sameRuntimeDevices.Count; $i++) {
-            if ( [string]::IsNullOrEmpty($($sameRuntimeDevices[$i+1].DeviceName)) ){
-                Write-Host "No more devices to compare in $simRuntume"
-                Write-Host "-------------------------------------------------------------------"
-                continue
-            }
-            Write-Host "$($sameRuntimeDevices[$i].DeviceName) - DeviceId $($sameRuntimeDevices[$i].DeviceId) comparing with"
-            Write-Host "$($sameRuntimeDevices[$i+1].DeviceName) - DeviceId $($sameRuntimeDevices[$i+1].DeviceId)"
+
+        # Fixed iteration logic - don't increment when removing duplicates
+        $i = 0
+        while ($i -lt ($sameRuntimeDevices.Count - 1)) {
+            $current = $sameRuntimeDevices[$i]
+            $next = $sameRuntimeDevices[$i + 1]
+
+            Write-Host "$($current.DeviceName) - DeviceId $($current.DeviceId) comparing with"
+            Write-Host "$($next.DeviceName) - DeviceId $($next.DeviceId)"
             Write-Host "-------------------------------------------------------------------"
-            if ($sameRuntimeDevices[$i].DeviceName -eq $sameRuntimeDevices[$i+1].DeviceName) {
+
+            if ($current.DeviceName -eq $next.DeviceName) {
                 Write-Host "*******************************************************************"
                 Write-Host "** Duplicate found"
-                if ($sameRuntimeDevices[$i].DeviceCreationTime -lt $sameRuntimeDevices[$i+1].DeviceCreationTime) {
-                    Write-Host "** will be removed $($sameRuntimeDevices[$i+1].DeviceName) with id $($sameRuntimeDevices[$i+1].DeviceId)"
-                    xcrun simctl delete $sameRuntimeDevices[$i+1].DeviceId
-                    $sameRuntimeDevices.RemoveAt($i+1)
+                if ($current.DeviceCreationTime -lt $next.DeviceCreationTime) {
+                    Write-Host "** will be removed $($next.DeviceName) with id $($next.DeviceId)"
+                    xcrun simctl delete $next.DeviceId
+                    $sameRuntimeDevices.RemoveAt($i + 1)
                 } else {
-                    Write-Host "** will be removed $($sameRuntimeDevices[$i].DeviceName) with id $($sameRuntimeDevices[$i].DeviceId)"
-                    xcrun simctl delete $sameRuntimeDevices[$i].DeviceId
+                    Write-Host "** will be removed $($current.DeviceName) with id $($current.DeviceId)"
+                    xcrun simctl delete $current.DeviceId
                     $sameRuntimeDevices.RemoveAt($i)
                 }
                 Write-Host "*******************************************************************"
+                # don't increment; compare again at same index
+            } else {
+                $i++
             }
         }
+
+        Write-Host "No more devices to compare in $simRuntume"
+        Write-Host "-------------------------------------------------------------------"
     }
 }
 


### PR DESCRIPTION
# Description
Bug fix -- configure xcode simulators sometimes leaves duplicate entries

There is a case where some duplicate xcode simulators are being missed.

```
Case:

Here A and B are simulators and the numeric values are time.

Initial array:
[ A:0, A:1, A:2, B:0, B:1 ]

Index:
  0    1    2    3    4

Pass 1:
i = 0
   v
[ A:0, A:1, A:2, B:0, B:1 ]
  ^    ^
  |    |
  |    +-- compare with A:1 -> same simulator kind as A:0
  +------- current item A:0

Action:
- remove A:1

Array becomes:
[ A:0, A:2, B:0, B:1 ]

New index layout:
  0    1    2    3

Problem in old logic:
- after removal, loop still increments i
- so i becomes 1

Pass 2:
i = 1
        v
[ A:0, A:2, B:0, B:1 ]
  0    1    2    3

Now we are at:
       ^
       |
       +-- A:2

So the comparison is now effectively:
A:2 vs B:0

That is fine, but:

[ A:0, A:2, B:0, B:1 ]
  ^    ^
  |    |
  |    +-- still another A remains
  +------- original A still present

So we skipped re-checking index 0 against the new shifted value A:2.
```

The updated code basically updates i only if no simulator matches were found.

We can close this PR and do the co-author thing since this is a macos contribution
**For new tools, please provide total size and installation time.**

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
