### PR TITLE
[Ubuntu] Pin Pester PS module version to 5.9.0

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204-arm64.json
+++ b/images/ubuntu/toolsets/toolset-2204-arm64.json
@@ -93,7 +93,7 @@
     "powershellModules": [
         {"name": "MarkdownPS"},
         {"name": "Microsoft.Graph"},
-        {"name": "Pester"},
+        {"name": "Pester", "versions": "5.9.0" },
         {"name": "PSScriptAnalyzer"}
     ],
     "azureModules": [

--- a/images/ubuntu/toolsets/toolset-2204-arm64.json
+++ b/images/ubuntu/toolsets/toolset-2204-arm64.json
@@ -93,7 +93,7 @@
     "powershellModules": [
         {"name": "MarkdownPS"},
         {"name": "Microsoft.Graph"},
-        {"name": "Pester", "versions": "5.9.0" },
+        {"name": "Pester", "versions": ["5.9.0"]},
         {"name": "PSScriptAnalyzer"}
     ],
     "azureModules": [

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -99,7 +99,7 @@
     "powershellModules": [
         {"name": "MarkdownPS"},
         {"name": "Microsoft.Graph"},
-        {"name": "Pester"},
+        {"name": "Pester", "versions": "5.9.0" },
         {"name": "PSScriptAnalyzer"}
     ],
     "azureModules": [

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -99,7 +99,7 @@
     "powershellModules": [
         {"name": "MarkdownPS"},
         {"name": "Microsoft.Graph"},
-        {"name": "Pester", "versions": "5.9.0" },
+        {"name": "Pester", "versions": ["5.9.0"]},
         {"name": "PSScriptAnalyzer"}
     ],
     "azureModules": [

--- a/images/ubuntu/toolsets/toolset-2404-arm64.json
+++ b/images/ubuntu/toolsets/toolset-2404-arm64.json
@@ -91,7 +91,7 @@
     },
     "powershellModules": [
         {"name": "Microsoft.Graph"},
-        {"name": "Pester"},
+        {"name": "Pester", "versions": "5.9.0" },
         {"name": "PSScriptAnalyzer"}
     ],
     "azureModules": [

--- a/images/ubuntu/toolsets/toolset-2404-arm64.json
+++ b/images/ubuntu/toolsets/toolset-2404-arm64.json
@@ -91,7 +91,7 @@
     },
     "powershellModules": [
         {"name": "Microsoft.Graph"},
-        {"name": "Pester", "versions": "5.9.0" },
+        {"name": "Pester", "versions": ["5.9.0"]},
         {"name": "PSScriptAnalyzer"}
     ],
     "azureModules": [

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -95,7 +95,7 @@
     },
     "powershellModules": [
         {"name": "Microsoft.Graph"},
-        {"name": "Pester"},
+        {"name": "Pester", "versions": "5.9.0" },
         {"name": "PSScriptAnalyzer"}
     ],
     "azureModules": [

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -95,7 +95,7 @@
     },
     "powershellModules": [
         {"name": "Microsoft.Graph"},
-        {"name": "Pester", "versions": "5.9.0" },
+        {"name": "Pester", "versions": ["5.9.0"]},
         {"name": "PSScriptAnalyzer"}
     ],
     "azureModules": [

--- a/images/ubuntu/toolsets/toolset-2604-arm64.json
+++ b/images/ubuntu/toolsets/toolset-2604-arm64.json
@@ -82,7 +82,7 @@
     },
     "powershellModules": [
         {"name": "Microsoft.Graph"},
-        {"name": "Pester"},
+        {"name": "Pester", "versions": "5.9.0" },
         {"name": "PSScriptAnalyzer"}
     ],
     "azureModules": [

--- a/images/ubuntu/toolsets/toolset-2604-arm64.json
+++ b/images/ubuntu/toolsets/toolset-2604-arm64.json
@@ -82,7 +82,7 @@
     },
     "powershellModules": [
         {"name": "Microsoft.Graph"},
-        {"name": "Pester", "versions": "5.9.0" },
+        {"name": "Pester", "versions": ["5.9.0"]},
         {"name": "PSScriptAnalyzer"}
     ],
     "azureModules": [

--- a/images/ubuntu/toolsets/toolset-2604.json
+++ b/images/ubuntu/toolsets/toolset-2604.json
@@ -86,7 +86,7 @@
     },
     "powershellModules": [
         {"name": "Microsoft.Graph"},
-        {"name": "Pester", "versions": "5.9.0" },
+        {"name": "Pester", "versions": ["5.9.0"]},
         {"name": "PSScriptAnalyzer"}
     ],
     "azureModules": [

--- a/images/ubuntu/toolsets/toolset-2604.json
+++ b/images/ubuntu/toolsets/toolset-2604.json
@@ -86,7 +86,7 @@
     },
     "powershellModules": [
         {"name": "Microsoft.Graph"},
-        {"name": "Pester"},
+        {"name": "Pester", "versions": "5.9.0" },
         {"name": "PSScriptAnalyzer"}
     ],
     "azureModules": [


### PR DESCRIPTION
# Description

Pin Pester PS module version to 5.9.0

#### Related issue:

https://github.com/github/hosted-runners-images/issues/848

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
