### PR TITLE
[Ubuntu] Extend read_ahead_kb rule to NVMe devices

### DIFF
--- a/images/ubuntu/scripts/build/configure-environment.sh
+++ b/images/ubuntu/scripts/build/configure-environment.sh
@@ -57,9 +57,10 @@ echo 'ACTION=="add", SUBSYSTEM=="module", KERNEL=="nf_conntrack", RUN+="/usr/sbi
 # Linux kernel 6.17 changed read_ahead_kb default from 128 to 4096 on Azure VMs
 # where disks are presented as rotational (ROTA=1). This floods the page cache
 # with unused data during random-access I/O and causes memory exhaustion and thrashing.
+# Azure v4 VM series use SCSI disks (sd*); v5/v6 use NVMe namespaces (nvme*n*).
 if ! is_ubuntu22; then
     readahead_rule='/etc/udev/rules.d/99-readahead.rules'
-    echo 'ACTION=="add|change", KERNEL=="sd*", ATTR{queue/read_ahead_kb}="128"' | tee "$readahead_rule"
+    echo 'ACTION=="add|change", KERNEL=="sd*|nvme*n*", ATTR{queue/read_ahead_kb}="128"' | tee "$readahead_rule"
 fi
 
 # Create symlink for tests running

--- a/images/ubuntu/scripts/tests/System.Tests.ps1
+++ b/images/ubuntu/scripts/tests/System.Tests.ps1
@@ -30,14 +30,15 @@ Describe "ReadAhead udev rule" -Skip:(Test-IsUbuntu22) {
         "/etc/udev/rules.d/99-readahead.rules" | Should -Exist
     }
 
-    It "udev rule contains correct read_ahead_kb value" {
+    It "udev rule covers SCSI and NVMe devices with correct read_ahead_kb value" {
         $content = Get-Content "/etc/udev/rules.d/99-readahead.rules" -Raw
+        $content | Should -Match 'KERNEL=="sd\*\|nvme\*n\*"'
         $content | Should -Match 'ATTR\{queue/read_ahead_kb\}="128"'
     }
 
-    It "All sd* devices have read_ahead_kb set to 128" {
-        $devices = Get-ChildItem "/sys/block/sd*/queue/read_ahead_kb" -ErrorAction SilentlyContinue
-        $devices | Should -Not -BeNullOrEmpty -Because "there should be at least one sd* block device"
+    It "All SCSI and NVMe devices have read_ahead_kb set to 128" {
+        $devices = Get-ChildItem "/sys/block/sd*/queue/read_ahead_kb", "/sys/block/nvme*n*/queue/read_ahead_kb" -ErrorAction SilentlyContinue
+        $devices | Should -Not -BeNullOrEmpty -Because "there should be at least one sd* or nvme* block device"
         foreach ($dev in $devices) {
             $value = (Get-Content $dev.FullName).Trim()
             $value | Should -Be "128" -Because "read_ahead_kb for $($dev.FullName) should be 128 to prevent I/O thrashing"


### PR DESCRIPTION
# Description

**Bug fixing**

Extend the existing Ubuntu `read_ahead_kb` mitigation to NVMe-backed Azure VM series.

Linux kernel 6.17 changed how `read_ahead_kb` is calculated for disks reported as rotational. The existing udev rule pins the value to `128` for SCSI devices matching `sd*`, but Azure v5/v6 VM series can expose disks as NVMe namespaces (`nvme*n*`). Those devices were not covered and could retain the higher read-ahead value that contributes to page-cache pressure and I/O thrashing.

This change:

- extends the udev `KERNEL` match from `sd*` to `sd*|nvme*n*`;
- verifies that the generated rule explicitly covers both SCSI disks and NVMe namespaces;
- validates that every detected `/sys/block/sd*` and `/sys/block/nvme*n*` device has `read_ahead_kb` set to `128`.

No software inventory or tooling versions are changed.

#### Related issue:

- Refs https://github.com/actions/runner-images/issues/13770

## Check list

- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated

### Build results

| Image | Validation | Status | Link |
|---|---|---|---|
| Ubuntu 24.04 X64 | Images CI | SUCCESS | https://github.com/actions/runner-images-ci/actions/runs/31593609418 |
| Ubuntu 24.04 X64 | Production generation and canary | SUCCESS | https://github.com/github/hosted-runners-images/actions/runs/31598689583/attempts/2 |

The production run completed base image generation, GitHub and Azure DevOps specialization, VHD conversion, deployment to all four canary regions, and both Larger Runners and 4-9s canary test suites. Its first attempt stopped during Firefox installation because the Launchpad API response was interrupted (`http.client.IncompleteRead`); the unchanged retry completed successfully, confirming that the failure was transient and unrelated to this change.

The generated image (`20260812.273.2`) triggered the [deployment workflow](https://github.com/github/hosted-runners-images/actions/runs/31643190318), which is waiting at the expected `ship-it` approval gate.
