### PR TITLE
[Ubuntu] Install PostgreSQL on ARM64 images

### DIFF
--- a/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -259,9 +259,7 @@ $netCoreTools.AddNodes($(Get-DotnetTools))
 # Databases
 $databasesTools = $installedSoftware.AddHeader("Databases")
 $databasesTools.AddToolVersion("sqlite3", $(Get-SqliteVersion))
-if (Test-IsX64) {
-    $databasesTools.AddNode($(Build-PostgreSqlSection))
-}
+$databasesTools.AddNode($(Build-PostgreSqlSection))
 $databasesTools.AddNode($(Build-MySQLSection))
 if (Test-IsUbuntu22-X64) {
     $databasesTools.AddNode($(Build-MSSQLToolsSection))

--- a/images/ubuntu/scripts/tests/Databases.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Databases.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "PostgreSQL" -Skip:(Test-IsArm64) {
+Describe "PostgreSQL" {
     It "PostgreSQL Service" {
         "sudo systemctl start postgresql" | Should -ReturnZeroExitCode
         "pg_isready" | Should -OutputTextMatchingRegex "/var/run/postgresql:5432 - accepting connections"

--- a/images/ubuntu/templates/build.ubuntu-22_04-arm64.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-22_04-arm64.pkr.hcl
@@ -128,6 +128,7 @@ build {
       "${path.root}/../scripts/build/install-nodejs.sh",
       "${path.root}/../scripts/build/install-bazel.sh",
       "${path.root}/../scripts/build/install-php.sh",
+      "${path.root}/../scripts/build/install-postgresql.sh",
       "${path.root}/../scripts/build/install-pulumi.sh",
       "${path.root}/../scripts/build/install-ruby.sh",
       "${path.root}/../scripts/build/install-rust.sh",

--- a/images/ubuntu/templates/build.ubuntu-24_04-arm64.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-24_04-arm64.pkr.hcl
@@ -128,6 +128,7 @@ provisioner "shell" {
       "${path.root}/../scripts/build/install-copilot-cli.sh",
       "${path.root}/../scripts/build/install-bazel.sh",
       "${path.root}/../scripts/build/install-php.sh",
+      "${path.root}/../scripts/build/install-postgresql.sh",
       "${path.root}/../scripts/build/install-pulumi.sh",
       "${path.root}/../scripts/build/install-ruby.sh",
       "${path.root}/../scripts/build/install-rust.sh",

--- a/images/ubuntu/templates/build.ubuntu-26_04-arm64.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-26_04-arm64.pkr.hcl
@@ -127,6 +127,7 @@ provisioner "shell" {
       "${path.root}/../scripts/build/install-copilot-cli.sh",
       "${path.root}/../scripts/build/install-bazel.sh",
       "${path.root}/../scripts/build/install-php.sh",
+      "${path.root}/../scripts/build/install-postgresql.sh",
       "${path.root}/../scripts/build/install-ruby.sh",
       "${path.root}/../scripts/build/install-rust.sh",
       "${path.root}/../scripts/build/install-selenium.sh",


### PR DESCRIPTION
# Description
PostgreSQL is installed on x64 only, so `libpq-dev` and the client tools are missing on the ARM64 images. The ARM64 toolsets already pin a version (14/16/18), it was just unused.

**Changes:**
- added `install-postgresql.sh` to the three `build.ubuntu-*-arm64.pkr.hcl` templates
- `Databases.Tests.ps1`: removed `-Skip:(Test-IsArm64)`
- `Generate-SoftwareReport.ps1`: removed the `Test-IsX64` gate around the PostgreSQL section

**Testing:** ran `install-postgresql.sh` on `ubuntu-22.04-arm` and `ubuntu-24.04-arm` — installs in 36s (~100/109 MB), versions match the toolset (14.23/16.14), service disabled, tests pass, `psycopg2` builds from source. No hosted 26.04 ARM runner yet, so 18 is unverified.
https://github.com/v-davit-ioramashvili/runner-images/actions/runs/30546903523

#### Related issue:
Resolves #14070

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
