### PR TITLE
[Ubuntu] Pre-install Static Swift Linux SDK

### DIFF
--- a/images/ubuntu/Ubuntu2204-Readme.md
+++ b/images/ubuntu/Ubuntu2204-Readme.md
@@ -28,6 +28,7 @@
 - Python 3.10.12
 - Ruby 3.0.2p107
 - Swift 6.3.1
+- Swift Static Linux SDK 0.1.0
 
 ### Package Management
 - cpan 1.64
@@ -374,4 +375,3 @@ Use the following command as a part of your job to start the service: 'sudo syst
 | xz-utils               | 5.2.5-2ubuntu1                      |
 | zip                    | 3.0-12build2                        |
 | zsync                  | 0.6.2-3ubuntu1                      |
-

--- a/images/ubuntu/Ubuntu2404-Readme.md
+++ b/images/ubuntu/Ubuntu2404-Readme.md
@@ -26,6 +26,7 @@
 - Python 3.12.3
 - Ruby 3.2.3
 - Swift 6.3.1
+- Swift Static Linux SDK 0.1.0
 
 ### Package Management
 - cpan 1.64
@@ -328,4 +329,3 @@ Use the following command as a part of your job to start the service: 'sudo syst
 | xz-utils               | 5.6.1+really5.4.5-1ubuntu0.2 |
 | zip                    | 3.0-13ubuntu0.2              |
 | zsync                  | 0.6.2-5build1                |
-

--- a/images/ubuntu/scripts/build/install-swift.sh
+++ b/images/ubuntu/scripts/build/install-swift.sh
@@ -11,19 +11,38 @@ source $HELPER_SCRIPTS/os.sh
 
 # Install
 image_label="ubuntu$(lsb_release -rs)"
-swift_version=$(curl -fsSL "https://api.github.com/repos/apple/swift/releases/latest" | jq -r '.tag_name | match("[0-9.]+").string')
+swift_releases=$(curl -fsSL "https://www.swift.org/api/v1/install/releases.json")
+
+swift_version=$(echo "$swift_releases" | jq -r '.[-1].name')
+if [[ -z "$swift_version" || "$swift_version" == "null" ]]; then
+  echo "Unable to determine Swift version"
+  exit 1
+fi
+
+swift_tag=$(echo "$swift_releases" | jq -r '.[-1].tag')
+if [[ -z "$swift_tag" || "$swift_tag" == "null" ]]; then
+  echo "Unable to determine Swift tag"
+  exit 1
+fi
+
+swift_release_path_tag="${swift_tag/-RELEASE/-release}"
+if [[ "$swift_release_path_tag" == "$swift_tag" ]]; then
+  echo "Swift tag '$swift_tag' does not match expected '*-RELEASE' format"
+  exit 1
+fi
 
 if is_x64; then
-  swift_release_name="swift-${swift_version}-RELEASE-${image_label}"
-  archive_url="https://download.swift.org/swift-${swift_version}-release/${image_label//./}/swift-${swift_version}-RELEASE/${swift_release_name}.tar.gz"
+  swift_release_name="${swift_tag}-${image_label}"
+  url_image_label="${image_label//./}"
 elif is_arm64; then
-  swift_release_name="swift-${swift_version}-RELEASE-${image_label}-aarch64"
-  archive_url="https://download.swift.org/swift-${swift_version}-release/${image_label//./}-aarch64/swift-${swift_version}-RELEASE/${swift_release_name}.tar.gz"
+  swift_release_name="${swift_tag}-${image_label}-aarch64"
+  url_image_label="${image_label//./}-aarch64"
 else
   echo "Unsupported architecture"
   exit 1
 fi
 
+archive_url="https://download.swift.org/${swift_release_path_tag}/${url_image_label}/${swift_tag}/${swift_release_name}.tar.gz"
 archive_path=$(download_with_retry "$archive_url")
 
 # Verifying PGP signature using official Swift PGP key. Referring to https://www.swift.org/install/linux/#Installation-via-Tarball

--- a/images/ubuntu/scripts/build/install-swift.sh
+++ b/images/ubuntu/scripts/build/install-swift.sh
@@ -25,6 +25,18 @@ if [[ -z "$swift_tag" || "$swift_tag" == "null" ]]; then
   exit 1
 fi
 
+swift_static_sdk_version=$(echo "$swift_releases" | jq -r '.[-1].platforms[] | select(.platform == "static-sdk") | .version')
+if [[ -z "$swift_static_sdk_version" || "$swift_static_sdk_version" == "null" ]]; then
+  echo "Unable to determine Swift Static SDK version"
+  exit 1
+fi
+
+swift_static_sdk_checksum=$(echo "$swift_releases" | jq -r '.[-1].platforms[] | select(.platform == "static-sdk") | .checksum')
+if [[ -z "$swift_static_sdk_checksum" || "$swift_static_sdk_checksum" == "null" ]]; then
+  echo "Unable to determine Swift Static SDK checksum"
+  exit 1
+fi
+
 swift_release_path_tag="${swift_tag/-RELEASE/-release}"
 if [[ "$swift_release_path_tag" == "$swift_tag" ]]; then
   echo "Swift tag '$swift_tag' does not match expected '*-RELEASE' format"
