### PR TITLE
Use v2 registries.conf format

### DIFF
--- a/images/ubuntu/scripts/build/install-container-tools.sh
+++ b/images/ubuntu/scripts/build/install-container-tools.sh
@@ -28,6 +28,8 @@ fi
 apt-get update
 apt-get install ${install_packages[@]}
 mkdir -p /etc/containers
-printf "[registries.search]\nregistries = ['docker.io', 'quay.io']\n" | tee /etc/containers/registries.conf
+# Write registries.conf in v2 format; skopeo >= 1.8 rejects the legacy v1 schema
+# (see https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md)
+printf 'unqualified-search-registries = ["docker.io", "quay.io"]\n' | tee /etc/containers/registries.conf
 
 invoke_tests "Tools" "Containers"


### PR DESCRIPTION
Replace legacy [registries.search] schema with the v2 key unqualified-search-registries when writing /etc/containers/registries.conf. This makes the file compatible with skopeo >= 1.8 (which rejects the old v1 schema) and preserves docker.io and quay.io as search registries.

# Description
New tool, Bug fixing, or Improvement?
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.
**For new tools, please provide total size and installation time.**

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
