### PR TITLE
Close Setup Assistant window in configure-windows.sh

### DIFF
--- a/images/macos/scripts/build/configure-windows.sh
+++ b/images/macos/scripts/build/configure-windows.sh
@@ -12,8 +12,6 @@ if is_Arm64; then
     osascript -e 'tell application "System Preferences" to quit'
 
     # Close Setup Assistant window which can auto-launch on first boot of arm64 macOS 15.
-    # Log explicitly whether the window was present so we can correlate future failures
-    # against the actual behavior of this dismissal path.
     if pgrep -x "Setup Assistant" >/dev/null 2>&1; then
         echo "Setup Assistant detected; attempting graceful quit"
         osascript -e 'tell application "Setup Assistant" to quit' 2>/dev/null || true

--- a/images/macos/scripts/build/configure-windows.sh
+++ b/images/macos/scripts/build/configure-windows.sh
@@ -10,6 +10,13 @@ source ~/utils/utils.sh
 if is_Arm64; then
     echo "Close System Preferences window"
     osascript -e 'tell application "System Preferences" to quit'
+
+    # Close Setup Assistant window which can auto-launch on first boot of arm64 macOS 15.
+    # We try a graceful AppleScript quit first, then fall back to pkill in case the app
+    # is not yet scriptable. Both commands are tolerated to no-op when the app is absent.
+    echo "Close Setup Assistant window"
+    osascript -e 'tell application "Setup Assistant" to quit' 2>/dev/null || true
+    pkill -x "Setup Assistant" 2>/dev/null || true
 fi
 
 retry=10

--- a/images/macos/scripts/build/configure-windows.sh
+++ b/images/macos/scripts/build/configure-windows.sh
@@ -12,11 +12,21 @@ if is_Arm64; then
     osascript -e 'tell application "System Preferences" to quit'
 
     # Close Setup Assistant window which can auto-launch on first boot of arm64 macOS 15.
-    # We try a graceful AppleScript quit first, then fall back to pkill in case the app
-    # is not yet scriptable. Both commands are tolerated to no-op when the app is absent.
-    echo "Close Setup Assistant window"
-    osascript -e 'tell application "Setup Assistant" to quit' 2>/dev/null || true
-    pkill -x "Setup Assistant" 2>/dev/null || true
+    # Log explicitly whether the window was present so we can correlate future failures
+    # against the actual behavior of this dismissal path.
+    if pgrep -x "Setup Assistant" >/dev/null 2>&1; then
+        echo "Setup Assistant detected; attempting graceful quit"
+        osascript -e 'tell application "Setup Assistant" to quit' 2>/dev/null || true
+        sleep 1
+        if pgrep -x "Setup Assistant" >/dev/null 2>&1; then
+            echo "Setup Assistant still running; force-killing"
+            pkill -x "Setup Assistant" 2>/dev/null || true
+        else
+            echo "Setup Assistant exited gracefully"
+        fi
+    else
+        echo "Setup Assistant not running; no action needed"
+    fi
 fi
 
 retry=10

