### PR TITLE
Add option to pre-cache configured docker images on ubuntu

### DIFF
--- a/images/ubuntu/scripts/build/install-docker.sh
+++ b/images/ubuntu/scripts/build/install-docker.sh
@@ -75,6 +75,25 @@ sleep 10
 docker info
 
 if ! is_ubuntu22; then
+    docker_images=$(get_toolset_value '.docker.images[]?')
+    while IFS= read -r docker_image; do
+        [[ -z "$docker_image" ]] && continue
+
+        image_registry=${docker_image%%/*}
+        is_dockerhub_image=false
+        if [[ "$image_registry" != *.* && "$image_registry" != *:* && "$image_registry" != "localhost" ]]; then
+            is_dockerhub_image=true
+        fi
+
+        if [[ "$is_dockerhub_image" == "true" && "${DOCKERHUB_PULL_IMAGES:-no}" != "yes" ]]; then
+            echo "Skipping Docker Hub image ${docker_image}; set DOCKERHUB_PULL_IMAGES=yes to pull it"
+            continue
+        fi
+
+        echo "Pulling Docker image ${docker_image}"
+        docker pull "$docker_image"
+    done <<< "$docker_images"
+
     # Pull Dependabot docker image
     docker pull ghcr.io/dependabot/dependabot-updater-core:latest
 


### PR DESCRIPTION
# Description
Improvement to the Docker image handling on Ubuntu by adding functionality to pre-cache configured Docker images. This change allows users to pull specified images before they are needed, enhancing efficiency and reducing wait times during deployment. No related issues are fixed with this change. 

**For new tools, please provide total size and installation time.**

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
