### PR TITLE
[MacOS] Remove Setup Assistant handling during build

### DIFF
--- a/images/macos/scripts/build/configure-windows.sh
+++ b/images/macos/scripts/build/configure-windows.sh
@@ -10,21 +10,6 @@ source ~/utils/utils.sh
 if is_Arm64; then
     echo "Close System Preferences window"
     osascript -e 'tell application "System Preferences" to quit'
-
-    # Close Setup Assistant window which can auto-launch on first boot of arm64 macOS 15.
-    if pgrep -x "Setup Assistant" >/dev/null 2>&1; then
-        echo "Setup Assistant detected; attempting graceful quit"
-        osascript -e 'tell application "Setup Assistant" to quit' 2>/dev/null || true
-        sleep 1
-        if pgrep -x "Setup Assistant" >/dev/null 2>&1; then
-            echo "Setup Assistant still running; force-killing"
-            pkill -x "Setup Assistant" 2>/dev/null || true
-        else
-            echo "Setup Assistant exited gracefully"
-        fi
-    else
-        echo "Setup Assistant not running; no action needed"
-    fi
 fi
 
 retry=10


### PR DESCRIPTION
# Description
Sometimes Setup Assistant window can pop up after VM boot. There is a code to handle it during build, but this approach does not work, as closed window reopens upon VM reboot. Not working code should be cleaned up.

#### Related issue:
https://github.com/github/hosted-runners-images/issues/874

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
  - [Build](https://github.com/github/hosted-runners-images/actions/runs/30267162545)
