### PR TITLE
[MacOS] Added trust command for aws/tap

### DIFF
--- a/images/macos/scripts/build/install-aws-tools.sh
+++ b/images/macos/scripts/build/install-aws-tools.sh
@@ -12,6 +12,7 @@ sudo installer -pkg "$awscliv2_pkg_path" -target /
 
 echo "Installing aws sam cli..."
 brew tap aws/tap
+brew trust aws/tap
 brew_smart_install aws-sam-cli
 
 echo "Install aws cli session manager"


### PR DESCRIPTION
Replicates fix in https://github.com/actions/runner-images/pull/14235 for `aws/tap` - where new version of Homebrew require additional `trust` command.

Fixes: https://github.com/actions/runner-images/issues/14232