--- a/images/ubuntu/toolsets/toolset-2204-arm64.json
+++ b/images/ubuntu/toolsets/toolset-2204-arm64.json
@@ -339,7 +339,12 @@
         "version": "14"
     },
     "cmake": {
-        "version": "3.31.6"
+        "version": "3.31.6",
+        "pinnedDetails": {
+            "reason": "Pinned to avoid CMake 4.0 compatibility issues",
+            "link": "https://github.com/actions/runner-images/issues/11926",
+            "review-at": "2026-09-01"
+        }
     },
     "pwsh": {
         "version": "7.4"

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -350,7 +350,12 @@
         "version": "14"
     },
     "cmake": {
-        "version": "3.31.6"
+        "version": "3.31.6",
+        "pinnedDetails": {
+            "reason": "Pinned to avoid CMake 4.0 compatibility issues",
+            "link": "https://github.com/actions/runner-images/issues/11926",
+            "review-at": "2026-09-01"
+        }
     },
     "pwsh": {
         "version": "7.4"

--- a/images/ubuntu/toolsets/toolset-2404-arm64.json
+++ b/images/ubuntu/toolsets/toolset-2404-arm64.json
@@ -316,7 +316,12 @@
         "version": "16"
     },
     "cmake": {
-        "version": "3.31.6"
+        "version": "3.31.6",
+        "pinnedDetails": {
+            "reason": "Pinned to avoid CMake 4.0 compatibility issues",
+            "link": "https://github.com/actions/runner-images/issues/11926",
+            "review-at": "2026-09-01"
+        }
     },
     "pwsh": {
         "version": "7.4"

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -320,7 +320,12 @@
         "version": "16"
     },
     "cmake": {
-        "version": "3.31.6"
+        "version": "3.31.6",
+        "pinnedDetails": {
+            "reason": "Pinned to avoid CMake 4.0 compatibility issues",
+            "link": "https://github.com/actions/runner-images/issues/11926",
+            "review-at": "2026-09-01"
+        }
     },
     "pwsh": {
         "version": "7.4"

--- a/images/windows/toolsets/toolset-win-11-arm64.json
+++ b/images/windows/toolsets/toolset-win-11-arm64.json
@@ -294,7 +294,12 @@
         "version": "3.10"
     },
     "llvm": {
-        "version": "20.1.6"
+        "version": "20.1.6",
+        "pinnedDetails": {
+            "reason": "Pinned to a specific version for Windows 11 ARM64 initial image support",
+            "link": "https://github.com/actions/runner-images/pull/13879",
+            "review-at": "2026-09-01"
+        }
     },
     "php": {
         "version": "8.4"

--- a/images/windows/toolsets/toolset-win-11-vs2026-arm64.json
+++ b/images/windows/toolsets/toolset-win-11-vs2026-arm64.json
@@ -286,7 +286,12 @@
         "version": "3.10"
     },
     "llvm": {
-        "version": "20.1.6"
+        "version": "20.1.6",
+        "pinnedDetails": {
+            "reason": "Pinned to a specific version for Windows 11 ARM64 initial image support",
+            "link": "https://github.com/actions/runner-images/pull/13879",
+            "review-at": "2026-09-01"
+        }
     },
     "php": {
         "version": "8.4"


### PR DESCRIPTION
# Description

Fix an intermittent failure of [`images/macos/scripts/build/configure-windows.sh`](https://github.com/actions/runner-images/blob/main/images/macos/scripts/build/configure-windows.sh) on arm64 macOS 15 (`macOS-15.arm64.anka.pkr.hcl`) where the script aborts because the first-boot **Setup Assistant** window auto-launches after the reboot triggered by the preceding `configure-machine.sh` provisioner.

The post-reboot provisioner runs `configure-windows.sh` with only a 30s `pause_before`. The script enumerates open windows via AppleScript and exits 1 if it finds anything other than `NotificationCenter`. On arm64 macOS 15 the system Setup Assistant (`/System/Library/CoreServices/Setup Assistant.app`) often appears in that window list, failing the Packer build with:

```
Found opened window:
 - window Window of application process Setup Assistant
Script exited with non-zero exit status: 1.
```

This mirrors the existing handling of the System Preferences window: try a graceful AppleScript `quit` first, then fall back to a name-based process kill. Both calls are guarded with `|| true` so they no-op cleanly on healthy boots where Setup Assistant never launched.

The change is scoped to the existing `is_Arm64` block; Intel images are unaffected.

A follow-up commit adds explicit diagnostic logging so the runtime path is observable in future runs (one of three distinct messages per invocation: `not running; no action needed`, `exited gracefully`, or `still running; force-killing`).

## Validation

Validated end-to-end against the exact failing workflow path (`macOS-15.arm64.anka.pkr.hcl` on rack `sat12-bq148`, base `ghcr.io/github/mcv3-boot/macos-base-arm:15`) via downstream consumer [`github/hosted-runners-images`](https://github.com/github/hosted-runners-images):

**Workflow run:** [`Build GitHub-MacOS15-Arm64` (run 26115852227)](https://github.com/github/hosted-runners-images/actions/runs/26115852227) ✅ Build job success (full pipeline still running through Save/Triage at time of writing).

**Build log shows the new diagnostic block emitting the most informative branch:**

```
18:40:56.390  ==> null.template: Provisioning with shell script: …/scripts/build/configure-windows.sh
18:40:56.903  ==> null.template: Close System Preferences window
18:40:56.968  ==> null.template: Setup Assistant detected; attempting graceful quit
18:40:58.097  ==> null.template: Setup Assistant still running; force-killing
```

**Cross-checked against the VM's unified log (`log show --predicate process == "Setup Assistant"`):**

| Workflow log | VM unified log | What it confirms |
| --- | --- | --- |
| `Setup Assistant detected; attempting graceful quit` (18:40:56.968) | `Handling Quit AppleEvent` → `applicationShouldTerminate: NSTerminateCancel` → `App termination canceled` (18:40:56.127) | AppleScript quit was attempted and explicitly **refused** by Setup Assistant |
| `Setup Assistant still running; force-killing` (18:40:58.097) | `Untracked client disconnected: Setup Assistant (pid = 409)` → `launchd: pid/409 [Setup Assistant]: shutting down` → `cleaning up` (18:40:57.226) | `pkill -x` fallback fired and forcibly terminated the process |

**Notable finding:** the graceful AppleScript quit path does not actually work for Setup Assistant — it returns `NSTerminateCancel`. The `pkill -x` fallback is therefore load-bearing in production. The original "simple osascript quit" approach (mirroring System Preferences) would not have been sufficient on its own; the diagnostic logging makes this dynamic visible going forward.

After dismissal, the next provisioner (`install-powershell.sh`) started 3 seconds later, no `Found opened window` lines were emitted, and the full Packer build (~1h 55m of subsequent installs) completed successfully.

#### Related issue:

[github/maccloud#8731 — Setup Assistant Fails MacOS 15 ARM Image Builds](https://github.com/github/maccloud/issues/8731) (observed in downstream consumer `github/hosted-runners-images` Packer build for `GitHub-MacOS15-Arm64`).

#### Note on CI

A separate commit  adds the required `pinnedDetails` metadata (reason, link, review-at) to the `cmake` (Ubuntu) and `llvm` (Windows ARM64) toolset entries that have fully-pinned 3-segment versions, fixing the pre-existing `Validate JSON Schema` check failure that was red on every push to `main` and on every open PR. Files updated:

- `images/ubuntu/toolsets/toolset-2204{,-arm64}.json` (cmake 3.31.6)
- `images/ubuntu/toolsets/toolset-2404{,-arm64}.json` (cmake 3.31.6)
- `images/windows/toolsets/toolset-win-11{,-vs2026}-arm64.json` (llvm 20.1.6)

These are out of scope for the Setup Assistant fix itself but were folded in to keep this PR green and unblock review.

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
