### PR TITLE
[MacOS] Update Xcode default version to 26.6

### DIFF
--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -1,6 +1,6 @@
 {
     "xcode": {
-        "default": "26.5",
+        "default": "26.6",
         "x64": {
             "versions": [
                 {


### PR DESCRIPTION
# Description

This PR updating Xcode default version to 26.6 for fix canary test issues after base image version bump

#### Related issue:

https://github.com/actions/runner-images/issues/14344

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
