### PR TITLE
[Ubuntu] Update `podman` (5.8.4) to the Ubuntu 22.04 and 24.04 images.

### DIFF
--- a/images/ubuntu/scripts/build/install-container-tools.sh
+++ b/images/ubuntu/scripts/build/install-container-tools.sh
@@ -38,6 +38,25 @@ install_podman_static() {
     tar -xzf "$archive_path" -C / --strip-components=1 \
         "podman-linux-${arch}/usr" "podman-linux-${arch}/etc"
     rm -f "$archive_path"
+
+    # Ubuntu >= 23.10 restricts unprivileged user namespaces via AppArmor
+    # (kernel.apparmor_restrict_unprivileged_userns=1). The distro podman package
+    # ships an /etc/apparmor.d/podman profile that grants the `userns` permission,
+    # but the static binary in /usr/local/bin has none, so rootless podman fails
+    # with "failed to reexec: Permission denied". Provide the same profile for it.
+    if [[ "$(cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns 2>/dev/null)" == "1" ]]; then
+        cat > /etc/apparmor.d/podman <<'EOF'
+abi <abi/4.0>,
+include <tunables/global>
+
+profile podman /usr/{bin,local/bin}/podman flags=(unconfined) {
+  userns,
+
+  include if exists <local/podman>
+}
+EOF
+        apparmor_parser -r -W /etc/apparmor.d/podman
+    fi
 }
 
 apt-get update

--- a/images/ubuntu/scripts/build/install-container-tools.sh
+++ b/images/ubuntu/scripts/build/install-container-tools.sh
@@ -2,40 +2,62 @@
 ################################################################################
 ##  File:  install-container-tools.sh
 ##  Desc:  Install container tools: podman, buildah and skopeo onto the image
+##  Supply chain security: podman static bundle - pinned version + SHA256 validation
 ################################################################################
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/os.sh
+source $HELPER_SCRIPTS/install.sh
 
-#
-# pin podman due to https://github.com/actions/runner-images/issues/7753
-#                   https://bugs.launchpad.net/ubuntu/+source/libpod/+bug/2024394
-#
-if ! is_ubuntu22; then
-    install_packages=(podman buildah skopeo)
-else
-    install_packages=(podman=3.4.4+ds1-1ubuntu1 buildah skopeo)
-fi
+# Ubuntu 22.04/24.04 only ship an outdated podman via apt (3.4.4 / 4.9.3) whose
+# Docker-compatible API is too old for the current Docker daemon and breaks
+# `podman push docker-daemon:` (actions/runner-images#13691, #549). There is no
+# maintained podman apt repository for Ubuntu (Kubic/OBS was discontinued), so a
+# current self-contained static bundle (podman + crun/runc + conmon + netavark +
+# aardvark-dns + pasta) is installed instead. Ubuntu 26.04 already ships podman 5.x.
+podman_static_tag="v5.8.4"
+podman_static_sha256_amd64="a58765fe8be6ab3fb79f892f1a027b4ce4a7e8eb589df1ef960c167cbde08d69"
+podman_static_sha256_arm64="a2f6b73cc0f7018e2e8518338a4ec27db70148e1af86e16719235605aefd1df3"
 
+install_podman_static() {
+    local arch checksum
+    if is_x64; then
+        arch="amd64"
+        checksum="$podman_static_sha256_amd64"
+    else
+        arch="arm64"
+        checksum="$podman_static_sha256_arm64"
+    fi
 
-if is_ubuntu22_x64; then
-    # Install containernetworking-plugins for Ubuntu 22 x64
-    curl -O http://archive.ubuntu.com/ubuntu/pool/universe/g/golang-github-containernetworking-plugins/containernetworking-plugins_1.1.1+ds1-3build1_amd64.deb
-    dpkg -i containernetworking-plugins_1.1.1+ds1-3build1_amd64.deb
-fi
+    local archive_url="https://github.com/mgoltzsche/podman-static/releases/download/${podman_static_tag}/podman-linux-${arch}.tar.gz"
+    local archive_path
+    archive_path=$(download_with_retry "$archive_url")
+    use_checksum_comparison "$archive_path" "$checksum"
 
-# Install podman, buildah, skopeo container's tools
+    # The bundle ships ./usr and ./etc under a single top-level directory
+    tar -xzf "$archive_path" -C / --strip-components=1 \
+        "podman-linux-${arch}/usr" "podman-linux-${arch}/etc"
+    rm -f "$archive_path"
+}
+
 apt-get update
-apt-get install ${install_packages[@]}
+if is_ubuntu26; then
+    # apt already provides a current podman on 26.04
+    apt-get install podman buildah skopeo
+else
+    # buildah and skopeo from apt (podman is not a dependency of either);
+    # uidmap keeps rootless podman working; podman itself comes from the bundle
+    apt-get install buildah skopeo uidmap
+    install_podman_static
+fi
+
 mkdir -p /etc/containers
 printf "[registries.search]\nregistries = ['docker.io', 'quay.io']\n" | tee /etc/containers/registries.conf
 
