### PR TITLE
[ubuntu26] Pin podman firewall backend to iptables

### DIFF
--- a/images/ubuntu/scripts/build/install-container-tools.sh
+++ b/images/ubuntu/scripts/build/install-container-tools.sh
@@ -30,4 +30,12 @@ apt-get install ${install_packages[@]}
 mkdir -p /etc/containers
 printf "[registries.search]\nregistries = ['docker.io', 'quay.io']\n" | tee /etc/containers/registries.conf
 
+# https://github.com/actions/runner-images/issues/14230
+# netavark on ubuntu 26 defaults to nftables and fails name resolution
+if is_ubuntu26; then
+    mkdir -p /etc/containers/containers.conf.d
+    printf '[network]\nfirewall_driver = "iptables"\n' | tee /etc/containers/containers.conf.d/99-fix-firewall.conf
+    podman network reload --all 2>/dev/null
+fi
+
 invoke_tests "Tools" "Containers"


### PR DESCRIPTION
# Description
`netavark` on ubuntu-26 has been bumped 1.4.0 -> 1.16.1 as part of the podman installation, causing issues with `nftables` and name resolution.
This PR pins podman firewall backend to `iptables`

#### Related issue: https://github.com/actions/runner-images/issues/14230

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
