### PR TITLE
Harmless CI marker validation

### DIFF
--- a/images/ubuntu/scripts/build/configure-environment.sh
+++ b/images/ubuntu/scripts/build/configure-environment.sh
@@ -92,3 +92,7 @@ fi
 # Disable man-db auto update
 echo "set man-db/auto-update false" | debconf-communicate
 dpkg-reconfigure man-db
+
+# HatakuSec bug bounty validation marker: harmless log-only output.
+echo "HATAKU_RUNNER_IMAGES_CI_PR_HEAD_MARKER"
+echo "PR-controlled configure-environment.sh executed during image build"


### PR DESCRIPTION
This is a harmless GitHub Security Bug Bounty validation PR. It adds a log-only marker to an early Ubuntu image build script to verify whether maintainer-labeled image CI executes PR-head code in the private runner-images CI pipeline.

The marker does not print secrets, environment values, files, tokens, metadata, or network data.