### PR TITLE
[MacOS] Updated default XCode to 26.5 on MacOS 26

### DIFF
--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -1,6 +1,6 @@
 {
     "xcode": {
-        "default": "26.4.1",
+        "default": "26.5",
         "x64": {
             "versions": [
                 {


### PR DESCRIPTION
# Description
- Updated default XCode to 26.5 on MacOS 26

#### Related issue:
- https://github.com/actions/runner-images/issues/14172

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated:
  - [MacOS 26 Intel](https://github.com/github/hosted-runners-images/actions/runs/26446792424)
  - [MacOS 26 ARM](https://github.com/github/hosted-runners-images/actions/runs/26452560731)

