### PR TITLE
[macos-26] Update to xcode26.5beta2, xcode26.4.1

### DIFF
--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -15,6 +15,7 @@
                     "link": "26.4.1",
                     "filename": "Xcode_26.4.1_Universal",
                     "version": "26.4.1+17E202",
+                    "symlinks": ["26.4"],
                     "sha256": "e2698ef350e5b38740132b1110d02bd22a1feb928c3e019c168d373ce00e3ffa",
                     "install_runtimes": "default"
                 },
@@ -68,6 +69,7 @@
                     "link": "26.4.1",
                     "filename": "Xcode_26.4.1_Universal",
                     "version": "26.4.1+17E202",
+                    "symlinks": ["26.4"],
                     "sha256": "e2698ef350e5b38740132b1110d02bd22a1feb928c3e019c168d373ce00e3ffa",
                     "install_runtimes": "default"
                 },

--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -4,9 +4,9 @@
         "x64": {
             "versions": [
                 {
-                    "link": "26.5_beta",
-                    "filename": "Xcode_26.5_beta_Universal",
-                    "version": "26.5+17F5012f",
+                    "link": "26.5_beta_2",
+                    "filename": "Xcode_26.5_beta_2_Universal",
+                    "version": "26.5+17F5022i",
                     "symlinks": ["26.5"],
                     "sha256": "1342821cc2b93a64dfe06c4697617208df537cbfde4b66c4548e2310e4cb374e",
                     "install_runtimes": "none"

--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -57,18 +57,18 @@
         "arm64": {
             "versions": [
                 {
-                    "link": "26.5_beta",
-                    "filename": "Xcode_26.5_beta_Universal",
-                    "version": "26.5+17F5012f",
+                    "link": "26.5_beta_2",
+                    "filename": "Xcode_26.5_beta_2_Universal",
+                    "version": "26.5+17F5022i",
                     "symlinks": ["26.5"],
-                    "sha256": "1342821cc2b93a64dfe06c4697617208df537cbfde4b66c4548e2310e4cb374e",
+                    "sha256": "4e08f652cf56fe32d209f55d64f1ec71c20c8acfeb92898a21215ca71e17ff7d",
                     "install_runtimes": "none"
                 },
                 {
-                    "link": "26.4",
-                    "filename": "Xcode_26.4_Universal",
-                    "version": "26.4+17E192",
-                    "sha256": "1049032d89389cc7d803d7097359a7420c2e9747b4ce2b9cf4b81c9f3f634dfa",
+                    "link": "26.4.1",
+                    "filename": "Xcode_26.4.1_Universal",
+                    "version": "26.4.1+17E202",
+                    "sha256": "e2698ef350e5b38740132b1110d02bd22a1feb928c3e019c168d373ce00e3ffa",
                     "install_runtimes": "default"
                 },
                 {

--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -15,7 +15,7 @@
                     "link": "26.4.1",
                     "filename": "Xcode_26.4.1_Universal",
                     "version": "26.4.1+17E202",
-                    "sha256": "1049032d89389cc7d803d7097359a7420c2e9747b4ce2b9cf4b81c9f3f634dfa",
+                    "sha256": "e2698ef350e5b38740132b1110d02bd22a1feb928c3e019c168d373ce00e3ffa",
                     "install_runtimes": "default"
                 },
                 {

--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -8,7 +8,7 @@
                     "filename": "Xcode_26.5_beta_2_Universal",
                     "version": "26.5+17F5022i",
                     "symlinks": ["26.5"],
-                    "sha256": "1342821cc2b93a64dfe06c4697617208df537cbfde4b66c4548e2310e4cb374e",
+                    "sha256": "4e08f652cf56fe32d209f55d64f1ec71c20c8acfeb92898a21215ca71e17ff7d",
                     "install_runtimes": "none"
                 },
                 {

--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -12,9 +12,9 @@
                     "install_runtimes": "none"
                 },
                 {
-                    "link": "26.4",
-                    "filename": "Xcode_26.4_Universal",
-                    "version": "26.4+17E192",
+                    "link": "26.4.1",
+                    "filename": "Xcode_26.4.1_Universal",
+                    "version": "26.4.1+17E202",
                     "sha256": "1049032d89389cc7d803d7097359a7420c2e9747b4ce2b9cf4b81c9f3f634dfa",
                     "install_runtimes": "default"
                 },


### PR DESCRIPTION
# Description

This PR adds Xcode 26.5 beta 2, xcode26.4.1 to macos-26 and macos-26 ARM

#### Related issue: https://github.com/actions/runner-images/issues/13934

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
