### PR TITLE
[macOS] Add Xcode 26.6 RC2

### DIFF
--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -4,6 +4,14 @@
         "x64": {
             "versions": [
                 {
+                    "link": "26.6_Release_Candidate",
+                    "filename": "Xcode_26.6_Release_Candidate_Universal",
+                    "version": "26.6+17F109",
+                    "symlinks": ["26.6"],
+                    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "install_runtimes": "none"
+                },
+                {
                     "link": "26.5",
                     "filename": "Xcode_26.5_Universal",
                     "version": "26.5+17F42",
@@ -56,6 +64,14 @@
         },
         "arm64": {
             "versions": [
+                {
+                    "link": "26.6_Release_Candidate",
+                    "filename": "Xcode_26.6_Release_Candidate_Universal",
+                    "version": "26.6+17F109",
+                    "symlinks": ["26.6"],
+                    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "install_runtimes": "none"
+                },
                 {
                     "link": "26.5",
                     "filename": "Xcode_26.5_Universal",

--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -4,9 +4,9 @@
         "x64": {
             "versions": [
                 {
-                    "link": "26.6_Release_Candidate",
-                    "filename": "Xcode_26.6_Release_Candidate_Universal",
-                    "version": "26.6+17F109",
+                    "link": "26.6_Release_Candidate_2",
+                    "filename": "Xcode_26.6_Release_Candidate_2_Universal",
+                    "version": "26.6+17F113",
                     "symlinks": ["26.6"],
                     "sha256": "04376404d723ff282415c88fbe553587d32437622268f5b52732f94a49703c3c",
                     "install_runtimes": "none"
@@ -65,9 +65,9 @@
         "arm64": {
             "versions": [
                 {
-                    "link": "26.6_Release_Candidate",
-                    "filename": "Xcode_26.6_Release_Candidate_Universal",
-                    "version": "26.6+17F109",
+                    "link": "26.6_Release_Candidate_2",
+                    "filename": "Xcode_26.6_Release_Candidate_2_Universal",
+                    "version": "26.6+17F113",
                     "symlinks": ["26.6"],
                     "sha256": "04376404d723ff282415c88fbe553587d32437622268f5b52732f94a49703c3c",
                     "install_runtimes": "none"

--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -8,7 +8,7 @@
                     "filename": "Xcode_26.6_Release_Candidate_Universal",
                     "version": "26.6+17F109",
                     "symlinks": ["26.6"],
-                    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "sha256": "04376404d723ff282415c88fbe553587d32437622268f5b52732f94a49703c3c",
                     "install_runtimes": "none"
                 },
                 {
@@ -69,7 +69,7 @@
                     "filename": "Xcode_26.6_Release_Candidate_Universal",
                     "version": "26.6+17F109",
                     "symlinks": ["26.6"],
-                    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "sha256": "04376404d723ff282415c88fbe553587d32437622268f5b52732f94a49703c3c",
                     "install_runtimes": "none"
                 },
                 {

--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -8,7 +8,7 @@
                     "filename": "Xcode_26.6_Release_Candidate_2_Universal",
                     "version": "26.6+17F113",
                     "symlinks": ["26.6"],
-                    "sha256": "04376404d723ff282415c88fbe553587d32437622268f5b52732f94a49703c3c",
+                    "sha256": "3f7e2985a080d6166f178034a76a7e7a24e5e64a31f36772f9a3f55e27c94591",
                     "install_runtimes": "none"
                 },
                 {
@@ -69,7 +69,7 @@
                     "filename": "Xcode_26.6_Release_Candidate_2_Universal",
                     "version": "26.6+17F113",
                     "symlinks": ["26.6"],
-                    "sha256": "04376404d723ff282415c88fbe553587d32437622268f5b52732f94a49703c3c",
+                    "sha256": "3f7e2985a080d6166f178034a76a7e7a24e5e64a31f36772f9a3f55e27c94591",
                     "install_runtimes": "none"
                 },
                 {


### PR DESCRIPTION
# Description

**Improvement**

Add Xcode 26.6 Release Candidate 2 (17F113) to the macOS 26 image.

| Field | Value |
|---|---|
| `link` | `26.6_Release_Candidate_2` |
| `filename` | `Xcode_26.6_Release_Candidate_2_Universal` |
| `version` | `26.6+17F113` |
| `symlinks` | `["26.6"]` |
| `install_runtimes` | `none` |

#### Related issue:
- Fixes https://github.com/actions/runner-images/issues/14197

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated

### Build results

| Image | Status | Link |
|---|---|---|
| macOS 26 Arm64 | done | https://github.com/github/hosted-runners-images/actions/runs/27955236301 |
| macOS 26 X64 | done | https://github.com/github/hosted-runners-images/actions/runs/27955242476 |
