### PR TITLE
Fix apt retries no-op and bound acquire timeouts

### DIFF
--- a/images/ubuntu-slim/scripts/build/configure-apt.sh
+++ b/images/ubuntu-slim/scripts/build/configure-apt.sh
@@ -14,8 +14,19 @@ source $HELPER_SCRIPTS/os.sh
 # systemctl disable apt-daily-upgrade.timer
 # systemctl disable apt-daily-upgrade.service
 
-# Enable retry logic for apt up to 10 times
-echo "APT::Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries
+# Bound apt's network failure handling.
+# apt reads `Acquire::Retries`, not `APT::Acquire::Retries`, so the previous
+# value here was a no-op and these images have run with apt's default of 3.
+# Retries are counterproductive here: sources use a 3-mirror mirrorlist
+# (configure-apt-sources.sh), so a dead mirror is already covered by failover,
+# and re-attempting it per index item is what turns one slow mirror into a
+# multi-minute `apt-get update`. `Acquire::http::Timeout` was never set at all,
+# leaving the stock 120s per attempt.
+cat > /etc/apt/apt.conf.d/80-retries <<EOF
+Acquire::Retries "0";
+Acquire::http::Timeout "15";
+Acquire::https::Timeout "15";
+EOF
 
 # Configure apt to always assume Y
 echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes

--- a/images/ubuntu/scripts/build/configure-apt.sh
+++ b/images/ubuntu/scripts/build/configure-apt.sh
@@ -14,8 +14,19 @@ systemctl stop apt-daily-upgrade.timer
 systemctl disable apt-daily-upgrade.timer
 systemctl disable apt-daily-upgrade.service
 
-# Enable retry logic for apt up to 10 times
-echo "APT::Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries
+# Bound apt's network failure handling.
+# apt reads `Acquire::Retries`, not `APT::Acquire::Retries`, so the previous
+# value here was a no-op and these images have run with apt's default of 3.
+# Retries are counterproductive here: sources use a 3-mirror mirrorlist
+# (configure-apt-sources.sh), so a dead mirror is already covered by failover,
+# and re-attempting it per index item is what turns one slow mirror into a
+# multi-minute `apt-get update`. `Acquire::http::Timeout` was never set at all,
+# leaving the stock 120s per attempt.
+cat > /etc/apt/apt.conf.d/80-retries <<EOF
+Acquire::Retries "0";
+Acquire::http::Timeout "15";
+Acquire::https::Timeout "15";
+EOF
 
 # Configure apt to always assume Y
 echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes


### PR DESCRIPTION
## Problem

`images/ubuntu/scripts/build/configure-apt.sh` (and the identical copy in `ubuntu-slim`) writes:

```bash
# Enable retry logic for apt up to 10 times
echo "APT::Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries
```

apt does not read `APT::Acquire::Retries`. It reads `Acquire::Retries` ([`apt-pkg/acquire-item.cc`](https://salsa.debian.org/apt-team/apt/-/blob/main/apt-pkg/acquire-item.cc#L787): `_config->FindI("Acquire::Retries", 3)`). `apt.conf` is a flat namespace with no inheritance, so the `APT::`-prefixed line parses without error, sets nothing, and emits no warning. The stated intent of "up to 10 times" has never been in effect.

## Proof

### Static — on a stock `ubuntu-24.04` runner, image `20260810.271.1`

```
$ cat /etc/apt/apt.conf.d/80-retries
APT::Acquire::Retries "10";

$ apt-config dump Acquire::Retries
                                     # ← empty: apt sees no value, uses default 3

$ apt-config dump | grep -i retries
APT::Acquire::Retries "10";          # ← parsed into a node apt never reads

$ printf 'Acquire::Retries "10";\n' | sudo tee /etc/apt/apt.conf.d/80-retries
$ apt-config dump Acquire::Retries
Acquire::Retries "10";               # ← control: the correct key does register

$ apt-config dump Acquire::http::Timeout
                                     # ← empty: never set, so stock 120s/attempt
```

### Behavioral — attempts against a blackholed mirror

Single source pointing at a blackholed IP (`iptables -j DROP` on `192.0.2.1`, so connections hang rather than refuse), no fallback, `Acquire::http::Timeout=5` held constant. Only the retries config varies. Elapsed time is therefore directly proportional to attempts made.

| config | elapsed |
| --- | --- |
| stock image config (`APT::Acquire::Retries "10"`) | **13s** |
| explicit `Acquire::Retries=3` (apt's default) | **13s** |
| explicit `Acquire::Retries=10` (the stated intent) | **187s** |
| explicit `Acquire::Retries=0` | **6s** |

The shipped config is byte-for-byte indistinguishable from apt's default of 3, and differs from an explicit 10 by 14x. That is the no-op.

## Why not simply correct the key

Correcting the typo in place would take retries from an effective 3 to 10 and make the failure mode substantially worse.

These images point `sources` at a 3-tier mirrorlist via `configure-apt-sources.sh` (`azure.archive` → `archive.ubuntu.com` → `security.ubuntu.com`). Redundancy is already provided by mirror failover. Retries on top of that are not additional safety, they are a multiplier: with retries enabled, every index item re-attempts the dead mirror rather than staying failed over.

Measured on `ubuntu-24.04` with a blackholed `priority:1` mirror and a healthy `priority:2` fallback, ~65 index items:

| config | `apt-get update` |
| --- | --- |
| stock | **> 25 min** |
| `Acquire::Retries=1`, `Timeout=15` | **> 8m37s** |
| `Acquire::Retries=0`, `Timeout=5` | **12s** |
| healthy mirror (control) | 5s |

With `Acquire::Retries=0`, apt writes the dead mirror off after a single failure: first `Ign:` at +5.3s, the remaining 36 `Ign:` lines within milliseconds, then clean failover to `priority:2`, `Fetched 39.4 MB in 11s`, exit 0, all 65 index files present. Correctness is unchanged; only the wasted time goes away.

This is the difference between a transient mirror problem costing a job seconds versus costing it 20+ minutes of billable runner time, which is a failure mode users hit regularly (#675, #6894, #7048).

## Change

```bash
cat > /etc/apt/apt.conf.d/80-retries <<EOF
Acquire::Retries "0";
Acquire::http::Timeout "15";
Acquire::https::Timeout "15";
EOF
```

Applied to both `images/ubuntu` and `images/ubuntu-slim`, which had identical copies of the line and identical mirrorlist configuration.

## Tradeoff

`Retries=0` means a transient error on the *last* mirror in the list surfaces immediately instead of being retried. In exchange, the mirrorlist still provides three independent chances, and the worst case becomes bounded (3 mirrors x 15s) rather than unbounded.

If maintainers prefer to keep some retry behavior, `Acquire::Retries "1"` with the timeouts is still a large improvement over the status quo, though the data above shows it remains multi-minute in the mirrorlist failure case. I'm happy to adjust.

## Reproduction

Both experiments are public and re-runnable:

- Retries no-op proof: https://github.com/austenstone/actions-playground/actions/runs/32165998399
- Mirror failover timings: https://github.com/austenstone/actions-playground/actions/runs/32163370759
- Failover receipt (full log): https://github.com/austenstone/actions-playground/actions/runs/32164463827
