### PR TITLE
[windows] Ignore *Microsoft.WidgetsPlatformRuntime* update pester test

### DIFF
--- a/images/windows/scripts/tests/WindowsFeatures.Tests.ps1
+++ b/images/windows/scripts/tests/WindowsFeatures.Tests.ps1
@@ -82,6 +82,9 @@ Describe "Windows Updates" {
         if ( $Title -match "MicrosoftWindows.Client.WebExperience" ) {
             $expect = "Installed", "Failed", "Running"
         }
+        if ( $Title -match "Microsoft.WidgetsPlatformRuntime" ) {
+            $expect = "Installed", "Failed", "Running"
+        }
 
         $State | Should -BeIn $expect
     }


### PR DESCRIPTION
# Description
`9N3RK8ZV2ZR8-Microsoft.WidgetsPlatformRuntime` Appx package update pester test failure is false positive and can be ignored.

#### Related issue: https://github.com/github/hosted-runners-images/issues/770

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
