### PR TITLE
[macOS] Pre-approve screen capture to stop the private window picker alert

### DIFF
--- a/images/macos/scripts/build/configure-tccdb-macos.sh
+++ b/images/macos/scripts/build/configure-tccdb-macos.sh
@@ -97,3 +97,22 @@ userValuesArray=(
 for values in "${userValuesArray[@]}"; do
     configure_user_tccdb "$values,NULL,NULL,'UNUSED',${values##*,}"
 done
+
+# Pre-approve screen capture for the runner agent.
+# Granting kTCCServiceScreenCapture above is not enough on macOS 15+: capturing
+# the screen through a legacy API instead of ScreenCaptureKit's picker raises a
+# recurring "<app> is requesting to bypass the system private window picker"
+# alert, which takes focus and breaks headed UI tests. replayd tracks the
+# reminder in its own approvals file, keyed by the *responsible* process - on a
+# hosted runner that is the agent, whatever tool the job actually runs. Since
+# the file is absent in the image and every job gets a fresh VM, the reminder is
+# always overdue and the alert fires on the first capture of every job.
+# A far-future date suppresses it; replayd expands this into its own dictionary
+# form on first use and keeps the date.
+approvalsPlist="$HOME/Library/Group Containers/group.com.apple.replayd/ScreenCaptureApprovals.plist"
+mkdir -p "$(dirname "$approvalsPlist")"
+defaults write "$approvalsPlist" "/opt/hca/hosted-compute-agent" -date "3024-01-01 00:00:00 +0000"
+
+# flush the preferences cache so the write is on disk; System.Tests.ps1 asserts
+# the approval is there
+killall cfprefsd 2>/dev/null || true

--- a/images/macos/scripts/tests/System.Tests.ps1
+++ b/images/macos/scripts/tests/System.Tests.ps1
@@ -35,3 +35,13 @@ Describe "AutomationModeTool" {
         automationmodetool | Out-String | Should -Match "DOES NOT REQUIRE"
     }
 }
+
+Describe "Screen capture approval" {
+    It "Screen recording is pre-approved for the runner agent" {
+        # without this macOS re-confirms screen capture with a popup that steals
+        # focus from headed UI tests, see issue #14474
+        $approvalsPlist = "$env:HOME/Library/Group Containers/group.com.apple.replayd/ScreenCaptureApprovals.plist"
+        $approvalsPlist | Should -Exist
+        defaults read $approvalsPlist "/opt/hca/hosted-compute-agent" | Out-String | Should -Match "3024"
+    }
+}


### PR DESCRIPTION
# Description

* **Changes:** seed `replayd`'s screen capture approval for the runner agent in `configure-tccdb-macos.sh`, so macOS stops re-asking mid-job and stealing focus from UI tests. Assert it in `System.Tests.ps1`.
* **Testing:** ran the changed script on macos-15-intel, macos-15 and macos-26 — popup appears without it, gone with it, `ffmpeg` exits 0. New test checked both ways: passes when seeded, fails when not. [Validation run](https://github.com/v-davit-ioramashvili/runner-images/actions/runs/30623385110). Tests run before the image is captured, so worth a look at the first built image to confirm the file is there.

#### Related issue:
Fixes #14474

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
