### PR TITLE
[windows] Label R as x86_64 emulated on arm64 images

### DIFF
--- a/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -103,7 +103,12 @@ if (-not (Test-IsWin25-X64)) {
 $tools.AddToolVersion("OpenSSL", $(Get-OpenSSLVersion))
 $tools.AddToolVersion("Packer", $(Get-PackerVersion))
 $tools.AddToolVersion("Pulumi", $(Get-PulumiVersion))
-$tools.AddToolVersion("R", $(Get-RVersion))
+if (Test-IsArm64) {
+    # The choco R.Project package ships only the x86_64 installer, so R runs emulated here
+    $tools.AddToolVersion("R", "$(Get-RVersion) (x86_64, emulated)")
+} else {
+    $tools.AddToolVersion("R", $(Get-RVersion))
+}
 if (Test-IsX64) {
     $tools.AddToolVersion("Service Fabric SDK", $(Get-ServiceFabricSDKVersion))
 }


### PR DESCRIPTION
# Description
Bug fixing / documentation accuracy.

R is installed from the choco `R.Project` package, which ships only CRAN's x86_64 installer, so on arm64 images R runs under Windows-on-ARM emulation and reports `arch = x86_64`. That is correct behaviour — R is reporting the build it actually is — but the software report listed it as plain `R 4.6.1` with no architecture qualifier, so nothing indicated the build was emulated. That is what prompted #14089.

This labels the entry `R 4.6.1 (x86_64, emulated)` on arm64 images only. x64 images are unchanged.

Verified on `windows-11-arm` (image `20260706.102.1`): `Rscript.exe`, `R.exe`, `R.dll` and `Rblas.dll` are all compiled for x64 (PE machine `0x8664`), while `pwsh.exe` on the same machine is native ARM64 (`0xAA64`). R is installed under `C:\Program Files (x86)\R\R-4.6.1` and no native `R-aarch64` build is present.

Only the generator is changed — the readme files themselves are regenerated on the next image build.

#### Related issue:
#14089

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable) — n/a, no test asserts software report content; the existing `Tools.Tests.ps1` R test is unaffected
- [x] Documentation is updated (if applicable) — this change *is* the documentation fix; the readme regenerates on the next build
- [ ] Changes are tested and related VM images are successfully generated