### PR TITLE
[Ubuntu] Use archive.apache.org for Maven downloads

### DIFF
--- a/images/ubuntu/scripts/build/install-java-tools.sh
+++ b/images/ubuntu/scripts/build/install-java-tools.sh
@@ -90,7 +90,7 @@ set_etc_environment_variable "ANT_HOME" "/usr/share/ant"
 
 # Install Maven
 mavenVersion=$(get_toolset_value '.java.maven')
-mavenDownloadUrl="https://dlcdn.apache.org/maven/maven-3/${mavenVersion}/binaries/apache-maven-${mavenVersion}-bin.zip"
+mavenDownloadUrl="https://archive.apache.org/dist/maven/maven-3/${mavenVersion}/binaries/apache-maven-${mavenVersion}-bin.zip"
 maven_archive_path=$(download_with_retry "$mavenDownloadUrl")
 unzip -qq -d /usr/share "$maven_archive_path"
 ln -s /usr/share/apache-maven-${mavenVersion}/bin/mvn /usr/bin/mvn


### PR DESCRIPTION
# Description

Switches Ubuntu Maven download source from `dlcdn.apache.org` to `archive.apache.org` in `images/ubuntu/scripts/build/install-java-tools.sh`.

This avoids recurring build failures when older Maven patch versions are removed from the CDN mirror and the pinned version in the toolset is no longer available.

## Related issue

Fixes #13771
Fixes #13961
Closes #13961 

## Validation

- Verified the updated Maven URL pattern resolves for the currently pinned Maven version (`3.9.14`): HTTP `200 OK`.
- Confirmed the change is minimal and preserves existing install flow (single URL host change).

## Check list

- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated