### PR TITLE
[Ubuntu] Fix GHCup version regex to accept v-prefixed banner

### DIFF
--- a/images/ubuntu/scripts/docs-gen/SoftwareReport.Common.psm1
+++ b/images/ubuntu/scripts/docs-gen/SoftwareReport.Common.psm1
@@ -222,7 +222,7 @@ function Get-GHCVersion {
 }
 
 function Get-GHCupVersion {
-    $(ghcup --version) -match "version (?<version>\d+(\.\d+){2,})" | Out-Null
+    $(ghcup --version) -match "version v?(?<version>\d+(\.\d+){2,})" | Out-Null
     return $Matches.version
 }
 


### PR DESCRIPTION
## Description

GHCup 0.2.x reintroduced a `v` prefix in its `--version` banner, e.g.

```
The GHCup Haskell installer, version v0.2.2.0
```

The current regex in `Get-GHCupVersion` requires a digit immediately after `version `, so the match fails, `$Matches.version` is `$null`, and software-report generation aborts with:

```
ToolVersionNode 'GHCup' has empty version
At /imagegeneration/SoftwareReport/software-report-base/SoftwareReport.Nodes.psm1:166
```

This is a regression of #6919, which removed the `v` from the regex at a time when GHCup had stopped emitting one. Now that it's back, the regex needs to accept both forms.

The change makes the `v` optional (`v?`) so the regex matches both old (`0.1.50.2`) and new (`v0.2.2.0`) banners.

## Reproduction

```bash
$ docker run --rm ubuntu:24.04 bash -c '
    apt-get update -qq && apt-get install -y -qq curl ca-certificates build-essential libffi-dev libgmp-dev libncurses-dev > /dev/null
    BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_INSTALL_NO_STACK_HOOK=1 BOOTSTRAP_HASKELL_GHC_VERSION=0 GHCUP_INSTALL_BASE_PREFIX=/usr/local \
        curl --proto =https --tlsv1.2 -fsSL https://get-ghcup.haskell.org | sh > /dev/null 2>&1
    /usr/local/.ghcup/bin/ghcup --version'
The GHCup Haskell installer, version v0.2.2.0
```

Fixes #14142