### PR TITLE
[windows] Unpin SqlServer powershell module

### DIFF
--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -81,7 +81,7 @@
         { "name": "PowerShellGet" },
         { "name": "PSScriptAnalyzer" },
         { "name": "PSWindowsUpdate" },
-        { "name": "SqlServer", "versions": [ "22.3.0" ] },
+        { "name": "SqlServer" },
         { "name": "VSSetup" },
         { "name": "Microsoft.Graph" },
         {"name": "AWSPowershell"}

--- a/images/windows/toolsets/toolset-2025-vs2026.json
+++ b/images/windows/toolsets/toolset-2025-vs2026.json
@@ -66,7 +66,7 @@
         { "name": "PowerShellGet" },
         { "name": "PSScriptAnalyzer" },
         { "name": "PSWindowsUpdate" },
-        { "name": "SqlServer", "versions": [ "22.3.0" ] },
+        { "name": "SqlServer" },
         { "name": "VSSetup" },
         { "name": "Microsoft.Graph" },
         {"name": "AWSPowershell"}

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -66,7 +66,7 @@
         { "name": "PowerShellGet" },
         { "name": "PSScriptAnalyzer" },
         { "name": "PSWindowsUpdate" },
-        { "name": "SqlServer", "versions": [ "22.3.0" ] },
+        { "name": "SqlServer" },
         { "name": "VSSetup" },
         { "name": "Microsoft.Graph" },
         {"name": "AWSPowershell"}


### PR DESCRIPTION
# Description
This PR unpins `SqlServer` module version for PowerShell, as while fixing [one](https://github.com/actions/runner-images/issues/13578) issues, it introduces several more: https://github.com/actions/runner-images/issues/13611, https://github.com/actions/runner-images/issues/13850.

Desired versions of powershell modules can be installed in runtime

#### Related issue: https://github.com/github/hosted-runners-images/issues/794

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
