### PR TITLE
[MacOS] Install xcodes from XcodesOrg's prebuilt release binary

### DIFF
--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -29,14 +29,11 @@ for package in $common_packages; do
                 # xcodes formulae still works on MacOS 15 ARM and 26 ARM
                 brew_smart_install "$package"
             else
-                # xcodes formulae for the rest of OS versions was broken, using pinned commit
-                echo "Installing pinned xcodes formulae..."
-                COMMIT=7236cc49de96b89c4e46ca28a36993578423df8d
-                FORMULA_URL="https://raw.githubusercontent.com/Homebrew/homebrew-core/$COMMIT/Formula/x/xcodes.rb"
-                FORMULA_PATH="$(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/x/xcodes.rb"
-                mkdir -p "$(dirname $FORMULA_PATH)"
-                curl -fsSL $FORMULA_URL -o $FORMULA_PATH
-                HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install xcodes
+                # homebrew-core provides no x86_64 bottle for current xcodes (Homebrew Tier 3),
+                # and the previously pinned 1.6.2 is too old to parse Apple's simulator runtime
+                # catalog. Install from XcodesOrg's own tap, which ships an Intel/universal bottle.
+                echo "Installing xcodes from XcodesOrg tap..."
+                HOMEBREW_NO_REQUIRE_TAP_TRUST=1 brew install xcodesorg/made/xcodes
             fi
             ;;
 

--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -29,11 +29,14 @@ for package in $common_packages; do
                 # xcodes formulae still works on MacOS 15 ARM and 26 ARM
                 brew_smart_install "$package"
             else
-                # homebrew-core provides no x86_64 bottle for current xcodes (Homebrew Tier 3),
-                # and the previously pinned 1.6.2 is too old to parse Apple's simulator runtime
-                # catalog. Install from XcodesOrg's own tap, which ships an Intel/universal bottle.
-                echo "Installing xcodes from XcodesOrg tap..."
-                HOMEBREW_NO_REQUIRE_TAP_TRUST=1 brew install xcodesorg/made/xcodes
+                # homebrew-core ships no x86_64 bottle for current xcodes, and building it
+                # from source needs xcbuild (unavailable during image build). Install the
+                # prebuilt Developer-ID-signed universal binary from XcodesOrg's release.
+                echo "Installing xcodes from XcodesOrg release..."
+                curl -fsSL "https://github.com/XcodesOrg/xcodes/releases/latest/download/xcodes.zip" -o /tmp/xcodes.zip
+                unzip -oq /tmp/xcodes.zip -d /tmp/xcodes-bin
+                sudo install -m 0755 /tmp/xcodes-bin/xcodes /usr/local/bin/xcodes
+                rm -rf /tmp/xcodes.zip /tmp/xcodes-bin
             fi
             ;;
 


### PR DESCRIPTION
# Description

**Bug fix**

Install `xcodes` from XcodesOrg's prebuilt release binary on the out-of-support macOS versions (Intel + macOS 14), replacing the pinned `xcodes` 1.6.2 Homebrew formula that can no longer manage simulator runtimes.

The pinned out-of-support `xcodes` **1.6.2** is too old to parse Apple's current simulator-runtime *downloadables* catalog, so `xcodes runtimes install` (and even the `xcodes runtimes` listing) fail on the **macOS 26 Intel** canary with:

```
Error: DecodingError.dataCorrupted: … downloadables[…].authentication …
Cannot initialize Authentication from invalid String value none
```

`xcodes` was pinned to 1.6.2 (homebrew-core commit `7236cc49`) because homebrew-core no longer ships an x86_64 bottle for the current 2.0.x releases — Intel on the newest macOS is a Homebrew **Tier 3** configuration. But 1.6.2 predates the `authentication: none` value Apple added to the catalog, so it can no longer install runtimes. Apple Silicon (macOS 15/26 ARM) is unaffected — it already uses the current formula and gets the fix automatically.

## Changes

`images/macos/scripts/build/install-common-utils.sh` — in the `xcodes` case, the non-`SequoiaArm64`/`TahoeArm64` branch now downloads the prebuilt, Developer-ID-signed **universal** binary from XcodesOrg's GitHub release instead of `brew install`-ing the pinned formula:

```bash
else
    # homebrew-core ships no x86_64 bottle for current xcodes, and building it
    # from source needs xcbuild (unavailable during image build). Install the
    # prebuilt Developer-ID-signed universal binary from XcodesOrg's release.
    echo "Installing xcodes from XcodesOrg release..."
    curl -fsSL "https://github.com/XcodesOrg/xcodes/releases/latest/download/xcodes.zip" -o /tmp/xcodes.zip
    unzip -oq /tmp/xcodes.zip -d /tmp/xcodes-bin
    sudo install -m 0755 /tmp/xcodes-bin/xcodes /usr/local/bin/xcodes
    rm -rf /tmp/xcodes.zip /tmp/xcodes-bin
fi
```

### Why the prebuilt binary (and not brew)
- **homebrew-core** has no x86_64 bottle for current `xcodes` (Tier 3) → `brew install` reports `xcodes: no bottle available!`.
- The **XcodesOrg tap** (`xcodesorg/made/xcodes`) *does* declare an Intel bottle, but on Tahoe `brew` does not pour the old `mojave` tag and falls back to `make install`, which needs `xcbuild` (absent in the image build) → `xcbuild … does not exist`. `brew install --build-from-source` fails the same way.
- The release `xcodes.zip` is a single **universal (x86_64 + arm64)** binary, Developer-ID-signed (`com.xcodesorg.xcodes`), self-contained (links only system + Swift-runtime dylibs). The only consumers on the image — `xcodes version` (software report) and the canary `xcodes select` / `xcodes runtimes` — just need it on `PATH`; nothing relies on `brew list xcodes`.

#### Related issue:
- _<add issue / work item link>_ (macOS 26 Intel canary `xcodes` regression, tracked in the DRI shift report)

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable) — covered by the existing canary `xcodes` jobs
- [x] Documentation is updated (if applicable) — n/a (`xcodes version` in the software report is unchanged)
- [x] Changes are tested and related VM images are successfully generated

### Build results

| Image | Status | Link |
|---|---|---|
| macOS 26 X64 | Build SUCCESS — `Installing xcodes from XcodesOrg release…`, `xcodes` 2.0.3 installed | https://github.com/github/hosted-runners-images/actions/runs/29082061075 |

> Validation build from `github-maccloud/runner-images:v-georgypuzakov/xcodesfix852`. The **Build** job is green — `xcodes` now installs from the release binary and the earlier `xcbuild` / pinned-formula failures are gone. The run shows "cancelled" only because its downstream **Run Canary Tests** job was cancelled (staging canary capacity), not a build failure.

### Canary tests

| Image | Status | Link |
|---|---|---|
| macOS 26 X64 | _validation in progress_ | _<canary run link>_ |

> Deploying the canary image (`4090 / 20260710.0353.1`) and re-running the `xcodes` canary jobs (`xcodes 26.2 / 26.3 / 26.4.1 / 26.5`) to confirm `xcodes runtimes install` succeeds (no `DecodingError`). Link to be added once the canary run is green.
