### PR TITLE
[Windows] Pin Microsoft install-docker-ce.ps1 to last known-good commit

### DIFF
--- a/images/windows/scripts/build/Install-Docker.ps1
+++ b/images/windows/scripts/build/Install-Docker.ps1
@@ -28,7 +28,8 @@ $dockerPath = "$env:TEMP_DIR\docker\docker.exe"
 $dockerdPath = "$env:TEMP_DIR\docker\dockerd.exe"
 
 Write-Host "Install Docker CE"
-$instScriptUrl = "https://raw.githubusercontent.com/microsoft/Windows-Containers/Main/helpful_tools/Install-DockerCE/install-docker-ce.ps1"
+# Pinned to the last commit before docker.exe moved out of System32, which breaks the symlink below (actions/runner-images#14572)
+$instScriptUrl = "https://raw.githubusercontent.com/microsoft/Windows-Containers/8ea2a92d8dfa7815abcf5cc44a756a0ac3d0f513/helpful_tools/Install-DockerCE/install-docker-ce.ps1"
 $instScriptPath = Invoke-DownloadWithRetry $instScriptUrl
 & $instScriptPath -DockerPath $dockerPath -DockerDPath $dockerdPath
 if ($LastExitCode -ne 0) {


### PR DESCRIPTION
# Description

This is a bug fix. MSFT changed their `install-docker-ce.ps1` (which we pull live from their `main`) to install `docker.exe` into `C:\Program Files\Docker` instead of `C:\Windows\System32`. Our script then tries to create a `SysWOW64` shortcut pointing at the old location, can't find it, and the build dies. This breaks `windows-2022`, `windows-2025` and `windows-2025-vs2026`, which all share this script.

This pins our reference to the last known-good commit (`8ea2a92`) instead of tracking their latest, so we get green builds back and we know no other behavior change slipped in with it. A follow up is needed once builds are stable to adopt the new layout properly.

#### Related issue:

https://github.com/actions/runner-images/issues/14572

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated