### PR TITLE
[Windows] Add aarch64-pc-windows-gnullvm Rust target on ARM64

### DIFF
--- a/images/windows/scripts/build/Install-Rust.ps1
+++ b/images/windows/scripts/build/Install-Rust.ps1
@@ -36,6 +36,9 @@ $env:Path += ";$env:CARGO_HOME\bin"
 
 if (Test-IsArm64) {
     rustup target add aarch64-pc-windows-msvc
+
+    # Add target for building LLVM-MinGW (gnullvm) binaries
+    rustup target add aarch64-pc-windows-gnullvm
 } else {
     # Add i686 target for building 32-bit binaries
     rustup target add i686-pc-windows-msvc

--- a/images/windows/scripts/tests/Rust.Tests.ps1
+++ b/images/windows/scripts/tests/Rust.Tests.ps1
@@ -28,6 +28,13 @@ Describe "Rust" {
         @{envVar = "CARGO_HOME"}
     )
 
+    $rustTargetNames = if (Test-IsArm64) {
+        @("aarch64-pc-windows-msvc", "aarch64-pc-windows-gnullvm")
+    } else {
+        @("i686-pc-windows-msvc", "x86_64-pc-windows-gnu")
+    }
+    $rustTargets = $rustTargetNames | ForEach-Object { @{ Target = $_ } }
+
     It "C:\Users\Default\.rustup and C:\Users\Default\.cargo folders exist" {
         "C:\Users\Default\.rustup", "C:\Users\Default\.cargo" | Should -Exist
     }
@@ -39,5 +46,9 @@ Describe "Rust" {
     It "<ToolName> is installed to the '<binPath>' folder" -TestCases $rustTools {
         "$ToolName --version" | Should -ReturnZeroExitCode
         $binPath | Should -Exist
+    }
+
+    It "<Target> rustup target is installed" -TestCases $rustTargets {
+        (rustup target list --installed) | Should -Contain $Target
     }
 }


### PR DESCRIPTION
# Description

* **Changes:** add `rustup target add aarch64-pc-windows-gnullvm` to the ARM64 branch of `Install-Rust.ps1`, mirroring the `x86_64-pc-windows-gnu` MinGW target already shipped on x64. Assert installed targets in `Rust.Tests.ps1`.
* **Why:** the Windows 11 ARM image only ships the MSVC target, so users building against the LLVM-MinGW (`gnullvm`) toolchain must `rustup target add` it by hand in every workflow. `aarch64-pc-windows-gnullvm` is Tier 2 with host tools, so `std` is distributed and the target add is supported; it pulls only the precompiled std, no extra C toolchain.
* **Testing:** validated on a real `windows-11-arm` runner (image `20260804.129.1`, before the fix): confirmed `aarch64-pc-windows-gnullvm` is absent today, then the PR's `rustup target add` line installs it and a crate compiles against it (`cargo check`). Also reproduced the issue's exact MSYS2 CLANGARM64 scenario — `cargo build --target aarch64-pc-windows-gnullvm --release` succeeds and produces the `.exe`. [Validation run](https://github.com/v-davit-ioramashvili/runner-images/actions/runs/31601234115)

#### Related issue:
Fixes #14491

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated