### PR TITLE
[MacOS] XCode 26.4 GA, modified available runtimes

### DIFF
--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -4,12 +4,11 @@
         "x64": {
             "versions": [
                 {
-                    "link": "26.4_Release_Candidate",
-                    "filename": "Xcode_26.4_Release_Candidate_Universal",
+                    "link": "26.4",
+                    "filename": "Xcode_26.4_Universal",
                     "version": "26.4+17E192",
-                    "symlinks": ["26.4"],
                     "sha256": "1049032d89389cc7d803d7097359a7420c2e9747b4ce2b9cf4b81c9f3f634dfa",
-                    "install_runtimes": "none"
+                    "install_runtimes": "default"
                 },
                 {
                     "link": "26.3",
@@ -43,19 +42,18 @@
                     "version": "26.0.1+17A400",
                     "symlinks": ["26.0"],
                     "sha256": "9881c457068c86ac91e94cca2d7116dfd01cb7179c22b0863b63c7f3bb7e7695",
-                    "install_runtimes": "default"
+                    "install_runtimes": "none"
                 }
             ]
         },
         "arm64": {
             "versions": [
                 {
-                    "link": "26.4_Release_Candidate",
-                    "filename": "Xcode_26.4_Release_Candidate_Universal",
+                    "link": "26.4",
+                    "filename": "Xcode_26.4_Universal",
                     "version": "26.4+17E192",
-                    "symlinks": ["26.4"],
                     "sha256": "1049032d89389cc7d803d7097359a7420c2e9747b4ce2b9cf4b81c9f3f634dfa",
-                    "install_runtimes": "none"
+                    "install_runtimes": "default"
                 },
                 {
                     "link": "26.3",
@@ -90,7 +88,7 @@
                     "version": "26.0.1+17A400",
                     "symlinks": ["26.0"],
                     "sha256": "9881c457068c86ac91e94cca2d7116dfd01cb7179c22b0863b63c7f3bb7e7695",
-                    "install_runtimes": "default"
+                    "install_runtimes": "none"
                 }
             ]
         }


### PR DESCRIPTION
# Description
- XCode 26.4 moved to GA
- Added 26.4 runtimes
- Removed 26.0.1 runtimes

#### Related issue:
- https://github.com/actions/runner-images/issues/13853

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
