### PR TITLE
[Windows] Fix misleading WSLv1 entry in Arm64 software reports

### DIFF
--- a/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -20,7 +20,11 @@ Import-Module (Join-Path $PSScriptRoot "SoftwareReport.VisualStudio.psm1") -Disa
 # Software report
 $softwareReport = [SoftwareReport]::new($(Build-OSInfoSection))
 $optionalFeatures = $softwareReport.Root.AddHeader("Windows features")
-$optionalFeatures.AddToolVersion("Windows Subsystem for Linux (WSLv1):", "Enabled")
+# WSL is not functional on Arm64: WSL2 needs nested virtualization (unavailable on Azure Arm64 sizes)
+# and WSL1 is a legacy component that does not work on Arm64. See actions/runner-images#14076.
+if (-not (Test-IsWin11-Arm64)) {
+    $optionalFeatures.AddToolVersion("Windows Subsystem for Linux (WSLv1):", "Enabled")
+}
 if (Test-IsWin25-X64) {
     $optionalFeatures.AddToolVersion("Windows Subsystem for Linux (Default, WSLv2):", $(Get-WSL2Version))
 }


### PR DESCRIPTION
# Description
Bug fixing.

The Arm64 Windows software reports advertise `Windows Subsystem for Linux (WSLv1): Enabled`, but WSL is not functional on `windows-11-arm`: WSL2 requires nested virtualization (unavailable on Azure Arm64 VM sizes) and WSL1 is a legacy component that does not work on Arm64. This is misleading to customers.

This guards the WSLv1 line in `Generate-SoftwareReport.ps1` so it is not emitted on Arm64. The generated Arm64 readmes will drop the line automatically on the next image build / readme update.

#### Related issue:
#14076

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
