### PR TITLE
[Windows][Ubuntu] Add client_jwt variable to azure-arm templates for Ubuntu and Windows

### DIFF
--- a/docs/create-image-and-azure-resources.md
+++ b/docs/create-image-and-azure-resources.md
@@ -235,6 +235,7 @@ The following variables are required to be passed to the Packer process:
 | `client_id` | `ARM_CLIENT_ID` | The Active Directory service principal associated with your builder.
 | `client_secret` | `ARM_CLIENT_SECRET` | The password or secret for your service principal; may be omitted if `client_cert_path` is set.
 | `client_cert_path` | `ARM_CLIENT_CERT_PATH` | The location of a PEM file containing a certificate and private key for the service principal; may be omitted if `client_secret` is set.
+| `client_jwt` | `ARM_CLIENT_JWT` | A bearer JWT assertion for federated/workload identity authentication (e.g. Azure DevOps workload identity federation); may be omitted if `client_secret` or `client_cert_path` is set.
 | `location` | `ARM_RESOURCE_LOCATION` | The Azure datacenter in which your VM will be built.
 | `managed_image_resource_group_name` | `ARM_RESOURCE_GROUP` | The resource group under which the final artifact will be stored.
 

--- a/docs/create-image-and-azure-resources.md
+++ b/docs/create-image-and-azure-resources.md
@@ -233,8 +233,8 @@ The following variables are required to be passed to the Packer process:
 | ------------ | ------- | -----------
 | `subscription_id` | `ARM_SUBSCRIPTION_ID` | The subscription under which the build will be performed.
 | `client_id` | `ARM_CLIENT_ID` | The Active Directory service principal associated with your builder.
-| `client_secret` | `ARM_CLIENT_SECRET` | The password or secret for your service principal; may be omitted if `client_cert_path` is set.
-| `client_cert_path` | `ARM_CLIENT_CERT_PATH` | The location of a PEM file containing a certificate and private key for the service principal; may be omitted if `client_secret` is set.
+| `client_secret` | `ARM_CLIENT_SECRET` | The password or secret for your service principal; may be omitted if `client_cert_path` or `client_jwt` is set.
+| `client_cert_path` | `ARM_CLIENT_CERT_PATH` | The location of a PEM file containing a certificate and private key for the service principal; may be omitted if `client_secret` or `client_jwt` is set.
 | `client_jwt` | `ARM_CLIENT_JWT` | A bearer JWT assertion for federated/workload identity authentication (e.g. Azure DevOps workload identity federation); may be omitted if `client_secret` or `client_cert_path` is set.
 | `location` | `ARM_RESOURCE_LOCATION` | The Azure datacenter in which your VM will be built.
 | `managed_image_resource_group_name` | `ARM_RESOURCE_GROUP` | The resource group under which the final artifact will be stored.

--- a/images/ubuntu/templates/source.ubuntu.pkr.hcl
+++ b/images/ubuntu/templates/source.ubuntu.pkr.hcl
@@ -1,6 +1,7 @@
 source "azure-arm" "image" {
   client_cert_path                       = var.client_cert_path
   client_id                              = var.client_id
+  client_jwt                             = var.client_jwt
   client_secret                          = var.client_secret
   object_id                              = var.object_id
   oidc_request_token                     = var.oidc_request_token

--- a/images/ubuntu/templates/variable.ubuntu.pkr.hcl
+++ b/images/ubuntu/templates/variable.ubuntu.pkr.hcl
@@ -7,6 +7,11 @@ variable "client_id" {
   type    = string
   default = "${env("ARM_CLIENT_ID")}"
 }
+variable "client_jwt" {
+  type      = string
+  default   = "${env("ARM_CLIENT_JWT")}"
+  sensitive = true
+}
 variable "client_secret" {
   type      = string
   default   = "${env("ARM_CLIENT_SECRET")}"

--- a/images/windows/templates/source.windows.pkr.hcl
+++ b/images/windows/templates/source.windows.pkr.hcl
@@ -1,6 +1,7 @@
 source "azure-arm" "image" {
   client_cert_path                       = var.client_cert_path
   client_id                              = var.client_id
+  client_jwt                             = var.client_jwt
   client_secret                          = var.client_secret
   object_id                              = var.object_id
   oidc_request_token                     = var.oidc_request_token

--- a/images/windows/templates/variable.windows.pkr.hcl
+++ b/images/windows/templates/variable.windows.pkr.hcl
@@ -7,6 +7,11 @@ variable "client_id" {
   type    = string
   default = "${env("ARM_CLIENT_ID")}"
 }
+variable "client_jwt" {
+  type      = string
+  default   = "${env("ARM_CLIENT_JWT")}"
+  sensitive = true
+}
 variable "client_secret" {
   type      = string
   default   = "${env("ARM_CLIENT_SECRET")}"


### PR DESCRIPTION
# Description
## Summary
Adds a client_jwt variable to variable.ubuntu.pkr.hcl and variable.windows.pkr.hcl, and wires it into the azure-arm source block in source.ubuntu.pkr.hcl / source.windows.pkr.hcl.
Enables OIDC / workload identity federation authentication for the azure-arm Packer builder, as an alternative to client_secret.
## Motivation
Azure DevOps pipelines using a service connection with workload identity federation expose an OIDC token via $env:idToken, but no service principal secret. Builds relying on this auth method currently fail with Undefined -var variable for client_jwt, since it isn't declared anywhere in these templates.

The azure-arm builder (packer-plugin-azure) has supported client_jwt as a config field for OIDC/workload-identity auth for several releases — the templates simply never expose it as a variable or wire it into the source block.

#### Related issue:
- https://github.com/actions/runner-images/issues/14439

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
