### PR TITLE
[MacOS] Updated XCode 27 to Beta 4

### DIFF
--- a/images/macos/toolsets/toolset-xcode-27.json
+++ b/images/macos/toolsets/toolset-xcode-27.json
@@ -8,7 +8,7 @@
                     "filename": "Xcode_27_beta_4",
                     "version": "27.0+27A5228h",
                     "symlinks": ["27.0"],
-                    "sha256": "b36b35f8c9d3b3c298fcb5676ad4a9bf229095579e40d99d5deff8a8d19688ad",
+                    "sha256": "808582beef282213b3a5a1132338ea7f866010a819543fcc91ab12f24c15919d",
                     "install_runtimes": "default"
                 }
             ]
@@ -20,7 +20,7 @@
                     "filename": "Xcode_27_beta_4",
                     "version": "27.0+27A5228h",
                     "symlinks": ["27.0"],
-                    "sha256": "b36b35f8c9d3b3c298fcb5676ad4a9bf229095579e40d99d5deff8a8d19688ad",
+                    "sha256": "808582beef282213b3a5a1132338ea7f866010a819543fcc91ab12f24c15919d",
                     "install_runtimes": "default"
                 }
             ]

--- a/images/macos/toolsets/toolset-xcode-27.json
+++ b/images/macos/toolsets/toolset-xcode-27.json
@@ -1,12 +1,12 @@
 {
     "xcode": {
-        "default": "27_beta_3",
+        "default": "27_beta_4",
         "x64": {
             "versions": [
                 {
-                    "link": "27_beta_3",
-                    "filename": "Xcode_27_beta_3",
-                    "version": "27.0+27A5218g",
+                    "link": "27_beta_4",
+                    "filename": "Xcode_27_beta_4",
+                    "version": "27.0+27A5228h",
                     "symlinks": ["27.0"],
                     "sha256": "b36b35f8c9d3b3c298fcb5676ad4a9bf229095579e40d99d5deff8a8d19688ad",
                     "install_runtimes": "default"
@@ -16,9 +16,9 @@
         "arm64": {
             "versions": [
                 {
-                    "link": "27_beta_3",
-                    "filename": "Xcode_27_beta_3",
-                    "version": "27.0+27A5218g",
+                    "link": "27_beta_4",
+                    "filename": "Xcode_27_beta_4",
+                    "version": "27.0+27A5228h",
                     "symlinks": ["27.0"],
                     "sha256": "b36b35f8c9d3b3c298fcb5676ad4a9bf229095579e40d99d5deff8a8d19688ad",
                     "install_runtimes": "default"


### PR DESCRIPTION
# Description
Updated `xcode-27` image to use XCode 27 Beta 4

#### Related issue:
- https://github.com/actions/runner-images/issues/14429

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated:
  - [Build](https://github.com/github/hosted-runners-images/actions/runs/29825024100)
