### PR TITLE
[MacOS] Update readme file name and image label for xcode-27

### DIFF
--- a/images/macos/templates/xcode-27.arm64.anka.pkr.hcl
+++ b/images/macos/templates/xcode-27.arm64.anka.pkr.hcl
@@ -184,7 +184,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["IMAGE_VERSION=${var.build_id}", "IMAGE_OS=${var.image_os}", "IMAGE_LABEL_OVERRIDE=xcode-27", "PASSWORD=${var.vm_password}"]
+    environment_vars = ["IMAGE_VERSION=${var.build_id}", "IMAGE_OS=${var.image_os}", "IMAGE_LABEL_OVERRIDE=xcode-27-arm64", "PASSWORD=${var.vm_password}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
     scripts          = [
       "${path.root}/../scripts/build/configure-preimagedata.sh",
@@ -276,7 +276,7 @@ build {
   }
 
   provisioner "file" {
-    destination = "${path.root}/../../image-output/xcode-27-Readme.md"
+    destination = "${path.root}/../../image-output/xcode-27-arm64-Readme.md"
     direction   = "download"
     source      = "${local.image_folder}/output/software-report.md"
   }


### PR DESCRIPTION
# Description
Update readme file name and image label for `xcode-27` to match naming conventions for repo.

#### Related issue:
- https://github.com/github/hosted-runners-images/issues/879

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
  - [Passed build](https://github.com/github/hosted-runners-images/actions/runs/30624544018)
