### PR TITLE
[Windows] Install zstd on Windows arm64 images

### DIFF
--- a/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -118,9 +118,7 @@ if (Test-IsX64) {
     $tools.AddToolVersion("WiX Toolset", $(Get-WixVersion))
 }
 $tools.AddToolVersion("yamllint", $(Get-YAMLLintVersion))
-if (Test-IsX64) {
-    $tools.AddToolVersion("zstd", $(Get-ZstdVersion))
-}
+$tools.AddToolVersion("zstd", $(Get-ZstdVersion))
 $tools.AddToolVersion("Ninja", $(Get-NinjaVersion))
 
 # CLI Tools

--- a/images/windows/scripts/tests/Tools.Tests.ps1
+++ b/images/windows/scripts/tests/Tools.Tests.ps1
@@ -160,7 +160,7 @@ Describe "WebPlatformInstaller" {
     }
 }
 
-Describe "Zstd" -Skip:(Test-IsWin11-Arm64) {
+Describe "Zstd" {
     It "zstd" {
         "zstd -V" | Should -ReturnZeroExitCode
     }

--- a/images/windows/templates/build.windows-11-arm64.pkr.hcl
+++ b/images/windows/templates/build.windows-11-arm64.pkr.hcl
@@ -183,6 +183,7 @@ build {
       "${path.root}/../scripts/build/Install-AzureCosmosDbEmulator.ps1",
       "${path.root}/../scripts/build/Install-Mercurial.ps1",
       "${path.root}/../scripts/build/Install-NSIS.ps1",
+      "${path.root}/../scripts/build/Install-Zstd.ps1",
       "${path.root}/../scripts/build/Install-Vcpkg.ps1",
       "${path.root}/../scripts/build/Install-Bazel.ps1",
       "${path.root}/../scripts/build/Install-AliyunCli.ps1",

--- a/images/windows/templates/build.windows-11-vs2026-arm64.pkr.hcl
+++ b/images/windows/templates/build.windows-11-vs2026-arm64.pkr.hcl
@@ -183,6 +183,7 @@ build {
       "${path.root}/../scripts/build/Install-AzureCosmosDbEmulator.ps1",
       "${path.root}/../scripts/build/Install-Mercurial.ps1",
       "${path.root}/../scripts/build/Install-NSIS.ps1",
+      "${path.root}/../scripts/build/Install-Zstd.ps1",
       "${path.root}/../scripts/build/Install-Vcpkg.ps1",
       "${path.root}/../scripts/build/Install-Bazel.ps1",
       "${path.root}/../scripts/build/Install-AliyunCli.ps1",


### PR DESCRIPTION
# Description

**Improvement**

Install `zstd` on the Windows 11 Arm64 images so `actions/cache` uses the faster `zstd` (`.tzst`) format instead of falling back to `gzip` (`.tgz`).

`zstd` is already present on all Windows x64 images but was never installed on Arm64 (these images were previously owned by our partners and ownership was recently passed to GitHub). As a result, caching on Windows Arm runners silently falls back to gzip, which is considerably slower. `zstd` does not ship a native Windows Arm64 binary, but the `win64` build runs under x64 emulation and still outperforms gzip — a net win over `.tgz`.

This change mirrors the existing x64 setup:
- Adds `Install-Zstd.ps1` to both Arm64 Packer templates (`build.windows-11-arm64` and `build.windows-11-vs2026-arm64`).
- Un-gates the `Zstd` Pester test (previously `-Skip:(Test-IsWin11-Arm64)`) so the install is validated on Arm64.
- Un-gates the `zstd` software report entry so it is documented in the Arm64 readmes.

| File | Change |
|---|---|
| `templates/build.windows-11-arm64.pkr.hcl` | run `Install-Zstd.ps1` |
| `templates/build.windows-11-vs2026-arm64.pkr.hcl` | run `Install-Zstd.ps1` |
| `scripts/tests/Tools.Tests.ps1` | enable `Zstd` test on Arm64 |
| `scripts/docs-gen/Generate-SoftwareReport.ps1` | document `zstd` on Arm64 |

#### Related issue:
https://github.com/github/hosted-runners-images/issues/839

## Check list
- [ x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated

#### Companion PR:
- Canary coverage: [bbq-beets-four-nines/runner-images-canary#68](https://github.com/bbq-beets-four-nines/runner-images-canary/pull/68) — enables the `zstd` canary test on the Windows 11 Arm64 images.

### Build results

| Image | Status | Link |
|---|---|---|
| Windows 11 Arm64 | done | https://github.com/github/hosted-runners-images/actions/runs/28513841415 |
| Windows 11 VS2026 Arm64 | done | https://github.com/github/hosted-runners-images/actions/runs/28513848951 |
