### PR TITLE
[documentation] Add new image references and update workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/announcement.yml
+++ b/.github/ISSUE_TEMPLATE/announcement.yml
@@ -37,7 +37,11 @@ body:
       label: Runner images affected
       options:
         - label: Ubuntu 22.04
+        - label: Ubuntu 22.04 Arm64
         - label: Ubuntu 24.04
+        - label: Ubuntu 24.04 Arm64
+        - label: Ubuntu 26.04
+        - label: Ubuntu 26.04 Arm64
         - label: Ubuntu Slim
         - label: macOS 14
         - label: macOS 14 Arm64
@@ -48,6 +52,8 @@ body:
         - label: Windows Server 2022
         - label: Windows Server 2025
         - label: Windows Server 2025 with Visual Studio 2026
+        - label: Windows Desktop 11
+        - label: Windows Desktop 11 with Visual Studio 2026
   - type: textarea
     attributes:
       label: Mitigation ways

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -20,7 +20,11 @@ body:
       label: Runner images affected
       options:
         - label: Ubuntu 22.04
+        - label: Ubuntu 22.04 Arm64
         - label: Ubuntu 24.04
+        - label: Ubuntu 24.04 Arm64
+        - label: Ubuntu 26.04
+        - label: Ubuntu 26.04 Arm64
         - label: Ubuntu Slim
         - label: macOS 14
         - label: macOS 14 Arm64
@@ -31,6 +35,8 @@ body:
         - label: Windows Server 2022
         - label: Windows Server 2025
         - label: Windows Server 2025 with Visual Studio 2026
+        - label: Windows Desktop 11
+        - label: Windows Desktop 11 with Visual Studio 2026
   - type: textarea
     attributes:
       label: Image version and build link

--- a/.github/ISSUE_TEMPLATE/tool-request.yml
+++ b/.github/ISSUE_TEMPLATE/tool-request.yml
@@ -58,7 +58,11 @@ body:
       label: Runner images where you need the tool
       options:
         - label: Ubuntu 22.04
+        - label: Ubuntu 22.04 Arm64
         - label: Ubuntu 24.04
+        - label: Ubuntu 24.04 Arm64
+        - label: Ubuntu 26.04
+        - label: Ubuntu 26.04 Arm64
         - label: Ubuntu Slim
         - label: macOS 14
         - label: macOS 14 Arm64
@@ -69,6 +73,8 @@ body:
         - label: Windows Server 2022
         - label: Windows Server 2025
         - label: Windows Server 2025 with Visual Studio 2026
+        - label: Windows Desktop 11
+        - label: Windows Desktop 11 with Visual Studio 2026
   - type: textarea
     attributes:
       label: Can this tool be installed during the build?

--- a/.github/workflows/ubuntu2604.yml
+++ b/.github/workflows/ubuntu2604.yml
@@ -1,0 +1,20 @@
+name: Trigger Ubuntu26.04 CI
+run-name: Ubuntu26.04 - ${{ github.event.pull_request.title }}
+
+on:
+  pull_request_target:
+    types: labeled
+    paths:
+    - 'images/ubuntu/**'
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  Ubuntu_2604:
+    if: github.event.label.name == 'CI ubuntu-all' || github.event.label.name == 'CI ubuntu-2604'
+    uses: ./.github/workflows/trigger-ubuntu-win-build.yml
+    with:
+      image_type: 'ubuntu2604'
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ To build a VM machine from this repo's source, see the [instructions](docs/creat
 
 | Image | Architecture | YAML Label | Included Software |
 | --------------------|--------------|---------------------|------------------|
