### PR TITLE
[Ubuntu] Add workaround for Chromium dependency

### DIFF
--- a/images/ubuntu/scripts/build/install-google-chrome.sh
+++ b/images/ubuntu/scripts/build/install-google-chrome.sh
@@ -67,6 +67,9 @@ chmod +x $chromedriver_bin
 ln -s "$chromedriver_bin" /usr/bin/
 set_etc_environment_variable "CHROMEWEBDRIVER" "${CHROMEDRIVER_DIR}"
 
+# Workaround for https://github.com/actions/runner-images/issues/14475
+apt-get install libxtst6
+
 # Download and unpack Chromium
 chrome_revision=$(echo "${chrome_versions_json}" | jq -r '.builds["'"$chrome_version"'"].revision')
 chromium_revision=$(get_chromium_revision $chrome_revision)


### PR DESCRIPTION
# Description
New Google Chrome version does not have `libxtst6` dependency, which is still needed for Chromium. Added explicit installation of this dependency.

#### Related issue:
- https://github.com/actions/runner-images/issues/14475

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
