### PR TITLE
[MacOS] Added workaround for broken AzCopy ARM link

### DIFF
--- a/images/macos/scripts/build/install-azcopy.sh
+++ b/images/macos/scripts/build/install-azcopy.sh
@@ -7,7 +7,9 @@
 source ~/utils/utils.sh
 
 if is_Arm64; then
-    url="https://aka.ms/downloadazcopy-v10-mac-arm64"
+    # Temporarily hardcoded until common link is fixed
+    # url="https://aka.ms/downloadazcopy-v10-mac-arm64"
+    url="https://github.com/Azure/azure-storage-azcopy/releases/download/v10.32.3/azcopy_darwin_arm64_10.32.3.zip"
 else
     url="https://aka.ms/downloadazcopy-v10-mac"
 fi


### PR DESCRIPTION
# Description
AzCopy ARM link has been broken after latest release, this PR adds a workaround for it until link is fixed in upstream.

## Check list
- [x] Changes are tested
