### PR TITLE
[Ubuntu] Add select_by_arch helper and use it in build scripts

### DIFF
--- a/images/ubuntu/scripts/build/configure-image-data.sh
+++ b/images/ubuntu/scripts/build/configure-image-data.sh
@@ -17,18 +17,13 @@ version_major=${os_version/.*/}
 version_wo_dot=${os_version/./}
 github_url="https://github.com/actions/runner-images/blob"
 
-if is_x64; then
-  image_label="ubuntu-${os_version}"
-  software_url="${github_url}/ubuntu${version_major}/${image_version_major}.${image_version_minor}/images/ubuntu/Ubuntu${version_wo_dot}-Readme.md"
-  releaseUrl="https://github.com/actions/runner-images/releases/tag/ubuntu${version_major}%2F${image_version_major}.${image_version_minor}"
-elif is_arm64; then
-  image_label="ubuntu-${os_version}-arm"
-  software_url="${github_url}/ubuntu${version_major}-arm64/${image_version_major}.${image_version_minor}/images/ubuntu/Ubuntu${version_wo_dot}-Arm64-Readme.md"
-  releaseUrl="https://github.com/actions/runner-images/releases/tag/ubuntu${version_major}-arm64%2F${image_version_major}.${image_version_minor}"
-else
-  echo "Unsupported architecture"
-  exit 1
-fi
+image_label=$(select_by_arch "ubuntu-${os_version}" "ubuntu-${os_version}-arm")
+software_url=$(select_by_arch \
+  "${github_url}/ubuntu${version_major}/${image_version_major}.${image_version_minor}/images/ubuntu/Ubuntu${version_wo_dot}-Readme.md" \
+  "${github_url}/ubuntu${version_major}-arm64/${image_version_major}.${image_version_minor}/images/ubuntu/Ubuntu${version_wo_dot}-Arm64-Readme.md")
+releaseUrl=$(select_by_arch \
+  "https://github.com/actions/runner-images/releases/tag/ubuntu${version_major}%2F${image_version_major}.${image_version_minor}" \
+  "https://github.com/actions/runner-images/releases/tag/ubuntu${version_major}-arm64%2F${image_version_major}.${image_version_minor}")
 
 cat <<EOF > $imagedata_file
 [

--- a/images/ubuntu/scripts/build/install-aws-tools.sh
+++ b/images/ubuntu/scripts/build/install-aws-tools.sh
@@ -9,18 +9,9 @@
 source $HELPER_SCRIPTS/os.sh
 source $HELPER_SCRIPTS/install.sh
 
-if is_x64; then
-  cli_suffix="x86_64"
-  smplugin_arch="64bit"
-  sam_cli_suffix="x86_64"
-elif is_arm64; then
-  cli_suffix="aarch64"
-  smplugin_arch="arm64"
-  sam_cli_suffix="arm64"
-else
-  echo "Unsupported architecture"
-  exit 1
-fi
+cli_suffix=$(select_by_arch "x86_64" "aarch64")
+smplugin_arch=$(select_by_arch "64bit" "arm64")
+sam_cli_suffix=$(select_by_arch "x86_64" "arm64")
 
 awscliv2_archive_path=$(download_with_retry "https://awscli.amazonaws.com/awscli-exe-linux-${cli_suffix}.zip")
 unzip -qq "$awscliv2_archive_path" -d /tmp

--- a/images/ubuntu/scripts/build/install-azcopy.sh
+++ b/images/ubuntu/scripts/build/install-azcopy.sh
@@ -8,14 +8,7 @@
 source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 
-if is_x64; then
-  azcopy_download_url="https://aka.ms/downloadazcopy-v10-linux"
-elif is_arm64; then
-  azcopy_download_url="https://aka.ms/downloadazcopy-v10-linux-arm64"
-else
-  echo "Unsupported architecture"
-  exit 1
-fi
+azcopy_download_url=$(select_by_arch "https://aka.ms/downloadazcopy-v10-linux" "https://aka.ms/downloadazcopy-v10-linux-arm64")
 
 # Install AzCopy10
 archive_path=$(download_with_retry "$azcopy_download_url")

--- a/images/ubuntu/scripts/build/install-cmake.sh
+++ b/images/ubuntu/scripts/build/install-cmake.sh
@@ -9,14 +9,7 @@
 source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 
-if is_x64; then
-	cmake_arch="x86_64"
-elif is_arm64; then
-	cmake_arch="aarch64"
-else
-	echo "Unsupported architecture"
-	exit 1
-fi
+cmake_arch=$(select_by_arch "x86_64" "aarch64")
 
 cmake_version=$(get_toolset_value .cmake.version)
 

--- a/images/ubuntu/scripts/build/install-docker.sh
+++ b/images/ubuntu/scripts/build/install-docker.sh
@@ -9,14 +9,7 @@
 source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 
-if is_x64; then
-  docker_arch="amd64"
-elif is_arm64; then
-  docker_arch="arm64"
-else
-  echo "Unsupported architecture"
-  exit 1
-fi
+docker_arch=$(select_by_arch "amd64" "arm64")
 
 REPO_URL="https://download.docker.com/linux/ubuntu"
 GPG_KEY="/usr/share/keyrings/docker.gpg"

--- a/images/ubuntu/scripts/build/install-firefox.sh
+++ b/images/ubuntu/scripts/build/install-firefox.sh
@@ -9,14 +9,7 @@ source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/etc-environment.sh
 source $HELPER_SCRIPTS/os.sh
 
-if is_x64; then
-  driver_arch="linux64"
-elif is_arm64; then
-  driver_arch="linux-aarch64"
-else
-  echo "Unsupported architecture"
-  exit 1
-fi
+driver_arch=$(select_by_arch "linux64" "linux-aarch64")
 
 FIREFOX_REPO="ppa:mozillateam/ppa"
 

--- a/images/ubuntu/scripts/build/install-github-cli.sh
+++ b/images/ubuntu/scripts/build/install-github-cli.sh
@@ -10,14 +10,7 @@
 source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 
-if is_x64; then
-  gh_cli_arch="amd64"
-elif is_arm64; then
-  gh_cli_arch="arm64"
-else
-  echo "Unsupported architecture"
-  exit 1
-fi
+gh_cli_arch=$(select_by_arch "amd64" "arm64")
 
 # Download GitHub CLI
 gh_cli_url=$(resolve_github_release_asset_url "cli/cli" "contains(\"linux\") and contains(\"$gh_cli_arch\") and endswith(\".deb\")" "latest")

--- a/images/ubuntu/scripts/build/install-java-tools.sh
+++ b/images/ubuntu/scripts/build/install-java-tools.sh
@@ -9,14 +9,7 @@ source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/etc-environment.sh
 source $HELPER_SCRIPTS/os.sh
 
-if is_x64; then
-  java_arch="amd64"
-elif is_arm64; then
-  java_arch="arm64"
-else
-  echo "Unsupported architecture"
-  exit 1
-fi
+java_arch=$(select_by_arch "amd64" "arm64")
 
 create_java_environment_variable() {
     local java_version=$1

--- a/images/ubuntu/scripts/build/install-kubernetes-tools.sh
+++ b/images/ubuntu/scripts/build/install-kubernetes-tools.sh
@@ -9,14 +9,7 @@
 source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 
-if is_x64; then
-  tools_arch="amd64"
-elif is_arm64; then
-  tools_arch="arm64"
-else
-  echo "Unsupported architecture"
-  exit 1
-fi
+tools_arch=$(select_by_arch "amd64" "arm64")
 
 # Download KIND
 kind_url=$(resolve_github_release_asset_url "kubernetes-sigs/kind" "endswith(\"kind-linux-${tools_arch}\")" "latest")

--- a/images/ubuntu/scripts/build/install-ninja.sh
+++ b/images/ubuntu/scripts/build/install-ninja.sh
@@ -8,14 +8,7 @@
 source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 
-if is_x64; then
-  ninja_asset_name="ninja-linux.zip"
-elif is_arm64; then
-  ninja_asset_name="ninja-linux-aarch64.zip"
-else
-  echo "Unsupported architecture"
-  exit 1
-fi
+ninja_asset_name=$(select_by_arch "ninja-linux.zip" "ninja-linux-aarch64.zip")
 
 # Install ninja
 download_url=$(resolve_github_release_asset_url "ninja-build/ninja" "endswith(\"${ninja_asset_name}\")" "latest")

--- a/images/ubuntu/scripts/build/install-oc-cli.sh
+++ b/images/ubuntu/scripts/build/install-oc-cli.sh
@@ -8,14 +8,9 @@
 source $HELPER_SCRIPTS/os.sh
 source $HELPER_SCRIPTS/install.sh
 
-if is_x64; then
-  download_url="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz"
-elif is_arm64; then
-  download_url="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux-arm64.tar.gz"
-else
-  echo "Unsupported architecture"
-  exit 1
-fi
+download_url=$(select_by_arch \
+  "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz" \
+  "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux-arm64.tar.gz")
 
 archive_path=$(download_with_retry "$download_url")
 

--- a/images/ubuntu/scripts/build/install-packer.sh
+++ b/images/ubuntu/scripts/build/install-packer.sh
@@ -8,14 +8,7 @@
 source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 
-if is_x64; then
-  packer_arch="amd64"
-elif is_arm64; then
-  packer_arch="arm64"
-else
-  echo "Unsupported architecture"
-  exit 1
-fi
+packer_arch=$(select_by_arch "amd64" "arm64")
 
 # Install Packer
 download_url=$(curl -fsSL https://api.releases.hashicorp.com/v1/releases/packer/latest | jq -r ".builds[] | select((.arch==\"$packer_arch\") and (.os==\"linux\")).url")

--- a/images/ubuntu/scripts/build/install-powershell.sh
+++ b/images/ubuntu/scripts/build/install-powershell.sh
@@ -8,14 +8,7 @@
 source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 
-if is_x64; then
-  pwsh_arch="x64"
-elif is_arm64; then
-  pwsh_arch="arm64"
-else
-  echo "Unsupported architecture"
-  exit 1
-fi
+pwsh_arch=$(select_by_arch "x64" "arm64")
 
 pwsh_version=$(get_toolset_value .pwsh.version)
 

--- a/images/ubuntu/scripts/build/install-pulumi.sh
+++ b/images/ubuntu/scripts/build/install-pulumi.sh
@@ -9,14 +9,7 @@
 source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 
-if is_x64; then
-  pulumi_arch="x64"
-elif is_arm64; then
-  pulumi_arch="arm64"
-else
-  echo "Unsupported architecture"
-  exit 1
-fi
+pulumi_arch=$(select_by_arch "x64" "arm64")
 
 # Dowload Pulumi
 version=$(curl -fsSL "https://www.pulumi.com/latest-version")

--- a/images/ubuntu/scripts/build/install-swift.sh
+++ b/images/ubuntu/scripts/build/install-swift.sh
@@ -13,16 +13,10 @@ source $HELPER_SCRIPTS/os.sh
 image_label="ubuntu$(lsb_release -rs)"
 swift_version=$(curl -fsSL "https://api.github.com/repos/apple/swift/releases/latest" | jq -r '.tag_name | match("[0-9.]+").string')
 
-if is_x64; then
-  swift_release_name="swift-${swift_version}-RELEASE-${image_label}"
-  archive_url="https://download.swift.org/swift-${swift_version}-release/${image_label//./}/swift-${swift_version}-RELEASE/${swift_release_name}.tar.gz"
-elif is_arm64; then
-  swift_release_name="swift-${swift_version}-RELEASE-${image_label}-aarch64"
-  archive_url="https://download.swift.org/swift-${swift_version}-release/${image_label//./}-aarch64/swift-${swift_version}-RELEASE/${swift_release_name}.tar.gz"
-else
-  echo "Unsupported architecture"
-  exit 1
-fi
+swift_release_name=$(select_by_arch "swift-${swift_version}-RELEASE-${image_label}" "swift-${swift_version}-RELEASE-${image_label}-aarch64")
+archive_url=$(select_by_arch \
+  "https://download.swift.org/swift-${swift_version}-release/${image_label//./}/swift-${swift_version}-RELEASE/${swift_release_name}.tar.gz" \
+  "https://download.swift.org/swift-${swift_version}-release/${image_label//./}-aarch64/swift-${swift_version}-RELEASE/${swift_release_name}.tar.gz")
 
 archive_path=$(download_with_retry "$archive_url")
 

--- a/images/ubuntu/scripts/build/install-terraform.sh
+++ b/images/ubuntu/scripts/build/install-terraform.sh
@@ -7,14 +7,7 @@
 source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 
-if is_x64; then
-  terraform_arch="amd64"
-elif is_arm64; then
-  terraform_arch="arm64"
-else
-  echo "Unsupported architecture"
-  exit 1
-fi
+terraform_arch=$(select_by_arch "amd64" "arm64")
 
 # Install Terraform
 download_url=$(curl -fsSL https://api.releases.hashicorp.com/v1/releases/terraform/latest | jq -r ".builds[] | select((.arch==\"$terraform_arch\") and (.os==\"linux\")).url")

--- a/images/ubuntu/scripts/build/install-yq.sh
+++ b/images/ubuntu/scripts/build/install-yq.sh
@@ -9,14 +9,7 @@
 source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 
-if is_x64; then
-  yq_arch="amd64"
-elif is_arm64; then
-  yq_arch="arm64"
-else
-  echo "Unsupported architecture"
-  exit 1
-fi
+yq_arch=$(select_by_arch "amd64" "arm64")
 
 # Download yq
 yq_url=$(resolve_github_release_asset_url "mikefarah/yq" "endswith(\"yq_linux_${yq_arch}\")" "latest")

--- a/images/ubuntu/scripts/helpers/os.sh
+++ b/images/ubuntu/scripts/helpers/os.sh
@@ -47,3 +47,14 @@ is_ubuntu24_x64() {
 is_ubuntu26_x64() {
     is_ubuntu26 && is_x64
 }
+
+select_by_arch() {
+    if is_x64; then
+        echo "$1"
+    elif is_arm64; then
+        echo "$2"
+    else
+        echo "Unsupported architecture"
+        exit 1
+    fi
+}


### PR DESCRIPTION
Add a select_by_arch helper to images/ubuntu/scripts/helpers/os.sh that returns the caller-provided value for the current architecture, removing the duplicated x64/arm64 if/else blocks scattered across the build scripts.

This is similar to the macOS get_arch helper in
images/macos/scripts/helpers/utils.sh, but instead of returning a fixed arch string it lets the caller pass the value to return for each architecture, so the same helper covers the many different per-arch values (suffixes, URLs, asset names) the scripts need.

# Description
Improvement

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