@@ -42,8 +54,8 @@ else
   exit 1
 fi
 
-archive_url="https://download.swift.org/${swift_release_path_tag}/${url_image_label}/${swift_tag}/${swift_release_name}.tar.gz"
-archive_path=$(download_with_retry "$archive_url")
+swift_archive_url="https://download.swift.org/${swift_release_path_tag}/${url_image_label}/${swift_tag}/${swift_release_name}.tar.gz"
+swift_static_sdk_archive_url="https://download.swift.org/${swift_release_path_tag}/static-sdk/${swift_tag}/${swift_tag}_static-linux-${swift_static_sdk_version}.artifactbundle.tar.gz"
 
 # Verifying PGP signature using official Swift PGP key. Referring to https://www.swift.org/install/linux/#Installation-via-Tarball
 # Download and import Swift PGP keys
@@ -62,7 +74,8 @@ gpg --keyserver hkps://keyserver.ubuntu.com:443 \
 gpg --keyserver hkps://keyserver.ubuntu.com:443 --refresh-keys Swift
 
 # Download and verify signature
-signature_path=$(download_with_retry "${archive_url}.sig")
+archive_path=$(download_with_retry "$swift_archive_url")
+signature_path=$(download_with_retry "${swift_archive_url}.sig")
 gpg --verify "$signature_path" "$archive_path"
 
 # Remove Swift PGP public key with temporary keyring
@@ -82,6 +95,10 @@ ln -s "$swift_bin_root/swift" /usr/local/bin/swift
 ln -s "$swift_bin_root/swiftc" /usr/local/bin/swiftc
 ln -s "$swift_lib_root/libsourcekitdInProc.so" /usr/local/lib/libsourcekitdInProc.so
 
+swift sdk install "$swift_static_sdk_archive_url" --checksum "$swift_static_sdk_checksum"
+
 set_etc_environment_variable "SWIFT_PATH" "${swift_bin_root}"
+set_etc_environment_variable "SWIFT_VERSION" "${swift_version}"
+set_etc_environment_variable "SWIFT_STATIC_SDK_VERSION" "${swift_static_sdk_version}"
 
 invoke_tests "Common" "Swift"

--- a/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -58,6 +58,7 @@ $languageAndRuntime.AddToolVersion("Ruby", $(Get-RubyVersion))
 if (-not (Test-IsUbuntu26)) {
     # No Ubuntu 26 support yet
     $languageAndRuntime.AddToolVersion("Swift", $(Get-SwiftVersion))
+    $languageAndRuntime.AddToolVersion("Swift Static Linux SDK", $(Get-SwiftStaticSDKVersion))
 }
 
 

--- a/images/ubuntu/scripts/docs-gen/SoftwareReport.Common.psm1
+++ b/images/ubuntu/scripts/docs-gen/SoftwareReport.Common.psm1
@@ -102,6 +102,16 @@ function Get-SwiftVersion {
     return $swiftVersion
 }
 
+function Get-SwiftStaticSDKVersion {
+    $swiftVersion = Get-SwiftVersion
+    $swiftStaticSDK = Get-CommandResult "swift sdk list"
+    $pattern = "swift-${swiftVersion}-RELEASE_static-linux-(?<version>\d+\.\d+\.\d+)"
+    if ($swiftStaticSDK.Output -match $pattern) {
+        return $Matches.version
+    }
+    throw "Unable to detect Swift Static SDK version for Swift ${swiftVersion}"
+}
+
 function Get-KotlinVersion {
     $kotlinVersion = kotlin -version | Out-String | Get-StringPart -Part 2
     return $kotlinVersion

--- a/images/ubuntu/scripts/tests/Common.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Common.Tests.ps1
@@ -36,6 +36,16 @@ Describe "Swift" -Skip:(Test-IsUbuntu26) {
     It "libsourcekitd" {
         "/usr/local/lib/libsourcekitdInProc.so" | Should -Exist
     }
+
+    It "SDK list" {
+        "swift sdk list" | Should -ReturnZeroExitCode
+    }
+
+    It "SDK registered" {
+        $expectedSdk = "swift-${env:SWIFT_VERSION}-RELEASE_static-linux-${env:SWIFT_STATIC_SDK_VERSION}"
+        $sdkListOutput = swift sdk list
+        $sdkListOutput | Should -Be $expectedSdk
+    }
 }
 
 Describe "PipxPackages" {


### PR DESCRIPTION
# Description

The [Static Swift Linux SDK](https://www.swift.org/documentation/articles/static-linux-getting-started.html) allows users to compile statically-linked Linux binaries. Consumers can directly run them without runtime dependencies. It's pretty common that command-line tools are (additionally) distributed like that.

Action users need to install the SDK as one of their first build steps as of now. That's normally pretty fast. However, the difficulty is to install the right SDK version for the pre-installed Swift version. Which version to use is not obvious without checking the image documentation and therefore requires some effort.

The unpacked SDK is 1.1 GB in size at the moment.

As a preparation for the SDK installation, I also refactored the script so that it uses the official swift.org API to retrieve the latest release. That's a separate commit.

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
