### PR TITLE
[MacOS] Fix for failing builds due to Parallels cask update

### DIFF
--- a/images/macos/scripts/build/configure-system.sh
+++ b/images/macos/scripts/build/configure-system.sh
@@ -43,7 +43,7 @@ sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.PerfPowerServic
 # https://github.com/actions/runner-images/issues/6105
 # https://github.com/actions/runner-images/issues/10143
 if is_SonomaX64 || is_SequoiaX64; then
-    brew uninstall --cask --force --zap parallels
+    brew uninstall --cask parallels
 fi
 
 # Simple warmup of the default Xcode

--- a/images/macos/scripts/build/configure-system.sh
+++ b/images/macos/scripts/build/configure-system.sh
@@ -116,3 +116,6 @@ sudo rm -rf /Users/$USER/Library/Caches/Homebrew/downloads/*
 
 # Uninstall expect used in configure-machine.sh
 brew uninstall expect
+
+# Remove temp tap if it was used
+brew_cleanup_temp_tap

--- a/images/macos/scripts/build/configure-system.sh
+++ b/images/macos/scripts/build/configure-system.sh
@@ -43,7 +43,7 @@ sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.PerfPowerServic
 # https://github.com/actions/runner-images/issues/6105
 # https://github.com/actions/runner-images/issues/10143
 if is_SonomaX64 || is_SequoiaX64; then
-    brew uninstall parallels
+    brew brew uninstall --cask --force --zap parallels
 fi
 
 # Simple warmup of the default Xcode

--- a/images/macos/scripts/build/configure-system.sh
+++ b/images/macos/scripts/build/configure-system.sh
@@ -43,7 +43,7 @@ sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.PerfPowerServic
 # https://github.com/actions/runner-images/issues/6105
 # https://github.com/actions/runner-images/issues/10143
 if is_SonomaX64 || is_SequoiaX64; then
-    brew brew uninstall --cask --force --zap parallels
+    brew uninstall --cask --force --zap parallels
 fi
 
 # Simple warmup of the default Xcode

--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -53,7 +53,9 @@ for package in $cask_packages; do
     if is_Arm64 && [[ $package == "parallels" ]]; then
         echo "Parallels installation is skipped for arm64 architecture"
     else
-        brew install --cask https://raw.githubusercontent.com/Homebrew/homebrew-cask/adfc07a7bc28a32037851be4d7a0bd4f8b239565/Casks/p/parallels.rb
+        curl -fsSL "https://raw.githubusercontent.com/Homebrew/homebrew-cask/adfc07a7bc28a32037851be4d7a0bd4f8b239565/Casks/p/parallels.rb" -o /tmp/parallels.rb
+        brew install --cask /tmp/parallels.rb
+        rm -f /tmp/parallels.rb
         # brew install --cask $package
     fi
 done

--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -53,9 +53,9 @@ for package in $cask_packages; do
     if is_Arm64 && [[ $package == "parallels" ]]; then
         echo "Parallels installation is skipped for arm64 architecture"
     else
-        curl -fsSL "https://raw.githubusercontent.com/Homebrew/homebrew-cask/adfc07a7bc28a32037851be4d7a0bd4f8b239565/Casks/p/parallels.rb" -o /tmp/parallels.rb
-        brew install --cask /tmp/parallels.rb
-        rm -f /tmp/parallels.rb
+        curl -fsSL "https://raw.githubusercontent.com/Homebrew/homebrew-cask/adfc07a7bc28a32037851be4d7a0bd4f8b239565/Casks/p/parallels.rb" -o ./parallels.rb
+        brew install --cask ./parallels.rb
+        rm -f ./parallels.rb
         # brew install --cask $package
     fi
 done

--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -53,7 +53,8 @@ for package in $cask_packages; do
     if is_Arm64 && [[ $package == "parallels" ]]; then
         echo "Parallels installation is skipped for arm64 architecture"
     else
-        brew install --cask $package
+        brew install --cask https://raw.githubusercontent.com/Homebrew/homebrew-cask/adfc07a7bc28a32037851be4d7a0bd4f8b239565/Casks/p/parallels.rb
+        # brew install --cask $package
     fi
 done
 

--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -53,23 +53,12 @@ for package in $cask_packages; do
     if is_Arm64 && [[ $package == "parallels" ]]; then
         echo "Parallels installation is skipped for arm64 architecture"
     else
-        # Temporary tap name
-        TEMP_TAP="local/temp"
+        # Workaround for https://github.com/github/hosted-runners-images/issues/886
+        # brew install --cask $package
         CASK_NAME="parallels"
         CASK_URL="https://raw.githubusercontent.com/Homebrew/homebrew-cask/adfc07a7bc28a32037851be4d7a0bd4f8b239565/Casks/p/${CASK_NAME}.rb"
         
-        # Install parallels using temporary tap to comply with Homebrew's security requirements
-        brew tap-new "$TEMP_TAP"
-        TAP_DIR="$(brew --repository "$TEMP_TAP")"
-        curl -fsSL "$CASK_URL" -o "$TAP_DIR/Casks/${CASK_NAME}.rb"
-        brew trust --cask "$TEMP_TAP/$CASK_NAME"
-        brew install --cask "$TEMP_TAP/$CASK_NAME"
-
-        # Clean up temporary tap and cask
-        brew untrust --cask "$TEMP_TAP/$CASK_NAME"
-        brew untap "$TEMP_TAP"
-
-        # brew install --cask $package
+        brew_install_pinned_cask "$CASK_NAME" "$CASK_URL"
     fi
 done
 

--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -53,9 +53,22 @@ for package in $cask_packages; do
     if is_Arm64 && [[ $package == "parallels" ]]; then
         echo "Parallels installation is skipped for arm64 architecture"
     else
-        curl -fsSL "https://raw.githubusercontent.com/Homebrew/homebrew-cask/adfc07a7bc28a32037851be4d7a0bd4f8b239565/Casks/p/parallels.rb" -o ./parallels.rb
-        brew install --cask ./parallels.rb
-        rm -f ./parallels.rb
+        # Temporary tap name
+        TEMP_TAP="local/temp"
+        CASK_NAME="parallels"
+        CASK_URL="https://raw.githubusercontent.com/Homebrew/homebrew-cask/adfc07a7bc28a32037851be4d7a0bd4f8b239565/Casks/p/${CASK_NAME}.rb"
+        
+        # Install parallels using temporary tap to comply with Homebrew's security requirements
+        brew tap-new "$TEMP_TAP"
+        TAP_DIR="$(brew --repository "$TEMP_TAP")"
+        curl -fsSL "$CASK_URL" -o "$TAP_DIR/Casks/${CASK_NAME}.rb"
+        brew trust --cask "$TEMP_TAP/$CASK_NAME"
+        brew install --cask "$TEMP_TAP/$CASK_NAME"
+
+        # Clean up temporary tap and cask
+        brew untrust --cask "$TEMP_TAP/$CASK_NAME"
+        brew untap "$TEMP_TAP"
+
         # brew install --cask $package
     fi
 done

--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -53,12 +53,15 @@ for package in $cask_packages; do
     if is_Arm64 && [[ $package == "parallels" ]]; then
         echo "Parallels installation is skipped for arm64 architecture"
     else
-        # Workaround for https://github.com/github/hosted-runners-images/issues/886
-        # brew install --cask $package
-        CASK_NAME="parallels"
-        CASK_URL="https://raw.githubusercontent.com/Homebrew/homebrew-cask/adfc07a7bc28a32037851be4d7a0bd4f8b239565/Casks/p/${CASK_NAME}.rb"
-        
-        brew_install_pinned_cask "$CASK_NAME" "$CASK_URL"
+        if [[ $package == "parallels" ]]; then
+            # Workaround for https://github.com/github/hosted-runners-images/issues/886
+            CASK_NAME="parallels"
+            CASK_URL="https://raw.githubusercontent.com/Homebrew/homebrew-cask/adfc07a7bc28a32037851be4d7a0bd4f8b239565/Casks/p/${CASK_NAME}.rb"
+            
+            brew_install_pinned_cask "$CASK_NAME" "$CASK_URL"
+        else
+            brew install --cask $package
+        fi
     fi
 done
 

--- a/images/macos/scripts/helpers/utils.sh
+++ b/images/macos/scripts/helpers/utils.sh
@@ -245,7 +245,7 @@ brew_install_pinned_cask() {
 # WARNING! This function WILL fail if some packages/casks are installed from a temporary tap and the tap is not cleaned up after installation.
 # This is intended behavior - no temporary taps should be left behind after installation. 
 brew_cleanup_temp_tap() {
-    temp_tap="local/temp"
+    local temp_tap="local/temp"
 
     if brew tap | grep -Fxq "$temp_tap"; then
         echo "Temp Tap exists, cleaning up..."

--- a/images/macos/scripts/helpers/utils.sh
+++ b/images/macos/scripts/helpers/utils.sh
@@ -212,3 +212,46 @@ use_checksum_comparison() {
         echo "Checksum verification passed"
     fi
 }
+
+brew_install_pinned_cask() {
+    local cask_name=$1
+    local cask_url=$2
+    local temp_tap="local/temp"
+
+    echo "Installing pinned cask: $cask_name"
+
+    if brew tap | grep -Fxq "$temp_tap"; then
+        echo "Temp Tap already exists"
+    else
+        echo "No temp Tap found. Creating a new one"
+        brew tap-new "$temp_tap"
+        brew trust --tap "$temp_tap"
+    fi
+
+    TAP_DIR="$(brew --repository "$temp_tap")"
+    CASKS_DIR="$TAP_DIR/Casks"
+    if [[ -d "$CASKS_DIR" ]]; then
+        echo "Casks directory already exists"
+    else
+        echo "Casks directory does not exist. Creating a new one"
+        mkdir -p "$CASKS_DIR"
+    fi
+    
+    curl -fsSL "$cask_url" -o "$CASKS_DIR/${cask_name}.rb"
+    
+    brew install --cask "$temp_tap/$cask_name"
+}
+
+# WARNING! This function WILL fail if some packages/casks are installed from a temporary tap and the tap is not cleaned up after installation.
+# This is intended behavior - no temporary taps should be left behind after installation. 
+brew_cleanup_temp_tap() {
+    temp_tap="local/temp"
+
+    if brew tap | grep -Fxq "$temp_tap"; then
+        echo "Temp Tap exists, cleaning up..."
+        brew untrust --tap "$temp_tap" -v
+        brew untap "$temp_tap" -v
+    else
+        echo "No Temp Tap found. Nothing to clean up."
+    fi
+}


### PR DESCRIPTION
# Description
- [Updated cask](https://github.com/Homebrew/homebrew-cask/blob/adfc07a7bc28a32037851be4d7a0bd4f8b239565/Casks/p/parallels.rb) for Parallels broke uninstallation step, blocking MacOS builds
- To unblock builds old version of cask has been pinned
- Homebrew security policies do not allow simple cask pinning, so new utility script has been added to allow this functionality

#### Related issue:
- https://github.com/github/hosted-runners-images/issues/886

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
  - [MacOS 14 x64](https://github.com/github/hosted-runners-images/actions/runs/31015574794)
  - [MacOS 15 x64](https://github.com/github/hosted-runners-images/actions/runs/31051090236)
  - [MacOS 26 x64](https://github.com/github/hosted-runners-images/actions/runs/31051108070)
  - [XCode 27](https://github.com/github/hosted-runners-images/actions/runs/31090949234)