### PR TITLE
Add aarch64-pc-windows-gnullvm target for Rust

### DIFF
--- a/images/windows/scripts/build/Install-Rust.ps1
+++ b/images/windows/scripts/build/Install-Rust.ps1
@@ -36,6 +36,7 @@ $env:Path += ";$env:CARGO_HOME\bin"
 
 if (Test-IsArm64) {
     rustup target add aarch64-pc-windows-msvc
+    rustup target add aarch64-pc-windows-gnullvm
 } else {
     # Add i686 target for building 32-bit binaries
     rustup target add i686-pc-windows-msvc


### PR DESCRIPTION
Open source ecosystems based on msys2 use clang-arm64 toolchains , which require the `aarch64-pc-windows-gnullvm` target in rust. We also [need this for the R project](https://contributor.r-project.org/windows-arm64/).

This is basically the native target on arm64 for most oss projects, it is a bit surprising it is not installed.

