### PR TITLE
[MacOS] Update Rust installation script to pin rustup formula

### DIFF
--- a/images/macos/scripts/build/install-rust.sh
+++ b/images/macos/scripts/build/install-rust.sh
@@ -7,7 +7,7 @@
 source ~/utils/utils.sh
 
 echo "Installing Rustup..."
-## Pin rustup due https://github.com/actions/runner-images/issues/14097
+## Pin rustup due to https://github.com/actions/runner-images/issues/14097
 COMMIT=cfffe64fa6fc4d56b3b2299ce07f224191098b6a
 FORMULA_URL="https://raw.githubusercontent.com/Homebrew/homebrew-core/$COMMIT/Formula/r/rustup.rb"
 FORMULA_PATH="$(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/r/rustup.rb"

--- a/images/macos/scripts/build/install-rust.sh
+++ b/images/macos/scripts/build/install-rust.sh
@@ -7,7 +7,13 @@
 source ~/utils/utils.sh
 
 echo "Installing Rustup..."
-brew_smart_install "rustup-init"
+## Pin rustup due https://github.com/actions/runner-images/issues/14097
+COMMIT=cfffe64fa6fc4d56b3b2299ce07f224191098b6a
+FORMULA_URL="https://raw.githubusercontent.com/Homebrew/homebrew-core/$COMMIT/Formula/r/rustup.rb"
+FORMULA_PATH="$(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/r/rustup.rb"
+mkdir -p "$(dirname $FORMULA_PATH)"
+curl -fsSL $FORMULA_URL -o $FORMULA_PATH
+HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install rustup
 
 echo "Installing Rust language..."
 rustup-init -y --no-modify-path --default-toolchain=stable --profile=minimal


### PR DESCRIPTION
# Description
Pin rustup installation to a specific commit and update the installation method due broken symlinks 

#### Related issue:

https://github.com/actions/runner-images/issues/14097

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
