### PR TITLE
[Windows 11 Arm] Remove x64 Python version entries from toolset

### DIFF
--- a/images/windows/toolsets/toolset-win-11-arm64.json
+++ b/images/windows/toolsets/toolset-win-11-arm64.json
@@ -12,15 +12,6 @@
         {
             "name": "Python",
             "url" : "https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json",
-            "arch": "x64",
-            "platform" : "win32",
-            "versions": [
-                "3.13.*"
-            ]
-        },
-        {
-            "name": "Python",
-            "url" : "https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json",
             "arch": "arm64",
             "platform" : "win32",
             "versions": [

--- a/images/windows/toolsets/toolset-win-11-vs2026-arm64.json
+++ b/images/windows/toolsets/toolset-win-11-vs2026-arm64.json
@@ -12,15 +12,6 @@
         {
             "name": "Python",
             "url" : "https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json",
-            "arch": "x64",
-            "platform" : "win32",
-            "versions": [
-                "3.13.*"
-            ]
-        },
-        {
-            "name": "Python",
-            "url" : "https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json",
             "arch": "arm64",
             "platform" : "win32",
             "versions": [


### PR DESCRIPTION

# Description

This PR removes x64 Python version entries from toolset configurations for Windows 11 Arm images.

#### Related issue:
https://github.com/actions/runner-images/issues/14289
https://github.com/actions/runner-images/issues/14074

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
