### PR TITLE
[MacOS] Restored short link to AzCopy download

### DIFF
--- a/images/macos/scripts/build/install-azcopy.sh
+++ b/images/macos/scripts/build/install-azcopy.sh
@@ -7,9 +7,7 @@
 source ~/utils/utils.sh
 
 if is_Arm64; then
-    # Temporarily hardcoded until common link is fixed
-    # url="https://aka.ms/downloadazcopy-v10-mac-arm64"
-    url="https://github.com/Azure/azure-storage-azcopy/releases/download/v10.32.3/azcopy_darwin_arm64_10.32.3.zip"
+    url="https://aka.ms/downloadazcopy-v10-mac-arm64"
 else
     url="https://aka.ms/downloadazcopy-v10-mac"
 fi


### PR DESCRIPTION
# Description
Short link to download AzCopy for MacOS ARM has been fixed in upstream. Workaround with pinned version removed.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated:
  - [MacOS 15 ARM](https://github.com/github/hosted-runners-images/actions/runs/25852894606)
  - [MacOS 26 ARM](https://github.com/github/hosted-runners-images/actions/runs/25852903005)