### PR TITLE
[All OS] .NET: add test "latest" version case and bring macOS to parity 

### DIFF
--- a/images/macos/scripts/tests/Common.Tests.ps1
+++ b/images/macos/scripts/tests/Common.Tests.ps1
@@ -4,8 +4,55 @@ Import-Module "$PSScriptRoot/Helpers.psm1" -DisableNameChecking
 $os = Get-OSVersion
 
 Describe ".NET" {
-    It ".NET" {
-        "dotnet --version" | Should -ReturnZeroExitCode
+    $arch = Get-Architecture
+    $dotnetVersions = (Get-ToolsetContent).dotnet.arch.${arch}.versions
+
+    Context "Default" {
+        It "Default Dotnet SDK is available" {
+            "dotnet --version" | Should -ReturnZeroExitCode
+        }
+    }
+
+    Context "Latest" {
+        $latestVersion = @($dotnetVersions | Sort-Object { [Version] $_ })[-1]
+        $dotnetLatest = @{ dotnetVersion = $latestVersion }
+
+        It "Latest SDK $latestVersion is available" -TestCases $dotnetLatest {
+            (dotnet --list-sdks | Where-Object { $_ -match "${dotnetVersion}\.[0-9]*" }).Count | Should -BeGreaterThan 0
+        }
+
+        It "Default 'dotnet --version' resolves to the latest SDK $latestVersion" -TestCases $dotnetLatest {
+            (dotnet --version) | Should -BeLike "${dotnetVersion}.*"
+        }
+    }
+
+    foreach ($version in $dotnetVersions) {
+        Context "Dotnet $version" {
+            $dotnet = @{ dotnetVersion = $version }
+
+            It "SDK $version is available" -TestCases $dotnet {
+                (dotnet --list-sdks | Where-Object { $_ -match "${dotnetVersion}\.[0-9]*" }).Count | Should -BeGreaterThan 0
+            }
+
+            It "Runtime $version is available" -TestCases $dotnet {
+                (dotnet --list-runtimes | Where-Object { $_ -match "${dotnetVersion}\.[0-9]*" }).Count | Should -BeGreaterThan 0
+            }
+        }
+    }
+
+    Context "Dotnet tools" {
+        $dotnetTools = (Get-ToolsetContent).dotnet.tools
+        $testCases = @($dotnetTools | Where-Object { $_ } | ForEach-Object { @{ ToolName = $_.name; TestInstance = $_.test } })
+
+        if ($testCases.Count -gt 0) {
+            $env:PATH = "$HOME/.dotnet/tools:$env:PATH"
+
+            It "<ToolName> is available" -TestCases $testCases {
+                "$TestInstance" | Should -ReturnZeroExitCode
+            }
+        } else {
+            It "has no dotnet tools defined in toolset" -Skip:$true {}
+        }
     }
 }
 

--- a/images/ubuntu/scripts/tests/DotnetSDK.Tests.ps1
+++ b/images/ubuntu/scripts/tests/DotnetSDK.Tests.ps1
@@ -15,6 +15,19 @@ Describe "Dotnet and tools" {
         }
     }
 
+    Context "Latest" {
+        $latestVersion = @($dotnetVersions | Sort-Object { [Version] $_ })[-1]
+        $dotnetLatest = @{ dotnetVersion = $latestVersion }
+
+        It "Latest SDK <dotnetVersion> is available" -TestCases $dotnetLatest {
+            $dotnetSDKs | Should -Match "$dotnetVersion.[1-9]*"
+        }
+
+        It "Default 'dotnet --version' resolves to the latest SDK <dotnetVersion>" -TestCases $dotnetLatest {
+            (dotnet --version) | Should -BeLike "$dotnetVersion.*"
+        }
+    }
+
     foreach ($version in $dotnetVersions) {
         Context "Dotnet $version" {
             $dotnet = @{ dotnetVersion = $version }

--- a/images/windows/scripts/tests/DotnetSDK.Tests.ps1
+++ b/images/windows/scripts/tests/DotnetSDK.Tests.ps1
@@ -9,6 +9,19 @@ Describe "Dotnet SDK and tools" {
         }
     }
 
+    Context "Latest" {
+        $latestVersion = @($dotnetVersions | Sort-Object { [Version] $_ })[-1]
+        $dotnetLatest = @{ dotnetVersion = $latestVersion }
+
+        It "Latest SDK $latestVersion is available" -TestCases $dotnetLatest {
+            (dotnet --list-sdks | Where-Object { $_ -match "${dotnetVersion}\.[0-9]*" }).Count | Should -BeGreaterThan 0
+        }
+
+        It "Default 'dotnet --version' resolves to the latest SDK $latestVersion" -TestCases $dotnetLatest {
+            (dotnet --version) | Should -BeLike "${dotnetVersion}.*"
+        }
+    }
+
     foreach ($version in $dotnetVersions) {
         Context "Dotnet $version" {
             $dotnet = @{ dotnetVersion = $version }


### PR DESCRIPTION
# Description

**Improvement**

Validate and expand the `.NET` SDK test coverage across all runner images (Windows, Ubuntu, and macOS).

Investigation of the current tests (issue #543) showed:

- **Windows** and **Ubuntu** (`DotnetSDK.Tests.ps1`) already validate the **default** SDK (`dotnet --version`) and each **specific** feature band from the toolset (`8.0`, `9.0`, `10.0`) — checking both the SDK (`dotnet --list-sdks`) and the runtime (`dotnet --list-runtimes`) — plus the configured dotnet tools. However, there was **no explicit assertion for the latest** SDK.
- **macOS** (`Common.Tests.ps1`) had only a single `dotnet --version` smoke test — no per-version, latest, or tools coverage.

This change closes those gaps and brings all three OSes to parity on the three cases from the issue (**specific / default / latest** version):

- **Windows & Ubuntu** (`DotnetSDK.Tests.ps1`) — added a `Latest` context that asserts the newest feature-band SDK is installed and that the default `dotnet --version` resolves to that latest band.
- **macOS** (`Common.Tests.ps1`) — expanded the `.NET` block from a single smoke test to the full set: **Default**, **Latest**, per-band **SDK + Runtime** presence, and **dotnet tools** (guarded, since the macOS toolset defines none). macOS versions are read per-architecture (`.dotnet.arch.<arch>.versions`).

Test-only change — no product/tooling behavior is affected.

#### Related issue:
- Fixes https://github.com/github/hosted-runners-images/issues/543

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated

### Build results

| Image | Status | Link |
|---|---|---|
| Ubuntu 24.04 X64 | SUCCESS | https://github.com/github/hosted-runners-images/actions/runs/29417879974 |
| Windows Server 2025 X64 | SUCCESS | https://github.com/github/hosted-runners-images/actions/runs/29417882462 |
| macOS 15 X64 | FAILURE* | https://github.com/github/hosted-runners-images/actions/runs/29342686262 |

> **\*Note:** Both failures are **not related to this change**. In every run the image **Build** stage — where the new `.NET` Pester tests execute — completed successfully and all `.NET` tests passed.
>
> - **Windows Server 2025 X64** failed only during canary image **deployment** to one of four regions (`prod-eus-01`) with `HCRA API call failed: Connection timed out` (transient infrastructure; the other three regions deployed successfully). The same branch built and passed all tests end-to-end in CI: https://github.com/actions/runner-images-ci/actions/runs/29342750154
> - **macOS 15 X64** failed only in the post-deploy canary `xcodes` tests — a pre-existing Xcode-tooling issue unrelated to `.NET`.
> - For reference, Ubuntu also built green in CI: https://github.com/actions/runner-images-ci/actions/runs/29342753409
