### PR TITLE
[windows-11] Unset DisableBlockAtFirstSeen defender preference

### DIFF
--- a/images/windows/scripts/build/Configure-WindowsDefender.ps1
+++ b/images/windows/scripts/build/Configure-WindowsDefender.ps1
@@ -32,7 +32,7 @@ $avPreference += @(
 # DisableBlockAtFirstSeen=1 is flagged as a threat by defender and gets remediated (removed) on Windows 11 during build
 # Running defender scan later causes false positive alert on older remediation event
 # Set this preference only for Windows Servers
-if (not(Test-IsWin11-Arm64)) {
+if (-not (Test-IsWin11-Arm64)) {
     $avPreference += @{DisableBlockAtFirstSeen = $true}
 }
 

--- a/images/windows/scripts/build/Configure-WindowsDefender.ps1
+++ b/images/windows/scripts/build/Configure-WindowsDefender.ps1
@@ -8,7 +8,6 @@ $avPreference = @(
     @{DisableArchiveScanning = $true}
     @{DisableAutoExclusions = $true}
     @{DisableBehaviorMonitoring = $true}
-    @{DisableBlockAtFirstSeen = $true}
     @{DisableCatchupFullScan = $true}
     @{DisableCatchupQuickScan = $true}
     @{DisableIntrusionPreventionSystem = $true}
@@ -29,6 +28,13 @@ $avPreference += @(
     @{EnableControlledFolderAccess = "Disable"}
     @{EnableNetworkProtection = "Disabled"}
 )
+
+# DisableBlockAtFirstSeen=1 is flagged as a threat by defender and gets remediated (removed) on Windows 11 during build
+# Running defender scan later causes false positive alert on older remediation event
+# Set this preference only for Windows Servers
+if (not(Test-IsWin11-Arm64)) {
+    $avPreference += @{DisableBlockAtFirstSeen = $true}
+}
 
 $avPreference | Foreach-Object {
     $avParams = $_


### PR DESCRIPTION
# Description
`DisableBlockAtFirstSeen=1` is flagged as a threat by defender and gets remediated (removed) on Windows 11 during image build. Running defender scan later causes false positive alert on older remediation event.
Set this preference for Windows Servers

#### Related issue: https://github.com/github/hosted-runners-images/issues/608

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