+| Ubuntu 26.04 ![preview](https://img.shields.io/badge/preview-0969DA?style=flat&logoColor=white)<br>![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fhosted-runners-images-bot%2F79267492faab096d04cdd25ce7014cec%2Fraw%2Fubuntu26.json) | x64 | `ubuntu-26.04` | [ubuntu-26.04] |
+| Ubuntu 26.04 Arm64 ![preview](https://img.shields.io/badge/preview-0969DA?style=flat&logoColor=white)<br>![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fhosted-runners-images-bot%2F79267492faab096d04cdd25ce7014cec%2Fraw%2Fubuntu26-arm64.json) | arm64 | `ubuntu-26.04-arm` | [ubuntu-26.04-arm64] |
 | Ubuntu 24.04<br>![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fhosted-runners-images-bot%2F79267492faab096d04cdd25ce7014cec%2Fraw%2Fubuntu24.json) | x64 | `ubuntu-latest` or `ubuntu-24.04` | [ubuntu-24.04] |
 | Ubuntu 24.04 Arm64<br>![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fhosted-runners-images-bot%2F79267492faab096d04cdd25ce7014cec%2Fraw%2Fubuntu24-arm64.json) | arm64 | `ubuntu-24.04-arm` | [ubuntu-24.04-arm64] |
 | Ubuntu 22.04<br>![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fhosted-runners-images-bot%2F79267492faab096d04cdd25ce7014cec%2Fraw%2Fubuntu22.json) | x64 | `ubuntu-22.04` | [ubuntu-22.04] |
@@ -35,6 +37,7 @@ To build a VM machine from this repo's source, see the [instructions](docs/creat
 | Windows Server 2025<br>![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fhosted-runners-images-bot%2F79267492faab096d04cdd25ce7014cec%2Fraw%2Fwin25.json) | x64 | `windows-latest` or `windows-2025` | [windows-2025] |
 | Windows Server 2022<br>![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fhosted-runners-images-bot%2F79267492faab096d04cdd25ce7014cec%2Fraw%2Fwin22.json) | x64 | `windows-2022` | [windows-2022] |
 | Windows 11 Arm64<br>![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fhosted-runners-images-bot%2F79267492faab096d04cdd25ce7014cec%2Fraw%2Fwin11-arm64.json) | arm64 | `windows-11-arm` | [windows-11-arm64] |
+| Windows 11 Arm64 with Visual Studio 2026 ![preview](https://img.shields.io/badge/preview-0969DA?style=flat&logoColor=white)<br>![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fhosted-runners-images-bot%2F79267492faab096d04cdd25ce7014cec%2Fraw%2Fwin11-vs2026-arm64.json) | arm64 | `windows-11-vs2026-arm` | [windows-11-vs2026-arm64] |
 
 ### Label scheme
 
@@ -42,6 +45,8 @@ To build a VM machine from this repo's source, see the [instructions](docs/creat
 - Before moving the `-latest` label to a new OS version we will announce the change and give sufficient lead time for users to update their workflows.
 - The `-xlarge` and `-large` suffixes are unique to macOS images and are only available for GitHub Actions. Learn more about [GitHub Actions larger runners](https://docs.github.com/en/actions/reference/runners/larger-runners#available-macos-larger-runners-and-labels).
 
+[ubuntu-26.04]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2604-Readme.md
+[ubuntu-26.04-arm64]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2604-Arm64-Readme.md
 [ubuntu-24.04]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
 [ubuntu-24.04-arm64]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Arm64-Readme.md
 [ubuntu-22.04]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
@@ -51,6 +56,7 @@ To build a VM machine from this repo's source, see the [instructions](docs/creat
 [windows-2025-vs2026]: https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-VS2026-Readme.md
 [windows-2022]: https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
 [windows-11-arm64]: https://github.com/actions/runner-images/blob/main/images/windows/Windows11-Arm64-Readme.md
+[windows-11-vs2026-arm64]: https://github.com/actions/runner-images/blob/main/images/windows/Windows11-VS2026-Arm64-Readme.md
 [macOS-14]: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
 [macOS-14-arm64]: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
 [macOS-15]: https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md

--- a/docs/create-image-and-azure-resources.md
+++ b/docs/create-image-and-azure-resources.md
@@ -1,6 +1,6 @@
 # GitHub Actions Runner Images
 
-The runner-images project uses [Packer](https://www.packer.io/) to generate disk images for Windows 2022/2025 and Ubuntu 22.04/24.04.
+The runner-images project uses [Packer](https://www.packer.io/) to generate disk images for Windows 2022/2025 and Ubuntu 22.04/24.04/26.04.
 
 Each image is configured by a HCL2 Packer template that specifies where to build the image (Azure, in this case),
 and what steps to run to install software and prepare the disk.
@@ -98,7 +98,7 @@ Finally, run the `GenerateResourcesAndImage` function, setting the mandatory arg
 - `ResourceGroupName` - the name of the resource group that will store the resulting artifact (e.g., "imagegen-test").
     The resource group must already exist in your Azure subscription;
 - `AzureLocation` - the location where resources will be created (e.g., "East US");
-- `ImageType` - the type of image to build (valid options are "Windows2022", "Windows2025", "Ubuntu2204", "Ubuntu2404").
+- `ImageType` - the type of image to build (valid options are "Windows2022", "Windows2025", "Windows2025_vs2026", "Ubuntu2204", "Ubuntu2404", "Ubuntu2604").
 
 This function automatically creates all required Azure resources and initiates the Packer image generation for the selected image type.
 
@@ -200,7 +200,7 @@ Then, you can invoke Packer in your CI/CD pipeline using the following commands:
 ```powershell
 packer plugins install github.com/hashicorp/azure 2.2.1
 
-packer build -only "$BuildName*" `
+packer build -only "$BuildName.*" `
              -var "subscription_id=$SubscriptionId" `
              -var "client_id=$ClientId" `
              -var "client_secret=$ClientSecret" `

--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -6,6 +6,7 @@ enum ImageType {
     Windows2025_vs2026  = 3
     Ubuntu2204          = 4
     Ubuntu2404          = 5
+    Ubuntu2604          = 6
 }
 
 Function Get-PackerTemplate {
@@ -37,6 +38,10 @@ Function Get-PackerTemplate {
         ([ImageType]::Ubuntu2404) {
             $relativeTemplatePath = Join-Path (Join-Path "ubuntu" "templates") "build.ubuntu-24_04.pkr.hcl"
             $imageOS = "ubuntu24"
+        }
+        ([ImageType]::Ubuntu2604) {
+            $relativeTemplatePath = Join-Path (Join-Path "ubuntu" "templates") "build.ubuntu-26_04.pkr.hcl"
+            $imageOS = "ubuntu26"
         }
         default { throw "Unknown type of image" }
     }
@@ -117,7 +122,7 @@ Function GenerateResourcesAndImage {
         .PARAMETER ResourceGroupName
             The name of the resource group to store the resulting artifact. Resource group must already exist.
         .PARAMETER ImageType
-            The type of image to generate. Valid values are: Windows2022, Windows2025, Windows2025_vs2026, Ubuntu2204, Ubuntu2404.
+            The type of image to generate. Valid values are: Windows2022, Windows2025, Windows2025_vs2026, Ubuntu2204, Ubuntu2404, Ubuntu2604.
         .PARAMETER ManagedImageName
             The name of the managed image to create. The default is "Runner-Image-{{ImageType}}".
         .PARAMETER AzureLocation


### PR DESCRIPTION
# Description
This PR updates `ubuntu-26.04`, `ubuntu-26.04-arm`, `windows-11-vs2026-arm` image references and workflows

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
