### PR TITLE
Add new Ubuntu images to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -20,7 +20,11 @@ body:
       label: Runner images affected
       options:
         - label: Ubuntu 22.04
+        - label: Ubuntu 22.04 Arm64
         - label: Ubuntu 24.04
+        - label: Ubuntu 24.04 Arm64
+        - label: Ubuntu 26.04
+        - label: Ubuntu 26.04 Arm64
         - label: Ubuntu Slim
         - label: macOS 14
         - label: macOS 14 Arm64

--- a/.github/ISSUE_TEMPLATE/tool-request.yml
+++ b/.github/ISSUE_TEMPLATE/tool-request.yml
@@ -58,7 +58,11 @@ body:
       label: Runner images where you need the tool
       options:
         - label: Ubuntu 22.04
+        - label: Ubuntu 22.04 Arm64
         - label: Ubuntu 24.04
+        - label: Ubuntu 24.04 Arm64
+        - label: Ubuntu 26.04
+        - label: Ubuntu 26.04 Arm64
         - label: Ubuntu Slim
         - label: macOS 14
         - label: macOS 14 Arm64


### PR DESCRIPTION
Add Ubuntu 22.04 Arm64, Ubuntu 24.04 Arm64, Ubuntu 26.04, and Ubuntu 26.04 Arm64 to the bug report and tool request templates.

# Description
New tool, Bug fixing, or Improvement?
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.
**For new tools, please provide total size and installation time.**

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
