### PR TITLE
Fix strikethrough on removed Docker digests in release notes

### DIFF
--- a/images/ubuntu/scripts/docs-gen/SoftwareReport.Common.psm1
+++ b/images/ubuntu/scripts/docs-gen/SoftwareReport.Common.psm1
@@ -275,7 +275,7 @@ function Get-CachedDockerImages {
 }
 
 function Get-CachedDockerImagesTableData {
-    $allImages = sudo docker images --digests --format "*{{.Repository}}:{{.Tag}}|{{.Digest}} |{{.CreatedAt}}"
+    $allImages = sudo docker images --digests --format "*{{.Repository}}:{{.Tag}}|{{.Digest}}|{{.CreatedAt}}"
     $allImages.Split("*") | Where-Object { $_ } | ForEach-Object {
         $parts = $_.Split("|")
         [PSCustomObject] @{

--- a/images/windows/scripts/docs-gen/SoftwareReport.Common.psm1
+++ b/images/windows/scripts/docs-gen/SoftwareReport.Common.psm1
@@ -248,7 +248,7 @@ function Get-PowerShellModules {
 }
 
 function Get-CachedDockerImagesTableData {
-    $allImages = docker images --digests --format "*{{.Repository}}:{{.Tag}}|{{.Digest}} |{{.CreatedAt}}"
+    $allImages = docker images --digests --format "*{{.Repository}}:{{.Tag}}|{{.Digest}}|{{.CreatedAt}}"
     if (-not $allImages) {
         return $null
     }


### PR DESCRIPTION
# Description

**Bug fixing.**

Removed cached Docker images render as literal `~~sha256:… ~~` in the release notes instead of struck-through text (see the [win22/20260720.249 release](https://github.com/actions/runner-images/releases/tag/win22/20260720.249)).

**Root cause:** `Get-CachedDockerImagesTableData` builds the Digest cell from the `docker images --format` template, which terminated the digest field with a trailing space:

```
"*{{.Repository}}:{{.Tag}}|{{.Digest}} |{{.CreatedAt}}"
```

So the Digest cell value is `sha256:… ` (trailing space). When an image is removed between builds, `StrikeTableRow` wraps every cell in `~~…~~`, yielding `~~sha256:… ~~`. GitHub's GFM strikethrough will not render when the closing `~~` is preceded by whitespace, so the digest is shown literally. It never surfaced before because trailing whitespace is harmless in normal (non-struck) tables — only the deleted-images diff path breaks.

**Fix:** drop the trailing space in the format string (`{{.Digest}} |` → `{{.Digest}}|`) in both the Windows and Ubuntu report generators. Cell indexing is unaffected — the space lived entirely inside the Digest field.

**Validation:** ran the real parse + `StrikeTableRow` logic and rendered the output through GitHub's GFM API (`gh api /markdown --mode gfm`):

| Case | Digest cell markdown | GitHub renders |
|------|----------------------|----------------|
| Before (`{{.Digest}} \|`) | `~~sha256:…e9 ~~` | `~~sha256:…e9 ~~` (literal, not struck) |
| After (`{{.Digest}}\|`) | `~~sha256:…e9~~` | `<del>sha256:…e9</del>` (struck) |

#### Related issue:
Fixes #14432

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable) — no automated test added; behavior verified against GitHub's live GFM renderer (table above)
- [ ] Documentation is updated (if applicable) — N/A
- [ ] Changes are tested and related VM images are successfully generated — **not** verified: this requires a full image build that can't be run locally; needs a maintainer image-generation run
