### PR TITLE
[Windows] Add cache policy for VS2026 to registry | Remove missing VS26 component

### DIFF
--- a/images/windows/scripts/build/Install-VisualStudio.ps1
+++ b/images/windows/scripts/build/Install-VisualStudio.ps1
@@ -20,19 +20,6 @@ Install-VisualStudio `
     -ExtraArgs "--allWorkloads --includeRecommended --remove Component.CPython3.x64" `
     -Architecture $vsArch
 
-$vsPackagesPath = "C:\ProgramData\Microsoft\VisualStudio\Packages"
-if (Test-Path -Path $vsPackagesPath) {
-    $vsPackagesSizeBytes = (Get-ChildItem -Path $vsPackagesPath -Recurse -File -Force | Measure-Object -Property Length -Sum).Sum
-    if (-not $vsPackagesSizeBytes) {
-        $vsPackagesSizeBytes = 0
-    }
-
-    $vsPackagesSizeGb = [Math]::Round($vsPackagesSizeBytes / 1GB, 2)
-    Write-Host "Size of ${vsPackagesPath}: $vsPackagesSizeBytes bytes ($vsPackagesSizeGb GB)"
-} else {
-    Write-Host "Path not found: $vsPackagesPath"
-}
-
 # Find the version of VS installed for this instance
 # Only supports a single instance
 $vsProgramData = Get-Item -Path "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances"

--- a/images/windows/scripts/build/Install-VisualStudio.ps1
+++ b/images/windows/scripts/build/Install-VisualStudio.ps1
@@ -20,6 +20,19 @@ Install-VisualStudio `
     -ExtraArgs "--allWorkloads --includeRecommended --remove Component.CPython3.x64" `
     -Architecture $vsArch
 
+$vsPackagesPath = "C:\ProgramData\Microsoft\VisualStudio\Packages"
+if (Test-Path -Path $vsPackagesPath) {
+    $vsPackagesSizeBytes = (Get-ChildItem -Path $vsPackagesPath -Recurse -File -Force | Measure-Object -Property Length -Sum).Sum
+    if (-not $vsPackagesSizeBytes) {
+        $vsPackagesSizeBytes = 0
+    }
+
+    $vsPackagesSizeGb = [Math]::Round($vsPackagesSizeBytes / 1GB, 2)
+    Write-Host "Size of ${vsPackagesPath}: $vsPackagesSizeBytes bytes ($vsPackagesSizeGb GB)"
+} else {
+    Write-Host "Path not found: $vsPackagesPath"
+}
+
 # Find the version of VS installed for this instance
 # Only supports a single instance
 $vsProgramData = Get-Item -Path "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances"

--- a/images/windows/scripts/helpers/VisualStudioHelpers.ps1
+++ b/images/windows/scripts/helpers/VisualStudioHelpers.ps1
@@ -70,6 +70,13 @@ Function Install-VisualStudio {
         $responseDataPath = "$env:TEMP\vs_install_response.json"
         $responseData | ConvertTo-Json | Out-File -FilePath $responseDataPath
 
+        # Disable keeping downloaded VS payloads in cache via policy.
+        $vsSetupPolicyPath = "HKLM:\SOFTWARE\Policies\Microsoft\VisualStudio\Setup"
+        if (-not (Test-Path -Path $vsSetupPolicyPath)) {
+            New-Item -Path $vsSetupPolicyPath -Force | Out-Null
+        }
+        New-ItemProperty -Path $vsSetupPolicyPath -Name "KeepDownloadedPayloads" -PropertyType DWord -Value 0 -Force | Out-Null
+
         $installStartTime = Get-Date
         Write-Host "Starting Install ..."
         $bootstrapperArgumentList = ('/c', $bootstrapperFilePath, '--in', $responseDataPath, $ExtraArgs, '--quiet', '--norestart', '--wait', '--nocache' )

--- a/images/windows/toolsets/toolset-2025-vs2026.json
+++ b/images/windows/toolsets/toolset-2025-vs2026.json
@@ -134,7 +134,6 @@
         "workloads": [
             "Component.Linux.CMake",
             "Component.UnityEngine.x64",
-            "Microsoft.Component.VC.Runtime.UCRTSDK",
             "Microsoft.Net.Component.4.8.1.SDK",
             "Microsoft.Net.Component.4.8.1.TargetingPack",
             "Microsoft.VisualStudio.Component.AspNet45",

--- a/images/windows/toolsets/toolset-win-11-vs2026-arm64.json
+++ b/images/windows/toolsets/toolset-win-11-vs2026-arm64.json
@@ -122,7 +122,6 @@
         "workloads": [
             "Component.Linux.CMake",
             "Component.Unreal.Android",
-            "Microsoft.Component.VC.Runtime.UCRTSDK",
             "Microsoft.Net.Component.4.7.2.SDK",
             "Microsoft.Net.Component.4.7.TargetingPack",
             "Microsoft.Net.Component.4.7.2.TargetingPack",


### PR DESCRIPTION
# Description
In images/windows/scripts/helpers/VisualStudioHelpers.ps1, this PR adds a registry policy before Visual Studio installation starts:

- creates HKLM:\SOFTWARE\Policies\Microsoft\VisualStudio\Setup if it does not already exist
- sets KeepDownloadedPayloads=0

This makes the Visual Studio setup policy explicit and aligns installation behavior with the existing --nocache usage in the bootstrapper arguments.

#### Remove missing VS2026 component from toolsets
This PR removes Microsoft.Component.VC.Runtime.UCRTSDK from the following VS2026 toolset definitions:

images/windows/toolsets/toolset-2025-vs2026.json
images/windows/toolsets/toolset-win-11-vs2026-arm64.json

This change prevents installation from requesting a component that is currently missing or unavailable for the VS2026 image configuration.

#### Related issue:
https://github.com/actions/runner-images/issues/14400

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
