### PR TITLE
[Ubuntu, Windows] Add CI workflows for Ubuntu 22.04, 24.04, 26.04, and Windows 11 Arm64

### DIFF
--- a/.github/workflows/ubuntu2204-arm64.yml
+++ b/.github/workflows/ubuntu2204-arm64.yml
@@ -1,0 +1,20 @@
+name: Trigger Ubuntu22.04 Arm64 CI
+run-name: Ubuntu22.04 Arm64 - ${{ github.event.pull_request.title }}
+
+on:
+  pull_request_target:
+    types: labeled
+    paths:
+    - 'images/ubuntu/**'
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  Ubuntu_2204_Arm64:
+    if: github.event.label.name == 'CI ubuntu-all' || github.event.label.name == 'CI ubuntu-2204-arm64'
+    uses: ./.github/workflows/trigger-ubuntu-win-build.yml
+    with:
+      image_type: 'ubuntu2204-arm64'
+    secrets: inherit

--- a/.github/workflows/ubuntu2404-arm64.yml
+++ b/.github/workflows/ubuntu2404-arm64.yml
@@ -1,0 +1,20 @@
+name: Trigger Ubuntu24.04 Arm64 CI
+run-name: Ubuntu24.04 Arm64 - ${{ github.event.pull_request.title }}
+
+on:
+  pull_request_target:
+    types: labeled
+    paths:
+    - 'images/ubuntu/**'
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  Ubuntu_2404_Arm64:
+    if: github.event.label.name == 'CI ubuntu-all' || github.event.label.name == 'CI ubuntu-2404-arm64'
+    uses: ./.github/workflows/trigger-ubuntu-win-build.yml
+    with:
+      image_type: 'ubuntu2404-arm64'
+    secrets: inherit

--- a/.github/workflows/ubuntu2604-arm64.yml
+++ b/.github/workflows/ubuntu2604-arm64.yml
@@ -1,0 +1,20 @@
+name: Trigger Ubuntu26.04 Arm64 CI
+run-name: Ubuntu26.04 Arm64 - ${{ github.event.pull_request.title }}
+
+on:
+  pull_request_target:
+    types: labeled
+    paths:
+    - 'images/ubuntu/**'
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  Ubuntu_2604_Arm64:
+    if: github.event.label.name == 'CI ubuntu-all' || github.event.label.name == 'CI ubuntu-2604-arm64'
+    uses: ./.github/workflows/trigger-ubuntu-win-build.yml
+    with:
+      image_type: 'ubuntu2604-arm64'
+    secrets: inherit

--- a/.github/workflows/windows11-arm64.yml
+++ b/.github/workflows/windows11-arm64.yml
@@ -1,0 +1,20 @@
+name: Trigger Windows11 Arm64 CI
+run-name: Windows11 Arm64 - ${{ github.event.pull_request.title }}
+
+on:
+  pull_request_target:
+    types: labeled
+    paths:
+    - 'images/windows/**'
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  Windows_11_Arm64:
+    if: github.event.label.name == 'CI windows-all' || github.event.label.name == 'CI windows-11-arm64'
+    uses: ./.github/workflows/trigger-ubuntu-win-build.yml
+    with:
+      image_type: 'windows11-arm64'
+    secrets: inherit

--- a/.github/workflows/windows11-vs2026-arm64.yml
+++ b/.github/workflows/windows11-vs2026-arm64.yml
@@ -1,0 +1,20 @@
+name: Trigger Windows11 Arm64 with VS 2026 CI
+run-name: Windows11 Arm64 with VS 2026 - ${{ github.event.pull_request.title }}
+
+on:
+  pull_request_target:
+    types: labeled
+    paths:
+    - 'images/windows/**'
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  Windows_11_vs_2026_Arm64:
+    if: github.event.label.name == 'CI windows-all' || github.event.label.name == 'CI windows-11-vs2026-arm64'
+    uses: ./.github/workflows/trigger-ubuntu-win-build.yml
+    with:
+      image_type: 'windows11-vs2026-arm64'
+    secrets: inherit


### PR DESCRIPTION
# Description

This improvement adds label-triggered CI workflows for the following ARM64 images:

- Windows 11
- Windows 11 with Visual Studio 2026
- Ubuntu 22.04
- Ubuntu 24.04
- Ubuntu 26.04

Each workflow supports its image-specific CI label and the corresponding `windows-all` or `ubuntu-all` label. The workflows delegate builds to the existing reusable `trigger-ubuntu-win-build.yml` workflow.

#### Related issue:

https://github.com/github/hosted-runners-images/issues/916

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
