### PR TITLE
[Ubuntu] Write registries.conf in v2 format

### DIFF
--- a/images/ubuntu/scripts/build/install-container-tools.sh
+++ b/images/ubuntu/scripts/build/install-container-tools.sh
@@ -71,7 +71,7 @@ else
 fi
 
 mkdir -p /etc/containers
-printf "[registries.search]\nregistries = ['docker.io', 'quay.io']\n" | tee /etc/containers/registries.conf
+printf 'unqualified-search-registries = ["docker.io", "quay.io"]\n' | tee /etc/containers/registries.conf
 
 # netavark (used by podman 5.x) can default to nftables on Ubuntu and then fails
 # name resolution; force iptables. https://github.com/actions/runner-images/issues/14230

--- a/images/ubuntu/scripts/tests/Tools.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Tools.Tests.ps1
@@ -323,6 +323,14 @@ Describe "Containers" {
         "podman network rm test-net" | Should -ReturnZeroExitCode
     }
 
+    # https://github.com/actions/runner-images/issues/14406
+    # registries.conf must be valid v2 format; a v1 file is rejected by newer podman.
+    It "podman registries.conf" {
+        "podman info" | Should -ReturnZeroExitCode
+        "podman info" | Should -OutputTextMatchingRegex "docker.io"
+        "podman info" | Should -OutputTextMatchingRegex "quay.io"
+    }
+
 }
 
 Describe "nvm" {


### PR DESCRIPTION
# Description

**Bug fixing** (with a small test improvement).

`install-container-tools.sh` writes `/etc/containers/registries.conf` in the
deprecated v1 `[registries.search]` format. `containers/image` v5.40.0 removed
v1 auto-conversion for the main `registries.conf` and now hard-errors:

> registries.conf must be in v2 format but is in v1

This PR writes the v2 equivalent instead, keeping the same search registries:

```
unqualified-search-registries = ["docker.io", "quay.io"]
```

**Motivation / context:** v2 is parsed by every podman currently shipped, so
this is safe today and prevents an imminent break. The podman versions on the
images still tolerate v1 (they auto-convert), but that path is being removed
upstream and will fail the moment a newer podman lands:

| image lib | podman | ships on | main v1 config |
|---|---|---|---|
| v5.38.0 | 5.7.0 (apt) | 26.04 | auto-converts ✓ |
| v5.39.2 | 5.8.4 (static bundle, #14412) | 22.04 / 24.04 | auto-converts ✓ |
| v5.40.0 | — | not shipped yet | **rejected** ✗ |

Also adds a `podman info` test to the Containers suite. The existing tests only
run `podman -v`, which never reads `registries.conf`, so a broken/rejected
config would ship green. The new test asserts `podman info` succeeds and reports
the configured search registries.

_No new tool; no size/installation-time change (one config line + one test)._

#### Related issue:
Fixes #14406

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated