### PR TITLE
[Windows] Add cleanup before LLVM install

### DIFF
--- a/images/windows/scripts/build/Install-LLVM.ps1
+++ b/images/windows/scripts/build/Install-LLVM.ps1
@@ -3,6 +3,12 @@
 ##  Desc:  Install the stable version of llvm and clang compilers
 ################################################################################
 
+Write-Host "[DEBUG] Testing space before installing LLVM"
+
+Invoke-PesterTests -TestFile "WindowsFeatures"
+
+Write-Host "[DEBUG] Tests passed"
+
 $llvmVersion = (Get-ToolsetContent).llvm.version
 
 if (Test-IsArm64) {

--- a/images/windows/scripts/build/Install-LLVM.ps1
+++ b/images/windows/scripts/build/Install-LLVM.ps1
@@ -3,12 +3,6 @@
 ##  Desc:  Install the stable version of llvm and clang compilers
 ################################################################################
 
-Write-Host "[DEBUG] Testing space before installing LLVM"
-
-Invoke-PesterTests -TestFile "WindowsFeatures"
-
-Write-Host "[DEBUG] Tests passed"
-
 $llvmVersion = (Get-ToolsetContent).llvm.version
 
 if (Test-IsArm64) {

--- a/images/windows/templates/build.windows-2025.pkr.hcl
+++ b/images/windows/templates/build.windows-2025.pkr.hcl
@@ -199,6 +199,7 @@ build {
       "${path.root}/../scripts/build/Configure-GDIProcessHandleQuota.ps1",
       "${path.root}/../scripts/build/Configure-Shell.ps1",
       "${path.root}/../scripts/build/Configure-DeveloperMode.ps1",
+      "${path.root}/../scripts/build/Invoke-Cleanup.ps1",
       "${path.root}/../scripts/build/Install-LLVM.ps1"
     ]
   }


### PR DESCRIPTION
# Description
Windows 2025 build fails on LLVM install due to the lack of free space. To mitigate issue and unblock the builds added cleanup before LLVM installation. Testing showed no impact on build time or available space on image.

#### Related issue:
- https://github.com/github/hosted-runners-images/issues/873

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