-# https://github.com/actions/runner-images/issues/14230
-# netavark on ubuntu 26 defaults to nftables and fails name resolution
-if is_ubuntu26; then
-    mkdir -p /etc/containers/containers.conf.d
-    printf '[network]\nfirewall_driver = "iptables"\n' | tee /etc/containers/containers.conf.d/99-fix-firewall.conf
-    podman network reload --all 2>/dev/null
-fi
+# netavark (used by podman 5.x) can default to nftables on Ubuntu and then fails
+# name resolution; force iptables. https://github.com/actions/runner-images/issues/14230
+mkdir -p /etc/containers/containers.conf.d
+printf '[network]\nfirewall_driver = "iptables"\n' | tee /etc/containers/containers.conf.d/99-fix-firewall.conf
+podman network reload --all 2>/dev/null || true
 
 invoke_tests "Tools" "Containers"


### PR DESCRIPTION
# Description

**Improvement**

Bring a current `podman` (5.8.4) to the Ubuntu 22.04 and 24.04 images.

Both images install `podman` from `apt`, which only offers outdated versions — **3.4.4** on 22.04 and **4.9.3** on 24.04 — whose Docker-compatible API is too old for the current Docker daemon. This breaks `podman push docker-daemon:`:

```
client version 1.41 is too old. Minimum supported API version is 1.44
```

(reported in actions/runner-images#13691). Ubuntu 26.04 already ships `podman` 5.x via `apt` and is unaffected. Ubuntu provides no maintained newer-`podman` apt repository (the Kubic/OBS `devel:kubic:libcontainers` project was discontinued), so a newer version cannot be sourced through `apt` on 22.04/24.04.

**Change** — `images/ubuntu/scripts/build/install-container-tools.sh`:

- **22.04 & 24.04:** install a pinned, checksum-verified static `podman` bundle ([`mgoltzsche/podman-static` v5.8.4](https://github.com/mgoltzsche/podman-static)), which is self-contained (podman + crun/runc + conmon + netavark + aardvark-dns + pasta + fuse-overlayfs + catatonit). `buildah`/`skopeo` continue to come from `apt` (neither depends on `podman`); `uidmap` is added for rootless support.
- **26.04:** unchanged — keeps `apt` `podman` 5.x.
- **Supply chain:** the bundle version is pinned and both `amd64`/`arm64` archives are verified against a pinned SHA-256 before extraction.
- **AppArmor (24.04+):** Ubuntu ≥ 23.10 enables `kernel.apparmor_restrict_unprivileged_userns=1`. The distro `podman` package ships an `/etc/apparmor.d/podman` profile that grants the `userns` permission, but the static binary in `/usr/local/bin` has none, so rootless `podman` fails with `failed to reexec: Permission denied`. An equivalent profile covering `/usr/{bin,local/bin}/podman` is installed when the restriction is enabled.
- **Networking:** the `netavark` `firewall_driver = "iptables"` workaround (previously 26.04-only, actions/runner-images#14230) now applies to all Ubuntu versions, since `netavark` is podman 5's default backend. The obsolete 22.04-only `containernetworking-plugins` (CNI) step is removed.

#### Related issue:
- Tracking: github/hosted-runners-images#549
- Motivating bug: actions/runner-images#13691

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable) — covered by the existing `Tools.Tests.ps1` "Containers" tests (`podman`/`buildah`/`skopeo` + rootless `podman network` bridge test)
- [x] Documentation is updated (if applicable) — n/a (image readmes are regenerated by the build; the `Podman` version updates automatically)
- [x] Changes are tested and related VM images are successfully generated

### Build results

| Image | Status | Link |
|---|---|---|
| Ubuntu 22.04 X64 — curated (build + canary deploy + canary tests) | SUCCESS | https://github.com/github/hosted-runners-images/actions/runs/29508399684 |
| Ubuntu 24.04 X64 — curated (build + canary deploy + canary tests) | SUCCESS | https://github.com/github/hosted-runners-images/actions/runs/29508402503 |
| Ubuntu 22.04 Arm64 — curated (build + canary deploy + canary tests) | IN PROGRESS | https://github.com/github/hosted-runners-images/actions/runs/29587458224 |
| Ubuntu 24.04 Arm64 — curated (build + canary deploy + canary tests) | IN PROGRESS | https://github.com/github/hosted-runners-images/actions/runs/29587460859 |
| Ubuntu 22.04 X64 — CI | SUCCESS | https://github.com/actions/runner-images-ci/actions/runs/29480103130 |
| Ubuntu 24.04 X64 — CI | SUCCESS | https://github.com/actions/runner-images-ci/actions/runs/29480105091 |

