### PR TITLE
[Windows] Adjust pester tests to AllowNullOrEmptyForEach

### DIFF
--- a/images/windows/scripts/tests/WindowsFeatures.Tests.ps1
+++ b/images/windows/scripts/tests/WindowsFeatures.Tests.ps1
@@ -2,7 +2,7 @@ Describe "WindowsFeatures" {
     $windowsFeatures = (Get-ToolsetContent).windowsFeatures
     $testCases = $windowsFeatures | ForEach-Object { @{ Name = $_.name; OptionalFeature = $_.optionalFeature } }
 
-    It "Windows Feature <Name> is installed" -TestCases $testCases {
+    It "Windows Feature <Name> is installed" -TestCases $testCases -AllowNullOrEmptyForEach {
         if ($OptionalFeature) {
             (Get-WindowsOptionalFeature -Online -FeatureName $Name).State | Should -Be "Enabled"
         } else {
@@ -74,7 +74,7 @@ Describe "Windows Updates" {
         }
     }
 
-    It "<Title>" -TestCases $testCases {
+    It "<Title>" -TestCases $testCases -AllowNullOrEmptyForEach {
         $expect = "Installed"
         if ( $Title -match "Microsoft Defender Antivirus" ) {
             $expect = "Installed", "Failed", "Running"


### PR DESCRIPTION


# Description
Adjust pester tests to AllowNullOrEmptyForEach for fixing canary pester tests

#### Related issue:

https://github.com/github/hosted-runners-images/issues/848

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
