### PR TITLE
Add Windows 11 Arm64 with Visual Studio 2026 Readme file

### DIFF
--- a/images/windows/Windows11-VS2026-Arm64-Readme.md
+++ b/images/windows/Windows11-VS2026-Arm64-Readme.md
@@ -1,0 +1,381 @@
+# Windows 11 Enterprise
+- OS Version: 10.0.26200 Build 8457
+- Image Version: 20260605.53.1
+
+## Windows features
+- Windows Subsystem for Linux (WSLv1): Enabled
+
+## Installed Software
+
+### Language and Runtime
+- Bash 5.3.9(1)-release
+- Go 1.24.13
+- Julia 1.12.0
+- Kotlin 2.4.0
+- LLVM 20.1.6
+- Node 24.16.0
+- Perl 5.32.1
+- PHP 8.4.22
+- Python 3.13.13
+- Ruby 3.4.9
+
+### Package Management
+- Chocolatey 2.7.2
+- Composer 2.10.1
+- Helm 4.1.4
+- NPM 11.13.0
+- NuGet 7.6.0.59
+- pip 26.1.2 (python 3.13)
+- Pipx 1.14.0
+- RubyGems 3.6.9
+- Vcpkg (build from commit f6672d8e48)
+- Yarn 1.22.22
+
+#### Environment variables
+| Name                    | Value    |
+| ----------------------- | -------- |
+| VCPKG_INSTALLATION_ROOT | C:\vcpkg |
+
+### Project Management
+- Ant 1.10.17
+- Gradle 9.5
+- Maven 3.9.16
+- sbt 1.12.11
+
+### Tools
+- 7zip 26.01
+- aria2 1.37.0
+- azcopy 10.32.4
+- Bazel 9.1.1
+- Bazelisk 1.28.1
+- Bicep 0.43.8
+- CMake 4.3.3
+- CodeQL Action Bundle 2.25.6
+- Git 2.54.0.windows.1
+- Git LFS 3.7.1
+- ImageMagick 7.1.2-24
+- InnoSetup 6.7.1
+- jq 1.8.1
+- Kind 0.32.0
+- Kubectl 1.36.1
+- Mercurial 6.3.1
+- gcc 14.2.0
+- gdb 16.2
+- GNU Binutils 2.44
+- Newman 6.2.2
+- NSIS 3.10
+- OpenSSL 3.6.2
+- Packer 1.15.3
+- Pulumi 3.245.0
+- R 4.6.0
+- Stack 3.9.3
+- Swig 4.3.1
+- VSWhere 3.1.7
+- WinAppDriver 1.2.2009.02003
+- yamllint 1.38.0
+- Ninja 1.13.2
+
+### CLI Tools
+- Alibaba Cloud CLI 3.3.22
+- AWS CLI 2.34.61
+- AWS SAM CLI 1.161.1
+- AWS Session Manager CLI 1.2.814.0
+- Azure CLI 2.87.0
+- Azure DevOps CLI extension 1.0.4
+- GitHub CLI 2.93.0
+
+### Rust Tools
+- Cargo 1.96.0
+- Rust 1.96.0
+- Rustdoc 1.96.0
+- Rustup 1.29.0
+
+#### Packages
+- bindgen 0.72.1
+- cargo-audit 0.22.1
+- cargo-outdated 0.19.0
+- cbindgen 0.29.3
+- Clippy 0.1.96
+- Rustfmt 1.9.0
+
+### Browsers and Drivers
+- Google Chrome 149.0.7827.54
+- Chrome Driver 149.0.7827.54
+- Microsoft Edge 149.0.4022.52
+- Microsoft Edge Driver 149.0.4022.52
+- Mozilla Firefox 151.0.3
+- Gecko Driver 0.37.0
+- IE Driver 4.14.0.0
+- Selenium server 4.44.0
+
+#### Environment variables
+| Name              | Value                              |
+| ----------------- | ---------------------------------- |
+| CHROMEWEBDRIVER   | C:\SeleniumWebDrivers\ChromeDriver |
+| EDGEWEBDRIVER     | C:\SeleniumWebDrivers\EdgeDriver   |
+| GECKOWEBDRIVER    | C:\SeleniumWebDrivers\GeckoDriver  |
+| SELENIUM_JAR_PATH | C:\selenium\selenium-server.jar    |
+
+### Java
+| Version                | Environment Variable |
+| ---------------------- | -------------------- |
+| 21.0.11+10.0 (default) | JAVA_HOME_21_AARCH64 |
+| 23.0.2+7               | JAVA_HOME_23_AARCH64 |
+
+### Cached Tools
+
+#### Go
+- 1.22.12
+- 1.23.12
+- 1.24.13
+- 1.25.11
+
+#### Node.js
+- 22.22.3
+- 24.16.0
+
+#### Python
+- 3.12.10
+- 3.13.13
+- 3.14.5
+
+#### Ruby
+- 3.4.9
+
+### Database tools
+- Azure CosmosDb Emulator 2.14.27.0
+- DacFx 170.4.83.3
+- MySQL 8.0.46.0
+- SQL OLEDB Driver 18 18.7.5.0
+- SQL OLEDB Driver 19 19.4.1.0
+
+### Web Servers
+| Name   | Version | ConfigFile                            | ServiceName | ServiceStatus | ListenPort |
+| ------ | ------- | ------------------------------------- | ----------- | ------------- | ---------- |
+| Apache | 2.4.55  | C:\tools\Apache24\conf\httpd.conf     | Apache      | Stopped       | 80         |
+| Nginx  | 1.31.1  | C:\tools\nginx-1.31.1\conf\nginx.conf | nginx       | Stopped       | 80         |
+
+### Visual Studio Enterprise 2026
+| Name                          | Version        | Path                                                   |
+| ----------------------------- | -------------- | ------------------------------------------------------ |
+| Visual Studio Enterprise 2026 | 18.6.11822.322 | C:\Program Files\Microsoft Visual Studio\18\Enterprise |
+
+#### Workloads, components and extensions
+| Package                                                                   | Version         |
+| ------------------------------------------------------------------------- | --------------- |
+| android                                                                   | 36.1.43.0       |
+| Component.Android.NDK.R27C                                                | 18.6.11706.339  |
+| Component.Android.SDK.MAUI                                                | 18.6.11706.339  |
+| Component.Linux.CMake                                                     | 18.6.11706.339  |
+| Component.Linux.RemoteFileExplorer                                        | 18.6.11706.339  |
+| Component.MDD.Linux                                                       | 18.6.11706.339  |
+| Component.Microsoft.NET.AppModernization                                  | 18.6.11820.303  |
+| Component.Microsoft.VisualStudio.RazorExtension                           | 18.6.11706.339  |
+| Component.Microsoft.VisualStudio.Tools.Applications.amd64                 | 17.1.37110.1    |
+| Component.Microsoft.VisualStudio.Web.AzureFunctions                       | 18.6.11706.339  |
+| Component.Microsoft.Web.LibraryManager                                    | 18.6.11706.339  |
+| Component.Microsoft.Windows.DriverKit                                     | 10.0.26100.16   |
+| Component.OpenJDK                                                         | 18.6.11706.339  |
+| Component.Unreal                                                          | 18.6.11706.339  |
+| Component.Unreal.Android                                                  | 18.6.11706.339  |
+| Component.Unreal.Debugger                                                 | 18.6.11706.339  |
+| Component.Unreal.Ide                                                      | 18.6.11706.339  |
+| Component.VisualStudio.GitHub.Copilot                                     | 18.6.11706.339  |
+| Component.VSInstallerProjects2022_arm64                                   | 3.0.0           |
+| ComponentGroup.Microsoft.NET.AppModernization                             | 18.6.11706.339  |
+| ios                                                                       | 26.2.10233      |
+| maccatalyst                                                               | 26.2.10233      |
+| maui.blazor                                                               | 10.0.20.7528    |
+| maui.core                                                                 | 10.0.20.7528    |
+| maui.windows                                                              | 10.0.20.7528    |
+| Microsoft.Component.ClickOnce                                             | 18.6.11706.339  |
+| Microsoft.Component.CodeAnalysis.SDK                                      | 18.6.11706.339  |
+| Microsoft.Component.MSBuild                                               | 18.6.11706.339  |
+| Microsoft.Component.NetFX.Native                                          | 18.6.11706.339  |
+| Microsoft.Component.VC.Runtime.UCRTSDK                                    | 18.6.11706.339  |
+| Microsoft.ComponentGroup.ClickOnce.Publish                                | 18.6.11706.339  |
+| Microsoft.Net.Component.4.6.2.TargetingPack                               | 18.6.11706.339  |
+| Microsoft.Net.Component.4.7.1.TargetingPack                               | 18.6.11706.339  |
+| Microsoft.Net.Component.4.7.2.SDK                                         | 18.6.11706.339  |
+| Microsoft.Net.Component.4.7.2.TargetingPack                               | 18.6.11706.339  |
+| Microsoft.Net.Component.4.7.TargetingPack                                 | 18.6.11706.339  |
+| Microsoft.Net.Component.4.8.1.SDK                                         | 18.6.11706.339  |
+| Microsoft.Net.Component.4.8.1.TargetingPack                               | 18.6.11706.339  |
+| Microsoft.Net.Component.4.8.SDK                                           | 18.6.11706.339  |
+| Microsoft.Net.Component.4.8.TargetingPack                                 | 18.6.11706.339  |
+| Microsoft.Net.ComponentGroup.4.8.1.DeveloperTools                         | 18.6.11706.339  |
+| Microsoft.Net.ComponentGroup.4.8.DeveloperTools                           | 18.6.11706.339  |
+| Microsoft.Net.ComponentGroup.DevelopmentPrerequisites                     | 18.6.11706.339  |
+| Microsoft.Net.ComponentGroup.TargetingPacks.Common                        | 18.6.11706.339  |
+| microsoft.net.runtime.android                                             | 10.1.826.23019  |
+| microsoft.net.runtime.android.aot                                         | 10.1.826.23019  |
+| microsoft.net.runtime.android.aot.net9                                    | 10.1.826.23019  |
+| microsoft.net.runtime.android.net9                                        | 10.1.826.23019  |
+| microsoft.net.runtime.ios                                                 | 10.1.826.23019  |
+| microsoft.net.runtime.ios.net9                                            | 10.1.826.23019  |
+| microsoft.net.runtime.maccatalyst                                         | 10.1.826.23019  |
+| microsoft.net.runtime.maccatalyst.net9                                    | 10.1.826.23019  |
+| microsoft.net.runtime.mono.tooling                                        | 10.1.826.23019  |
+| microsoft.net.runtime.mono.tooling.net9                                   | 10.1.826.23019  |
+| microsoft.net.sdk.emscripten                                              | 10.1.826.23019  |
+| Microsoft.NetCore.Component.DevelopmentTools                              | 18.6.11706.339  |
+| Microsoft.NetCore.Component.Runtime.10.0                                  | 18.6.11806.211  |
+| Microsoft.NetCore.Component.Runtime.8.0                                   | 18.6.11806.211  |
+| Microsoft.NetCore.Component.SDK                                           | 18.6.11806.211  |
+| Microsoft.NetCore.Component.Web                                           | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.AppInsights.Tools                        | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.AspNet                                   | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.AspNet45                                 | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.CoreEditor                               | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.CppBuildInsights                         | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.Debugger.JustInTime                      | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.DiagnosticTools                          | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.DockerTools                              | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.DotNetModelBuilder                       | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.DslTools                                 | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.EntityFramework                          | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.FSharp                                   | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.FSharp.WebTemplates                      | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.Graphics                                 | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.HLSL                                     | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.IISExpress                               | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.IntelliCode                              | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.IntelliTrace.FrontEnd                    | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.JavaScript.Diagnostics                   | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.JavaScript.TypeScript                    | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.LiveUnitTesting                          | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.ManagedDesktop.Core                      | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.ManagedDesktop.Prerequisites             | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.MSODBC.SQL                               | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.MSSQL.CMDLnUtils                         | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.Node.Tools                               | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.NuGet                                    | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.NuGet.BuildTools                         | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.PortableLibrary                          | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.Roslyn.Compiler                          | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.Roslyn.LanguageServices                  | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.SQL.CLR                                  | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.SQL.DataSources                          | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.SQL.LocalDB.Runtime                      | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.SQL.SSDT                                 | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.TextTemplating                           | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.TypeScript.TSServer                      | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.Unity                                    | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.UWP.VC.ARM64                             | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.UWP.VC.ARM64EC                           | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.14.29.16.11.ARM                       | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.14.29.16.11.ARM64                     | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.14.44.17.14.ARM64                     | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.ASAN                                  | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.ATL                                   | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.ATL.ARM64                             | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.ATL.ARM64.Spectre                     | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.ATL.Spectre                           | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.ATLMFC                                | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.ATLMFC.Spectre                        | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.CLI.Support                           | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.CMake.Project                         | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.CoreIde                               | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.DiagnosticTools                       | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.Llvm.Clang                            | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset                     | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.MFC.ARM64                             | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.MFC.ARM64.Spectre                     | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.Redist.14.Latest                      | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.Redist.MSM                            | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre                | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.Runtimes.ARM64EC.Spectre              | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.TestAdapterForBoostTest               | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.TestAdapterForGoogleTest              | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.Tools.ARM64                           | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.Tools.ARM64EC                         | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VC.Tools.x86.x64                         | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.Vcpkg                                    | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.VSSDK                                    | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.Web                                      | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.WebDeploy                                | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.Windows10SDK                             | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.Windows11SDK.22621                       | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.Windows11SDK.26100                       | 18.6.11806.211  |
+| Microsoft.VisualStudio.Component.Windows11Sdk.WindowsPerformanceToolkit   | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.WindowsAppSdkSupport.CSharp              | 18.6.11706.339  |
+| Microsoft.VisualStudio.Component.WslDebugging                             | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.AzureFunctions                      | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.Maui.All                            | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.Maui.Android                        | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.Maui.Blazor                         | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.Maui.iOS                            | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.Maui.MacCatalyst                    | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.Maui.Shared                         | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.Maui.Windows                        | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.MSIX.Packaging                      | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core                  | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang            | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.UWP.NetCoreAndStandard              | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.UWP.VC.v142                         | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64                | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.VisualStudioExtension.Prerequisites | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.Web                                 | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.Web.CloudTools                      | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions                  | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions.CMake            | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions.TemplateEngine   | 18.6.11706.339  |
+| Microsoft.VisualStudio.ComponentGroup.WindowsAppDevelopment.Prerequisites | 18.6.11706.339  |
+| Microsoft.VisualStudio.Workload.CoreEditor                                | 18.6.11706.339  |
+| Microsoft.VisualStudio.Workload.ManagedDesktop                            | 18.6.11706.339  |
+| Microsoft.VisualStudio.Workload.ManagedGame                               | 18.6.11706.339  |
+| Microsoft.VisualStudio.Workload.NativeCrossPlat                           | 18.6.11706.339  |
+| Microsoft.VisualStudio.Workload.NativeDesktop                             | 18.6.11706.339  |
+| Microsoft.VisualStudio.Workload.NativeGame                                | 18.6.11706.339  |
+| Microsoft.VisualStudio.Workload.NetCrossPlat                              | 18.6.11706.339  |
+| Microsoft.VisualStudio.Workload.NetWeb                                    | 18.6.11706.339  |
+| Microsoft.VisualStudio.Workload.Node                                      | 18.6.11706.339  |
+| Microsoft.VisualStudio.Workload.Universal                                 | 18.6.11706.339  |
+| Microsoft.VisualStudio.Workload.VisualStudioExtension                     | 18.6.11706.339  |
+| runtimes.ios                                                              | 10.1.826.23019  |
+| runtimes.ios.net9                                                         | 10.1.826.23019  |
+| runtimes.maccatalyst                                                      | 10.1.826.23019  |
+| runtimes.maccatalyst.net9                                                 | 10.1.826.23019  |
+| wasm.tools                                                                | 10.1.826.23019  |
+| SSIS.MicrosoftDataToolsIntegrationServices                                | 2.2             |
+| VisualStudioClient.MicrosoftVisualStudio2022InstallerProjectsArm64        | 3.0.0           |
+| Windows Driver Kit                                                        | 10.1.26100.6584 |
+| Windows Driver Kit Visual Studio Extension                                | 10.0.26586.0    |
+| Windows Software Development Kit                                          | 10.1.26100.8249 |
+
+#### Microsoft Visual C++
+| Name                                         | Architecture | Version     |
+| -------------------------------------------- | ------------ | ----------- |
+| Microsoft Visual C++ 2013 Additional Runtime | x64          | 12.0.40660  |
+| Microsoft Visual C++ 2013 Minimum Runtime    | x64          | 12.0.40660  |
+| Microsoft Visual C++ 2022 Additional Runtime | x86          | 14.51.36231 |
+| Microsoft Visual C++ 2022 Debug Runtime      | x86          | 14.51.36231 |
+| Microsoft Visual C++ 2022 Minimum Runtime    | x86          | 14.51.36231 |
+
+#### Installed Windows SDKs
+- 10.0.22621.0
+- 10.0.26100.0
+
+### .NET Core Tools
+- .NET Core SDK: 6.0.136, 6.0.203, 6.0.321, 6.0.428, 8.0.127, 8.0.206, 8.0.319, 8.0.421, 9.0.117, 9.0.205, 9.0.314, 10.0.108, 10.0.204, 10.0.300
+- .NET Framework: 4.7.2, 4.8, 4.8.1
+- Microsoft.AspNetCore.App: 6.0.5, 6.0.26, 6.0.36, 8.0.6, 8.0.22, 8.0.27, 9.0.6, 9.0.16, 10.0.8
+- Microsoft.NETCore.App: 6.0.5, 6.0.26, 6.0.36, 8.0.6, 8.0.22, 8.0.27, 9.0.6, 9.0.16, 10.0.8
+- Microsoft.WindowsDesktop.App: 6.0.5, 6.0.26, 6.0.36, 8.0.6, 8.0.22, 8.0.27, 9.0.6, 9.0.16, 10.0.8
+- nbgv 3.9.50+6feeb89450
+
+### PowerShell Tools
+- PowerShell 7.4.16
+
+#### Powershell Modules
+- Az: 12.5.0
+- AWSPowershell: 5.0.227
+- DockerMsftProvider: 1.0.0.8
+- MarkdownPS: 1.10
+- Microsoft.Graph: 2.37.0
+- Pester: 3.4.0, 5.7.1
+- PowerShellGet: 1.0.0.1, 2.2.5
+- PSScriptAnalyzer: 1.25.0
+- PSWindowsUpdate: 2.2.1.5
+- SqlServer: 22.4.5.1
+- VSSetup: 2.2.16


### PR DESCRIPTION
# Description
This PR adds Windows 11 Arm64 with Visual Studio 2026 Readme file

#### Related issue: https://github.com/github/hosted-runners-images/issues/714

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
