### PR TITLE
[MacOS] Pinned xcodes formulae for out-of-support OS versions

### DIFF
--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -31,7 +31,7 @@ for package in $common_packages; do
             else
                 # xcodes formulae for the rest of OS versions was broken, using pinned commit
                 echo "Installing pinned xcodes formulae..."
-                COMMIT=ce1b5c047a79752104c9f32b4873ca21f409a11f
+                COMMIT=7236cc49de96b89c4e46ca28a36993578423df8d
                 FORMULA_URL="https://raw.githubusercontent.com/Homebrew/homebrew-core/$COMMIT/Formula/x/xcodes.rb"
                 FORMULA_PATH="$(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/x/xcodes.rb"
                 mkdir -p "$(dirname $FORMULA_PATH)"

--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -38,8 +38,6 @@ for package in $common_packages; do
                 curl -fsSL $FORMULA_URL -o $FORMULA_PATH
                 HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install xcodes
             fi
-            # Xcodes has migrated to separate org. Use correct link to install Xcodes.
-            brew install xcodesorg/made/xcodes
             ;;
 
         # Default behaviour for all other packages

--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -25,6 +25,19 @@ for package in $common_packages; do
             ;;
 
         xcodes)
+            if is_SequoiaArm64 || is_TahoeArm64; then
+                # xcodes formulae still works on MacOS 15 ARM and 26 ARM
+                brew_smart_install "$package"
+            else
+                # xcodes formulae for the rest of OS versions was broken, using pinned commit
+                echo "Installing pinned xcodes formulae..."
+                COMMIT=ce1b5c047a79752104c9f32b4873ca21f409a11f
+                FORMULA_URL="https://raw.githubusercontent.com/Homebrew/homebrew-core/$COMMIT/Formula/x/xcodes.rb"
+                FORMULA_PATH="$(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/x/xcodes.rb"
+                mkdir -p "$(dirname $FORMULA_PATH)"
+                curl -fsSL $FORMULA_URL -o $FORMULA_PATH
+                HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install xcodes
+            fi
             # Xcodes has migrated to separate org. Use correct link to install Xcodes.
             brew install xcodesorg/made/xcodes
             ;;

--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -24,6 +24,11 @@ for package in $common_packages; do
             fi
             ;;
 
+        xcodes)
+            # Xcodes has migrated to separate org. Use correct link to install Xcodes.
+            brew install xcodesorg/made/xcodes
+            ;;
+
         # Default behaviour for all other packages
         *)
             brew_smart_install "$package"


### PR DESCRIPTION
# Description
Xcodes dropped support for old MacOS versions with latest release. To unblock builds of these OS version, formulae has been selectively pinned.

#### Related issue:
- https://github.com/github/hosted-runners-images/issues/800

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated:
  - [MacOS 14 Intel](https://github.com/github/hosted-runners-images/actions/runs/27840461380)
  - [MacOS 15 Intel](https://github.com/github/hosted-runners-images/actions/runs/27840474819)
  - [MacOS 26 Intel](https://github.com/github/hosted-runners-images/actions/runs/27840492250)
