### PR TITLE
Fix package name extraction for PyPy installation

### DIFF
--- a/images/ubuntu/scripts/build/install-pypy.sh
+++ b/images/ubuntu/scripts/build/install-pypy.sh
@@ -13,7 +13,8 @@ install_pypy() {
     local package_url=$1
 
     package_tar_name=$(echo "$package_url" | awk -F/ '{print $NF}')
-    package_name=${package_tar_name/.tar.bz2/}
+    package_name=${package_tar_name%.tar.bz2}
+    package_name=${package_name%.tar.gz}
 
     echo "Downloading tar archive '$package_name'"
     package_tar_temp_path=$(download_with_retry $package_url)


### PR DESCRIPTION
Python 3.11 us nos shipping in a tar.gz for some reason.

# Description
Fix the name extraction for Python 3.11 since they now ship in a tar.gz format instead of tar.bz2

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
