### PR TITLE
[Windows] Fix MongoDB installer after release-notes URL and anchor ch…

### DIFF
--- a/images/windows/scripts/build/Install-MongoDB.ps1
+++ b/images/windows/scripts/build/Install-MongoDB.ps1
@@ -7,25 +7,20 @@
 $toolsetContent = Get-ToolsetContent
 $toolsetVersion = $toolsetContent.mongodb.version
 
-# The canonical release notes URL has no trailing slash. The trailing slash variant answers
-# 308 Permanent Redirect, which Invoke-WebRequest on Windows PowerShell 5.1 does not follow.
-$releaseNotesUrl = "https://www.mongodb.com/docs/v$toolsetVersion/release-notes/$toolsetVersion"
-$getMongoReleases = Invoke-WebRequest -Uri $releaseNotesUrl -UseBasicParsing
+# Resolve the latest patch release from the downloads feed rather than the release notes
+# page. The feed lists the newest release of each supported branch and is not subject to the
+# markup and URL changes that repeatedly broke scraping the docs.
+$mongoReleasesUrl = "https://downloads.mongodb.org/current.json"
+$mongoReleases = Invoke-RestMethod -Uri $mongoReleasesUrl
 
-# Released patch versions are linked as changelog anchors, e.g.
-# /docs/v7.0/release-notes/7.0-changelog/#std-label-7.0.40-changelog
-# The section anchors on the same page have their dots stripped (#7040---aug-11-2026), so
-# they are not usable to recover the version number.
-$versionPattern = "#std-label-($([regex]::Escape($toolsetVersion))\.\d+)-changelog"
-$minorVersions = $getMongoReleases.Links.href | Where-Object { $_ -notlike "*upcoming*" } | ForEach-Object {
-    if ($_ -match $versionPattern) { $Matches[1] }
+$latestVersion = $mongoReleases.versions.version |
+    Where-Object { $_ -like "$toolsetVersion.*" } |
+    Sort-Object { [version]$_ } -Descending |
+    Select-Object -First 1
+
+if (-not $latestVersion) {
+    throw "Unable to resolve latest MongoDB $toolsetVersion release from $mongoReleasesUrl"
 }
-
-if (-not $minorVersions) {
-    throw "Failed to parse any $toolsetVersion.x release version from $releaseNotesUrl"
-}
-
-$latestVersion = $minorVersions | Sort-Object { [version]$_ } -Descending | Select-Object -First 1
 
 Install-Binary `
     -Url "https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-$latestVersion-signed.msi" `

--- a/images/windows/scripts/build/Install-MongoDB.ps1
+++ b/images/windows/scripts/build/Install-MongoDB.ps1
@@ -7,19 +7,25 @@
 $toolsetContent = Get-ToolsetContent
 $toolsetVersion = $toolsetContent.mongodb.version
 
-$getMongoReleases = Invoke-WebRequest -Uri "mongodb.com/docs/v$toolsetVersion/release-notes/$toolsetVersion/" -UseBasicParsing
-$targetReleases = $getMongoReleases.Links.href | Where-Object { $_ -like "#$toolsetVersion*---*" }
+# The canonical release notes URL has no trailing slash. The trailing slash variant answers
+# 308 Permanent Redirect, which Invoke-WebRequest on Windows PowerShell 5.1 does not follow.
+$releaseNotesUrl = "https://www.mongodb.com/docs/v$toolsetVersion/release-notes/$toolsetVersion"
+$getMongoReleases = Invoke-WebRequest -Uri $releaseNotesUrl -UseBasicParsing
 
-$minorVersions = @()
-foreach ($release in $targetReleases) {
-    if ($release -notlike "*upcoming*") {
-        $pattern = '\d+\.\d+\.\d+'
-        $version = $release | Select-String -Pattern $pattern -AllMatches | ForEach-Object { $_.Matches } | ForEach-Object { $_.Value }
-        $minorVersions += $version
-    }
+# Released patch versions are linked as changelog anchors, e.g.
+# /docs/v7.0/release-notes/7.0-changelog/#std-label-7.0.40-changelog
+# The section anchors on the same page have their dots stripped (#7040---aug-11-2026), so
+# they are not usable to recover the version number.
+$versionPattern = "#std-label-($([regex]::Escape($toolsetVersion))\.\d+)-changelog"
+$minorVersions = $getMongoReleases.Links.href | Where-Object { $_ -notlike "*upcoming*" } | ForEach-Object {
+    if ($_ -match $versionPattern) { $Matches[1] }
 }
 
-$latestVersion = $minorVersions[0]
+if (-not $minorVersions) {
+    throw "Failed to parse any $toolsetVersion.x release version from $releaseNotesUrl"
+}
+
+$latestVersion = $minorVersions | Sort-Object { [version]$_ } -Descending | Select-Object -First 1
 
 Install-Binary `
     -Url "https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-$latestVersion-signed.msi" `


### PR DESCRIPTION
# Description
Bug fixing.

MongoDB changed its release-notes page, which breaks `Install-MongoDB.ps1` on `windows-2025`, `windows-2025-vs2026` and `windows-2022` — all three pin MongoDB `7.0` and share this script:

- The URL with a trailing slash now answers `308 Permanent Redirect`, which `Invoke-WebRequest` on Windows PowerShell 5.1 does not follow, so the request throws.
- The release anchors lost their dots (`#7040---aug-11-2026`), so the old parser matched nothing.

Rather than keep scraping the docs page — which has now broken twice — the fix resolves the latest patch release from the downloads feed at `https://downloads.mongodb.org/current.json`. The feed lists the newest release of each supported branch, so it is not subject to the markup and URL changes that keep breaking scraping. It fails with a clear message when the pinned branch is not present.

> Note: this uses `current.json`, not `full.json`. `full.json` includes release candidates (e.g. `7.0.41-rc0`), and casting those to `[version]` throws; `current.json` lists only the newest release per branch, with no RCs.

Validated on hosted runners for each affected toolset — resolved `7.0.40`, the MSI passed the existing `Test-FileSignature` assertion, `msiexec` returned 0, and `mongod --version` reported `v7.0.40`:

| Runner | Toolset | Resolved | Signature | msiexec | mongod |
| --- | --- | --- | --- | --- | --- |
| windows-2025 | toolset-2025.json | 7.0.40 | pass | 0 | v7.0.40 |
| windows-2025 | toolset-2025-vs2026.json | 7.0.40 | pass | 0 | v7.0.40 |
| windows-2022 | toolset-2022.json | 7.0.40 | pass | 0 | v7.0.40 |

There is no hosted `windows-2025-vs2026` label, so the vs2026 toolset was run on the `windows-2025` runner — the same OS and toolset that build feeds to this script.

#### Related issue:
https://github.com/github/hosted-runners-images/issues/911

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
